### PR TITLE
feat: declare stability tier per package [closes #227]

### DIFF
--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,0 +1,89 @@
+# Stability policy
+
+Every AgentsKit package declares a **stability tier** in its `package.json` under the `agentskit` field:
+
+```json
+{
+  "name": "@agentskit/core",
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Sacred package. Contract-stable per ADRs 0001-0006."
+  }
+}
+```
+
+Each package's `README.md` displays a corresponding badge at the top.
+
+## The three tiers
+
+### `stable`
+
+> Safe for production. Breaking changes require a major version bump and a deprecation cycle.
+
+- **API is frozen at the minor level** — we will not break public exports in a minor or patch release
+- **Contracts are pinned to ADRs** — any contract change needs a new ADR and coordinated major bump of all affected packages
+- **Deprecation path required** — a deprecated API remains available for at least one minor release before removal
+- **Changesets describe every user-facing change** explicitly
+
+### `beta`
+
+> Usable in production, but expect some rough edges and occasional breaking changes between minor versions.
+
+- Public API shape may still be adjusted as real usage teaches us
+- **Breaking changes land in minor bumps** with migration notes in the CHANGELOG (not a major bump — that's reserved for `stable` contracts)
+- Contracts derived from ADRs are respected; conveniences and helpers around them are still evolving
+- Semver-within-tier: within `0.x`, a minor bump can break beta packages; a patch bump cannot
+
+### `experimental`
+
+> Provisional. Treat the API as disposable. Do not build public libraries on top of this.
+
+- Anything may change in any release — including removal
+- No deprecation guarantees
+- Useful for exploring a design before committing to a contract
+- A package stays experimental until it either graduates to `beta` or is removed
+
+## Current tier map
+
+| Package | Tier | Rationale |
+|---|---|---|
+| `@agentskit/core` | `stable` | Sacred package. Contract-stable per ADRs 0001–0006 |
+| `@agentskit/adapters` | `stable` | All shipped adapters satisfy Adapter contract v1 |
+| `@agentskit/react` | `stable` | Production-ready hooks and headless components |
+| `@agentskit/ink` | `stable` | Terminal UI at parity with `@agentskit/react` |
+| `@agentskit/cli` | `stable` | `chat`, `init`, `run` commands stable |
+| `@agentskit/runtime` | `stable` | ReAct loop and delegation per ADR 0006 |
+| `@agentskit/tools` | `stable` | Web search, filesystem, shell — Tool contract v1 |
+| `@agentskit/skills` | `stable` | Pre-built skills — Skill contract v1 |
+| `@agentskit/memory` | `stable` | File/SQLite/Redis backends — Memory contract v1 |
+| `@agentskit/rag` | `stable` | Retriever contract v1 |
+| `@agentskit/templates` | `stable` | Authoring toolkit for custom skills/tools |
+| `@agentskit/observability` | `beta` | Observer contract stable; integration coverage growing |
+| `@agentskit/sandbox` | `beta` | E2B integration works; WebContainer fallback is still experimental |
+| `@agentskit/eval` | `beta` | Core APIs stable; richer metrics and reporters coming |
+
+## Until v1.0.0
+
+AgentsKit is pre-1.0 at the project level while every package is tier-declared individually. That is intentional: the **substrate** (core + the six ADR contracts) has stable semantics today, and we want to mark the packages implementing them honestly — but the project as a whole hasn't yet passed the version-1 commitment threshold (long-running public use, external contributors in steady state, stabilized CI gates).
+
+Reaching v1.0.0 means:
+
+- All six core contracts have at least one external consumer outside our repo
+- The CI gates (bundle size, coverage) have held for two full sprints without regression
+- A public commitment to the semver discipline above is documented and honored
+
+## How to change a tier
+
+- **`experimental` → `beta`**: open a PR that updates `package.json.agentskit.stability`, the README badge, and explains in the PR what changed to earn the bump. No RFC needed.
+- **`beta` → `stable`**: requires an RFC and at least one minor release where the package operated at beta without breaking changes. The RFC documents the public API surface being committed to.
+- **`stable` → `beta`** or lower: requires an RFC and a major version bump of the package. Do not demote a stable package lightly.
+
+## How consumers should read this
+
+If a package is `stable`, pin it with `^x.y.z` and trust the minor-bump contract. If it's `beta`, use `~x.y.z` if you're conservative, or accept minor bumps may break you. If it's `experimental`, pin exact and read the changelog on every update.
+
+## References
+
+- This policy lives at `/docs/STABILITY.md`
+- Cross-referenced from the [Manifesto](../MANIFESTO.md) (principle 1 — "the core is sacred") and from every package README badge
+- Related ADRs: 0001 Adapter, 0002 Tool, 0003 Memory, 0004 Retriever, 0005 Skill, 0006 Runtime

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -1,5 +1,7 @@
 # @agentskit/adapters
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Connect to any LLM provider — and swap between them — without touching your app code.
 
 ## Why

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -46,5 +46,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "All 10+ adapters satisfy Adapter contract v1 (ADR 0001)."
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,7 @@
 # @agentskit/cli
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Chat with any LLM, scaffold projects, and run agents — all from your terminal.
 
 ## Why

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,5 +57,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "chat, init, run commands stable."
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,7 @@
 # @agentskit/core
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 The zero-dependency foundation that every AgentsKit package builds on.
 
 ## Why

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,5 +42,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Sacred package. Contract-stable per ADRs 0001-0006."
   }
 }

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,5 +1,7 @@
 # @agentskit/eval
 
