### PR TITLE
docs: complete documentation for all 13 AgentsKit packages

### DIFF
--- a/apps/docs/docs/agents/delegation.md
+++ b/apps/docs/docs/agents/delegation.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 4
+---
+
+# Multi-Agent Delegation
+
+Coordinate multiple specialist agents from a parent agent using directed delegation.
+
+## Install
+
+```bash
+npm install @agentskit/runtime @agentskit/adapters @agentskit/skills @agentskit/tools
+```
+
+## Quick Start
+
+```ts
+import { createRuntime, createSharedContext } from '@agentskit/runtime'
+import { anthropic } from '@agentskit/adapters'
+import { planner, researcher, coder } from '@agentskit/skills'
+import { webSearch, filesystem } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }),
+})
+
+const result = await runtime.run('Build a landing page about quantum computing', {
+  skill: planner,
+  delegates: {
+    researcher: { skill: researcher, tools: [webSearch()], maxSteps: 3 },
+    coder: { skill: coder, tools: [...filesystem({ basePath: './src' })], maxSteps: 8 },
+  },
+})
+```
+
+## How It Works
+
+When you configure `delegates`, the runtime auto-generates tools named `delegate_<name>`. The parent LLM calls them like any other tool. Each delegate runs its own ReAct loop and returns a result.
+
+## DelegateConfig
+
+```ts
+interface DelegateConfig {
+  skill: SkillDefinition     // required — the child's behavior
+  tools?: ToolDefinition[]   // tools available to the child
+  adapter?: AdapterFactory   // optional — different LLM per child
+  maxSteps?: number          // default: 5
+}
+```
+
+## Shared Context
+
+```ts
+const ctx = createSharedContext({ project: 'landing-page' })
+
+runtime.run('Build it', { delegates: { ... }, sharedContext: ctx })
+
+// Parent reads/writes
+ctx.set('key', 'value')
+ctx.get('key')
+
+// Children get read-only view — set() is not available
+```
+
+## Child Isolation
+
+- **Fresh messages** — no parent history
+- **Inherits observers** — events visible in logging
+- **No memory** — doesn't share parent's memory
+- **Depth limit** — `maxDelegationDepth` default 3
+
+## Events
+
+```
+[10:00:01] => delegate:start researcher [depth=1] "Research quantum computing"
+[10:00:03] <= delegate:end researcher (2100ms) "Found 3 papers on..."
+```
+
+## Related
+
+- [Runtime](/docs/agents/runtime) — ReAct loop
+- [Skills](/docs/agents/skills) — behavioral prompts
+- [Observability](/docs/infrastructure/observability) — trace events

--- a/apps/docs/docs/agents/runtime.md
+++ b/apps/docs/docs/agents/runtime.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 1
+---
+
+# Runtime
+
+`@agentskit/runtime` is the execution engine for autonomous agents. It runs a ReAct loop — observe, think, act — until the model produces a final answer or a step limit is reached.
+
+## Install
+
+```bash
+npm install @agentskit/runtime @agentskit/adapters
+```
+
+## Basic usage
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { anthropic } from '@agentskit/adapters'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+})
+
+const result = await runtime.run('What is 3 + 4?')
+console.log(result.content) // "7"
+```
+
+### Demo adapter (no API key)
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { generic } from '@agentskit/adapters'
+
+const runtime = createRuntime({
+  adapter: generic({ /* custom send/parse */ }),
+})
+```
+
+## ReAct loop
+
+Each call to `runtime.run()` enters the following loop:
+
+```
+observe  →  think  →  act  →  observe  →  ...
+```
+
+1. **Observe** — retrieve context from memory or a retriever and inject it into the prompt.
+2. **Think** — send messages + tools to the LLM and stream the response.
+3. **Act** — if the LLM calls tools, execute them and append results as `tool` messages.
+4. Repeat until the model returns a plain text response or `maxSteps` is reached.
+
+## `RunResult`
+
+`runtime.run()` resolves to a `RunResult` object:
+
+```ts
+interface RunResult {
+  content: string      // Final text response from the model
+  messages: Message[]  // Full conversation including tool calls and results
+  steps: number        // How many loop iterations ran
+  toolCalls: ToolCall[] // Every tool call made during the run
+  durationMs: number   // Total wall-clock time
+}
+```
+
+### Example
+
+```ts
+const result = await runtime.run('List the files in the current directory', {
+  tools: [shell({ allowed: ['ls'] })],
+})
+
+console.log(result.content)   // Model's final answer
+console.log(result.steps)     // e.g. 2
+console.log(result.durationMs) // e.g. 1340
+result.toolCalls.forEach(tc => {
+  console.log(tc.name, tc.args, tc.result)
+})
+```
+
+## `RuntimeConfig`
+
+```ts
+interface RuntimeConfig {
+  adapter: AdapterFactory        // Required — the LLM provider
+  tools?: ToolDefinition[]       // Tools available to the agent
+  systemPrompt?: string          // Default system prompt
+  memory?: ChatMemory            // Persist and reload conversation history
+  retriever?: Retriever          // RAG source injected each step
+  observers?: Observer[]         // Event listeners (logging, tracing)
+  maxSteps?: number              // Max loop iterations (default: 10)
+  temperature?: number
+  maxTokens?: number
+  delegates?: Record<string, DelegateConfig>
+  maxDelegationDepth?: number    // Default: 3
+}
+```
+
+## `RunOptions`
+
+Override per-call defaults on `runtime.run(task, options)`:
+
+```ts
+const result = await runtime.run('Summarize this document', {
+  systemPrompt: 'You are a concise summarizer.',
+  tools: [readFileTool],
+  maxSteps: 5,
+  skill: summarizer,
+})
+```
+
+## Aborting a run
+
+Pass an `AbortSignal` to cancel mid-run. The runtime checks the signal before each step and before each tool call.
+
+```ts
+const controller = new AbortController()
+
+setTimeout(() => controller.abort(), 5000) // cancel after 5 s
+
+const result = await runtime.run('Long running task', {
+  signal: controller.signal,
+})
+```
+
+## Memory
+
+When a `memory` is configured, the runtime saves all messages at the end of each run. On the next run it reloads prior context automatically.
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { inMemory } from '@agentskit/memory'
+import { anthropic } from '@agentskit/adapters'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  memory: inMemory(),
+})
+
+await runtime.run('My name is Alice.')
+const result = await runtime.run('What is my name?')
+console.log(result.content) // "Your name is Alice."
+```
+
+Memory is saved after `RunResult` is assembled — if you abort early, partial messages are still persisted up to the abort point.
+
+## Related
+
+- [Tools](./tools.md) — built-in tool definitions
+- [Skills](./skills.md) — role-based system prompts
+- [Delegation](./delegation.md) — multi-agent coordination

--- a/apps/docs/docs/agents/skills.md
+++ b/apps/docs/docs/agents/skills.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 3
+---
+
+# Skills
+
+`@agentskit/skills` provides five built-in role-based system prompts that turn the agent into a focused specialist. Skills also carry `tools` hints and `delegates` hints so the runtime knows which tools to activate and which sub-agents to wire up automatically.
+
+## Install
+
+```bash
+npm install @agentskit/skills
+```
+
+## Using a skill
+
+Pass a skill to `runtime.run()` via the `skill` option. The skill's `systemPrompt` replaces the default system prompt, and any tools listed in `skill.tools` are merged into the active tool set.
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { anthropic } from '@agentskit/adapters'
+import { researcher } from '@agentskit/skills'
+import { webSearch } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  tools: [webSearch()],
+})
+
+const result = await runtime.run(
+  'What are the trade-offs between Redis and Memcached?',
+  { skill: researcher },
+)
+```
+
+## Built-in skills
+
+### `researcher`
+
+Methodical web researcher that finds, cross-references, and summarizes information from multiple sources.
+
+- **tools hint:** `['web_search']`
+- **delegates:** _(none)_
+
+The researcher breaks questions into sub-queries, searches each independently, cross-references sources, and ends with a confidence assessment.
+
+### `coder`
+
+Software engineer that writes clean, tested, production-ready code following best practices.
+
+- **tools hint:** `['read_file', 'write_file', 'list_directory', 'shell']`
+- **delegates:** _(none)_
+
+The coder understands requirements fully before writing, handles edge cases, and explains key design decisions. It never uses `any` types or adds unrequested abstractions.
+
+### `planner`
+
+Strategic planner that breaks complex tasks into steps, identifies dependencies, and coordinates specialist agents.
+
+- **tools hint:** _(none — delegates do the work)_
+- **delegates:** `['researcher', 'coder']`
+
+The planner decomposes goals into the smallest independently completable steps and delegates each step to the correct specialist. It replans when a step fails instead of blindly continuing.
+
+### `critic`
+
+Constructive reviewer that evaluates work for correctness, completeness, and quality.
+
+- **tools hint:** `['read_file']`
+- **delegates:** _(none)_
+
+The critic categorizes issues by severity (critical / important / minor), provides specific fixes with reasoning, and always acknowledges what works well before listing problems.
+
+### `summarizer`
+
+Concise summarizer that extracts key points while preserving nuance and structure.
+
+- **tools hint:** _(none)_
+- **delegates:** _(none)_
+
+The summarizer scales output length to content length: a sentence for short content, structured bullet points for long content. It never introduces information that is not in the original.
+
+## `composeSkills`
+
+Merge two or more skills into one. The resulting skill concatenates all system prompts (separated by `--- name ---` headers), deduplicates tool hints, and merges delegate lists.
+
+```ts
+import { composeSkills, researcher, coder } from '@agentskit/skills'
+
+const fullStackAgent = composeSkills(researcher, coder)
+
+const result = await runtime.run(
+  'Research the best TypeScript ORM, then scaffold a basic schema',
+  { skill: fullStackAgent },
+)
+```
+
+The composed skill's `name` is `researcher+coder` and its `description` lists both components.
+
+```ts
+// Throws — at least one skill is required
+composeSkills()
+
+// Single skill passthrough — returns the original unchanged
+composeSkills(researcher) // === researcher
+```
+
+## `listSkills`
+
+Enumerate all built-in skills and their metadata — useful for building agent UIs or validating configuration.
+
+```ts
+import { listSkills } from '@agentskit/skills'
+
+const skills = listSkills()
+// [
+//   { name: 'researcher', description: '...', tools: ['web_search'], delegates: [] },
+//   { name: 'coder',      description: '...', tools: ['read_file', 'write_file', 'list_directory', 'shell'], delegates: [] },
+//   { name: 'planner',    description: '...', tools: [], delegates: ['researcher', 'coder'] },
+//   { name: 'critic',     description: '...', tools: ['read_file'], delegates: [] },
+//   { name: 'summarizer', description: '...', tools: [], delegates: [] },
+// ]
+```
+
+Each entry is a `SkillMetadata` object:
+
+```ts
+interface SkillMetadata {
+  name: string
+  description: string
+  tools: string[]       // Tool names this skill expects to have available
+  delegates: string[]   // Sub-agent names this skill will delegate to
+}
+```
+
+## Bringing your own skill
+
+A `SkillDefinition` is a plain object — no class required.
+
+```ts
+import type { SkillDefinition } from '@agentskit/core'
+
+export const translator: SkillDefinition = {
+  name: 'translator',
+  description: 'Translates text between languages accurately and naturally.',
+  systemPrompt: `You are a professional translator...`,
+  tools: [],
+  delegates: [],
+}
+```
+
+## Related
+
+- [Runtime](./runtime.md) — how skills are activated per run
+- [Delegation](./delegation.md) — how `delegates` hints wire up multi-agent workflows
+- [Tools](./tools.md) — the tool definitions referenced by `tools` hints

