### PR TITLE
ci: enforce bundle size budget with size-limit  [closes #217]

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,31 @@
+name: Bundle size
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  size:
+    name: Check bundle size
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Run size-limit
+        run: pnpm exec size-limit

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "@agentskit/core (ESM)",
+    "path": "packages/core/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/core (CJS)",
+    "path": "packages/core/dist/index.cjs",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/adapters (ESM)",
+    "path": "packages/adapters/dist/index.js",
+    "limit": "20 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/react (ESM)",
+    "path": "packages/react/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/runtime (ESM)",
+    "path": "packages/runtime/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/memory (ESM)",
+    "path": "packages/memory/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/rag (ESM)",
+    "path": "packages/rag/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/tools (ESM)",
+    "path": "packages/tools/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/skills (ESM)",
+    "path": "packages/skills/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/observability (ESM)",
+    "path": "packages/observability/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/eval (ESM)",
+    "path": "packages/eval/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/sandbox (ESM)",
+    "path": "packages/sandbox/dist/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/ink (ESM)",
+    "path": "packages/ink/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/cli (ESM)",
+    "path": "packages/cli/dist/index.js",
+    "limit": "20 KB",
+    "gzip": true
+  },
+  {
+    "name": "@agentskit/templates (ESM)",
+    "path": "packages/templates/dist/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  }
+]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "turbo run lint",
     "dev": "turbo run dev --parallel",
     "docs": "pnpm --filter @agentskit/docs start",
-    "release": "pnpm build && pnpm changeset publish"
+    "release": "pnpm build && pnpm changeset publish",
+    "size": "pnpm build && size-limit",
+    "size:why": "pnpm build && size-limit --why"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -30,6 +32,8 @@
     "@agentskit/templates": "workspace:*",
     "@agentskit/tools": "workspace:*",
     "@changesets/cli": "2.30.0",
+    "@size-limit/file": "^12.1.0",
+    "size-limit": "^12.1.0",
     "turbo": "2.9.5",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@changesets/cli':
         specifier: 2.30.0
         version: 2.30.0(@types/node@25.5.2)
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0)
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0
       turbo:
         specifier: 2.9.5
         version: 2.9.5
@@ -43,7 +49,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/docs:
     dependencies:
@@ -55,13 +61,13 @@ importers:
         version: link:../../packages/react
       '@docusaurus/core':
         specifier: ^3.7.0
-        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/preset-classic':
         specifier: ^3.10.0
-        version: 3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)
+        version: 3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)
       '@docusaurus/theme-common':
         specifier: ^3.7.0
-        version: 3.9.2(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+        version: 3.9.2(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -80,10 +86,10 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.0
-        version: 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@docusaurus/types':
         specifier: ^3.10.0
-        version: 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
@@ -154,13 +160,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/example-react:
     dependencies:
@@ -188,13 +194,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/example-runtime:
     dependencies:
@@ -238,7 +244,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -287,7 +293,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     devDependencies:
@@ -324,7 +330,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ink:
     dependencies:
@@ -355,7 +361,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/memory:
     dependencies:
@@ -386,7 +392,7 @@ importers:
         version: 0.14.0(ws@8.20.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/observability:
     dependencies:
@@ -417,7 +423,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rag:
     dependencies:
@@ -436,7 +442,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/react:
     dependencies:
@@ -479,7 +485,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/runtime:
     dependencies:
@@ -498,7 +504,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/sandbox:
     dependencies:
@@ -520,7 +526,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/skills:
     dependencies:
@@ -536,7 +542,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/templates:
     dependencies:
@@ -555,7 +561,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/tools:
     dependencies:
@@ -577,7 +583,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -1956,8 +1962,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1968,8 +1986,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1980,8 +2010,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1992,8 +2034,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2004,8 +2058,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2016,8 +2082,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2028,8 +2106,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2040,8 +2130,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2052,8 +2154,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2064,8 +2178,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2076,8 +2202,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2088,8 +2226,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2100,8 +2250,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2840,6 +3002,12 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@slorber/react-helmet-async@1.3.0':
     resolution: {integrity: sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==}
     peerDependencies:
@@ -3558,6 +3726,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -4305,6 +4477,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5758,6 +5935,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -6985,6 +7165,16 @@ packages:
     resolution: {integrity: sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==}
     engines: {node: '>=12.0.0', npm: '>=5.6.0'}
     hasBin: true
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -9340,7 +9530,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -9352,7 +9542,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -9365,7 +9555,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/babel@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -9378,7 +9568,7 @@ snapshots:
       '@babel/runtime-corejs3': 7.29.2
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -9391,32 +9581,32 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/bundler@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/babel': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.27.7))
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.28.0))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.0(esbuild@0.27.7))
-      css-loader: 6.11.0(webpack@5.106.0(esbuild@0.27.7))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.0(esbuild@0.28.0))
+      css-loader: 6.11.0(webpack@5.106.0(esbuild@0.28.0))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0))
       cssnano: 6.1.2(postcss@8.5.9)
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.0(esbuild@0.27.7))
-      null-loader: 4.0.1(webpack@5.106.0(esbuild@0.27.7))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.0(esbuild@0.28.0))
+      null-loader: 4.0.1(webpack@5.106.0(esbuild@0.28.0))
       postcss: 8.5.9
