### PR TITLE
chore: update README, dependabot, scaffold rag/sandbox/eval/observability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,31 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "npm"
+    directory: "/packages/memory"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/observability"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/rag"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/sandbox"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/eval"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
     directory: "/apps/docs"
     schedule:
       interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@ npm install @agentskit/react @agentskit/adapters
 ## Package Layout
 
 ```text
-@agentskit/core      portable runtime, tools, memory, retrieval
-@agentskit/react     React hooks + UI components + theme
-@agentskit/ink       terminal hooks + Ink components
-@agentskit/adapters  provider adapters and generic streams
-@agentskit/cli       chat + init commands
+@agentskit/core           portable runtime, types, events, contracts
+@agentskit/react          React hooks + UI components + theme
+@agentskit/ink            terminal hooks + Ink components
+@agentskit/adapters       LLM provider adapters (OpenAI, Anthropic, Gemini, etc.)
+@agentskit/cli            chat + init + run commands
+@agentskit/runtime        standalone agent runtime with ReAct loop
+@agentskit/tools          reusable tools (web search, filesystem, shell)
+@agentskit/skills         ready-made skills (researcher, coder, planner, etc.)
+@agentskit/memory         persistent backends (SQLite, Redis, vectra)
+@agentskit/observability  logging + tracing (console, LangSmith, OpenTelemetry)
+@agentskit/rag            plug-and-play retrieval-augmented generation
+@agentskit/sandbox        secure code execution (E2B, WebContainer)
+@agentskit/eval           agent evaluation and benchmarking
 ```
 
 ## React Quick Start