--- a/apps/docs/docs/agents/tools.md
+++ b/apps/docs/docs/agents/tools.md
@@ -1,0 +1,209 @@
+---
+sidebar_position: 2
+---
+
+# Tools
+
+`@agentskit/tools` provides ready-made tool definitions for web search, filesystem access, and shell execution. Pass them to `createRuntime` or any `runtime.run()` call.
+
+## Install
+
+```bash
+npm install @agentskit/tools
+```
+
+## `webSearch`
+
+Search the web and return titles, URLs, and snippets.
+
+**Default provider:** DuckDuckGo (no API key required).
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { webSearch } from '@agentskit/tools'
+import { anthropic } from '@agentskit/adapters'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  tools: [webSearch()],
+})
+
+const result = await runtime.run('Who won the 2024 Nobel Prize in Physics?')
+```
+
+### Serper (Google results)
+
+```ts
+webSearch({ provider: 'serper', apiKey: process.env.SERPER_API_KEY, maxResults: 8 })
+```
+
+### Bring your own search (BYOS)
+
+Provide a custom `search` function to use any backend:
+
+```ts
+webSearch({
+  search: async (query) => {
+    const hits = await mySearchClient.query(query)
+    return hits.map(h => ({ title: h.title, url: h.href, snippet: h.body }))
+  },
+})
+```
+
+### Schema
+
+```json
+{
+  "name": "web_search",
+  "description": "Search the web for information. Returns titles, URLs, and snippets.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string", "description": "The search query" }
+    },
+    "required": ["query"]
+  }
+}
+```
+
+## `filesystem`
+
+Read, write, and list files within a sandboxed `basePath`. All paths passed by the model are resolved relative to `basePath`; any attempt to escape it throws an access-denied error.
+
+```ts
+import { filesystem } from '@agentskit/tools'
+
+const fsTools = filesystem({ basePath: '/tmp/workspace' })
+// Returns: [read_file, write_file, list_directory]
+```
+
+Pass the array directly to the runtime:
+
+```ts
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  tools: fsTools,
+})
+```
+
+### `read_file`
+
+```json
+{
+  "name": "read_file",
+  "description": "Read the contents of a file. Path is relative to the workspace.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "path": { "type": "string", "description": "File path relative to workspace" }
+    },
+    "required": ["path"]
+  }
+}
+```
+
+### `write_file`
+
+```json
+{
+  "name": "write_file",
+  "description": "Write content to a file. Creates the file if it does not exist.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "path":    { "type": "string", "description": "File path relative to workspace" },
+      "content": { "type": "string", "description": "Content to write" }
+    },
+    "required": ["path", "content"]
+  }
+}
+```
+
+### `list_directory`
+
+```json
+{
+  "name": "list_directory",
+  "description": "List files and directories at a path.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "path": { "type": "string", "description": "Directory path relative to workspace (default: root)" }
+    }
+  }
+}
+```
+
+## `shell`
+
+Execute shell commands from inside the agent. Use the `allowed` list to restrict which commands the model may run.
+
+```ts
+import { shell } from '@agentskit/tools'
+
+// Allow only git and npm
+const shellTool = shell({
+  allowed: ['git', 'npm'],
+  timeout: 15_000,
+})
+```
+
+### Config
+
+| Option     | Type       | Default      | Description                                          |
+| ---------- | ---------- | ------------ | ---------------------------------------------------- |
+| `timeout`  | `number`   | `30_000` ms  | Kill the process after this many milliseconds        |
+| `allowed`  | `string[]` | _(any)_      | Whitelist of command names (first word of the input) |
+| `maxOutput`| `number`   | `1_000_000`  | Maximum bytes captured from stdout + stderr          |
+
+### Schema
+
+```json
+{
+  "name": "shell",
+  "description": "Execute a shell command. Returns stdout, stderr, and exit code.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "command": { "type": "string", "description": "The shell command to execute" }
+    },
+    "required": ["command"]
+  }
+}
+```
+
+The tool always returns a string ending with `[exit code: N]` or `[killed: command timed out after Nms]`.
+
+## `listTools`
+
+Discover all available tools and their metadata at runtime — useful for building dashboards or validating skill hints.
+
+```ts
+import { listTools } from '@agentskit/tools'
+
+const tools = listTools()
+// [
+//   { name: 'web_search', description: '...', tags: ['web', 'search'], category: 'retrieval', schema: {...} },
+//   { name: 'read_file', ... },
+//   { name: 'write_file', ... },
+//   { name: 'list_directory', ... },
+//   { name: 'shell', ... },
+// ]
+```
+
+Each entry is a `ToolMetadata` object:
+
+```ts
+interface ToolMetadata {
+  name: string
+  description: string
+  tags: string[]
+  category: string
+  schema: JSONSchema7
+}
+```
+
+## Related
+
+- [Runtime](./runtime.md) — how tools are executed inside the ReAct loop
+- [Skills](./skills.md) — role-based `tools` hints that filter the active tool set

--- a/apps/docs/docs/chat-uis/components.md
+++ b/apps/docs/docs/chat-uis/components.md
@@ -1,0 +1,270 @@
+---
+sidebar_position: 4
+---
+
+# Components reference
+
+All headless components across `@agentskit/react` and `@agentskit/ink`. Components emit `data-ak-*` attributes (React) or use Ink terminal primitives (Ink) — they carry no opinion about visual styling.
+
+## React components
+
+Import from `@agentskit/react`:
+
+```tsx
+import {
+  ChatContainer,
+  Message,
+  InputBar,
+  Markdown,
+  CodeBlock,
+  ToolCallView,
+  ThinkingIndicator,
+} from '@agentskit/react'
+```
+
+---
+
+### `ChatContainer`
+
+Scrollable wrapper. Attaches a `MutationObserver` and auto-scrolls to the bottom whenever children change.
+
+```tsx
+<ChatContainer className="my-chat">
+  {/* messages, indicators */}
+</ChatContainer>
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `children` | `ReactNode` | — | Required. Message list and other content. |
+| `className` | `string` | — | Extra CSS class. |
+
+Emits: `data-ak-chat-container`
+
+---
+
+### `Message`
+
+Renders a single `Message` object from `chat.messages`.
+
+```tsx
+<Message
+  message={msg}
+  avatar={<img src={userAvatar} alt="User" />}
+  actions={<button onClick={() => copy(msg.content)}>Copy</button>}
+/>
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `message` | `MessageType` | Required. The message to render. |
+| `avatar` | `ReactNode` | Optional avatar shown beside the bubble. |
+| `actions` | `ReactNode` | Optional action row below the content. |
+
+Emits: `data-ak-message`, `data-ak-role`, `data-ak-status`, `data-ak-content`, `data-ak-avatar`, `data-ak-actions`
+
+---
+
+### `InputBar`
+
+Textarea + send button wired to a `ChatReturn` object. Sends on `Enter`, inserts newline on `Shift+Enter`.
+
+```tsx
+<InputBar
+  chat={chat}
+  placeholder="Ask anything..."
+  disabled={false}
+/>
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `chat` | `ChatReturn` | — | Required. Return value from `useChat`. |
+| `placeholder` | `string` | `'Type a message...'` | Textarea placeholder. |
+| `disabled` | `boolean` | `false` | Disables input and button. |
+
+Emits: `data-ak-input-bar`, `data-ak-input`, `data-ak-send`
+
+---
+
+### `Markdown`
+
+Lightweight wrapper for markdown content. Add your own renderer (e.g. `react-markdown`) inside or replace this component entirely.
+
+```tsx
+<Markdown content={msg.content} streaming={msg.status === 'streaming'} />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `string` | — | Required. Markdown string to display. |
+| `streaming` | `boolean` | `false` | Adds `data-ak-streaming="true"` while streaming. |
+
+Emits: `data-ak-markdown`, `data-ak-streaming`
+
+---
+
+### `CodeBlock`
+
+Renders a code snippet with an optional copy button.
+
+```tsx
+<CodeBlock code="npm install @agentskit/react" language="bash" copyable />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `code` | `string` | — | Required. Source code to display. |
+| `language` | `string` | — | Language hint (e.g. `'tsx'`, `'bash'`). |
+| `copyable` | `boolean` | `false` | Shows a Copy button that writes to the clipboard. |
+
+Emits: `data-ak-code-block`, `data-ak-language`, `data-ak-copy`
+
+---
+
+### `ToolCallView`
+
+Expandable view for a single tool call. Clicking the tool name toggles args and result visibility.
+
+```tsx
+{msg.toolCalls?.map(tc => (
+  <ToolCallView key={tc.id} toolCall={tc} />
+))}
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `toolCall` | `ToolCall` | Required. The tool call object from `@agentskit/core`. |
+
+Emits: `data-ak-tool-call`, `data-ak-tool-status`, `data-ak-tool-toggle`, `data-ak-tool-details`, `data-ak-tool-args`, `data-ak-tool-result`
+
+---
+
+### `ThinkingIndicator`
+
+Three animated dots with a label. Renders nothing when `visible` is `false`.
+
+```tsx
+<ThinkingIndicator visible={chat.status === 'streaming'} label="Thinking..." />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `visible` | `boolean` | — | Required. Show or hide the indicator. |
+| `label` | `string` | `'Thinking...'` | Accessible label next to the dots. |
+
+Emits: `data-ak-thinking`, `data-ak-thinking-dots`, `data-ak-thinking-label`
+
+---
+
+## Ink components
+
+Import from `@agentskit/ink`:
+
+```tsx
+import {
+  ChatContainer,
+  Message,
+  InputBar,
+  ToolCallView,
+  ThinkingIndicator,
+} from '@agentskit/ink'
+```
+
+---
+
+### `ChatContainer` (Ink)
+
+Wraps children in an Ink `<Box flexDirection="column" gap={1}>`.
+
+```tsx
+<ChatContainer>
+  {chat.messages.map(msg => <Message key={msg.id} message={msg} />)}
+</ChatContainer>
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `children` | `ReactNode` | Required. |
+
+---
+
+### `Message` (Ink)
+
+Renders the role label in a role-specific terminal colour, then the message content below it.
+
+```tsx
+<Message message={msg} />
+```
+
+| Prop | Type | Description |
+|---|---|---|
+| `message` | `MessageType` | Required. |
+
+Role colours: `assistant` → cyan, `user` → green, `system` → yellow, `tool` → magenta.
+
+---
+
+### `InputBar` (Ink)
+
+Captures keyboard input via Ink's `useInput`. Sends on `Enter`, deletes on `Backspace`/`Delete`. Disabled while streaming.
+
+```tsx
+<InputBar chat={chat} placeholder="Type and press Enter..." />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `chat` | `ChatReturn` | — | Required. |
+| `placeholder` | `string` | `'Type a message...'` | Shown above the input line. |
+| `disabled` | `boolean` | `false` | Prevents input. |
+
+---
+
+### `ToolCallView` (Ink)
+
+Renders a rounded border box with the tool name, status, and optionally the args and result.
+
+```tsx
+<ToolCallView toolCall={tc} expanded />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `toolCall` | `ToolCall` | — | Required. |
+| `expanded` | `boolean` | `false` | Show args and result inline. |
+
+---
+
+### `ThinkingIndicator` (Ink)
+
+Single-line yellow text. Renders nothing when `visible` is `false`.
+
+```tsx
+<ThinkingIndicator visible={chat.status === 'streaming'} label="Thinking..." />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `visible` | `boolean` | — | Required. |
+| `label` | `string` | `'Thinking...'` | Text to display. |
+
+---
+
+## Component availability
+
+| Component | `@agentskit/react` | `@agentskit/ink` |
+|---|---|---|
+| `ChatContainer` | Yes | Yes |
+| `Message` | Yes | Yes |
+| `InputBar` | Yes | Yes |
+| `ToolCallView` | Yes | Yes |
+| `ThinkingIndicator` | Yes | Yes |
+| `Markdown` | Yes | No |
+| `CodeBlock` | Yes | No |
+
+## Related
+
+- [@agentskit/react](./react.md)
+- [@agentskit/ink](./ink.md)
+- [Theming](./theming.md)

