### PR TITLE
feat(observability): add @agentskit/observability — console, LangSmith, OpenTelemetry

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentskit/observability",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Logging and tracing layer for AgentsKit agents.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -13,7 +13,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -27,7 +29,11 @@
     "@agentskit/core": "workspace:*"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@types/node": "^25.5.2",
+    "langsmith": "^0.5.16",
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"

--- a/packages/observability/src/console-logger.ts
+++ b/packages/observability/src/console-logger.ts
@@ -1,0 +1,73 @@
+import type { AgentEvent, Observer } from '@agentskit/core'
+
+export interface ConsoleLoggerConfig {
+  format?: 'human' | 'json'
+}
+
+function timestamp(): string {
+  return new Date().toISOString().slice(11, 19)
+}
+
+function formatHuman(event: AgentEvent): string {
+  switch (event.type) {
+    case 'agent:step':
+      return `[${timestamp()}] >> step ${event.step} (${event.action})`
+    case 'llm:start':
+      return `[${timestamp()}] -> llm:start (${event.messageCount} messages${event.model ? `, model=${event.model}` : ''})`
+    case 'llm:first-token':
+      return `[${timestamp()}]    llm:first-token (${event.latencyMs}ms)`
+    case 'llm:end': {
+      const preview = event.content.length > 80 ? event.content.slice(0, 80) + '...' : event.content
+      const usage = event.usage ? ` tokens=${event.usage.promptTokens}+${event.usage.completionTokens}` : ''
+      return `[${timestamp()}] <- llm:end (${event.durationMs}ms${usage}) "${preview}"`
+    }
+    case 'tool:start':
+      return `[${timestamp()}] -> tool:start ${event.name} ${JSON.stringify(event.args)}`
+    case 'tool:end': {
+      const result = event.result.length > 80 ? event.result.slice(0, 80) + '...' : event.result
+      return `[${timestamp()}] <- tool:end ${event.name} (${event.durationMs}ms) "${result}"`
+    }
+    case 'memory:load':
+      return `[${timestamp()}]    memory:load (${event.messageCount} messages)`
+    case 'memory:save':
+      return `[${timestamp()}]    memory:save (${event.messageCount} messages)`
+    case 'error':
+      return `[${timestamp()}] !! error: ${event.error.message}`
+  }
+}
+
+function formatJSON(event: AgentEvent): string {
+  const base = { timestamp: new Date().toISOString(), type: event.type }
+  switch (event.type) {
+    case 'agent:step':
+      return JSON.stringify({ ...base, step: event.step, action: event.action })
+    case 'llm:start':
+      return JSON.stringify({ ...base, messageCount: event.messageCount, model: event.model })
+    case 'llm:first-token':
+      return JSON.stringify({ ...base, latencyMs: event.latencyMs })
+    case 'llm:end':
+      return JSON.stringify({ ...base, durationMs: event.durationMs, usage: event.usage, contentLength: event.content.length })
+    case 'tool:start':
+      return JSON.stringify({ ...base, name: event.name, args: event.args })
+    case 'tool:end':
+      return JSON.stringify({ ...base, name: event.name, durationMs: event.durationMs, resultLength: event.result.length })
+    case 'memory:load':
+      return JSON.stringify({ ...base, messageCount: event.messageCount })
+    case 'memory:save':
+      return JSON.stringify({ ...base, messageCount: event.messageCount })
+    case 'error':
+      return JSON.stringify({ ...base, error: event.error.message })
+  }
+}
+
+export function consoleLogger(config: ConsoleLoggerConfig = {}): Observer {
+  const { format = 'human' } = config
+  const formatter = format === 'json' ? formatJSON : formatHuman
+
+  return {
+    name: 'console-logger',
+    on(event: AgentEvent) {
+      process.stdout.write(formatter(event) + '\n')
+    },
+  }
+}

