### PR TITLE
feat(eval): implement @agentskit/eval — minimal agent evaluation runner

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -2,13 +2,59 @@
 
 Agent evaluation and benchmarking for [AgentsKit](https://github.com/EmersonBraun/agentskit).
 
-> **Coming soon.** This package is scaffolded and will be implemented in a future release. See [#15](https://github.com/EmersonBraun/agentskit/issues/15).
+## Install
 
-## Planned features
+```bash
+npm install @agentskit/eval
+```
 
-- `eval.run(agent, testCases)` API
-- Metrics: accuracy, latency, cost, token usage
-- Designed for CI/CD integration
+## Quick example
+
+```ts
+import { runEval } from '@agentskit/eval'
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({ adapter, tools: [...] })
+
+const result = await runEval({
+  agent: async (input) => {
+    const r = await runtime.run(input)
+    return r.content
+  },
+  suite: {
+    name: 'basic-qa',
+    cases: [
+      { input: 'What is 2+2?', expected: '4' },
+      { input: 'Capital of France?', expected: 'Paris' },
+      { input: 'Is water wet?', expected: (r) => r.toLowerCase().includes('yes') },
+    ],
+  },
+})
+
+console.log(`Accuracy: ${(result.accuracy * 100).toFixed(1)}%`)
+console.log(`Passed: ${result.passed}/${result.totalCases}`)
+
+for (const r of result.results) {
+  console.log(`${r.passed ? 'PASS' : 'FAIL'} [${r.latencyMs}ms] ${r.input}`)
+}
+```
+
+## With token usage
+
+```ts
+const result = await runEval({
+  agent: async (input) => {
+    const r = await runtime.run(input)
+    return { content: r.content, tokenUsage: { prompt: 100, completion: 20 } }
+  },
+  suite,
+})
+```
+
+## Comparison logic
+
+- **String expected**: uses `includes` (LLM output often wraps the answer)
+- **Function expected**: full control — `(result) => boolean`
 
 ## Docs
 

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentskit/eval",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agent evaluation and benchmarking for AgentsKit.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,5 +1,3 @@
-// @agentskit/eval — Agent evaluation and benchmarking
-// This package is scaffolded and will be implemented in a future release.
-// See https://github.com/EmersonBraun/agentskit/issues/15
-
-export {}
+export { runEval } from './runner'
+export type { AgentFn, AgentResponse, RunEvalConfig } from './types'
+export type { EvalSuite, EvalResult } from './types'

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -1,0 +1,61 @@
+import type { EvalResult, EvalTestCase } from '@agentskit/core'
+import type { AgentFn, AgentResponse, RunEvalConfig } from './types'
+
+function parseResponse(response: AgentResponse): {
+  content: string
+  tokenUsage?: { prompt: number; completion: number }
+} {
+  if (typeof response === 'string') {
+    return { content: response }
+  }
+  return response
+}
+
+function checkExpected(output: string, expected: EvalTestCase['expected']): boolean {
+  if (typeof expected === 'function') {
+    return expected(output)
+  }
+  return output.includes(expected)
+}
+
+export async function runEval(config: RunEvalConfig): Promise<EvalResult> {
+  const { agent, suite } = config
+  const results: EvalResult['results'] = []
+
+  for (const testCase of suite.cases) {
+    const startTime = Date.now()
+
+    try {
+      const response = await agent(testCase.input)
+      const { content, tokenUsage } = parseResponse(response)
+      const passed = checkExpected(content, testCase.expected)
+
+      results.push({
+        input: testCase.input,
+        output: content,
+        passed,
+        latencyMs: Date.now() - startTime,
+        tokenUsage,
+      })
+    } catch (err) {
+      results.push({
+        input: testCase.input,
+        output: '',
+        passed: false,
+        latencyMs: Date.now() - startTime,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const passed = results.filter(r => r.passed).length
+  const failed = results.filter(r => !r.passed).length
+
+  return {
+    totalCases: results.length,
+    passed,
+    failed,
+    accuracy: results.length > 0 ? passed / results.length : 0,
+    results,
+  }
+}

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -1,0 +1,15 @@
+import type { EvalSuite, EvalResult } from '@agentskit/core'
+
+export type AgentResponse = string | {
+  content: string
+  tokenUsage?: { prompt: number; completion: number }
+}
+
+export type AgentFn = (input: string) => Promise<AgentResponse>
+
+export interface RunEvalConfig {
+  agent: AgentFn
+  suite: EvalSuite
+}
+
+export type { EvalSuite, EvalResult }

--- a/packages/eval/tests/runner.test.ts
+++ b/packages/eval/tests/runner.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runEval } from '../src/runner'
+import type { EvalSuite } from '@agentskit/core'
+
+describe('runEval', () => {
+  const simpleSuite: EvalSuite = {
+    name: 'basic',
+    cases: [
+      { input: 'What is 2+2?', expected: '4' },
+      { input: 'What color is the sky?', expected: 'blue' },
+    ],
+  }
+
+  it('runs all test cases and returns EvalResult', async () => {
+    const agent = vi.fn()
+      .mockResolvedValueOnce('The answer is 4.')
+      .mockResolvedValueOnce('The sky is blue.')
+
+    const result = await runEval({ agent, suite: simpleSuite })
+
+    expect(result.totalCases).toBe(2)
+    expect(result.passed).toBe(2)
+    expect(result.failed).toBe(0)
+    expect(result.accuracy).toBe(1.0)
+    expect(result.results).toHaveLength(2)
+  })
+
+  it('uses includes for string expected', async () => {
+    const agent = vi.fn().mockResolvedValue('The answer is definitely 4, no doubt.')
+
+    const result = await runEval({
+      agent,
+      suite: { name: 'test', cases: [{ input: 'Q', expected: '4' }] },
+    })
+
+    expect(result.passed).toBe(1)
+  })
+
+  it('marks as failed when expected string not found', async () => {
+    const agent = vi.fn().mockResolvedValue('I have no idea')
+
+    const result = await runEval({ agent, suite: simpleSuite })
+
+    expect(result.passed).toBe(0)
+    expect(result.failed).toBe(2)
+    expect(result.accuracy).toBe(0)
+  })
+
+  it('supports function expected', async () => {
+    const agent = vi.fn().mockResolvedValue('42')
+
+    const result = await runEval({
+      agent,
+      suite: {
+        name: 'func',
+        cases: [
+          { input: 'Q', expected: (r: string) => parseInt(r, 10) > 40 },
+        ],
+      },
+    })
+
+    expect(result.passed).toBe(1)
+  })
+
+  it('function expected returning false marks failure', async () => {
+    const agent = vi.fn().mockResolvedValue('5')
+
+    const result = await runEval({
+      agent,
+      suite: {
+        name: 'func',
+        cases: [
+          { input: 'Q', expected: (r: string) => parseInt(r, 10) > 40 },
+        ],
+      },
+    })
+
+    expect(result.failed).toBe(1)
+  })
+
+  it('records latency per case', async () => {
+    const agent = vi.fn().mockImplementation(async () => {
+      await new Promise(r => setTimeout(r, 10))
+      return 'answer'
+    })
+
+    const result = await runEval({
+      agent,
+      suite: { name: 'test', cases: [{ input: 'Q', expected: 'answer' }] },
+    })
+
+    expect(result.results[0].latencyMs).toBeGreaterThanOrEqual(5)
+  })
+
+  it('handles agent errors — records and continues', async () => {
+    const agent = vi.fn()
+      .mockRejectedValueOnce(new Error('API timeout'))
+      .mockResolvedValueOnce('The sky is blue.')
+
+    const result = await runEval({ agent, suite: simpleSuite })
+
+    expect(result.totalCases).toBe(2)
+    expect(result.passed).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.results[0].error).toBe('API timeout')
+    expect(result.results[0].passed).toBe(false)
+    expect(result.results[1].passed).toBe(true)
+  })
+
+  it('supports agent returning object with tokenUsage', async () => {
+    const agent = vi.fn().mockResolvedValue({
+      content: 'The answer is 4.',
+      tokenUsage: { prompt: 100, completion: 20 },
+    })
+
+    const result = await runEval({
+      agent,
+      suite: { name: 'test', cases: [{ input: 'Q', expected: '4' }] },
+    })
+
+    expect(result.passed).toBe(1)
+    expect(result.results[0].tokenUsage).toEqual({ prompt: 100, completion: 20 })
+  })
+
+  it('handles mixed string and object responses', async () => {
+    const agent = vi.fn()
+      .mockResolvedValueOnce('plain string with 4')
+      .mockResolvedValueOnce({ content: 'object with blue', tokenUsage: { prompt: 50, completion: 10 } })
+
+    const result = await runEval({ agent, suite: simpleSuite })
+
+    expect(result.passed).toBe(2)
+    expect(result.results[0].tokenUsage).toBeUndefined()
+    expect(result.results[1].tokenUsage).toEqual({ prompt: 50, completion: 10 })
+  })
+
+  it('calculates accuracy correctly for partial pass', async () => {
+    const agent = vi.fn()
+      .mockResolvedValueOnce('4')
+      .mockResolvedValueOnce('green')
+
+    const result = await runEval({ agent, suite: simpleSuite })
+
+    expect(result.accuracy).toBeCloseTo(0.5)
+    expect(result.passed).toBe(1)
+    expect(result.failed).toBe(1)
+  })
+
+  it('handles empty suite', async () => {
+    const agent = vi.fn()
+
+    const result = await runEval({
+      agent,
+      suite: { name: 'empty', cases: [] },
+    })
+
+    expect(result.totalCases).toBe(0)
+    expect(result.accuracy).toBe(0)
+    expect(agent).not.toHaveBeenCalled()
+  })
+
+  it('runs cases sequentially', async () => {
+    const order: number[] = []
+    const agent = vi.fn().mockImplementation(async (input: string) => {
+      const idx = parseInt(input, 10)
+      order.push(idx)
+      await new Promise(r => setTimeout(r, 5))
+      return String(idx)
+    })
+
+    await runEval({
+      agent,
+      suite: {
+        name: 'order',
+        cases: [
+          { input: '1', expected: '1' },
+          { input: '2', expected: '2' },
+          { input: '3', expected: '3' },
+        ],
+      },
+    })
+
+    expect(order).toEqual([1, 2, 3])
+  })
+
+  it('EvalResult shape matches core contract', async () => {
+    const agent = vi.fn().mockResolvedValue('ok')
+
+    const result = await runEval({
+      agent,
+      suite: { name: 'shape', cases: [{ input: 'Q', expected: 'ok' }] },
+    })
+
+    // Verify all required fields exist
+    expect(result).toHaveProperty('totalCases')
+    expect(result).toHaveProperty('passed')
+    expect(result).toHaveProperty('failed')
+    expect(result).toHaveProperty('accuracy')
+    expect(result).toHaveProperty('results')
+    expect(result.results[0]).toHaveProperty('input')
+    expect(result.results[0]).toHaveProperty('output')
+    expect(result.results[0]).toHaveProperty('passed')
+    expect(result.results[0]).toHaveProperty('latencyMs')
+  })
+})


### PR DESCRIPTION
## Summary

Implements [#15](https://github.com/EmersonBraun/agentskit/issues/15).

### New: @agentskit/eval

```ts
import { runEval } from '@agentskit/eval'

const result = await runEval({
  agent: async (input) => runtime.run(input).then(r => r.content),
  suite: {
    name: 'qa',
    cases: [
      { input: 'What is 2+2?', expected: '4' },
      { input: 'Is water wet?', expected: (r) => r.includes('yes') },
    ],
  },
})

console.log(result.accuracy)  // 0-1
```

### Design decisions
- **Agent as function** — `(input) => Promise<string | { content, tokenUsage? }>`. No dependency on runtime.
- **String expected uses `includes`** — forgiving for LLM output that wraps answers in extra text
- **Function expected** — full control for complex assertions
- **Error handling** — records error and continues, doesn't stop the suite
- **Sequential execution** — one case at a time, no rate limiting issues
- **Token usage optional** — agent can return object with tokenUsage for cost tracking

### 13 tests
- Pass/fail with includes, function expected, partial accuracy
- Error recording + continue, token usage, mixed responses
- Empty suite, sequential order verification, EvalResult shape contract

## Test plan

- [x] 13 eval tests pass
- [x] All 20 test suites pass
- [x] All 16 builds pass
- [x] All 23 lint tasks pass