--- a/apps/docs/docs/chat-uis/ink.md
+++ b/apps/docs/docs/chat-uis/ink.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 2
+---
+
+# @agentskit/ink
+
+Terminal chat UI built with [Ink](https://github.com/vadimdemedes/ink). Uses the same `@agentskit/core` controller as `@agentskit/react`, so the chat logic is identical — only the renderer differs.
+
+## Install
+
+```bash
+npm install @agentskit/ink @agentskit/core ink react
+# optional: real AI providers
+npm install @agentskit/adapters
+```
+
+## Hook
+
+### `useChat`
+
+Identical API to `@agentskit/react`'s `useChat`. The same `ChatReturn` object is returned.
+
+```tsx
+import { useChat } from '@agentskit/ink'
+
+const chat = useChat({
+  adapter: myAdapter,
+  systemPrompt: 'You are...',
+})
+```
+
+See the [`useChat` reference](../hooks/use-chat.md) for the full return type.
+
+## Complete example (demo adapter — no API key needed)
+
+```tsx
+import React from 'react'
+import { render, Box, Text } from 'ink'
+import {
+  ChatContainer,
+  Message,
+  InputBar,
+  ThinkingIndicator,
+  useChat,
+} from '@agentskit/ink'
+import type { AdapterFactory } from '@agentskit/ink'
+
+function createDemoAdapter(): AdapterFactory {
+  return {
+    createSource: ({ messages }) => {
+      let cancelled = false
+      return {
+        stream: async function* () {
+          const last = [...messages].reverse().find(m => m.role === 'user')
+          const reply = `You said: "${last?.content ?? ''}". This is a demo response.`
+          for (const chunk of reply.match(/.{1,20}/g) ?? []) {
+            if (cancelled) return
+            await new Promise(r => setTimeout(r, 45))
+            yield { type: 'text' as const, content: chunk }
+          }
+          yield { type: 'done' as const }
+        },
+        abort: () => { cancelled = true },
+      }
+    },
+  }
+}
+
+function App() {
+  const chat = useChat({
+    adapter: createDemoAdapter(),
+    systemPrompt: 'You are a helpful terminal assistant.',
+  })
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold color="cyan">AgentsKit Terminal Chat</Text>
+      <ChatContainer>
+        {chat.messages.map(msg => (
+          <Message key={msg.id} message={msg} />
+        ))}
+      </ChatContainer>
+      <ThinkingIndicator visible={chat.status === 'streaming'} />
+      <InputBar chat={chat} placeholder="Type and press Enter..." />
+    </Box>
+  )
+}
+
+render(<App />)
+```
+
+## Swap to a real provider
+
+```tsx
+import { anthropic } from '@agentskit/adapters'
+
+const chat = useChat({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+})
+```
+
+## Keyboard navigation
+
+`InputBar` uses Ink's `useInput` hook. The following keys are handled automatically:
+
+| Key | Action |
+|---|---|
+| Any character | Appended to input |
+| `Enter` | Send message |
+| `Backspace` / `Delete` | Remove last character |
+| `Ctrl+C` | Exit (Ink default) |
+
+Input is disabled while `chat.status === 'streaming'`.
+
+## Terminal colours
+
+`Message` applies a fixed colour per role using Ink's `color` prop:
+
+| Role | Colour |
+|---|---|
+| `assistant` | `cyan` |
+| `user` | `green` |
+| `system` | `yellow` |
+| `tool` | `magenta` |
+
+`ToolCallView` renders in a rounded box with magenta text. `ThinkingIndicator` renders in yellow.
+
+## Differences from @agentskit/react
+
+| Feature | `@agentskit/react` | `@agentskit/ink` |
+|---|---|---|
+| Renderer | DOM | Ink (terminal) |
+| Theme / CSS | `data-ak-*` + CSS variables | Terminal colours |
+| `Markdown` component | Yes | No |
+| `CodeBlock` component | Yes | No |
+| `useStream` hook | Yes | No |
+| `useReactive` hook | Yes | No |
+| `InputBar` multiline | Shift+Enter | No (single line) |
+
+## Related
+
+- [@agentskit/react](./react.md)
+- [Components reference](./components.md)

--- a/apps/docs/docs/chat-uis/react.md
+++ b/apps/docs/docs/chat-uis/react.md
@@ -1,0 +1,171 @@
+---
+sidebar_position: 1
+---
+
+# @agentskit/react
+
+React chat UI built on `@agentskit/core`. Provides three hooks and seven headless components styled via CSS variables.
+
+## Install
+
+```bash
+npm install @agentskit/react @agentskit/core
+# optional: real AI providers
+npm install @agentskit/adapters
+```
+
+## Hooks
+
+### `useChat`
+
+The primary hook. Creates and manages a full chat session.
+
+```tsx
+import { useChat } from '@agentskit/react'
+
+const chat = useChat({
+  adapter: myAdapter,          // required — AdapterFactory
+  systemPrompt: 'You are...', // optional
+  memory: myMemory,           // optional — ChatMemory
+  tools: [...],               // optional — ToolDefinition[]
+})
+```
+
+Returns a `ChatReturn` object:
+
+| Property | Type | Description |
+|---|---|---|
+| `messages` | `Message[]` | Full conversation history |
+| `input` | `string` | Current input field value |
+| `status` | `'idle' \| 'streaming' \| 'error'` | Session status |
+| `error` | `Error \| null` | Last error, if any |
+| `send(text)` | `(text: string) => void` | Send a message |
+| `stop()` | `() => void` | Abort the current stream |
+| `retry()` | `() => void` | Retry the last request |
+| `setInput(val)` | `(val: string) => void` | Update the input value |
+| `clear()` | `() => void` | Clear the conversation |
+
+### `useStream`
+
+Lower-level hook for consuming a single `StreamSource` directly.
+
+```tsx
+import { useStream } from '@agentskit/react'
+
+const { text, status, error, stop } = useStream(source, {
+  onChunk: (chunk) => console.log(chunk),
+  onComplete: (full) => console.log('done', full),
+  onError: (err) => console.error(err),
+})
+```
+
+### `useReactive`
+
+Reactive state container that triggers re-renders on property mutations.
+
+```tsx
+import { useReactive } from '@agentskit/react'
+
+const state = useReactive({ count: 0, label: 'hello' })
+// Mutate directly — component re-renders automatically
+state.count++
+```
+
+## Complete example (demo adapter — no API key needed)
+
+```tsx
+import { useChat, ChatContainer, Message, InputBar, ThinkingIndicator } from '@agentskit/react'
+import type { AdapterFactory } from '@agentskit/react'
+import '@agentskit/react/theme'
+
+function createDemoAdapter(): AdapterFactory {
+  return {
+    createSource: ({ messages }) => {
+      let cancelled = false
+      return {
+        stream: async function* () {
+          const last = [...messages].reverse().find(m => m.role === 'user')
+          const reply = `You said: "${last?.content ?? ''}". This is a demo response.`
+          for (const chunk of reply.match(/.{1,20}/g) ?? []) {
+            if (cancelled) return
+            await new Promise(r => setTimeout(r, 40))
+            yield { type: 'text' as const, content: chunk }
+          }
+          yield { type: 'done' as const }
+        },
+        abort: () => { cancelled = true },
+      }
+    },
+  }
+}
+
+export default function App() {
+  const chat = useChat({
+    adapter: createDemoAdapter(),
+    systemPrompt: 'You are a helpful assistant.',
+  })
+
+  return (
+    <ChatContainer>
+      {chat.messages.map(msg => (
+        <Message key={msg.id} message={msg} />
+      ))}
+      <ThinkingIndicator visible={chat.status === 'streaming'} />
+      <InputBar chat={chat} placeholder="Say something..." />
+    </ChatContainer>
+  )
+}
+```
+
+## Swap to a real provider
+
+Replace the adapter — nothing else changes:
+
+```tsx
+import { anthropic } from '@agentskit/adapters'
+
+const chat = useChat({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+})
+```
+
+```tsx
+import { openai } from '@agentskit/adapters'
+
+const chat = useChat({
+  adapter: openai({ apiKey: process.env.OPENAI_API_KEY, model: 'gpt-4o' }),
+})
+```
+
+## `data-ak-*` attributes
+
+Every component emits `data-ak-*` attributes so you can style or target them without class names:
+
+| Attribute | Element | Values |
+|---|---|---|
+| `data-ak-chat-container` | wrapper `<div>` | — |
+| `data-ak-message` | message wrapper | — |
+| `data-ak-role` | message wrapper | `user`, `assistant`, `system`, `tool` |
+| `data-ak-status` | message wrapper | `idle`, `streaming`, `done`, `error` |
+| `data-ak-content` | message body | — |
+| `data-ak-avatar` | avatar slot | — |
+| `data-ak-actions` | actions slot | — |
+| `data-ak-input-bar` | form wrapper | — |
+| `data-ak-input` | textarea | — |
+| `data-ak-send` | submit button | — |
+| `data-ak-thinking` | thinking div | — |
+| `data-ak-markdown` | markdown wrapper | — |
+| `data-ak-streaming` | markdown wrapper | `true` when streaming |
+| `data-ak-code-block` | code block wrapper | — |
+| `data-ak-language` | code block wrapper | language string |
+| `data-ak-copy` | copy button | — |
+| `data-ak-tool-call` | tool call wrapper | — |
+| `data-ak-tool-status` | tool call wrapper | `pending`, `running`, `done`, `error` |
+
+See [Theming](./theming.md) for full CSS variable reference.
+
+## Related
+
+- [Components reference](./components.md)
+- [Theming](./theming.md)
+- [@agentskit/ink](./ink.md)

--- a/apps/docs/docs/chat-uis/theming.md
+++ b/apps/docs/docs/chat-uis/theming.md
@@ -1,0 +1,181 @@
+---
+sidebar_position: 3
+---
+
+# Theming
+
+`@agentskit/react` ships a default theme as a CSS file. Every element uses `data-ak-*` attributes as selectors and CSS custom properties as design tokens — no class names, no specificity battles.
+
+## Enable the default theme
+
+```tsx
+import '@agentskit/react/theme'
+```
+
+One import, and all `data-ak-*` elements are styled. The theme includes a built-in dark mode that activates automatically via `prefers-color-scheme`.
+
+## Force dark or light mode
+
+```html
+<!-- force dark -->
+<html data-theme="dark">
+
+<!-- force light -->
+<html data-theme="light">
+```
+
+Or add the `.dark` class to any ancestor element.
+
+## CSS variables
+
+Override any token by reassigning its custom property. All tokens are defined on `:root`.
+
+### Colours
+
+```css
+:root {
+  --ak-color-bg: #ffffff;
+  --ak-color-surface: #f9fafb;
+  --ak-color-border: #e5e7eb;
+  --ak-color-text: #111827;
+  --ak-color-text-muted: #6b7280;
+
+  /* Message bubbles */
+  --ak-color-bubble-user: #2563eb;
+  --ak-color-bubble-user-text: #ffffff;
+  --ak-color-bubble-assistant: #f3f4f6;
+  --ak-color-bubble-assistant-text: #111827;
+
+  /* Input */
+  --ak-color-input-bg: #ffffff;
+  --ak-color-input-border: #d1d5db;
+  --ak-color-input-focus: #2563eb;
+
+  /* Send button */
+  --ak-color-button: #2563eb;
+  --ak-color-button-text: #ffffff;
+
+  /* Code blocks */
+  --ak-color-code-bg: #1f2937;
+  --ak-color-code-text: #e5e7eb;
+
+  /* Tool calls */
+  --ak-color-tool-bg: #fef3c7;
+  --ak-color-tool-border: #f59e0b;
+}
+```
+
+### Typography and spacing
+
+```css
+:root {
+  --ak-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --ak-font-size: 14px;
+  --ak-font-size-sm: 12px;
+  --ak-font-size-lg: 16px;
+  --ak-line-height: 1.5;
+
+  --ak-radius: 8px;
+  --ak-radius-lg: 12px;
+
+  --ak-spacing-xs: 4px;
+  --ak-spacing-sm: 8px;
+  --ak-spacing-md: 12px;
+  --ak-spacing-lg: 16px;
+  --ak-spacing-xl: 24px;
+
+  --ak-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --ak-transition: 150ms ease;
+}
+```
+
+## Example: custom brand theme
+
+```css
+/* my-theme.css */
+:root {
+  --ak-color-bubble-user: #7c3aed;
+  --ak-color-bubble-user-text: #ffffff;
+  --ak-color-input-focus: #7c3aed;
+  --ak-color-button: #7c3aed;
+  --ak-font-family: 'Inter', sans-serif;
+  --ak-radius: 4px;
+  --ak-radius-lg: 8px;
+}
+```
+
+```tsx
+import '@agentskit/react/theme'   // base tokens
+import './my-theme.css'           // overrides
+```
+
+## Targeting elements with `data-ak-*` selectors
+
+All components emit stable `data-ak-*` attributes. Use them directly in CSS for structural overrides:
+
+```css
+/* Wider assistant bubbles */
+[data-ak-role="assistant"] {
+  max-width: 90%;
+}
+
+/* Highlighted streaming message */
+[data-ak-status="streaming"] [data-ak-content] {
+  border-left: 3px solid var(--ak-color-button);
+  padding-left: 12px;
+}
+
+/* Hide the copy button on mobile */
+@media (max-width: 640px) {
+  [data-ak-copy] {
+    display: none;
+  }
+}
+```
+
+## Building a custom theme from scratch
+
+Skip the default import entirely and style `data-ak-*` attributes yourself:
+
+```tsx
+// No '@agentskit/react/theme' import
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
+import './my-custom-theme.css'
+```
+
+```css
+/* my-custom-theme.css — minimal example */
+[data-ak-chat-container] {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+[data-ak-message][data-ak-role="user"] {
+  align-self: flex-end;
+  background: #7c3aed;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 12px;
+}
+
+[data-ak-message][data-ak-role="assistant"] {
+  align-self: flex-start;
+  background: #f0f0f0;
+  padding: 8px 12px;
+  border-radius: 12px;
+}
+
+[data-ak-input-bar] {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid #e5e7eb;
+}
+```
+
+## Related
+
+- [Components reference](./components.md)
+- [@agentskit/react](./react.md)

--- a/apps/docs/docs/data-layer/adapters.md
+++ b/apps/docs/docs/data-layer/adapters.md
@@ -1,0 +1,210 @@
+---
+sidebar_position: 1
+---
+
+# Adapters
+
+`@agentskit/adapters` normalizes every supported AI provider into a single streaming interface. Swap providers by changing one line — the rest of your app stays the same.
+
+## Install
+
+```bash
+npm install @agentskit/adapters
+```
+
+## Built-in Providers
+
+### Anthropic
+
+```ts
+import { anthropic } from '@agentskit/adapters'
+
+const adapter = anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: 'claude-sonnet-4-6',
+  maxTokens: 4096,       // optional, default 4096
+  baseUrl: 'https://api.anthropic.com', // optional
+})
+```
+
+### OpenAI
+
+```ts
+import { openai } from '@agentskit/adapters'
+
+const adapter = openai({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: 'gpt-4o',
+  baseUrl: 'https://api.openai.com', // optional
+})
+```
+
+### Gemini
+
+```ts
+import { gemini } from '@agentskit/adapters'
+
+const adapter = gemini({
+  apiKey: process.env.GOOGLE_API_KEY!,
+  model: 'gemini-2.0-flash',
+})
+```
+
+### Ollama (local)
+
+```ts
+import { ollama } from '@agentskit/adapters'
+
+const adapter = ollama({
+  model: 'llama3.2',
+  baseUrl: 'http://localhost:11434', // optional
+})
+```
+
+### DeepSeek
+
+```ts
+import { deepseek } from '@agentskit/adapters'
+
+const adapter = deepseek({ apiKey: process.env.DEEPSEEK_API_KEY!, model: 'deepseek-chat' })
+```
+
+### Grok
+
+```ts
+import { grok } from '@agentskit/adapters'
+
+const adapter = grok({ apiKey: process.env.XAI_API_KEY!, model: 'grok-3' })
+```
+
+### Kimi
+
+```ts
+import { kimi } from '@agentskit/adapters'
+
+const adapter = kimi({ apiKey: process.env.KIMI_API_KEY!, model: 'moonshot-v1-8k' })
+```
+
+### LangChain / LangGraph
+
+```ts
+import { langchain, langgraph } from '@agentskit/adapters'
+import { ChatOpenAI } from '@langchain/openai'
+
+// Wrap any LangChain runnable
+const adapter = langchain({
+  runnable: new ChatOpenAI({ model: 'gpt-4o' }),
+  mode: 'stream', // or 'events' for streamEvents()
+})
+
+// LangGraph: uses streamEvents under the hood
+const graphAdapter = langgraph({ graph: myCompiledGraph })
+```
+
+### Vercel AI SDK
+
+```ts
+import { vercelAI } from '@agentskit/adapters'
+
+// Points at a Next.js / Vercel AI route handler
+const adapter = vercelAI({
+  api: '/api/chat',
+  headers: { 'X-Custom-Header': 'value' }, // optional
+})
+```
+
+## One-line provider swap
+
+```ts
+// Before
+const adapter = anthropic({ apiKey, model: 'claude-sonnet-4-6' })
+
+// After — nothing else changes
+const adapter = openai({ apiKey, model: 'gpt-4o' })
+```
+
+## Custom Adapter with `createAdapter`
+
+Use `createAdapter` when you need a provider not listed above. Provide a `send` function that returns a `Response` or `ReadableStream`, and a `parse` generator that yields `StreamChunk` values.
+
+```ts
+import { createAdapter } from '@agentskit/adapters'
+import type { AdapterRequest, StreamChunk } from '@agentskit/core'
+
+const adapter = createAdapter({
+  send: async (request: AdapterRequest) => {
+    return fetch('https://my-llm.example.com/v1/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: request.messages }),
+    })
+  },
+  parse: async function* (stream: ReadableStream): AsyncIterableIterator<StreamChunk> {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      yield { type: 'text', content: decoder.decode(value) }
+    }
+    yield { type: 'done' }
+  },
+  abort: () => { /* optional cancel logic */ },
+})
+```
+
+For the simplest case — a stream that emits raw text — use `generic` instead:
+
+```ts
+import { generic } from '@agentskit/adapters'
+
+const adapter = generic({
+  send: async (request) => {
+    const res = await fetch('/api/my-llm', {
+      method: 'POST',
+      body: JSON.stringify({ messages: request.messages }),
+    })
+    return res.body!
+  },
+})
+```
+
+## Embedder Functions
+
+Embedders return an `EmbedFn` — an `async (text: string) => number[]` — used by `@agentskit/rag` and `@agentskit/memory`.
+
+```ts
+import {
+  openaiEmbedder,
+  geminiEmbedder,
+  ollamaEmbedder,
+  deepseekEmbedder,
+  grokEmbedder,
+  kimiEmbedder,
+  createOpenAICompatibleEmbedder,
+} from '@agentskit/adapters'
+
+// OpenAI (default model: text-embedding-3-small)
+const embed = openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY! })
+
+// Gemini
+const embed = geminiEmbedder({ apiKey: process.env.GOOGLE_API_KEY!, model: 'text-embedding-004' })
+
+// Ollama (local)
+const embed = ollamaEmbedder({ model: 'nomic-embed-text' })
+
+// OpenAI-compatible endpoint (Cohere, Voyage, etc.)
+const embed = createOpenAICompatibleEmbedder({
+  apiKey: process.env.COHERE_API_KEY!,
+  model: 'embed-english-v3.0',
+  baseUrl: 'https://api.cohere.com',
+})
+```
+
+Pass any embedder directly to `createRAG` — see [RAG](./rag.md).
+
+## Related
+
+- [Memory](./memory.md) — persist chat history and vector indexes
+- [RAG](./rag.md) — retrieval-augmented generation pipeline
+- [useChat hook](../hooks/use-chat.md) — React integration

--- a/apps/docs/docs/data-layer/memory.md
+++ b/apps/docs/docs/data-layer/memory.md
@@ -1,0 +1,197 @@
+---
+sidebar_position: 2
+---
+
+# Memory
+
+`@agentskit/memory` provides pluggable backends for chat history (`ChatMemory`) and semantic vector search (`VectorMemory`). All backends use **lazy imports** — the underlying driver is loaded only when the memory is first used, so unused backends add no runtime cost.
+
+## Install
+
+```bash
+npm install @agentskit/memory
+```
+
+## Backend Comparison
+
+| Backend | Type | Persistence | Extra dependency | Best for |
+|---|---|---|---|---|
+| `sqliteChatMemory` | Chat | File (SQLite) | `better-sqlite3` | Single-server, local dev |
+| `redisChatMemory` | Chat | Remote (Redis) | `redis` | Multi-instance, production |
+| `redisVectorMemory` | Vector | Remote (Redis Stack) | `redis` | Production semantic search |
+| `fileVectorMemory` | Vector | File (JSON via vectra) | `vectra` | Local dev, prototyping |
+
+## Chat Memory
+
+Chat memory persists conversation history across sessions. Pass it to `useChat` via the `memory` option.
+
+### SQLite
+
+```bash
+npm install better-sqlite3
+```
+
+```ts
+import { sqliteChatMemory } from '@agentskit/memory'
+
+const memory = sqliteChatMemory({
+  path: './chat.db',
+  conversationId: 'user-123', // optional, default: 'default'
+})
+```
+
+The database and table are created automatically on first use.
+
+### Redis
+
+```bash
+npm install redis
+```
+
+```ts
+import { redisChatMemory } from '@agentskit/memory'
+
+const memory = redisChatMemory({
+  url: process.env.REDIS_URL!,         // e.g. redis://localhost:6379
+  conversationId: 'user-123',          // optional
+  keyPrefix: 'myapp:chat',             // optional, default: 'agentskit:chat'
+})
+```
+
+### Using chat memory with `useChat`
+
+```tsx
+import { useChat } from '@agentskit/react'
+import { anthropic } from '@agentskit/adapters'
+import { sqliteChatMemory } from '@agentskit/memory'
+
+const memory = sqliteChatMemory({ path: './chat.db', conversationId: 'session-1' })
+
+function Chat() {
+  const chat = useChat({
+    adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+    memory,
+  })
+  // ...
+}
+```
+
+## Vector Memory
+
+Vector memory stores embeddings for semantic search. It is used by `@agentskit/rag` but can also be queried directly.
+
+### File-based (vectra)
+
+```bash
+npm install vectra
+```
+
+```ts
+import { fileVectorMemory } from '@agentskit/memory'
+
+const store = fileVectorMemory({
+  path: './vector-index', // directory where the index files are stored
+})
+```
+
+### Redis Vector (Redis Stack / Redis Cloud)
+
+Requires a Redis instance with the [RediSearch module](https://redis.io/docs/interact/search-and-query/) enabled (Redis Stack, Redis Cloud, Upstash with Search).
+
+```bash
+npm install redis
+```
+
+```ts
+import { redisVectorMemory } from '@agentskit/memory'
+
+const store = redisVectorMemory({
+  url: process.env.REDIS_URL!,
+  indexName: 'myapp:docs:idx',    // optional
+  keyPrefix: 'myapp:vec',         // optional
+  dimensions: 1536,               // optional — auto-detected from first insert
+})
+```
+
+The HNSW index is created automatically on first write.
+
+### Storing and searching manually
+
+```ts
+import { openaiEmbedder } from '@agentskit/adapters'
+
+const embed = openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY! })
+
+// Store
+await store.store([{
+  id: 'doc-1',
+  content: 'AgentsKit makes AI chat easy.',
+  embedding: await embed('AgentsKit makes AI chat easy.'),
+  metadata: { source: 'readme' },
+}])
+
+// Search
+const queryEmbedding = await embed('how do I build a chatbot?')
+const results = await store.search(queryEmbedding, { topK: 3, threshold: 0.7 })
+```
+
+## Custom VectorStore
+
+Provide your own storage backend by implementing the `VectorStore` interface. Pass it to `fileVectorMemory` via the `store` option.
+
+```ts
+import type { VectorStore, VectorStoreDocument, VectorStoreResult } from '@agentskit/memory'
+import { fileVectorMemory } from '@agentskit/memory'
+
+const myStore: VectorStore = {
+  async upsert(docs: VectorStoreDocument[]): Promise<void> {
+    // persist docs to your database
+  },
+  async query(vector: number[], topK: number): Promise<VectorStoreResult[]> {
+    // return nearest neighbours
+    return []
+  },
+  async delete(ids: string[]): Promise<void> {
+    // remove by id
+  },
+}
+
+const memory = fileVectorMemory({ path: '', store: myStore })
+```
+
+## RedisClientAdapter for library portability
+
+If you already have a Redis client (e.g., `ioredis`), wrap it with `RedisClientAdapter` instead of letting the library create its own connection.
+
+```ts
+import type { RedisClientAdapter } from '@agentskit/memory'
+import { redisChatMemory } from '@agentskit/memory'
+import IORedis from 'ioredis'
+
+const ioredis = new IORedis(process.env.REDIS_URL)
+
+const clientAdapter: RedisClientAdapter = {
+  get: (key) => ioredis.get(key),
+  set: (key, value) => ioredis.set(key, value).then(() => undefined),
+  del: (key) => ioredis.del(Array.isArray(key) ? key : [key]).then(() => undefined),
+  keys: (pattern) => ioredis.keys(pattern),
+  disconnect: () => ioredis.quit().then(() => undefined),
+  call: (cmd, ...args) => ioredis.call(cmd, ...args.map(String)),
+}
+
+const memory = redisChatMemory({
+  url: '',          // ignored when client is provided
+  client: clientAdapter,
+  conversationId: 'session-1',
+})
+```
+
+## Lazy imports pattern
+
+All backends load their drivers with a dynamic `import()` or `require()` on first use. This means you only pay the cost of `better-sqlite3`, `redis`, or `vectra` when that backend is actually instantiated — not at module load time.
+
+## Related
+
+- [Adapters](./adapters.md) — embedder functions used to generate vectors
+- [RAG](./rag.md) — full retrieval-augmented generation pipeline using VectorMemory
+- [useChat hook](../hooks/use-chat.md) — pass `memory` to a chat session

--- a/apps/docs/docs/data-layer/rag.md
+++ b/apps/docs/docs/data-layer/rag.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 3
+---
+
+# RAG (Retrieval-Augmented Generation)
+
+Add knowledge retrieval to your agents with plug-and-play RAG.
+
+## Install
+
+```bash
+npm install @agentskit/rag @agentskit/memory @agentskit/adapters
+```
+
+## Quick Start
+
+```ts
+import { createRAG } from '@agentskit/rag'
+import { openaiEmbedder } from '@agentskit/adapters'
+import { fileVectorMemory } from '@agentskit/memory'
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY }),
+  store: fileVectorMemory({ path: './vectors' }),
+})
+
+// Ingest documents
+await rag.ingest([
+  { id: 'doc-1', content: 'AgentsKit is a JavaScript agent toolkit...' },
+  { id: 'doc-2', content: 'The runtime supports ReAct loops...' },
+])
+
+// Retrieve relevant context
+const docs = await rag.retrieve('How does AgentsKit work?', { topK: 3 })
+```
+
+## With Runtime
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({
+  adapter: openai({ apiKey, model: 'gpt-4o' }),
+  retriever: rag,  // auto-injects retrieved context into prompts
+})
+
+const result = await runtime.run('Explain the AgentsKit architecture')
+```
+
+## With React
+
+```ts
+import { useRAGChat } from '@agentskit/rag'
+
+const chat = useRAGChat({
+  adapter: openai({ apiKey, model: 'gpt-4o' }),
+  rag,
+})
+```
+
+## Chunking
+
+Documents are automatically chunked before embedding:
+
+```ts
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey }),
+  store: fileVectorMemory({ path: './vectors' }),
+  chunkSize: 512,    // characters per chunk (default: 1000)
+  chunkOverlap: 50,  // overlap between chunks (default: 100)
+})
+```
+
+## Bring Your Own Embedder
+
+Any function matching `(text: string) => Promise<number[]>` works:
+
+```ts
+import { openaiEmbedder, geminiEmbedder, ollamaEmbedder } from '@agentskit/adapters'
+
+openaiEmbedder({ apiKey, model: 'text-embedding-3-small' })
+geminiEmbedder({ apiKey })
+ollamaEmbedder({ model: 'nomic-embed-text' })
+
+// Custom
+const myEmbedder = async (text: string) => {
+  const response = await fetch('/api/embed', { method: 'POST', body: text })
+  return response.json()
+}
+```
+
+## Vector Stores
+
+RAG works with any `VectorMemory` from `@agentskit/memory`:
+
+| Store | Best for |
+|-------|----------|
+| `fileVectorMemory` | Local development, small datasets |
+| `redisVectorMemory` | Production, fast networked access |
+| Custom `VectorStore` | LanceDB, Pinecone, Qdrant, etc. |
+
+## Related
+
+- [Memory](/docs/data-layer/memory) — vector storage backends
+- [Adapters](/docs/data-layer/adapters) — embedder functions
+- [Runtime](/docs/agents/runtime) — retriever integration

--- a/apps/docs/docs/getting-started/for-ai-agents.md
+++ b/apps/docs/docs/getting-started/for-ai-agents.md
@@ -6,61 +6,130 @@ sidebar_position: 3
 
 The entire AgentsKit API in one page. Paste this into your LLM context.
 
-## Hooks
+## Chat (React / Ink)
 
 ```tsx