--- a/packages/observability/src/langsmith.ts
+++ b/packages/observability/src/langsmith.ts
@@ -1,0 +1,67 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from './trace-tracker'
+
+export interface LangSmithConfig {
+  apiKey: string
+  projectName?: string
+  endpoint?: string
+}
+
+interface LangSmithClient {
+  createRun(params: Record<string, unknown>): Promise<void>
+  updateRun(id: string, params: Record<string, unknown>): Promise<void>
+}
+
+export function langsmith(config: LangSmithConfig): Observer {
+  const { apiKey, projectName = 'agentskit', endpoint = 'https://api.smith.langchain.com' } = config
+  let clientPromise: Promise<LangSmithClient> | null = null
+
+  const getClient = (): Promise<LangSmithClient> => {
+    if (clientPromise) return clientPromise
+    clientPromise = (async () => {
+      try {
+        const mod = await import('langsmith')
+        const ClientClass = mod.Client as unknown as new (c: { apiKey: string; apiUrl: string }) => LangSmithClient
+        return new ClientClass({ apiKey, apiUrl: endpoint })
+      } catch {
+        throw new Error('Install langsmith to use the LangSmith observer: npm install langsmith')
+      }
+    })()
+    return clientPromise
+  }
+
+  const sendRun = async (span: TraceSpan, isEnd: boolean) => {
+    try {
+      const client = await getClient()
+      if (isEnd) {
+        await client.updateRun(span.id, {
+          end_time: span.endTime,
+          outputs: span.attributes,
+          error: span.status === 'error' ? String(span.attributes['error.message'] ?? 'unknown') : undefined,
+        })
+      } else {
+        await client.createRun({
+          id: span.id,
+          name: span.name,
+          run_type: span.name.startsWith('gen_ai') ? 'llm' : 'tool',
+          project_name: projectName,
+          parent_run_id: span.parentId ?? undefined,
+          start_time: span.startTime,
+          inputs: span.attributes,
+        })
+      }
+    } catch {
+      // Observability errors should not break the main loop
+    }
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) { void sendRun(span, false) },
+    onSpanEnd(span) { void sendRun(span, true) },
+  })
+
+  return {
+    name: 'langsmith',
+    on(event) { tracker.handle(event) },
+  }
+}

--- a/packages/observability/src/opentelemetry.ts
+++ b/packages/observability/src/opentelemetry.ts
@@ -1,0 +1,98 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from './trace-tracker'
+
+export interface OpenTelemetryConfig {
+  endpoint?: string
+  serviceName?: string
+}
+
+interface OtelBridge {
+  startSpan(span: TraceSpan): void
+  endSpan(span: TraceSpan): void
+}
+
+export function opentelemetry(config: OpenTelemetryConfig = {}): Observer {
+  const { endpoint = 'http://localhost:4318/v1/traces', serviceName = 'agentskit' } = config
+  let bridgeReady: Promise<OtelBridge> | null = null
+
+  const getBridge = (): Promise<OtelBridge> => {
+    if (bridgeReady) return bridgeReady
+    bridgeReady = (async (): Promise<OtelBridge> => {
+      let api: typeof import('@opentelemetry/api')
+      try {
+        api = await import('@opentelemetry/api')
+      } catch {
+        throw new Error('Install @opentelemetry/api to use the OpenTelemetry observer: npm install @opentelemetry/api')
+      }
+
+      // Try to set up the full SDK (optional — user may have their own provider)
+      try {
+        const sdk = await import('@opentelemetry/sdk-trace-base') as unknown as Record<string, unknown>
+        const otlp = await import('@opentelemetry/exporter-trace-otlp-http') as unknown as Record<string, unknown>
+
+        const OTLPExporter = otlp.OTLPTraceExporter as new (config: { url: string }) => unknown
+        const exporter = new OTLPExporter({ url: endpoint })
+
+        const BatchProcessor = sdk.BatchSpanProcessor as new (e: unknown) => unknown
+        const processor = new BatchProcessor(exporter)
+
+        const Provider = sdk.BasicTracerProvider as new (...args: unknown[]) => { addSpanProcessor?: (p: unknown) => void; register?: () => void; shutdown?: () => Promise<void> }
+        const provider = new Provider()
+        if (typeof provider.addSpanProcessor === 'function') {
+          provider.addSpanProcessor(processor)
+        }
+        if (typeof provider.register === 'function') {
+          provider.register()
+        }
+      } catch {
+        // SDK not available — use whatever provider is already registered
+      }
+
+      const tracer = api.trace.getTracer(serviceName, '0.4.0')
+      const spanMap = new Map<string, ReturnType<typeof tracer.startSpan>>()
+
+      return {
+        startSpan(span: TraceSpan) {
+          const parentOtel = span.parentId ? spanMap.get(span.parentId) : undefined
+          const parentCtx = parentOtel
+            ? api.trace.setSpan(api.context.active(), parentOtel)
+            : api.context.active()
+
+          const attrs: Record<string, string> = {}
+          for (const [k, v] of Object.entries(span.attributes)) {
+            if (v != null) attrs[k] = String(v)
+          }
+
+          const otelSpan = tracer.startSpan(span.name, { startTime: span.startTime, attributes: attrs }, parentCtx)
+          spanMap.set(span.id, otelSpan)
+        },
+        endSpan(span: TraceSpan) {
+          const otelSpan = spanMap.get(span.id)
+          if (!otelSpan) return
+
+          for (const [k, v] of Object.entries(span.attributes)) {
+            if (v != null) otelSpan.setAttribute(k, String(v))
+          }
+
+          if (span.status === 'error') {
+            otelSpan.setStatus({ code: api.SpanStatusCode.ERROR, message: String(span.attributes['error.message'] ?? '') })
+          }
+
+          otelSpan.end(span.endTime)
+          spanMap.delete(span.id)
+        },
+      }
+    })()
+    return bridgeReady
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) { void getBridge().then(b => b.startSpan(span)).catch(() => {}) },
+    onSpanEnd(span) { void getBridge().then(b => b.endSpan(span)).catch(() => {}) },
+  })
+
+  return {
+    name: 'opentelemetry',
+    on(event) { tracker.handle(event) },
+  }
+}