+![stability: beta](https://img.shields.io/badge/stability-beta-yellow)
+
 Measure agent quality with numbers, not vibes — ship with confidence.
 
 ## Why

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -44,5 +44,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "beta",
+    "stabilityNote": "Core APIs stable; richer metrics and reporters coming."
   }
 }

--- a/packages/ink/README.md
+++ b/packages/ink/README.md
@@ -1,5 +1,7 @@
 # @agentskit/ink
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Build terminal AI chat interfaces with the exact same API as `@agentskit/react`.
 
 ## Why

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -51,5 +51,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Terminal UI at parity with @agentskit/react."
   }
 }

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -1,5 +1,7 @@
 # @agentskit/memory
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Persist conversations and add vector search to your agents — swap backends without changing agent code.
 
 ## Why

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -48,5 +48,9 @@
     "typescript": "^6.0.2",
     "vectra": "^0.14.0",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "File/SQLite/Redis backends — Memory contract v1."
   }
 }

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,5 +1,7 @@
 # @agentskit/observability
 
+![stability: beta](https://img.shields.io/badge/stability-beta-yellow)
+
 See exactly what your agent does — every LLM call, tool execution, and reasoning step — with zero coupling to your agent code.
 
 ## Why

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -48,5 +48,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "beta",
+    "stabilityNote": "Observer contract stable; integration coverage growing."
   }
 }

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -1,5 +1,7 @@
 # @agentskit/rag
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Plug-and-play retrieval-augmented generation: chunk documents, embed them, and retrieve the right context at query time.
 
 ## Why

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -44,5 +44,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Retriever contract v1. Ingest + retrieve shipped."
   }
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,7 @@
 # @agentskit/react
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Add streaming AI chat to any React app in 10 lines of code.
 
 ## Why

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,5 +57,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Production-ready hooks and headless components."
   }
 }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,5 +1,7 @@
 # @agentskit/runtime
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Run autonomous agents in 5 lines — no UI, no boilerplate, just results.
 
 ## Why

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -44,5 +44,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "ReAct loop and delegation per ADR 0006."
   }
 }

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,5 +1,7 @@
 # @agentskit/sandbox
 
+![stability: beta](https://img.shields.io/badge/stability-beta-yellow)
+
 Let agents write and run code safely — in isolated cloud VMs, not on your machine.
 
 ## Why

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -45,5 +45,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "beta",
+    "stabilityNote": "E2B integration works; WebContainer fallback experimental."
   }
 }

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,5 +1,7 @@
 # @agentskit/skills
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Pre-tuned agent personas that work out of the box — skills are what your agent IS, tools are what it CAN DO.
 
 ## Why

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -43,5 +43,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Pre-built skills — Skill contract v1."
   }
 }

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,5 +1,7 @@
 # @agentskit/templates
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Create, validate, and scaffold custom AgentsKit extensions — tools, skills, and adapters — ready to publish and share.
 
 ## Why

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -44,5 +44,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Authoring toolkit for custom skills/tools."
   }
 }

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,5 +1,7 @@
 # @agentskit/tools
 
+![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
+
 Give your agents real-world capabilities without writing a single integration.
 
 ## Why

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -45,5 +45,9 @@
     "tsup": "^8.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "agentskit": {
+    "stability": "stable",
+    "stabilityNote": "Web search, filesystem, shell tools — Tool contract v1."
   }
 }


### PR DESCRIPTION
## Summary

Every package now declares an explicit **stability tier** in `package.json` under a new `agentskit` field, with a matching badge in each README.

Closes #227. Pairs with the Manifesto (principle 1 — 'the core is sacred') and the six ADRs which pin the contracts each 'stable' package implements.

## What changed

### Every `package.json`

```json
{
  "name": "@agentskit/core",
  "agentskit": {
    "stability": "stable",
    "stabilityNote": "Sacred package. Contract-stable per ADRs 0001-0006."
  }
}
```

The `stabilityNote` is for future programmatic uses (e.g., `agentskit doctor` could warn when a beta package is used in a 'production' config).

### Every package README

A shields.io badge right under the title:

```markdown
# @agentskit/core

![stability: stable](https://img.shields.io/badge/stability-stable-brightgreen)
```

### New `docs/STABILITY.md`

Full policy doc explaining:

- What each tier means (API freeze level, break-rules, deprecation path)
- Current tier map for all 14 packages with rationale
- Rules for promoting/demoting between tiers (beta→stable needs RFC; stable→beta needs major bump)
- The path to v1.0.0 at the project level

## Tier map

| Tier | Packages |
|---|---|
| `stable` (11) | core, adapters, react, ink, cli, runtime, tools, skills, memory, rag, templates |
| `beta` (3) | observability, sandbox, eval |

## Rationale for `beta` trio

- `@agentskit/observability` — Observer contract is stable (RT9), but provider integrations (LangSmith, OpenTelemetry, PostHog) are still being rounded out
- `@agentskit/sandbox` — E2B backend works; WebContainer fallback is still experimental
- `@agentskit/eval` — core APIs stable, but richer metrics and reporters are coming in Phase 2/3

## Test plan

- [x] 14 `package.json` files updated with matching `agentskit` blocks
- [x] 14 README files show the correct badge
- [x] New `docs/STABILITY.md` renders on GitHub
- [x] `pnpm test` — 13 packages pass (ink fails due to pre-existing ink@7 / ink-testing-library@4 incompat fixed in #265; unchanged by this PR)
- [ ] Reviewer: confirm the beta trio is fair (should anything be downgraded to experimental or upgraded to stable?)
- [ ] Reviewer: confirm the v1.0.0 criteria in STABILITY.md are the right bar

Refs #227 #211