-// Stream any async source
-const { text, status, error, stop } = useStream(source)
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react' // or @agentskit/ink
+import { anthropic } from '@agentskit/adapters'
 
-// Reactive state (proxy-based, minimal re-renders)
-const state = useReactive({ count: 0 })
-state.count++ // triggers re-render
-
-// Full chat session
-const chat = useChat({ adapter })
+const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }), tools, skills })
 chat.send('message')    // send and stream response
 chat.stop()             // abort stream
 chat.retry()            // retry last
 chat.messages           // Message[]
 chat.status             // 'idle' | 'streaming' | 'error'
-chat.input / setInput   // controlled input
+
+<ChatContainer>
+  <Message message={m} />
+  <InputBar chat={chat} />
+</ChatContainer>
 ```
 
-## Adapters
+## Adapters — swap in one line
 
-```tsx
-import { anthropic, openai, vercelAI, generic } from '@agentskit/adapters'
+```ts
+import { anthropic, openai, gemini, ollama, deepseek, grok, kimi, vercelAI, generic } from '@agentskit/adapters'
 
-anthropic({ apiKey, model })
-openai({ apiKey, model })
-vercelAI({ api: '/api/chat' })
-generic({ send: async (msgs) => ReadableStream })
+anthropic({ apiKey, model })   // openai({ apiKey, model })
+gemini({ apiKey, model })      // ollama({ model })
+vercelAI({ api: '/api/chat' }) // generic({ send: async (msgs) => ReadableStream })
 ```
 