--- a/packages/observability/src/trace-tracker.ts
+++ b/packages/observability/src/trace-tracker.ts
@@ -1,0 +1,137 @@
+import type { AgentEvent } from '@agentskit/core'
+
+export interface TraceSpan {
+  id: string
+  name: string
+  parentId: string | null
+  startTime: number
+  endTime?: number
+  attributes: Record<string, unknown>
+  status: 'ok' | 'error'
+}
+
+export interface TraceTrackerCallbacks {
+  onSpanStart: (span: TraceSpan) => void
+  onSpanEnd: (span: TraceSpan) => void
+}
+
+let nextSpanId = 0
+function generateSpanId(): string {
+  return `span-${Date.now()}-${nextSpanId++}`
+}
+
+export function createTraceTracker(callbacks: TraceTrackerCallbacks) {
+  const spanStack: TraceSpan[] = []
+  let currentStepSpan: TraceSpan | null = null
+
+  const currentParentId = (): string | null => {
+    if (spanStack.length > 0) return spanStack[spanStack.length - 1].id
+    return currentStepSpan?.id ?? null
+  }
+
+  const startSpan = (name: string, attributes: Record<string, unknown> = {}): TraceSpan => {
+    const span: TraceSpan = {
+      id: generateSpanId(),
+      name,
+      parentId: currentParentId(),
+      startTime: Date.now(),
+      attributes,
+      status: 'ok',
+    }
+    spanStack.push(span)
+    callbacks.onSpanStart(span)
+    return span
+  }
+
+  const endSpan = (attributes: Record<string, unknown> = {}, status: 'ok' | 'error' = 'ok'): TraceSpan | null => {
+    const span = spanStack.pop()
+    if (!span) return null
+    span.endTime = Date.now()
+    span.status = status
+    Object.assign(span.attributes, attributes)
+    callbacks.onSpanEnd(span)
+    return span
+  }
+
+  return {
+    handle(event: AgentEvent): void {
+      switch (event.type) {
+        case 'agent:step': {
+          // Close previous step span if still open
+          if (currentStepSpan && !currentStepSpan.endTime) {
+            currentStepSpan.endTime = Date.now()
+            callbacks.onSpanEnd(currentStepSpan)
+          }
+          currentStepSpan = {
+            id: generateSpanId(),
+            name: `agentskit.agent.step`,
+            parentId: null,
+            startTime: Date.now(),
+            attributes: { 'agentskit.step': event.step, 'agentskit.action': event.action },
+            status: 'ok',
+          }
+          callbacks.onSpanStart(currentStepSpan)
+          break
+        }
+        case 'llm:start':
+          startSpan('gen_ai.chat', {
+            'gen_ai.system': 'agentskit',
+            'gen_ai.request.model': event.model ?? 'unknown',
+            'agentskit.message_count': event.messageCount,
+          })
+          break
+        case 'llm:first-token':
+          // Add attribute to current LLM span
+          if (spanStack.length > 0) {
+            spanStack[spanStack.length - 1].attributes['gen_ai.response.first_token_ms'] = event.latencyMs
+          }
+          break
+        case 'llm:end':
+          endSpan({
+            'gen_ai.response.content': event.content.slice(0, 500),
+            'gen_ai.usage.input_tokens': event.usage?.promptTokens,
+            'gen_ai.usage.output_tokens': event.usage?.completionTokens,
+            'agentskit.duration_ms': event.durationMs,
+          })
+          break
+        case 'tool:start':
+          startSpan(`agentskit.tool.${event.name}`, {
+            'agentskit.tool.name': event.name,
+            'agentskit.tool.args': JSON.stringify(event.args),
+          })
+          break
+        case 'tool:end':
+          endSpan({
+            'agentskit.tool.result': event.result.slice(0, 500),
+            'agentskit.duration_ms': event.durationMs,
+          })
+          break
+        case 'memory:load':
+          startSpan('agentskit.memory.load', { 'agentskit.message_count': event.messageCount })
+          endSpan()
+          break
+        case 'memory:save':
+          startSpan('agentskit.memory.save', { 'agentskit.message_count': event.messageCount })
+          endSpan()
+          break
+        case 'error': {
+          const span = spanStack.length > 0 ? spanStack[spanStack.length - 1] : currentStepSpan
+          if (span) {
+            span.attributes['error.message'] = event.error.message
+            span.status = 'error'
+          }
+          break
+        }
+      }
+    },
+    flush(): void {
+      // Close any remaining open spans
+      while (spanStack.length > 0) endSpan({}, 'ok')
+      if (currentStepSpan && !currentStepSpan.endTime) {
+        currentStepSpan.endTime = Date.now()
+        callbacks.onSpanEnd(currentStepSpan)
+        currentStepSpan = null
+      }
+    },
+  }
+}