-      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.27.7))
+      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.28.0))
       postcss-preset-env: 10.6.1(postcss@8.5.9)
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
-      webpack: 5.106.0(esbuild@0.27.7)
-      webpackbar: 6.0.1(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
+      webpack: 5.106.0(esbuild@0.28.0)
+      webpackbar: 6.0.1(webpack@5.106.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -9432,32 +9622,32 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/bundler@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/babel': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@docusaurus/cssnano-preset': 3.9.2
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/types': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.27.7))
+      '@docusaurus/types': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.28.0))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.0(esbuild@0.27.7))
-      css-loader: 6.11.0(webpack@5.106.0(esbuild@0.27.7))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.0(esbuild@0.28.0))
+      css-loader: 6.11.0(webpack@5.106.0(esbuild@0.28.0))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0))
       cssnano: 6.1.2(postcss@8.5.9)
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.0(esbuild@0.27.7))
-      null-loader: 4.0.1(webpack@5.106.0(esbuild@0.27.7))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.0(esbuild@0.28.0))
+      null-loader: 4.0.1(webpack@5.106.0(esbuild@0.28.0))
       postcss: 8.5.9
-      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.27.7))
+      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.28.0))
       postcss-preset-env: 10.6.1(postcss@8.5.9)
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
-      webpack: 5.106.0(esbuild@0.27.7)
-      webpackbar: 6.0.1(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
+      webpack: 5.106.0(esbuild@0.28.0)
+      webpackbar: 6.0.1(webpack@5.106.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -9473,15 +9663,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/babel': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/babel': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/bundler': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -9497,7 +9687,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.4
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.6(webpack@5.106.0(esbuild@0.27.7))
+      html-webpack-plugin: 5.6.6(webpack@5.106.0(esbuild@0.28.0))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -9507,7 +9697,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.0(esbuild@0.27.7))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.0(esbuild@0.28.0))
       react-router: 5.3.4(react@19.2.5)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5)
       react-router-dom: 5.3.4(react@19.2.5)
@@ -9516,9 +9706,9 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.0(esbuild@0.27.7))
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.0(esbuild@0.28.0))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -9536,15 +9726,15 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/core@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/core@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/babel': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/babel': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/bundler': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/mdx-loader': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -9560,7 +9750,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.4
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.6(webpack@5.105.4(esbuild@0.27.7))
+      html-webpack-plugin: 5.6.6(webpack@5.105.4(esbuild@0.28.0))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -9570,7 +9760,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.105.4(esbuild@0.27.7))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.105.4(esbuild@0.28.0))
       react-router: 5.3.4(react@19.2.5)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5)
       react-router-dom: 5.3.4(react@19.2.5)
@@ -9579,9 +9769,9 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.4(esbuild@0.27.7))
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.4(esbuild@0.28.0))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -9624,16 +9814,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       fs-extra: 11.3.4
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -9649,9 +9839,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
       vfile: 6.0.3
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -9659,16 +9849,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/mdx-loader@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       fs-extra: 11.3.4
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -9684,9 +9874,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
       vfile: 6.0.3
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -9694,9 +9884,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -9712,9 +9902,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -9730,17 +9920,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -9753,7 +9943,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9772,17 +9962,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.4
@@ -9793,7 +9983,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9812,18 +10002,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9842,12 +10032,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -9869,11 +10059,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
@@ -9897,11 +10087,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
       tslib: 2.8.1
@@ -9923,11 +10113,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
@@ -9950,11 +10140,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
       tslib: 2.8.1