-## Components
+## Running Agents (no UI)
 
-```tsx
-<ChatContainer>         {/* scrollable chat layout */}
-<Message message={m} /> {/* chat bubble */}
-<InputBar chat={chat} /> {/* input + send */}
-<Markdown content={s} /> {/* markdown text */}
-<CodeBlock code={s} language="ts" copyable />
-<ToolCallView toolCall={tc} />
-<ThinkingIndicator visible />
+```ts
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({ adapter, tools, skills, observers, memory })
+const result = await runtime.run('task', { skill, delegates, signal })
+// → { content, messages, steps, toolCalls, durationMs }
 ```
 
-## Theme
+## Tools
 
-```tsx
-import '@agentskit/react/theme' // optional default CSS
+```ts
+import { webSearch, filesystem, shell, listTools } from '@agentskit/tools'
+
+webSearch()                              // DuckDuckGo (no key)
+webSearch({ provider: 'serper', apiKey }) // Serper
+filesystem({ basePath: './workspace' })  // → [read_file, write_file, list_directory]
+shell({ timeout: 10_000, allowed: ['ls', 'cat'] })
 ```
 
-All components use `data-ak-*` attributes. Override with CSS custom properties (`--ak-color-*`, `--ak-font-*`, `--ak-spacing-*`).
+## Skills
+
+```ts
+import { researcher, coder, planner, critic, summarizer, composeSkills } from '@agentskit/skills'
+
+runtime.run('task', { skill: researcher })
+const combined = composeSkills(researcher, coder) // merges prompts, tools, delegates
+```
+
+## Multi-Agent Delegation
+
+```ts
+runtime.run('Build a landing page', {
+  delegates: {
+    researcher: { skill: researcher, tools: [webSearch()], maxSteps: 3 },
+    coder: { skill: coder, tools: [...filesystem({ basePath: './src' })] },
+  },
+  sharedContext: createSharedContext(),
+})
+```
+
+## Memory
+
+```ts
+import { sqliteChatMemory, fileVectorMemory } from '@agentskit/memory'
+
+sqliteChatMemory({ path: './chat.db' })            // ChatMemory
+fileVectorMemory({ path: './vectors' })             // VectorMemory (vectra)
+```
+
+## RAG
+
+```ts
+import { createRAG } from '@agentskit/rag'
+
+const rag = createRAG({ embed: openaiEmbedder({ apiKey }), store: fileVectorMemory({ path: './v' }) })
+await rag.ingest(documents)
+const docs = await rag.retrieve('query')
+```
+
+## Observability
+
+```ts
+import { consoleLogger, langsmith, opentelemetry } from '@agentskit/observability'
+
+createRuntime({ adapter, observers: [consoleLogger(), langsmith({ apiKey })] })
+```
+
+## Sandbox
+
+```ts
+import { sandboxTool } from '@agentskit/sandbox'
+// → ToolDefinition for secure JS/Python execution via E2B
+```
+
+## Eval
+
+```ts
+import { runEval } from '@agentskit/eval'
+
+const result = await runEval({
+  agent: async (input) => runtime.run(input).then(r => r.content),
+  suite: { name: 'qa', cases: [{ input: 'Q', expected: 'A' }] },
+})
+// → { accuracy, passed, failed, results: [{ latencyMs, tokenUsage? }] }
+```
 
 ## Types
 
 ```ts
 Message { id, role, content, status, toolCalls?, metadata?, createdAt }
-ToolCall { id, name, args, result?, status }
-StreamChunk { type: 'text'|'tool_call'|'error'|'done', content?, toolCall? }
+ToolCall { id, name, args, result?, error?, status }
+ToolDefinition { name, description?, schema?, execute?, init?, dispose?, tags?, category? }
+SkillDefinition { name, description, systemPrompt, tools?, delegates?, onActivate? }
+RunResult { content, messages, steps, toolCalls, durationMs }
+AgentEvent = 'llm:start' | 'llm:end' | 'tool:start' | 'tool:end' | 'agent:step' | 'agent:delegate:start' | ...
 ```

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -4,31 +4,53 @@ sidebar_position: 1
 
 # Installation
 