--- a/packages/observability/tests/console-logger.test.ts
+++ b/packages/observability/tests/console-logger.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { consoleLogger } from '../src/console-logger'
+import type { AgentEvent } from '@agentskit/core'
+
+describe('consoleLogger', () => {
+  let output: string[]
+  const originalWrite = process.stdout.write
+
+  beforeEach(() => {
+    output = []
+    process.stdout.write = ((chunk: string) => { output.push(chunk); return true }) as typeof process.stdout.write
+  })
+
+  afterEach(() => {
+    process.stdout.write = originalWrite
+  })
+
+  describe('human format (default)', () => {
+    it('logs agent:step', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'agent:step', step: 1, action: 'initial' })
+      expect(output[0]).toContain('step 1')
+      expect(output[0]).toContain('initial')
+    })
+
+    it('logs llm:start', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'llm:start', messageCount: 3, model: 'gpt-4o' })
+      expect(output[0]).toContain('llm:start')
+      expect(output[0]).toContain('3 messages')
+      expect(output[0]).toContain('gpt-4o')
+    })
+
+    it('logs llm:end with preview', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'llm:end', content: 'Hello world', durationMs: 500 })
+      expect(output[0]).toContain('llm:end')
+      expect(output[0]).toContain('500ms')
+      expect(output[0]).toContain('Hello world')
+    })
+
+    it('truncates long content', () => {
+      const logger = consoleLogger()
+      const longContent = 'a'.repeat(200)
+      logger.on({ type: 'llm:end', content: longContent, durationMs: 100 })
+      expect(output[0]).toContain('...')
+      expect(output[0].length).toBeLessThan(300)
+    })
+
+    it('logs tool:start and tool:end', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'tool:start', name: 'web_search', args: { query: 'test' } })
+      expect(output[0]).toContain('tool:start')
+      expect(output[0]).toContain('web_search')
+
+      logger.on({ type: 'tool:end', name: 'web_search', result: 'found it', durationMs: 200 })
+      expect(output[1]).toContain('tool:end')
+      expect(output[1]).toContain('200ms')
+    })
+
+    it('logs error', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'error', error: new Error('boom') })
+      expect(output[0]).toContain('error')
+      expect(output[0]).toContain('boom')
+    })
+
+    it('logs memory events', () => {
+      const logger = consoleLogger()
+      logger.on({ type: 'memory:load', messageCount: 5 })
+      expect(output[0]).toContain('memory:load')
+      expect(output[0]).toContain('5 messages')
+    })
+  })
+
+  describe('json format', () => {
+    it('outputs valid JSON', () => {
+      const logger = consoleLogger({ format: 'json' })
+      logger.on({ type: 'llm:start', messageCount: 3 })
+      const parsed = JSON.parse(output[0])
+      expect(parsed.type).toBe('llm:start')
+      expect(parsed.messageCount).toBe(3)
+      expect(parsed.timestamp).toBeTruthy()
+    })
+
+    it('includes all event types', () => {
+      const logger = consoleLogger({ format: 'json' })
+      const events: AgentEvent[] = [
+        { type: 'agent:step', step: 1, action: 'initial' },
+        { type: 'llm:start', messageCount: 1 },
+        { type: 'llm:first-token', latencyMs: 50 },
+        { type: 'llm:end', content: 'hi', durationMs: 100 },
+        { type: 'tool:start', name: 'test', args: {} },
+        { type: 'tool:end', name: 'test', result: 'ok', durationMs: 10 },
+        { type: 'memory:load', messageCount: 0 },
+        { type: 'memory:save', messageCount: 2 },
+        { type: 'error', error: new Error('fail') },
+      ]
+      for (const event of events) {
+        logger.on(event)
+      }
+      expect(output).toHaveLength(9)
+      for (const line of output) {
+        expect(() => JSON.parse(line)).not.toThrow()
+      }
+    })
+  })
+
+  it('satisfies Observer contract', () => {
+    const logger = consoleLogger()
+    expect(logger.name).toBe('console-logger')
+    expect(logger.on).toBeTypeOf('function')
+  })
+})