@@ -9976,14 +10166,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
@@ -10007,18 +10197,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@svgr/core': 8.1.0(typescript@6.0.2)
       '@svgr/webpack': 8.1.0(typescript@6.0.2)
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10037,23 +10227,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/theme-classic': 3.10.0(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/theme-classic': 3.10.0(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.4(react@19.2.5)
     transitivePeerDependencies:
@@ -10082,21 +10272,21 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.0(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
+  '@docusaurus/theme-classic@3.10.0(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -10130,13 +10320,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -10154,13 +10344,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -10178,17 +10368,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.2)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.50.1)(algoliasearch@5.50.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.2(@algolia/client-search@5.50.1)(@types/react@19.2.14)(algoliasearch@5.50.1)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       algoliasearch: 5.50.1
       algoliasearch-helper: 3.28.1(algoliasearch@5.50.1)
       clsx: 2.1.1
@@ -10225,7 +10415,7 @@ snapshots:
       fs-extra: 11.3.4
       tslib: 2.8.1
 
-  '@docusaurus/types@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -10237,7 +10427,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -10246,7 +10436,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/types@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -10258,7 +10448,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -10267,9 +10457,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -10280,9 +10470,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -10293,11 +10483,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -10312,11 +10502,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -10331,14 +10521,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -10351,9 +10541,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10363,14 +10553,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/types': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.9.2(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.9.2(esbuild@0.28.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -10383,9 +10573,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0))
       utility-types: 3.11.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10418,79 +10608,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@exodus/bytes@1.15.0': {}
@@ -11200,6 +11468,10 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      size-limit: 12.1.0
+
   '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11570,10 +11842,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -11592,6 +11864,24 @@ snapshots:
     optionalDependencies:
       msw: 2.13.2(@types/node@25.5.2)(typescript@6.0.2)
       vite: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.2(@types/node@25.5.2)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.2(@types/node@25.5.2)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -11858,12 +12148,12 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.27.7)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -12027,6 +12317,8 @@ snapshots:
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.0.0: {}
 
@@ -12316,7 +12608,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.0(esbuild@0.27.7)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -12324,7 +12616,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -12371,7 +12663,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.106.0(esbuild@0.27.7)):
+  css-loader@6.11.0(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.9)
       postcss: 8.5.9
@@ -12382,9 +12674,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.9)
@@ -12392,10 +12684,10 @@ snapshots:
       postcss: 8.5.9
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     optionalDependencies:
       clean-css: 5.3.3
-      esbuild: 0.27.7
+      esbuild: 0.28.0
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.9):
     dependencies:
@@ -12788,6 +13080,36 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+    optional: true
+
   escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
@@ -12969,11 +13291,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)):
+  file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   file-uri-to-path@1.0.0: {}
 
@@ -13394,7 +13716,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.6(webpack@5.105.4(esbuild@0.27.7)):
+  html-webpack-plugin@5.6.6(webpack@5.105.4(esbuild@0.28.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -13402,9 +13724,9 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.2
     optionalDependencies:
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
 
-  html-webpack-plugin@5.6.6(webpack@5.106.0(esbuild@0.27.7)):
+  html-webpack-plugin@5.6.6(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -13412,7 +13734,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.2
     optionalDependencies:
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -14544,11 +14866,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.106.0(esbuild@0.27.7)):
+  mini-css-extract-plugin@2.10.2(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.2
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   minimalistic-assert@1.0.1: {}
 
@@ -14625,6 +14947,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   napi-build-utils@2.0.0: {}
 
   negotiator@0.6.3: {}
@@ -14671,11 +14997,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.106.0(esbuild@0.27.7)):
+  null-loader@4.0.1(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   object-assign@4.1.1: {}
 
@@ -15078,13 +15404,13 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-loader@7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.27.7)):
+  postcss-loader@7.3.4(postcss@8.5.9)(typescript@6.0.2)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.2)
       jiti: 1.21.7
       postcss: 8.5.9
       semver: 7.7.4
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - typescript
 
@@ -15519,17 +15845,17 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.105.4(esbuild@0.27.7)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.105.4(esbuild@0.28.0)):
     dependencies:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.0(esbuild@0.27.7)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
 
   react-reconciler@0.33.0(react@19.2.4):
     dependencies:
@@ -16055,6 +16381,14 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  size-limit@12.1.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -16292,25 +16626,25 @@ snapshots:
 
   terminal-size@4.0.1: {}
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.7)(webpack@5.105.4(esbuild@0.27.7)):
+  terser-webpack-plugin@5.4.0(esbuild@0.28.0)(webpack@5.105.4(esbuild@0.28.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.0
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7)):
+  terser-webpack-plugin@5.4.0(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.0
 
   terser@5.46.1:
     dependencies:
@@ -16586,14 +16920,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.27.7)))(webpack@5.106.0(esbuild@0.27.7)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.0(esbuild@0.28.0)))(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.27.7))
+      file-loader: 6.2.0(webpack@5.106.0(esbuild@0.28.0))
 
   util-deprecate@1.0.2: {}
 