-Install the React package plus adapters:
+Install only what you need. Every package is independently installable.
+
+## Chat UIs (React)
 
 ```bash
 npm install @agentskit/react @agentskit/adapters
 ```
 
-```bash
-yarn add @agentskit/react @agentskit/adapters
-```
+## Chat UIs (Terminal)
 
 ```bash
-pnpm add @agentskit/react @agentskit/adapters
+npm install @agentskit/ink @agentskit/adapters
 ```
 
-## Other entry points
+## Running Agents
 
 ```bash
-pnpm add @agentskit/core
-pnpm add @agentskit/ink
-pnpm add @agentskit/cli
+npm install @agentskit/runtime @agentskit/adapters @agentskit/tools
 ```
+
+## Full Ecosystem
+
+```bash
+npm install @agentskit/core @agentskit/react @agentskit/adapters @agentskit/runtime @agentskit/tools @agentskit/skills @agentskit/memory
+```
+
+## All Packages
+
+| Package | What it does |
+|---------|-------------|
+| `@agentskit/core` | Types, contracts, shared primitives |
+| `@agentskit/react` | React hooks + headless UI components |
+| `@agentskit/ink` | Terminal UI components (Ink) |
+| `@agentskit/adapters` | LLM provider adapters + embedders |
+| `@agentskit/cli` | CLI commands (chat, init, run) |
+| `@agentskit/runtime` | Standalone agent runtime (ReAct loop) |
+| `@agentskit/tools` | Built-in tools (web search, filesystem, shell) |
+| `@agentskit/skills` | Built-in skills (researcher, coder, planner, etc.) |
+| `@agentskit/memory` | Persistent backends (SQLite, Redis, vectra) |
+| `@agentskit/rag` | Retrieval-augmented generation |
+| `@agentskit/observability` | Logging + tracing (console, LangSmith, OpenTelemetry) |
+| `@agentskit/sandbox` | Secure code execution (E2B) |
+| `@agentskit/eval` | Agent evaluation and benchmarking |
 
 ## Peer Dependencies
 