--- a/docs/superpowers/plans/2026-04-06-adapter-embedders.md
+++ b/docs/superpowers/plans/2026-04-06-adapter-embedders.md
@@ -1,0 +1,1132 @@
+# Adapter Embedders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add standalone embedder functions (`openaiEmbedder`, `geminiEmbedder`, `ollamaEmbedder`, `deepseekEmbedder`, `grokEmbedder`, `kimiEmbedder`) to `@agentskit/adapters`, each returning an `EmbedFn` that satisfies the core embedding contract.
+
+**Architecture:** New `src/embedders/` directory in the adapters package. A shared `openaiCompatibleEmbedder` handles the OpenAI-compatible API pattern; thin wrappers set default base URLs. Each embedder uses raw `fetch` — no SDK dependencies. On missing `model`, fetches available models from provider's API to show a helpful error. `EmbedFn` type defined in core.
+
+**Tech Stack:** TypeScript, vitest, msw (for HTTP mocking in tests), raw fetch
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `packages/core/src/types.ts` | Add `EmbedFn` type |
+| Modify | `packages/core/src/index.ts` | Export `EmbedFn` |
+| Create | `packages/adapters/src/embedders/openai.ts` | OpenAI embedder |
+| Create | `packages/adapters/src/embedders/gemini.ts` | Gemini embedder |
+| Create | `packages/adapters/src/embedders/ollama.ts` | Ollama embedder |
+| Create | `packages/adapters/src/embedders/openai-compatible.ts` | Shared factory for OpenAI-compatible providers |
+| Create | `packages/adapters/src/embedders/deepseek.ts` | DeepSeek embedder (thin wrapper) |
+| Create | `packages/adapters/src/embedders/grok.ts` | Grok embedder (thin wrapper) |
+| Create | `packages/adapters/src/embedders/kimi.ts` | Kimi embedder (thin wrapper) |
+| Create | `packages/adapters/src/embedders/index.ts` | Barrel export for all embedders |
+| Modify | `packages/adapters/src/index.ts` | Re-export embedders |
+| Modify | `packages/adapters/package.json` | Add `msw` devDependency |
+| Create | `packages/adapters/tests/embedders/openai.test.ts` | Tests for OpenAI embedder |
+| Create | `packages/adapters/tests/embedders/gemini.test.ts` | Tests for Gemini embedder |
+| Create | `packages/adapters/tests/embedders/ollama.test.ts` | Tests for Ollama embedder |
+| Create | `packages/adapters/tests/embedders/openai-compatible.test.ts` | Tests for shared factory + thin wrappers |
+| Create | `packages/adapters/tests/embedders/contract.test.ts` | Contract tests verifying all embedders return `number[]` |
+
+---
+
+### Task 1: Add `EmbedFn` type to core
+
+**Files:**
+- Modify: `packages/core/src/types.ts:204` (after `VectorMemory`)
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add the `EmbedFn` type to core types**
+
+In `packages/core/src/types.ts`, add after the `VectorMemory` interface (after line 204):
+
+```typescript
+export type EmbedFn = (text: string) => Promise<number[]>
+```
+
+- [ ] **Step 2: Export `EmbedFn` from core index**
+
+In `packages/core/src/index.ts`, add `EmbedFn` to the type exports:
+
+```typescript
+export type {
+  // ... existing exports ...
+  EmbedFn,
+} from './types'
+```
+
+- [ ] **Step 3: Verify core builds**
+
+Run: `pnpm --filter @agentskit/core build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/types.ts packages/core/src/index.ts
+git commit -m "feat(core): add EmbedFn type for embedding contract"
+```
+
+---
+
+### Task 2: Install `msw` and set up test infrastructure
+
+**Files:**
+- Modify: `packages/adapters/package.json`
+
+- [ ] **Step 1: Install msw**
+
+Run: `pnpm --filter @agentskit/adapters add -D msw`
+
+- [ ] **Step 2: Verify install**
+
+Run: `pnpm --filter @agentskit/adapters test`
+Expected: Existing tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/package.json pnpm-lock.yaml
+git commit -m "chore(adapters): add msw for HTTP mocking in embedder tests"
+```
+
+---
+
+### Task 3: Implement `openaiEmbedder`
+
+**Files:**
+- Create: `packages/adapters/src/embedders/openai.ts`
+- Create: `packages/adapters/tests/embedders/openai.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/adapters/tests/embedders/openai.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { openaiEmbedder } from '../../src/embedders/openai'
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('openaiEmbedder', () => {
+  it('returns an embedding vector from the OpenAI API', async () => {
+    const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+    server.use(
+      http.post('https://api.openai.com/v1/embeddings', () => {
+        return HttpResponse.json({
+          object: 'list',
+          data: [{ object: 'embedding', embedding: mockEmbedding, index: 0 }],
+          model: 'text-embedding-3-small',
+          usage: { prompt_tokens: 5, total_tokens: 5 },
+        })
+      }),
+    )
+
+    const embed = openaiEmbedder({ apiKey: 'test-key' })
+    const result = await embed('hello world')
+
+    expect(result).toEqual(mockEmbedding)
+    expect(Array.isArray(result)).toBe(true)
+    result.forEach(v => expect(typeof v).toBe('number'))
+  })
+
+  it('uses custom model and baseUrl', async () => {
+    const mockEmbedding = [0.9, 0.8]
+    let capturedUrl = ''
+    let capturedBody: Record<string, unknown> = {}
+
+    server.use(
+      http.post('https://custom.api.com/v1/embeddings', async ({ request }) => {
+        capturedUrl = request.url
+        capturedBody = await request.json() as Record<string, unknown>
+        return HttpResponse.json({
+          object: 'list',
+          data: [{ object: 'embedding', embedding: mockEmbedding, index: 0 }],
+          model: 'text-embedding-3-large',
+          usage: { prompt_tokens: 5, total_tokens: 5 },
+        })
+      }),
+    )
+
+    const embed = openaiEmbedder({
+      apiKey: 'test-key',
+      model: 'text-embedding-3-large',
+      baseUrl: 'https://custom.api.com',
+    })
+    const result = await embed('test')
+
+    expect(capturedUrl).toBe('https://custom.api.com/v1/embeddings')
+    expect(capturedBody).toMatchObject({ model: 'text-embedding-3-large', input: 'test' })
+    expect(result).toEqual(mockEmbedding)
+  })
+
+  it('throws with available models when API returns an error', async () => {
+    server.use(
+      http.post('https://api.openai.com/v1/embeddings', () => {
+        return HttpResponse.json({ error: { message: 'invalid model' } }, { status: 400 })
+      }),
+      http.get('https://api.openai.com/v1/models', () => {
+        return HttpResponse.json({
+          data: [
+            { id: 'text-embedding-3-small' },
+            { id: 'text-embedding-3-large' },
+            { id: 'gpt-4o' },
+          ],
+        })
+      }),
+    )
+
+    const embed = openaiEmbedder({ apiKey: 'test-key' })
+    await expect(embed('test')).rejects.toThrow(/text-embedding-3-small/)
+  })
+
+  it('shows fallback error when model list fetch also fails', async () => {
+    server.use(
+      http.post('https://api.openai.com/v1/embeddings', () => {
+        return HttpResponse.json({ error: { message: 'invalid model' } }, { status: 400 })
+      }),
+      http.get('https://api.openai.com/v1/models', () => {
+        return HttpResponse.error()
+      }),
+    )
+
+    const embed = openaiEmbedder({ apiKey: 'test-key' })
+    await expect(embed('test')).rejects.toThrow(/Could not fetch available models/)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/openai.test.ts`
+Expected: FAIL — module `../../src/embedders/openai` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/adapters/src/embedders/openai.ts`:
+
+```typescript
+import type { EmbedFn } from '@agentskit/core'
+
+export interface OpenAIEmbedderConfig {
+  apiKey: string
+  model?: string
+  baseUrl?: string
+}
+
+async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/v1/models`, {
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  const data = await response.json() as { data: Array<{ id: string }> }
+  return data.data
+    .map(m => m.id)
+    .filter(id => id.includes('embed'))
+    .sort()
+}
+
+async function buildModelError(
+  provider: string,
+  baseUrl: string,
+  apiKey: string,
+  originalError: string,
+): Promise<Error> {
+  try {
+    const models = await fetchAvailableModels(baseUrl, apiKey)
+    const list = models.length > 0 ? models.join(', ') : 'none found'
+    return new Error(
+      `${provider} embedding failed: ${originalError}. Available embedding models: ${list}`,
+    )
+  } catch (fetchError) {
+    return new Error(
+      `${provider} embedding failed: ${originalError}. Could not fetch available models: ${(fetchError as Error).message}`,
+    )
+  }
+}
+
+export function openaiEmbedder(config: OpenAIEmbedderConfig): EmbedFn {
+  const { apiKey, model = 'text-embedding-3-small', baseUrl = 'https://api.openai.com' } = config
+
+  return async (text: string): Promise<number[]> => {
+    const response = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, input: text }),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({})) as { error?: { message?: string } }
+      const message = errorBody.error?.message ?? `HTTP ${response.status}`
+      throw await buildModelError('OpenAI', baseUrl, apiKey, message)
+    }
+
+    const data = await response.json() as { data: Array<{ embedding: number[] }> }
+    return data.data[0].embedding
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/openai.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/src/embedders/openai.ts packages/adapters/tests/embedders/openai.test.ts
+git commit -m "feat(adapters): add openaiEmbedder with model discovery on error"
+```
+
+---
+
+### Task 4: Implement `geminiEmbedder`
+
+**Files:**
+- Create: `packages/adapters/src/embedders/gemini.ts`
+- Create: `packages/adapters/tests/embedders/gemini.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/adapters/tests/embedders/gemini.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { geminiEmbedder } from '../../src/embedders/gemini'
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('geminiEmbedder', () => {
+  it('returns an embedding vector from the Gemini API', async () => {
+    const mockEmbedding = [0.1, 0.2, 0.3]
+
+    server.use(
+      http.post(
+        'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent',
+        ({ request }) => {
+          const url = new URL(request.url)
+          expect(url.searchParams.get('key')).toBe('test-key')
+          return HttpResponse.json({
+            embedding: { values: mockEmbedding },
+          })
+        },
+      ),
+    )
+
+    const embed = geminiEmbedder({ apiKey: 'test-key' })
+    const result = await embed('hello')
+
+    expect(result).toEqual(mockEmbedding)
+  })
+
+  it('uses custom model', async () => {
+    const mockEmbedding = [0.5, 0.6]
+
+    server.use(
+      http.post(
+        'https://generativelanguage.googleapis.com/v1beta/models/custom-model:embedContent',
+        () => {
+          return HttpResponse.json({
+            embedding: { values: mockEmbedding },
+          })
+        },
+      ),
+    )
+
+    const embed = geminiEmbedder({ apiKey: 'test-key', model: 'custom-model' })
+    const result = await embed('test')
+
+    expect(result).toEqual(mockEmbedding)
+  })
+
+  it('throws with available models on error', async () => {
+    server.use(
+      http.post(
+        'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent',
+        () => {
+          return HttpResponse.json({ error: { message: 'bad request' } }, { status: 400 })
+        },
+      ),
+      http.get(
+        'https://generativelanguage.googleapis.com/v1beta/models',
+        () => {
+          return HttpResponse.json({
+            models: [
+              { name: 'models/text-embedding-004', supportedGenerationMethods: ['embedContent'] },
+              { name: 'models/gemini-pro', supportedGenerationMethods: ['generateContent'] },
+            ],
+          })
+        },
+      ),
+    )
+
+    const embed = geminiEmbedder({ apiKey: 'test-key' })
+    await expect(embed('test')).rejects.toThrow(/text-embedding-004/)
+  })
+
+  it('shows fallback error when model list fetch fails', async () => {
+    server.use(
+      http.post(
+        'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent',
+        () => {
+          return HttpResponse.json({ error: { message: 'bad' } }, { status: 400 })
+        },
+      ),
+      http.get('https://generativelanguage.googleapis.com/v1beta/models', () => {
+        return HttpResponse.error()
+      }),
+    )
+
+    const embed = geminiEmbedder({ apiKey: 'test-key' })
+    await expect(embed('test')).rejects.toThrow(/Could not fetch available models/)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/gemini.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/adapters/src/embedders/gemini.ts`:
+
+```typescript
+import type { EmbedFn } from '@agentskit/core'
+
+export interface GeminiEmbedderConfig {
+  apiKey: string
+  model?: string
+  baseUrl?: string
+}
+
+async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/v1beta/models?key=${apiKey}`)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  const data = await response.json() as {
+    models: Array<{ name: string; supportedGenerationMethods: string[] }>
+  }
+  return data.models
+    .filter(m => m.supportedGenerationMethods.includes('embedContent'))
+    .map(m => m.name.replace('models/', ''))
+    .sort()
+}
+
+async function buildModelError(
+  baseUrl: string,
+  apiKey: string,
+  originalError: string,
+): Promise<Error> {
+  try {
+    const models = await fetchAvailableModels(baseUrl, apiKey)
+    const list = models.length > 0 ? models.join(', ') : 'none found'
+    return new Error(
+      `Gemini embedding failed: ${originalError}. Available embedding models: ${list}`,
+    )
+  } catch (fetchError) {
+    return new Error(
+      `Gemini embedding failed: ${originalError}. Could not fetch available models: ${(fetchError as Error).message}`,
+    )
+  }
+}
+
+export function geminiEmbedder(config: GeminiEmbedderConfig): EmbedFn {
+  const {
+    apiKey,
+    model = 'text-embedding-004',
+    baseUrl = 'https://generativelanguage.googleapis.com',
+  } = config
+
+  return async (text: string): Promise<number[]> => {
+    const response = await fetch(
+      `${baseUrl}/v1beta/models/${model}:embedContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: `models/${model}`,
+          content: { parts: [{ text }] },
+        }),
+      },
+    )
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({})) as { error?: { message?: string } }
+      const message = errorBody.error?.message ?? `HTTP ${response.status}`
+      throw await buildModelError(baseUrl, apiKey, message)
+    }
+
+    const data = await response.json() as { embedding: { values: number[] } }
+    return data.embedding.values
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/gemini.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/src/embedders/gemini.ts packages/adapters/tests/embedders/gemini.test.ts
+git commit -m "feat(adapters): add geminiEmbedder with model discovery on error"
+```
+
+---
+
+### Task 5: Implement `ollamaEmbedder`
+
+**Files:**
+- Create: `packages/adapters/src/embedders/ollama.ts`
+- Create: `packages/adapters/tests/embedders/ollama.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/adapters/tests/embedders/ollama.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { ollamaEmbedder } from '../../src/embedders/ollama'
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('ollamaEmbedder', () => {
+  it('returns an embedding vector from the Ollama API', async () => {
+    const mockEmbedding = [0.1, 0.2, 0.3]
+
+    server.use(
+      http.post('http://localhost:11434/api/embed', async ({ request }) => {
+        const body = await request.json() as Record<string, unknown>
+        expect(body).toMatchObject({ model: 'nomic-embed-text', input: 'hello' })
+        return HttpResponse.json({ embeddings: [mockEmbedding] })
+      }),
+    )
+
+    const embed = ollamaEmbedder({})
+    const result = await embed('hello')
+
+    expect(result).toEqual(mockEmbedding)
+  })
+
+  it('uses custom model and baseUrl', async () => {
+    const mockEmbedding = [0.4, 0.5]
+
+    server.use(
+      http.post('http://myhost:11434/api/embed', async ({ request }) => {
+        const body = await request.json() as Record<string, unknown>
+        expect(body).toMatchObject({ model: 'mxbai-embed-large' })
+        return HttpResponse.json({ embeddings: [mockEmbedding] })
+      }),
+    )
+
+    const embed = ollamaEmbedder({ model: 'mxbai-embed-large', baseUrl: 'http://myhost:11434' })
+    const result = await embed('test')
+
+    expect(result).toEqual(mockEmbedding)
+  })
+
+  it('throws with available models on error', async () => {
+    server.use(
+      http.post('http://localhost:11434/api/embed', () => {
+        return HttpResponse.json({ error: 'model not found' }, { status: 400 })
+      }),
+      http.get('http://localhost:11434/api/tags', () => {
+        return HttpResponse.json({
+          models: [
+            { name: 'nomic-embed-text:latest' },
+            { name: 'llama3:latest' },
+          ],
+        })
+      }),
+    )
+
+    const embed = ollamaEmbedder({})
+    await expect(embed('test')).rejects.toThrow(/nomic-embed-text/)
+  })
+
+  it('shows fallback error when model list fetch fails', async () => {
+    server.use(
+      http.post('http://localhost:11434/api/embed', () => {
+        return HttpResponse.json({ error: 'bad' }, { status: 400 })
+      }),
+      http.get('http://localhost:11434/api/tags', () => {
+        return HttpResponse.error()
+      }),
+    )
+
+    const embed = ollamaEmbedder({})
+    await expect(embed('test')).rejects.toThrow(/Could not fetch available models/)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/ollama.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/adapters/src/embedders/ollama.ts`:
+
+```typescript
+import type { EmbedFn } from '@agentskit/core'
+
+export interface OllamaEmbedderConfig {
+  model?: string
+  baseUrl?: string
+}
+
+async function fetchAvailableModels(baseUrl: string): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/api/tags`)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  const data = await response.json() as { models: Array<{ name: string }> }
+  return data.models
+    .map(m => m.name)
+    .filter(name => name.includes('embed'))
+    .sort()
+}
+
+async function buildModelError(
+  baseUrl: string,
+  originalError: string,
+): Promise<Error> {
+  try {
+    const models = await fetchAvailableModels(baseUrl)
+    const list = models.length > 0 ? models.join(', ') : 'none found'
+    return new Error(
+      `Ollama embedding failed: ${originalError}. Available embedding models: ${list}`,
+    )
+  } catch (fetchError) {
+    return new Error(
+      `Ollama embedding failed: ${originalError}. Could not fetch available models: ${(fetchError as Error).message}`,
+    )
+  }
+}
+
+export function ollamaEmbedder(config: OllamaEmbedderConfig): EmbedFn {
+  const { model = 'nomic-embed-text', baseUrl = 'http://localhost:11434' } = config
+
+  return async (text: string): Promise<number[]> => {
+    const response = await fetch(`${baseUrl}/api/embed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, input: text }),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({})) as { error?: string }
+      const message = errorBody.error ?? `HTTP ${response.status}`
+      throw await buildModelError(baseUrl, message)
+    }
+
+    const data = await response.json() as { embeddings: number[][] }
+    return data.embeddings[0]
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/ollama.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/src/embedders/ollama.ts packages/adapters/tests/embedders/ollama.test.ts
+git commit -m "feat(adapters): add ollamaEmbedder with model discovery on error"
+```
+
+---
+
+### Task 6: Implement `openaiCompatibleEmbedder` + thin wrappers
+
+**Files:**
+- Create: `packages/adapters/src/embedders/openai-compatible.ts`
+- Create: `packages/adapters/src/embedders/deepseek.ts`
+- Create: `packages/adapters/src/embedders/grok.ts`
+- Create: `packages/adapters/src/embedders/kimi.ts`
+- Create: `packages/adapters/tests/embedders/openai-compatible.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/adapters/tests/embedders/openai-compatible.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { deepseekEmbedder } from '../../src/embedders/deepseek'
+import { grokEmbedder } from '../../src/embedders/grok'
+import { kimiEmbedder } from '../../src/embedders/kimi'
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('openaiCompatibleEmbedder wrappers', () => {
+  describe('deepseekEmbedder', () => {
+    it('requires model and calls DeepSeek endpoint', async () => {
+      const mockEmbedding = [0.1, 0.2]
+
+      server.use(
+        http.post('https://api.deepseek.com/v1/embeddings', async ({ request }) => {
+          const body = await request.json() as Record<string, unknown>
+          expect(body).toMatchObject({ model: 'deepseek-embed', input: 'hello' })
+          return HttpResponse.json({
+            data: [{ embedding: mockEmbedding }],
+          })
+        }),
+      )
+
+      const embed = deepseekEmbedder({ apiKey: 'test-key', model: 'deepseek-embed' })
+      const result = await embed('hello')
+
+      expect(result).toEqual(mockEmbedding)
+    })
+
+    it('throws requiring model when model is omitted', () => {
+      expect(() => deepseekEmbedder({ apiKey: 'key' } as never)).toThrow(/Model is required/)
+    })
+  })
+
+  describe('grokEmbedder', () => {
+    it('requires model and calls xAI endpoint', async () => {
+      const mockEmbedding = [0.3, 0.4]
+
+      server.use(
+        http.post('https://api.x.ai/v1/embeddings', () => {
+          return HttpResponse.json({
+            data: [{ embedding: mockEmbedding }],
+          })
+        }),
+      )
+
+      const embed = grokEmbedder({ apiKey: 'test-key', model: 'grok-embed' })
+      const result = await embed('test')
+
+      expect(result).toEqual(mockEmbedding)
+    })
+
+    it('throws requiring model when model is omitted', () => {
+      expect(() => grokEmbedder({ apiKey: 'key' } as never)).toThrow(/Model is required/)
+    })
+  })
+
+  describe('kimiEmbedder', () => {
+    it('requires model and calls Moonshot endpoint', async () => {
+      const mockEmbedding = [0.5, 0.6]
+
+      server.use(
+        http.post('https://api.moonshot.ai/v1/embeddings', () => {
+          return HttpResponse.json({
+            data: [{ embedding: mockEmbedding }],
+          })
+        }),
+      )
+
+      const embed = kimiEmbedder({ apiKey: 'test-key', model: 'kimi-embed' })
+      const result = await embed('test')
+
+      expect(result).toEqual(mockEmbedding)
+    })
+
+    it('throws requiring model when model is omitted', () => {
+      expect(() => kimiEmbedder({ apiKey: 'key' } as never)).toThrow(/Model is required/)
+    })
+  })
+
+  describe('model discovery on error', () => {
+    it('fetches available models when embedding fails', async () => {
+      server.use(
+        http.post('https://api.deepseek.com/v1/embeddings', () => {
+          return HttpResponse.json({ error: { message: 'invalid model' } }, { status: 400 })
+        }),
+        http.get('https://api.deepseek.com/v1/models', () => {
+          return HttpResponse.json({
+            data: [{ id: 'deepseek-embed-v1' }, { id: 'deepseek-chat' }],
+          })
+        }),
+      )
+
+      const embed = deepseekEmbedder({ apiKey: 'test-key', model: 'bad-model' })
+      await expect(embed('test')).rejects.toThrow(/deepseek-embed-v1/)
+    })
+
+    it('shows fallback when model list fetch fails', async () => {
+      server.use(
+        http.post('https://api.deepseek.com/v1/embeddings', () => {
+          return HttpResponse.json({ error: { message: 'bad' } }, { status: 400 })
+        }),
+        http.get('https://api.deepseek.com/v1/models', () => {
+          return HttpResponse.error()
+        }),
+      )
+
+      const embed = deepseekEmbedder({ apiKey: 'test-key', model: 'bad' })
+      await expect(embed('test')).rejects.toThrow(/Could not fetch available models/)
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/openai-compatible.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the shared factory**
+
+Create `packages/adapters/src/embedders/openai-compatible.ts`:
+
+```typescript
+import type { EmbedFn } from '@agentskit/core'
+
+export interface OpenAICompatibleEmbedderConfig {
+  apiKey: string
+  model: string
+  baseUrl?: string
+}
+
+async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/v1/models`, {
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  const data = await response.json() as { data: Array<{ id: string }> }
+  return data.data
+    .map(m => m.id)
+    .filter(id => id.includes('embed'))
+    .sort()
+}
+
+async function buildModelError(
+  provider: string,
+  baseUrl: string,
+  apiKey: string,
+  originalError: string,
+): Promise<Error> {
+  try {
+    const models = await fetchAvailableModels(baseUrl, apiKey)
+    const list = models.length > 0 ? models.join(', ') : 'none found'
+    return new Error(
+      `${provider} embedding failed: ${originalError}. Available embedding models: ${list}`,
+    )
+  } catch (fetchError) {
+    return new Error(
+      `${provider} embedding failed: ${originalError}. Could not fetch available models: ${(fetchError as Error).message}`,
+    )
+  }
+}
+
+export function createOpenAICompatibleEmbedder(provider: string, defaultBaseUrl: string) {
+  return function embedder(config: OpenAICompatibleEmbedderConfig): EmbedFn {
+    if (!config.model) {
+      throw new Error(`Model is required for ${provider}. Pass { model: "<model-name>" }.`)
+    }
+    const { apiKey, model, baseUrl = defaultBaseUrl } = config
+
+    return async (text: string): Promise<number[]> => {
+      const response = await fetch(`${baseUrl}/v1/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ model, input: text }),
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({})) as { error?: { message?: string } }
+        const message = errorBody.error?.message ?? `HTTP ${response.status}`
+        throw await buildModelError(provider, baseUrl, apiKey, message)
+      }
+
+      const data = await response.json() as { data: Array<{ embedding: number[] }> }
+      return data.data[0].embedding
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Write the thin wrappers**
+
+Create `packages/adapters/src/embedders/deepseek.ts`:
+
+```typescript
+import { createOpenAICompatibleEmbedder, type OpenAICompatibleEmbedderConfig } from './openai-compatible'
+
+export interface DeepSeekEmbedderConfig extends OpenAICompatibleEmbedderConfig {}
+
+export const deepseekEmbedder = createOpenAICompatibleEmbedder('DeepSeek', 'https://api.deepseek.com')
+```
+
+Create `packages/adapters/src/embedders/grok.ts`:
+
+```typescript
+import { createOpenAICompatibleEmbedder, type OpenAICompatibleEmbedderConfig } from './openai-compatible'
+
+export interface GrokEmbedderConfig extends OpenAICompatibleEmbedderConfig {}
+
+export const grokEmbedder = createOpenAICompatibleEmbedder('Grok', 'https://api.x.ai')
+```
+
+Create `packages/adapters/src/embedders/kimi.ts`:
+
+```typescript
+import { createOpenAICompatibleEmbedder, type OpenAICompatibleEmbedderConfig } from './openai-compatible'
+
+export interface KimiEmbedderConfig extends OpenAICompatibleEmbedderConfig {}
+
+export const kimiEmbedder = createOpenAICompatibleEmbedder('Kimi', 'https://api.moonshot.ai')
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @agentskit/adapters test -- --run tests/embedders/openai-compatible.test.ts`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/src/embedders/openai-compatible.ts packages/adapters/src/embedders/deepseek.ts packages/adapters/src/embedders/grok.ts packages/adapters/src/embedders/kimi.ts packages/adapters/tests/embedders/openai-compatible.test.ts
+git commit -m "feat(adapters): add openaiCompatibleEmbedder + deepseek, grok, kimi wrappers"
+```
+
+---
+
+### Task 7: Barrel exports and wiring
+
+**Files:**
+- Create: `packages/adapters/src/embedders/index.ts`
+- Modify: `packages/adapters/src/index.ts`
+
+- [ ] **Step 1: Create embedders barrel export**
+
+Create `packages/adapters/src/embedders/index.ts`:
+
+```typescript
+export { openaiEmbedder, type OpenAIEmbedderConfig } from './openai'
+export { geminiEmbedder, type GeminiEmbedderConfig } from './gemini'
+export { ollamaEmbedder, type OllamaEmbedderConfig } from './ollama'
+export { createOpenAICompatibleEmbedder, type OpenAICompatibleEmbedderConfig } from './openai-compatible'
+export { deepseekEmbedder, type DeepSeekEmbedderConfig } from './deepseek'
+export { grokEmbedder, type GrokEmbedderConfig } from './grok'
+export { kimiEmbedder, type KimiEmbedderConfig } from './kimi'
+```
+
+- [ ] **Step 2: Add embedder exports to main index**
+
+In `packages/adapters/src/index.ts`, append:
+
+```typescript
+export {
+  openaiEmbedder,
+  geminiEmbedder,
+  ollamaEmbedder,
+  createOpenAICompatibleEmbedder,
+  deepseekEmbedder,
+  grokEmbedder,
+  kimiEmbedder,
+} from './embedders'
+export type {
+  OpenAIEmbedderConfig,
+  GeminiEmbedderConfig,
+  OllamaEmbedderConfig,
+  OpenAICompatibleEmbedderConfig,
+  DeepSeekEmbedderConfig,
+  GrokEmbedderConfig,
+  KimiEmbedderConfig,
+} from './embedders'
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `pnpm --filter @agentskit/adapters build`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/adapters/src/embedders/index.ts packages/adapters/src/index.ts
+git commit -m "feat(adapters): export all embedders from main entry point"
+```
+
+---
+
+### Task 8: Contract tests
+
+**Files:**
+- Create: `packages/adapters/tests/embedders/contract.test.ts`
+
+- [ ] **Step 1: Write contract tests**
+
+Create `packages/adapters/tests/embedders/contract.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import {
+  openaiEmbedder,
+  geminiEmbedder,
+  ollamaEmbedder,
+  deepseekEmbedder,
+  grokEmbedder,
+  kimiEmbedder,
+} from '../../src/embedders'
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const mockOpenAIResponse = (url: string) =>
+  http.post(url, () =>
+    HttpResponse.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
+  )
+
+const embedders = [
+  {
+    name: 'openaiEmbedder',
+    create: () => openaiEmbedder({ apiKey: 'k' }),
+    mock: () => mockOpenAIResponse('https://api.openai.com/v1/embeddings'),
+  },
+  {
+    name: 'geminiEmbedder',
+    create: () => geminiEmbedder({ apiKey: 'k' }),
+    mock: () =>
+      http.post(
+        'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent',
+        () => HttpResponse.json({ embedding: { values: [0.1, 0.2, 0.3] } }),
+      ),
+  },
+  {
+    name: 'ollamaEmbedder',
+    create: () => ollamaEmbedder({}),
+    mock: () =>
+      http.post('http://localhost:11434/api/embed', () =>
+        HttpResponse.json({ embeddings: [[0.1, 0.2, 0.3]] }),
+      ),
+  },
+  {
+    name: 'deepseekEmbedder',
+    create: () => deepseekEmbedder({ apiKey: 'k', model: 'm' }),
+    mock: () => mockOpenAIResponse('https://api.deepseek.com/v1/embeddings'),
+  },
+  {
+    name: 'grokEmbedder',
+    create: () => grokEmbedder({ apiKey: 'k', model: 'm' }),
+    mock: () => mockOpenAIResponse('https://api.x.ai/v1/embeddings'),
+  },
+  {
+    name: 'kimiEmbedder',
+    create: () => kimiEmbedder({ apiKey: 'k', model: 'm' }),
+    mock: () => mockOpenAIResponse('https://api.moonshot.ai/v1/embeddings'),
+  },
+]
+
+describe('EmbedFn contract', () => {
+  for (const { name, create, mock } of embedders) {
+    describe(name, () => {
+      it('returns a function', () => {
+        server.use(mock())
+        const embed = create()
+        expect(typeof embed).toBe('function')
+      })
+
+      it('returns number[] from a string input', async () => {
+        server.use(mock())
+        const embed = create()
+        const result = await embed('test input')
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result.length).toBeGreaterThan(0)
+        result.forEach(v => expect(typeof v).toBe('number'))
+      })
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run all embedder tests**
+
+Run: `pnpm --filter @agentskit/adapters test`
+Expected: All tests PASS (existing adapter tests + all embedder tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/tests/embedders/contract.test.ts
+git commit -m "test(adapters): add contract tests for all embedders"
+```
+
+---
+
+### Task 9: Final build and lint verification
+
+- [ ] **Step 1: Build all packages**
+
+Run: `pnpm build`
+Expected: All packages build successfully.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests pass across all packages.
+
+- [ ] **Step 3: Lint**
+
+Run: `pnpm lint`
+Expected: No type errors.
+
+- [ ] **Step 4: Commit any fixes if needed**
+
+If any fixes were required, commit them:
+
+```bash
+git add -A
+git commit -m "fix(adapters): resolve build/lint issues in embedders"
+```

--- a/packages/eval/CHANGELOG.md
+++ b/packages/eval/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,0 +1,15 @@
+# @agentskit/eval
+
+Agent evaluation and benchmarking for [AgentsKit](https://github.com/EmersonBraun/agentskit).
+
+> **Coming soon.** This package is scaffolded and will be implemented in a future release. See [#15](https://github.com/EmersonBraun/agentskit/issues/15).
+
+## Planned features
+
+- `eval.run(agent, testCases)` API
+- Metrics: accuracy, latency, cost, token usage
+- Designed for CI/CD integration
+
+## Docs
+
+[Full documentation](https://emersonbraun.github.io/agentskit/)

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agentskit/eval",
+  "version": "0.1.0",
+  "description": "Agent evaluation and benchmarking for AgentsKit.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,0 +1,5 @@
+// @agentskit/eval — Agent evaluation and benchmarking
+// This package is scaffolded and will be implemented in a future release.
+// See https://github.com/EmersonBraun/agentskit/issues/15
+
+export {}

--- a/packages/eval/tsconfig.json
+++ b/packages/eval/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/eval/tsup.config.ts
+++ b/packages/eval/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/eval/vitest.config.ts
+++ b/packages/eval/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+})

--- a/packages/observability/CHANGELOG.md
+++ b/packages/observability/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,0 +1,16 @@
+# @agentskit/observability
+
+Logging and tracing layer for [AgentsKit](https://github.com/EmersonBraun/agentskit) agents.
+
+> **Coming soon.** This package is scaffolded and will be implemented in a future release. See [#11](https://github.com/EmersonBraun/agentskit/issues/11).
+
+## Planned features
+
+- `consoleLogger()` — pretty-print or JSON format
+- `langsmith({ apiKey })` — full trace hierarchy to LangSmith
+- `opentelemetry({ endpoint })` — OTLP spans with GenAI conventions
+- Custom observers via `{ name, on(event) }` contract
+
+## Docs
+
+[Full documentation](https://emersonbraun.github.io/agentskit/)

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agentskit/observability",
+  "version": "0.1.0",
+  "description": "Logging and tracing layer for AgentsKit agents.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,5 @@
+// @agentskit/observability — Logging and tracing layer
+// This package is scaffolded and will be implemented in a future release.
+// See https://github.com/EmersonBraun/agentskit/issues/11
+
+export {}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/observability/tsup.config.ts
+++ b/packages/observability/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/observability/vitest.config.ts
+++ b/packages/observability/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+})

--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -1,0 +1,16 @@
+# @agentskit/rag
+
+Plug-and-play retrieval-augmented generation for [AgentsKit](https://github.com/EmersonBraun/agentskit).
+
+> **Coming soon.** This package is scaffolded and will be implemented in a future release. See [#13](https://github.com/EmersonBraun/agentskit/issues/13).
+
+## Planned features
+
+- Document chunking, embedding, and retrieval
+- Integration with `@agentskit/memory` VectorMemory
+- BYOE (bring your own embedder) via `@agentskit/adapters`
+- `rag.retrieve(query)` and `useRAGChat()` React hook
+
+## Docs
+
+[Full documentation](https://emersonbraun.github.io/agentskit/)

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agentskit/rag",
+  "version": "0.1.0",
+  "description": "Plug-and-play retrieval-augmented generation for AgentsKit.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -1,0 +1,5 @@
+// @agentskit/rag — Plug-and-play retrieval-augmented generation
+// This package is scaffolded and will be implemented in a future release.
+// See https://github.com/EmersonBraun/agentskit/issues/13
+
+export {}

--- a/packages/rag/tsconfig.json
+++ b/packages/rag/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/rag/tsup.config.ts
+++ b/packages/rag/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/rag/vitest.config.ts
+++ b/packages/rag/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+})

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,16 @@
+# @agentskit/sandbox
+
+Secure code execution for [AgentsKit](https://github.com/EmersonBraun/agentskit) agents.
+
+> **Coming soon.** This package is scaffolded and will be implemented in a future release. See [#14](https://github.com/EmersonBraun/agentskit/issues/14).
+
+## Planned features
+
+- E2B (primary) and WebContainer (fallback) backends
+- JavaScript and Python execution with timeouts
+- No network by default, configurable security limits
+- Standalone primitive + integration with `@agentskit/tools`
+
+## Docs
+
+[Full documentation](https://emersonbraun.github.io/agentskit/)

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agentskit/sandbox",
+  "version": "0.1.0",
+  "description": "Secure code execution for AgentsKit agents.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,0 +1,5 @@
+// @agentskit/sandbox — Secure code execution
+// This package is scaffolded and will be implemented in a future release.
+// See https://github.com/EmersonBraun/agentskit/issues/14
+
+export {}

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/sandbox/tsup.config.ts
+++ b/packages/sandbox/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,25 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
+  packages/eval:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+
   packages/ink:
     dependencies:
       '@agentskit/core':
@@ -268,6 +287,44 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
+  packages/observability:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+
+  packages/rag:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+
   packages/react:
     dependencies:
       '@agentskit/core':
@@ -312,6 +369,25 @@ importers:
         version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
 
   packages/runtime:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.1)(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+
+  packages/sandbox:
     dependencies:
       '@agentskit/core':
         specifier: workspace:*
@@ -10266,7 +10342,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 25.5.2
 
   '@types/body-parser@1.19.6':
     dependencies:


### PR DESCRIPTION
## Summary

### README updated
Package Layout now lists all 13 packages in the ecosystem (was 5).

### dependabot.yml
Added: memory, observability, rag, sandbox, eval (was missing).

### 4 new package scaffolds at 0.1.0
Each has package.json, tsconfig, tsup, vitest, README, CHANGELOG, and an empty `src/index.ts` with a comment linking to the implementation issue.

| Package | Issue | Status |
|---------|-------|--------|
| `@agentskit/rag` | #13 | Scaffolded |
| `@agentskit/sandbox` | #14 | Scaffolded |
| `@agentskit/eval` | #15 | Scaffolded |
| `@agentskit/observability` | #11 | Scaffolded |

## Test plan

- [x] 23 lint tasks pass
- [x] 20 test tasks pass
- [x] 16 build tasks pass