@@ -16666,6 +17000,37 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.2
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.2
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
@@ -16687,6 +17052,66 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.5.2
+      happy-dom: 20.8.9
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.5.2
+      happy-dom: 20.8.9
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -16739,7 +17164,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.4(esbuild@0.27.7)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.4(esbuild@0.28.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -16748,11 +17173,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.0(esbuild@0.27.7)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -16761,11 +17186,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.4(esbuild@0.27.7)):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.4(esbuild@0.28.0)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16793,10 +17218,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.4(esbuild@0.27.7))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.4(esbuild@0.28.0))
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.105.4(esbuild@0.27.7)
+      webpack: 5.105.4(esbuild@0.28.0)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16804,7 +17229,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.0(esbuild@0.27.7)):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16832,10 +17257,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.0(esbuild@0.27.7))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.0(esbuild@0.28.0))
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16857,7 +17282,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.105.4(esbuild@0.27.7):
+  webpack@5.105.4(esbuild@0.28.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16881,7 +17306,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.105.4(esbuild@0.27.7))
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.105.4(esbuild@0.28.0))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -16889,7 +17314,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.106.0(esbuild@0.27.7):
+  webpack@5.106.0(esbuild@0.28.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16913,7 +17338,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.106.0(esbuild@0.28.0))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -16921,7 +17346,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.106.0(esbuild@0.27.7)):
+  webpackbar@6.0.1(webpack@5.106.0(esbuild@0.28.0)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -16930,7 +17355,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.106.0(esbuild@0.27.7)
+      webpack: 5.106.0(esbuild@0.28.0)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:


### PR DESCRIPTION
## Summary

Adds **`size-limit`** to enforce gzipped bundle sizes on every PR. Closes #217 and verifies Manifesto principle 1 (`@agentskit/core` < 10 KB gzipped).

## How it works

- `.size-limit.json` declares budgets per package (gzipped, ESM + CJS where relevant)
- Local commands:
  - `pnpm size` — verify all packages
  - `pnpm size:why` — bundle inspector
- CI workflow `.github/workflows/size.yml` runs on every PR + push to main; blocks merge if any package exceeds its budget

## Current measured sizes (all under budget)

| Package | Limit | Actual | Headroom |
|---|---|---|---|
| `@agentskit/core` (ESM) | 10 KB | **5.22 KB** | 48% |
| `@agentskit/core` (CJS) | 10 KB | 5.30 KB | 47% |
| `@agentskit/adapters` | 20 KB | 4.32 KB | 78% |
| `@agentskit/react` | 15 KB | 2.58 KB | 83% |
| `@agentskit/runtime` | 15 KB | 2.34 KB | 84% |
| `@agentskit/memory` | 15 KB | 2.73 KB | 82% |
| `@agentskit/rag` | 10 KB | 852 B | 92% |
| `@agentskit/tools` | 15 KB | 2.27 KB | 85% |
| `@agentskit/skills` | 10 KB | 5.19 KB | 48% |
| `@agentskit/observability` | 10 KB | 2.95 KB | 70% |
| `@agentskit/eval` | 10 KB | 556 B | 95% |
| `@agentskit/sandbox` | 10 KB | 1.53 KB | 85% |
| `@agentskit/ink` | 15 KB | 1.33 KB | 91% |
| `@agentskit/cli` | 20 KB | 177 B | 99% |
| `@agentskit/templates` | 15 KB | 2.89 KB | 81% |

## Why `@size-limit/file` instead of `preset-small-lib`

The small-lib preset bundles via esbuild expecting browser code. Most AgentsKit packages use Node builtins (`fs/promises`, `path`, `child_process`) which esbuild can't resolve without `platform: 'node'`. Since these are libs published to npm (consumers bundle them, not us), measuring the **published file gzipped** is the right metric. `@size-limit/file` does exactly that.

## Trade-offs

- **No tree-shake measurement** — small-lib measures "what would a user pay if they imported the whole index". File mode measures "the published file". For libs with named exports (which we encourage in CLAUDE.md), tree-shaking handles userland anyway.
- **Headroom is generous** — limits are set 2-4x current size. This gives breathing room for legitimate growth without becoming a meaningless rubber-stamp. Will tighten if any package consistently grows.

## Test plan

- [x] `pnpm size` runs locally and passes
- [x] `pnpm build && pnpm exec size-limit` produces correct numbers
- [x] Workflow YAML validates
- [ ] CI on this PR shows the size check passing
- [ ] (Future PR test) deliberately bloat a package, confirm CI blocks merge

## Follow-ups

- Add size-limit comment-on-PR action (currently CLI-only)
- Add `size-limit-action` from andresz1/size-limit-action for delta reporting (size went up by X% in this PR)
- Tighten budgets after 2-3 sprints of stable measurement

Closes #217
Refs #211