--- a/packages/observability/tests/observers.test.ts
+++ b/packages/observability/tests/observers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { consoleLogger } from '../src/console-logger'
+import { langsmith } from '../src/langsmith'
+import { opentelemetry } from '../src/opentelemetry'
+
+describe('Observer contract compliance', () => {
+  it('consoleLogger satisfies Observer', () => {
+    const obs = consoleLogger()
+    expect(obs.name).toBeTypeOf('string')
+    expect(obs.name).toBeTruthy()
+    expect(obs.on).toBeTypeOf('function')
+  })
+
+  it('langsmith satisfies Observer', () => {
+    const obs = langsmith({ apiKey: 'test-key' })
+    expect(obs.name).toBeTypeOf('string')
+    expect(obs.name).toBeTruthy()
+    expect(obs.on).toBeTypeOf('function')
+  })
+
+  it('opentelemetry satisfies Observer', () => {
+    const obs = opentelemetry()
+    expect(obs.name).toBeTypeOf('string')
+    expect(obs.name).toBeTruthy()
+    expect(obs.on).toBeTypeOf('function')
+  })
+})

--- a/packages/observability/tests/trace-tracker.test.ts
+++ b/packages/observability/tests/trace-tracker.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createTraceTracker, type TraceSpan } from '../src/trace-tracker'
+import type { AgentEvent } from '@agentskit/core'
+
+describe('createTraceTracker', () => {
+  it('creates root span for agent:step', () => {
+    const started: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: () => {},
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+
+    expect(started).toHaveLength(1)
+    expect(started[0].name).toBe('agentskit.agent.step')
+    expect(started[0].parentId).toBeNull()
+    expect(started[0].attributes['agentskit.step']).toBe(1)
+  })
+
+  it('nests llm span under agent step', () => {
+    const started: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: () => {},
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 3 })
+
+    expect(started).toHaveLength(2)
+    expect(started[1].name).toBe('gen_ai.chat')
+    expect(started[1].parentId).toBe(started[0].id)
+    expect(started[1].attributes['agentskit.message_count']).toBe(3)
+  })
+
+  it('closes llm span on llm:end with attributes', () => {
+    const ended: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: () => {},
+      onSpanEnd: (s) => ended.push(s),
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 1 })
+    tracker.handle({ type: 'llm:end', content: 'response', durationMs: 500 })
+
+    expect(ended).toHaveLength(1)
+    expect(ended[0].name).toBe('gen_ai.chat')
+    expect(ended[0].endTime).toBeDefined()
+    expect(ended[0].attributes['agentskit.duration_ms']).toBe(500)
+  })
+
+  it('adds first-token latency to llm span', () => {
+    const started: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: () => {},
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 1 })
+    tracker.handle({ type: 'llm:first-token', latencyMs: 150 })
+
+    expect(started[1].attributes['gen_ai.response.first_token_ms']).toBe(150)
+  })
+
+  it('nests tool span under agent step', () => {
+    const started: TraceSpan[] = []
+    const ended: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: (s) => ended.push(s),
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'tool:start', name: 'web_search', args: { q: 'test' } })
+
+    expect(started[1].name).toBe('agentskit.tool.web_search')
+    expect(started[1].parentId).toBe(started[0].id)
+
+    tracker.handle({ type: 'tool:end', name: 'web_search', result: 'found', durationMs: 200 })
+
+    expect(ended).toHaveLength(1)
+    expect(ended[0].attributes['agentskit.duration_ms']).toBe(200)
+  })
+
+  it('handles memory events as instant spans', () => {
+    const started: TraceSpan[] = []
+    const ended: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: (s) => ended.push(s),
+    })
+
+    tracker.handle({ type: 'memory:load', messageCount: 5 })
+
+    expect(started).toHaveLength(1)
+    expect(ended).toHaveLength(1)
+    expect(started[0].name).toBe('agentskit.memory.load')
+  })
+
+  it('marks span as error on error event', () => {
+    const started: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: () => {},
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 1 })
+    tracker.handle({ type: 'error', error: new Error('timeout') })
+
+    expect(started[1].status).toBe('error')
+    expect(started[1].attributes['error.message']).toBe('timeout')
+  })
+
+  it('flush closes all open spans', () => {
+    const ended: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: () => {},
+      onSpanEnd: (s) => ended.push(s),
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 1 })
+    // Don't send llm:end — flush should close everything
+
+    tracker.flush()
+
+    // LLM span + step span should both be closed
+    expect(ended.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('full trace: step → llm → tool → llm → done', () => {
+    const started: TraceSpan[] = []
+    const ended: TraceSpan[] = []
+    const tracker = createTraceTracker({
+      onSpanStart: (s) => started.push(s),
+      onSpanEnd: (s) => ended.push(s),
+    })
+
+    tracker.handle({ type: 'agent:step', step: 1, action: 'initial' })
+    tracker.handle({ type: 'llm:start', messageCount: 2 })
+    tracker.handle({ type: 'llm:end', content: 'let me search', durationMs: 300 })
+    tracker.handle({ type: 'tool:start', name: 'search', args: { q: 'test' } })
+    tracker.handle({ type: 'tool:end', name: 'search', result: 'found', durationMs: 150 })
+    tracker.handle({ type: 'agent:step', step: 2, action: 'tool-result-loop' })
+    tracker.handle({ type: 'llm:start', messageCount: 4 })
+    tracker.handle({ type: 'llm:end', content: 'here is the answer', durationMs: 400 })
+
+    // Started: step1, llm1, tool, step2(closes step1), llm2
+    expect(started.length).toBeGreaterThanOrEqual(5)
+    // Ended: llm1, tool, step1, llm2
+    expect(ended.length).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/cli:
     dependencies:
@@ -186,7 +186,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/core:
     devDependencies:
@@ -204,7 +204,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/eval:
     dependencies:
@@ -223,7 +223,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/ink:
     dependencies:
@@ -254,7 +254,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/memory:
     dependencies:
@@ -266,8 +266,8 @@ importers:
         specifier: ^7.6.12
         version: 7.6.13
       '@types/node':
-        specifier: ^24.0.0
-        version: 24.12.2
+        specifier: ^25.5.2
+        version: 25.5.2
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -285,7 +285,7 @@ importers:
         version: 0.14.0(ws@8.20.0)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/observability:
     dependencies:
@@ -293,9 +293,21 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.214.0
+        version: 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      langsmith:
+        specifier: ^0.5.16
+        version: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0))(ws@8.20.0)
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)
@@ -304,7 +316,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/rag:
     dependencies:
@@ -323,7 +335,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/react:
     dependencies:
@@ -366,7 +378,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/runtime:
     dependencies:
@@ -385,7 +397,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/sandbox:
     dependencies:
@@ -404,7 +416,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/skills:
     dependencies:
@@ -420,7 +432,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/tools:
     dependencies:
@@ -442,7 +454,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
 packages:
 
@@ -2150,6 +2162,66 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0':
+    resolution: {integrity: sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.214.0':
+    resolution: {integrity: sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.214.0':
+    resolution: {integrity: sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.6.1':
+    resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.214.0':
+    resolution: {integrity: sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.6.1':
+    resolution: {integrity: sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.1':
+    resolution: {integrity: sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
@@ -3500,6 +3572,9 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
@@ -4840,6 +4915,26 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  langsmith@0.5.16:
+    resolution: {integrity: sha512-nSsSnTo3gjg1dnb48vb8i582zyjvtPbn+EpR6P1pNELb+4Hb4R3nt7LDy+Tl1ltw73vPGfJQtUWOl28irI1b5w==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
+        optional: true
 
   latest-version@7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
@@ -6533,6 +6628,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -7061,6 +7159,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -9692,34 +9794,12 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/confirm@5.1.21(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
-
   '@inquirer/confirm@5.1.21(@types/node@25.5.2)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.5.2)
       '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
       '@types/node': 25.5.2
-
-  '@inquirer/core@10.3.2(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.5.2)':
     dependencies:
@@ -9742,11 +9822,6 @@ snapshots:
       '@types/node': 25.5.2
 
   '@inquirer/figures@1.0.15': {}
-
-  '@inquirer/type@3.0.10(@types/node@24.12.2)':
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.5.2)':
     optionalDependencies:
@@ -10012,6 +10087,72 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@oxc-project/types@0.122.0': {}
 
@@ -10692,15 +10833,6 @@ snapshots:
       '@vitest/utils': 4.1.2
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.2(msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 4.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.0(@types/node@24.12.2)(typescript@6.0.2)
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/mocker@4.1.2(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
@@ -11396,6 +11528,10 @@ snapshots:
   connect-history-api-fallback@2.0.0: {}
 
   consola@3.4.2: {}
+
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
 
   content-disposition@0.5.2: {}
 
@@ -12852,6 +12988,19 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  langsmith@0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0))(ws@8.20.0):
+    dependencies:
+      chalk: 5.6.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      openai: 4.104.0(ws@8.20.0)
+      ws: 8.20.0
+
   latest-version@7.0.0:
     dependencies:
       package-json: 8.1.1
@@ -13565,32 +13714,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@24.12.2)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.13.2
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.10.1
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.5.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2):
     dependencies:
@@ -15025,6 +15148,8 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  simple-wcswidth@1.1.2: {}
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -15549,6 +15674,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@10.0.0: {}
+
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
@@ -15594,24 +15721,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      terser: 5.46.1
-      tsx: 4.21.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -15630,36 +15739,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
-    dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.2
-      happy-dom: 20.8.9
-      jsdom: 29.0.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
@@ -15682,6 +15762,7 @@ snapshots:
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.5.2
       happy-dom: 20.8.9
       jsdom: 29.0.1


### PR DESCRIPTION
## Summary

Implements [#11](https://github.com/EmersonBraun/agentskit/issues/11).

### New package: @agentskit/observability

| Observer | Backend | Deps |
|----------|---------|------|
| `consoleLogger()` | stdout (human or JSON) | None |
| `langsmith({ apiKey })` | LangSmith API | `langsmith` (lazy) |
| `opentelemetry({ endpoint })` | OTLP export | `@opentelemetry/*` (lazy) |

### Key design
- **`createTraceTracker()`** — shared span management state machine used by both LangSmith and OpenTelemetry. Tracks parent/child relationships via a span stack.
- **Full trace hierarchy** — root spans per agent step, child spans for LLM calls and tool calls
- **GenAI semantic conventions** — `gen_ai.chat`, `gen_ai.request.model`, `gen_ai.usage.*` for OTel compatibility with Arize/Langfuse/Datadog
- **Lazy dynamic imports** — external SDKs loaded only when used, clear error if not installed
- **consoleLogger configurable** — human-readable default, JSON format for piping

### 22 tests
- consoleLogger: human format, JSON format, all event types, truncation (12)
- traceTracker: span creation, nesting, closing, error marking, flush, full trace (7)
- Contract compliance for all 3 observers (3)

## Test plan

- [x] 22 observability tests pass
- [x] All 17 test suites across monorepo pass
- [x] All 13 packages build
- [x] All 20 lint tasks pass