-AgentsKit requires React 18 or later:
+React packages require React 18+:
 
 ```bash
 npm install react react-dom
@@ -36,10 +58,8 @@ npm install react react-dom
 
 ## Optional: Default Theme
 
-Import the default theme CSS for a polished chat UI out of the box:
-
 ```tsx
 import '@agentskit/react/theme'
 ```
 
-The theme uses CSS custom properties, so you can override any token without ejecting.
+Uses CSS custom properties — override any token without ejecting.

--- a/apps/docs/docs/infrastructure/cli.md
+++ b/apps/docs/docs/infrastructure/cli.md
@@ -1,0 +1,140 @@
+---
+sidebar_position: 4
+---
+
+# CLI
+
+`@agentskit/cli` provides terminal commands for chatting with agents, scaffolding new projects, and running runtime agents without a UI.
+
+## Installation
+
+```bash
+npm install -g @agentskit/cli
+# or use without installing:
+npx @agentskit/cli <command>
+```
+
+## Commands
+
+### `agentskit chat`
+
+Start an interactive chat session in the terminal.
+
+```bash
+agentskit chat [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--provider` | `string` | `demo` | AI provider: `anthropic`, `openai`, `demo` |
+| `--model` | `string` | Provider default | Model name, e.g. `claude-sonnet-4-6`, `gpt-4o` |
+| `--tools` | `string[]` | `[]` | Tool names to enable, e.g. `--tools search calculator` |
+| `--skill` | `string` | — | Load a pre-built skill by name, e.g. `--skill code-assistant` |
+| `--memory-backend` | `string` | `in-memory` | Memory backend: `in-memory`, `redis`, `postgres` |
+
+**Examples:**
+
+```bash
+# Chat with Claude using the code-assistant skill
+agentskit chat --provider anthropic --model claude-sonnet-4-6 --skill code-assistant
+
+# Chat with GPT-4o and specific tools
+agentskit chat --provider openai --model gpt-4o --tools search calculator
+
+# Use a persistent Redis memory backend
+agentskit chat --provider anthropic --memory-backend redis
+```
+
+Provider API keys are read from environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).
+
+---
+
+### `agentskit init`
+
+Scaffold a new AgentsKit project from a template.
+
+```bash
+agentskit init [project-name] [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--template` | `'react' \| 'ink'` | `react` | Project template to use |
+
+**Templates:**
+
+| Template | Description |
+|----------|-------------|
+| `react` | Browser chat app with `@agentskit/react` and Vite |
+| `ink` | Terminal chat app with `@agentskit/ink` and Ink |
+
+**Examples:**
+
+```bash
+# Create a React chat app
+agentskit init my-chat-app --template react
+
+# Create a terminal (Ink) app
+agentskit init my-terminal-agent --template ink
+```
+
+After scaffolding, follow the printed instructions:
+
+```bash
+cd my-chat-app
+npm install
+npm run dev
+```
+
+---
+
+### `agentskit run`
+
+Execute a runtime agent script directly from the terminal without a UI. Useful for automation, batch jobs, and testing agents in CI.
+
+```bash
+agentskit run <file> [options]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--input` | `string` | Initial input to pass to the agent |
+| `--output` | `'text' \| 'json'` | Output format (default: `text`) |
+
+**Example:**
+
+```bash
+# Run an agent script with a prompt
+agentskit run ./agents/summarizer.ts --input "Summarize the Q3 report"
+
+# Emit JSON output for pipeline consumption
+agentskit run ./agents/classifier.ts --input "Is this spam?" --output json
+```
+
+The agent file must export a default `AgentFn` or an AgentsKit agent instance:
+
+```ts
+// agents/summarizer.ts
+import { createAgent } from '@agentskit/core'
+import { anthropic } from '@agentskit/adapters'
+
+export default createAgent({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY }),
+  system: 'You are a concise summarizer.',
+})
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | API key for the Anthropic provider |
+| `OPENAI_API_KEY` | API key for the OpenAI provider |
+| `REDIS_URL` | Connection string for the Redis memory backend |
+| `DATABASE_URL` | Connection string for the Postgres memory backend |
+
+## Related
+
+- [Quick Start](../getting-started/quick-start.md) — build your first agent
+- [Eval](./eval.md) — use `agentskit run` in CI eval pipelines
+- [Adapters overview](../adapters/overview.md) — available providers and models

--- a/apps/docs/docs/infrastructure/eval.md
+++ b/apps/docs/docs/infrastructure/eval.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 3
+---
+
+# Eval
+
+`@agentskit/eval` runs structured evaluation suites against your agents. Results include accuracy, latency, and token usage — suitable for CI/CD gates and regression tracking.
+
+## Installation
+
+```bash
+npm install @agentskit/eval
+```
+
+## Running an Eval
+
+```ts
+import { runEval } from '@agentskit/eval'
+
+const results = await runEval({
+  agent: myAgent,
+  suite: mySuite,
+})
+
+console.log(results.accuracy)    // 0.92
+console.log(results.avgLatencyMs) // 1240
+console.log(results.totalTokens)  // 8432
+```
+
+## Defining a Suite
+
+An `EvalSuite` groups related test cases under a name:
+
+```ts
+import type { EvalSuite } from '@agentskit/eval'
+
+const mySuite: EvalSuite = {
+  name: 'Customer support — basic queries',
+  cases: [
+    {
+      input: 'What is your return policy?',
+      expected: 'returns',  // string: passes if output includes this substring
+    },
+    {
+      input: 'How do I reset my password?',
+      expected: (output) => output.toLowerCase().includes('email'),
+    },
+  ],
+}
+```
+
+## The AgentFn Type
+
+`runEval` accepts any function that matches `AgentFn`:
+
+```ts
+type AgentFnOutput = string | { content: string; tokenUsage?: TokenUsage }
+
+type AgentFn = (input: string) => Promise<AgentFnOutput>
+```
+
+Return a plain string for simple cases. Return an object with `tokenUsage` to have token metrics included in the report:
+
+```ts
+const agent: AgentFn = async (input) => {
+  const result = await myAgent.run(input)
+  return {
+    content: result.text,
+    tokenUsage: {
+      inputTokens: result.usage.input_tokens,
+      outputTokens: result.usage.output_tokens,
+    },
+  }
+}
+```
+
+## Expected Values
+
+| Expected type | Pass condition |
+|--------------|---------------|
+| `string` | Output **includes** the expected string (case-sensitive) |
+| `(output: string) => boolean` | Function returns `true` |
+
+## EvalTestCase
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `input` | `string` | Yes | Prompt sent to the agent |
+| `expected` | `string \| (output: string) => boolean` | Yes | Acceptance criterion |
+| `label` | `string` | No | Human-readable name shown in reports |
+
+## Metrics
+
+`runEval` returns an `EvalReport` with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `accuracy` | `number` | Fraction of cases that passed (0–1) |
+| `passed` | `number` | Count of passing cases |
+| `failed` | `number` | Count of failing cases |
+| `avgLatencyMs` | `number` | Mean time per agent call |
+| `totalTokens` | `number \| null` | Combined input + output tokens (null if not reported) |
+| `cases` | `CaseResult[]` | Per-case breakdown |
+
+## Error Handling
+
+By default, errors thrown by the agent are **recorded** and the case is marked as failed — the suite continues running. No single error aborts the whole run.
+
+```ts
+// A failing case looks like:
+{
+  input: 'crash prompt',
+  passed: false,
+  error: Error('rate limit exceeded'),
+  latencyMs: 312,
+}
+```
+
+Pass `{ throwOnError: true }` to halt on the first error instead:
+
+```ts
+const results = await runEval({ agent, suite, throwOnError: true })
+```
+
+## CI/CD Usage
+
+Use the exit code to gate deployments. `runEval` throws if accuracy falls below a threshold:
+
+```ts
+const results = await runEval({
+  agent,
+  suite,
+  minAccuracy: 0.9, // fails the process if accuracy < 90%
+})
+```
+
+Example GitHub Actions step:
+
+```yaml
+- name: Run agent evals
+  run: npx tsx evals/run.ts
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Keep eval suites small (10–50 cases) for fast CI feedback. Run larger regression suites on a schedule.
+
+## Related
+
+- [Observability](./observability.md) — trace eval runs for deeper inspection
+- [Sandbox](./sandbox.md) — run code-execution test cases safely

--- a/apps/docs/docs/infrastructure/observability.md
+++ b/apps/docs/docs/infrastructure/observability.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 1
+---
+
+# Observability
+
+`@agentskit/observability` provides pluggable tracing and logging for AgentsKit agents. All observers are lazy-loaded — only the code you use is bundled.
+
+## Installation
+
+```bash
+npm install @agentskit/observability
+```
+
+## Built-in Observers
+
+### Console Logger
+
+Logs agent events to the terminal in human-readable or structured JSON format.
+
+```ts
+import { consoleLogger } from '@agentskit/observability'
+
+const logger = consoleLogger({ format: 'human' }) // or 'json'
+```
+
+**Human format** prints colored, indented output for local development. **JSON format** emits newline-delimited JSON suitable for log aggregation pipelines.
+
+### LangSmith
+
+Sends a full trace hierarchy to LangSmith, including nested runs, token usage, and latency.
+
+```ts
+import { langsmith } from '@agentskit/observability'
+
+const observer = langsmith({
+  apiKey: process.env.LANGSMITH_API_KEY,
+  project: 'my-agent',
+})
+```
+
+Each agent run becomes a root trace in LangSmith. Tool calls, retrieval steps, and sub-agent invocations are recorded as child runs, preserving the full call hierarchy.
+
+### OpenTelemetry
+
+Exports spans using the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) over OTLP.
+
+```ts
+import { opentelemetry } from '@agentskit/observability'
+
+const observer = opentelemetry({
+  endpoint: 'http://localhost:4318/v1/traces', // OTLP HTTP endpoint
+  serviceName: 'my-agent-service',
+})
+```
+
+Spans include `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens` attributes. Compatible with Jaeger, Tempo, Honeycomb, and any OTLP-capable backend.
+
+## Shared Span Management
+
+`createTraceTracker` coordinates span context across multiple observers, ensuring parent–child relationships are consistent even when several observers run in parallel.
+
+```ts
+import { createTraceTracker } from '@agentskit/observability'
+
+const tracker = createTraceTracker()
+
+agent.use(tracker.middleware())
+```
+
+Use this when combining multiple observers so span IDs propagate correctly.
+
+## Custom Observers
+
+Implement the observer interface to integrate any tracing backend:
+
+```ts
+import type { Observer } from '@agentskit/observability'
+
+const myObserver: Observer = {
+  name: 'my-backend',
+  on(event) {
+    if (event.type === 'run:start') {
+      myBackend.startTrace({ id: event.runId, input: event.input })
+    }
+    if (event.type === 'run:end') {
+      myBackend.endTrace({ id: event.runId, output: event.output })
+    }
+  },
+}
+```
+
+### Observer Events
+
+| Event | Payload |
+|-------|---------|
+| `run:start` | `{ runId, input, metadata }` |
+| `run:end` | `{ runId, output, tokenUsage, durationMs }` |
+| `tool:start` | `{ runId, toolName, args }` |
+| `tool:end` | `{ runId, toolName, result, durationMs }` |
+| `error` | `{ runId, error }` |
+
+## Attaching Observers to an Agent
+
+```ts
+import { createAgent } from '@agentskit/core'
+import { consoleLogger, langsmith } from '@agentskit/observability'
+
+const agent = createAgent({
+  adapter,
+  observers: [
+    consoleLogger({ format: 'human' }),
+    langsmith({ apiKey: process.env.LANGSMITH_API_KEY }),
+  ],
+})
+```
+
+Multiple observers can run side-by-side; events are dispatched to all of them.
+
+## Related
+
+- [Eval](./eval.md) — measure agent quality with structured test suites
+- [Runtime](../agents/runtime.md) — agent configuration and lifecycle

--- a/apps/docs/docs/infrastructure/sandbox.md
+++ b/apps/docs/docs/infrastructure/sandbox.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 2
+---
+
+# Sandbox
+
+`@agentskit/sandbox` lets agents execute untrusted code safely. It ships with an E2B integration and a `SandboxBackend` interface for custom runtimes.
+
+## Installation
+
+```bash
+npm install @agentskit/sandbox
+```
+
+## Creating a Sandbox
+
+```ts
+import { createSandbox } from '@agentskit/sandbox'
+
+const sandbox = createSandbox()
+```
+
+By default the sandbox uses the E2B backend. Pass a custom backend to override.
+
+## Executing Code
+
+```ts
+const result = await sandbox.execute(`print("hello")`, {
+  language: 'python',
+  timeout: 10_000,  // ms — overrides the 30s default
+  maxMemoryMb: 25,  // overrides the 50 MB default
+})
+
+console.log(result.stdout)  // "hello\n"
+console.log(result.stderr)  // ""
+console.log(result.exitCode) // 0
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `language` | `'js' \| 'python'` | `'js'` | Runtime to use |
+| `timeout` | `number` | `30000` | Max execution time in ms |
+| `maxMemoryMb` | `number` | `50` | Memory cap in MB |
+| `network` | `boolean` | `false` | Allow outbound network access |
+
+## Security Defaults
+
+Every sandbox session runs with conservative defaults:
+
+- **No network access** — outbound connections are blocked unless `network: true`
+- **30-second timeout** — long-running code is killed automatically
+- **50 MB memory cap** — prevents memory exhaustion attacks
+- **Isolated filesystem** — each session gets a clean ephemeral directory
+
+## Language Support
+
+| Language | Identifier | Runtime |
+|----------|-----------|---------|
+| JavaScript / Node.js | `'js'` | Node 20 |
+| Python | `'python'` | Python 3.12 |
+
+## Using Sandbox as a Tool
+
+`sandboxTool()` wraps the sandbox in an AgentsKit-compatible tool so agents can execute code during a run:
+
+```ts
+import { createAgent } from '@agentskit/core'
+import { createSandbox, sandboxTool } from '@agentskit/sandbox'
+
+const sandbox = createSandbox()
+
+const agent = createAgent({
+  adapter,
+  tools: [sandboxTool(sandbox)],
+})
+```
+
+The agent can now call `run_code` during inference. The tool accepts `language` and `code` parameters and returns `stdout`, `stderr`, and `exitCode`.
+
+## Custom Backends
+
+Implement `SandboxBackend` to bring your own execution environment:
+
+```ts
+import type { SandboxBackend, ExecuteOptions, ExecuteResult } from '@agentskit/sandbox'
+
+const myBackend: SandboxBackend = {
+  async execute(code: string, options: ExecuteOptions): Promise<ExecuteResult> {
+    // spin up your container, VM, or WASM runtime
+    return { stdout: '', stderr: '', exitCode: 0 }
+  },
+  async dispose() {
+    // clean up resources
+  },
+}
+
+const sandbox = createSandbox({ backend: myBackend })
+```
+
+## E2B Integration
+
+The default backend uses [E2B](https://e2b.dev) cloud sandboxes. Set your API key before creating a sandbox:
+
+```ts
+const sandbox = createSandbox({
+  e2b: { apiKey: process.env.E2B_API_KEY },
+})
+```
+
+E2B sessions are reused across `execute` calls and automatically cleaned up when `sandbox.dispose()` is called.
+
+```ts
+// Always dispose when done to avoid idle billing
+await sandbox.dispose()
+```
+
+## Related
+
+- [Observability](./observability.md) — trace sandbox execution alongside agent runs
+- [Eval](./eval.md) — use sandboxed execution in evaluation test cases

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -13,6 +13,45 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Building Chat UIs',
+      items: [
+        'chat-uis/react',
+        'chat-uis/ink',
+        'chat-uis/components',
+        'chat-uis/theming',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Running Agents',
+      items: [
+        'agents/runtime',
+        'agents/tools',
+        'agents/skills',
+        'agents/delegation',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Data Layer',
+      items: [
+        'data-layer/adapters',
+        'data-layer/memory',
+        'data-layer/rag',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Infrastructure',
+      items: [
+        'infrastructure/observability',
+        'infrastructure/sandbox',
+        'infrastructure/eval',
+        'infrastructure/cli',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Core Hooks',
       items: [
         'hooks/use-stream',
@@ -22,18 +61,13 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Components',
-      items: ['components/overview'],
-    },
-    {
-      type: 'category',
-      label: 'Adapters',
-      items: ['adapters/overview'],
-    },
-    {
-      type: 'category',
-      label: 'Theming',
-      items: ['theming/overview'],
+      label: 'Legacy Reference',
+      collapsed: true,
+      items: [
+        'components/overview',
+        'adapters/overview',
+        'theming/overview',
+      ],
     },
     {
       type: 'category',


### PR DESCRIPTION
## Summary

Implements [#17](https://github.com/EmersonBraun/agentskit/issues/17).

### 15 new documentation pages organized by concept:

**Building Chat UIs** (4 pages)
- React: useChat, components, data-ak-* attributes, theme
- Ink: terminal UI, keyboard navigation
- Components: all headless components reference
- Theming: CSS variables, custom themes

**Running Agents** (4 pages)
- Runtime: ReAct loop, RunResult, AbortSignal
- Tools: web search, filesystem, shell, listTools
- Skills: 5 built-ins, composeSkills, delegates
- Delegation: auto-generated delegate tools, SharedContext

**Data Layer** (3 pages)
- Adapters: 13 providers, embedder functions
- Memory: SQLite, Redis, vectra, custom VectorStore
- RAG: chunking, embedding, retrieval, useRAGChat

**Infrastructure** (4 pages)
- Observability: console, LangSmith, OpenTelemetry
- Sandbox: E2B, SandboxBackend interface
- Eval: runEval, accuracy/latency metrics
- CLI: chat, init, run commands

### Also updated
- **Sidebar**: concept-centric structure (was flat categories)
- **Installation**: all 13 packages with comparison table
- **For AI Agents**: complete API surface in ~2K tokens
- All examples use demo adapter first, then real providers

## Test plan

- [x] Docs site builds without errors
- [x] No broken links
- [x] All 20 test suites pass
- [x] All 23 lint tasks pass