### PR TITLE
docs: CONVENTIONS.md per package [closes #232]

### DIFF
--- a/packages/adapters/CONVENTIONS.md
+++ b/packages/adapters/CONVENTIONS.md
@@ -1,0 +1,66 @@
+# Conventions — `@agentskit/adapters`
+
+The provider layer. Every file in this package maps one LLM or one embedding provider to AgentsKit's stable contracts.
+
+## Scope
+
+- **Chat adapters** — implement `AdapterFactory` per [ADR 0001](../../docs/architecture/adrs/0001-adapter-contract.md)
+- **Embedders** — implement `EmbedFn` per [ADR 0003](../../docs/architecture/adrs/0003-memory-contract.md)
+- **No UI.** No React, no Ink, no CLI here.
+- **No runtime logic.** No loops, no tool execution. Just transport.
+
+## Adding a new chat adapter
+
+1. Create `src/<provider>.ts`. Export a factory function that returns `AdapterFactory`.
+2. Accept configuration at construction time only: `apiKey`, `model`, `baseUrl` as needed.
+3. In `createSource`, build the request but **do not fetch yet**. Defer all I/O to `stream()` — invariant A1.
+4. In `stream()`, use the SSE utility from `src/utils.ts` if the provider speaks server-sent events. Otherwise write a parser that respects the chunk shape in `@agentskit/core`.
+5. Always end with `{ type: 'done' }`, an error chunk, or iterator return on abort — invariant A3.
+6. Yield `{ type: 'text', content }` for text deltas. Yield `{ type: 'tool_call', toolCall: { id, name, args } }` with **complete args** per invariant A5.
+7. Put provider-specific data in `chunk.metadata` (usage counts, raw response, reasoning). Consumers must not depend on its shape — A8.
+8. Re-export from `src/index.ts`.
+
+## Adding a new embedder
+
+1. Create `src/embedders/<provider>.ts`. Export a factory returning `EmbedFn`.
+2. Accept `apiKey`, `model` at construction.
+3. Return a function of `(text: string) => Promise<number[]>`.
+4. Must be stable: same input + same model = same vector. No randomness — invariant E1.
+5. Re-export from `src/embedders/index.ts` and from `src/index.ts`.
+
+## Naming
+
+- File name matches the provider: `openai.ts`, `anthropic.ts`, `gemini.ts`, etc.
+- Factory function matches the provider lowercase: `openai(opts)`, `anthropic(opts)`.
+- Options interface: `OpenAIAdapterOptions`, `AnthropicAdapterOptions`.
+- Types internal to one adapter live in the same file; shared types go in `src/types.ts`.
+
+## Testing
+
+For every new adapter:
+
+- **Contract test** using the shared `AdapterContractSuite` (when it lands — for now, at minimum run the ten invariants mentally against your implementation)
+- **Stream parsing test** with a recorded fixture (JSON file of SSE chunks) so tests are fast and deterministic
+- **Error path test** — what happens on 401, 429, 500, malformed response
+- **Abort test** — `stream()` iteration terminates when `abort()` is called mid-flight
+
+Tests live in `tests/<provider>.test.ts`.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Calling `fetch` from `createSource` | Defer to `stream()` |
+| Mutating the input `messages` array | Copy if you need to transform for the wire format |
+| Throwing from `stream()` on a provider error | Emit `{ type: 'error', metadata: { error } }` |
+| Streaming partial tool-call args across multiple chunks | v1 requires complete args in one chunk. Buffer internally. |
+| Exposing provider SDK types in your public API | Keep the public surface limited to `AdapterFactory` |
+
+## Review checklist for this package
+
+- [ ] Implements all ten invariants A1–A10
+- [ ] Bundle size under 20KB gzipped (tightens over time)
+- [ ] Coverage threshold holds (60% lines; aiming for 80%)
+- [ ] Contract-tested against the ten invariants
+- [ ] SSE parsing uses `src/utils.ts` helpers where possible
+- [ ] README updated if the public export surface changed

--- a/packages/cli/CONVENTIONS.md
+++ b/packages/cli/CONVENTIONS.md
@@ -1,0 +1,54 @@
+# Conventions — `@agentskit/cli`
+
+The `agentskit` command-line interface. The entry point for people who want to try AgentsKit without writing code first.
+
+## Scope
+
+- `agentskit chat` — interactive Ink chat with any provider
+- `agentskit init` — scaffold a new project
+- `agentskit run` — execute runtime agents from the terminal
+- Future: `agentskit doctor`, `agentskit dev`, `agentskit tunnel` (tracked in Phase 1)
+
+## Adding a new command
+
+1. Create `src/commands/<name>.ts`.
+2. Export a function that takes parsed arguments and runs the command — no classes.
+3. Wire the command in `src/bin.ts` using the existing argv parser.
+4. Print help output that fits on one screen (`--help` reads as documentation).
+5. Exit cleanly with `process.exit(code)` only at the top level. Never in a library function.
+
+## Output conventions
+
+- Keep terminal output terse. One line per meaningful event.
+- Use `chalk` or Ink for color. Do not hardcode ANSI codes.
+- Respect `--quiet` and `--json` flags where applicable.
+- Errors go to stderr; structured output goes to stdout.
+
+## Flag conventions
+
+- Short form (`-p`) for frequent flags, long form (`--provider`) always present.
+- Defaults shown in `--help`.
+- Mutually-exclusive flags fail fast with a clear error.
+
+## Testing
+
+- Use `vitest` with child-process spawns for e2e coverage of the `bin.ts` entry.
+- Unit-test individual commands with mocked adapters.
+- Test fixtures live in `tests/fixtures/`.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Using `process.exit` in a library function | Return an exit code from the command function; only `bin.ts` calls `process.exit` |
+| Reading `process.argv` outside `bin.ts` | Pass parsed args down |
+| Hardcoding provider names | Accept `--provider <name>` and route to the right adapter |
+| Emitting unstructured text with `--json` set | Emit JSON; add `--format=json` if both are needed |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 20KB gzipped
+- [ ] Coverage threshold holds (30%, climbing)
+- [ ] `--help` output is one screen and accurate
+- [ ] Spawn-based e2e test for the new command
+- [ ] Exit codes: 0 success, 1 expected failure, 2 usage error

--- a/packages/core/CONVENTIONS.md
+++ b/packages/core/CONVENTIONS.md
@@ -1,0 +1,62 @@
+# Conventions — `@agentskit/core`
+
+The sacred package. Every rule here is stricter than the rest of the monorepo.
+
+## Non-negotiables
+
+- **Zero runtime dependencies.** `dependencies` in `package.json` is empty and stays empty. Never add one, not even "small".
+- **Under 10KB gzipped.** CI (`size-limit`) enforces. If you're pushing the limit, the change is too big.
+- **Contracts first.** Public types and interfaces for every contract live here — Adapter, Tool, Memory, Retriever, Skill, Runtime. Implementations live in other packages.
+- **Named exports only.** No default exports, anywhere, ever.
+- **No `any`.** Use `unknown` and narrow with type guards.
+
+## What belongs here
+
+- **Types and interfaces** for the six core contracts (ADRs 0001–0006)
+- **Shared primitives** reused by multiple packages: `createEventEmitter`, `safeParseArgs`, `consumeStream`, message-building helpers
+- **The chat controller** (`controller.ts`) — headless state machine for a chat session
+- **The agent loop core** (`agent-loop.ts`) — the substrate the runtime builds on
+
+## What does NOT belong here
+
+- Any provider SDK or API client → `@agentskit/adapters`
+- Any React hook or component → `@agentskit/react`
+- Any Ink component → `@agentskit/ink`
+- Any file I/O → `@agentskit/memory` or a package that's not zero-dep
+- Any `node:*` import that's not available on every runtime we target (edge, Deno, browser)
+
+## Adding a new primitive
+
+1. Is the thing a **contract type**? Put it in `src/types/*.ts` and re-export from `src/types/index.ts`. Write an ADR if it's cross-package.
+2. Is it a **reusable helper** used by 2+ packages? Put it in `src/primitives.ts` or a dedicated file, export from `src/index.ts`.
+3. Write unit tests that exercise only the public export. Do **not** reach into internals.
+
+Every addition raises the bundle size. Run `pnpm size` in the repo root and verify the core budget still holds.
+
+## Testing
+
+- Pure unit tests with `vitest`. Environment is `node`.
+- Avoid mocks — test real functions with real inputs.
+- Mocked adapters for stream-related tests are acceptable since the Adapter contract is the seam.
+
+## Files you can edit without an ADR
+
+- Bug fixes that don't change exported types
+- New internal helpers (not exported)
+- JSDoc improvements
+- Test additions
+
+## Files that require an ADR first
+
+- Any `src/types/*.ts` change that alters an exported type
+- Any new exported function or class
+- Anything that touches the bundle size beyond ~500 bytes gzipped
+
+## Review checklist for this package
+
+- [ ] No new runtime dependency (check `package.json`)
+- [ ] Bundle size under 10KB gzipped (`pnpm size`)
+- [ ] Coverage threshold holds (75% lines)
+- [ ] No `any` introduced
+- [ ] Named exports only
+- [ ] ADR linked if a contract changed

--- a/packages/eval/CONVENTIONS.md
+++ b/packages/eval/CONVENTIONS.md
@@ -1,0 +1,56 @@
+# Conventions — `@agentskit/eval`
+
+Agent evaluation and benchmarking. Treats agents like production systems — scored, regressed-against, tracked over time.
+
+## Stability tier: `beta`
+
+Core `runEval(dataset)` is stable. Reporters, metrics, dataset shape may gain fields in minor bumps.
+
+## Scope
+
+- `runEval({ runtime, dataset, concurrency })` — runs a dataset, returns a report
+- Scoring helpers (exact-match, regex, LLM-as-judge)
+- Reporters (console, JSON file; more coming)
+- Types: `EvalCase`, `EvalReport`, `ScoreFn`
+
+## Design principles
+
+- **Evaluation is testing for non-determinism.** Consumers should use `vitest` or similar as the runner; this package provides the primitives.
+- **Scores are numbers in `[0, 1]`.** Boolean outcomes coerce (`true` → 1, `false` → 0).
+- **Every metric is optional**. Latency, cost, tokens — report if available, skip otherwise.
+- **Replay-first** (future): when deterministic replay lands, eval runs should be reproducible from a recorded trace.
+
+## Adding a metric
+
+1. Add the field to `EvalReport` in `src/types.ts`.
+2. Compute it in `runEval`'s aggregation loop.
+3. Make it optional — some runtimes/adapters won't have it.
+4. Document in the package README.
+
+## Adding a reporter
+
+1. Create `src/reporters/<name>.ts`.
+2. Export a factory: `export function jsonReporter(opts): Reporter`.
+3. `Reporter` has `onCase(case, result)` and `onComplete(report)` events.
+4. Keep it synchronous where possible; non-blocking where not.
+
+## Testing
+
+- Unit tests for scorers and aggregation with deterministic fixtures.
+- Integration test that runs a tiny dataset against a mock runtime end-to-end.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Blocking tests on real model calls | Use deterministic mock adapters |
+| Assuming every result has `tokensUsed` | Make metrics optional |
+| Scoring via string equality on LLM outputs | Use LLM-as-judge for fuzzy outputs |
+| Mutating input dataset | Treat `EvalCase[]` as read-only |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 10KB gzipped
+- [ ] Coverage threshold holds (95% lines — mostly pure logic)
+- [ ] New metric documented in README
+- [ ] No hard dependency on any one adapter or reporter

--- a/packages/ink/CONVENTIONS.md
+++ b/packages/ink/CONVENTIONS.md
@@ -1,0 +1,64 @@
+# Conventions — `@agentskit/ink`
+
+Terminal UI components for AgentsKit. Mirrors `@agentskit/react`'s surface but for Ink.
+
+## Scope
+
+- **Ink components** — `ChatContainer`, `Message`, `InputBar`, `ThinkingIndicator`, `ToolCallView`
+- **Ink hooks** — thin wrappers around `@agentskit/core` primitives for Ink-friendly consumption
+- Input handling that respects terminal raw-mode semantics
+
+## What does NOT belong here
+
+- React DOM components → `@agentskit/react`
+- Autonomous runtime → `@agentskit/runtime`
+- Anything requiring a DOM
+
+## Adding a new component
+
+1. Create `src/components/<Name>.tsx`. PascalCase.
+2. Use only `ink` primitives — `Box`, `Text`, `useInput`, `useFocus`, etc.
+3. No ANSI escape codes in component logic; let `ink` handle rendering.
+4. Re-export from `src/components/index.ts` and from `src/index.ts`.
+
+## Input handling
+
+- Use `ink`'s `useInput` hook. Do not read stdin directly.
+- Gate input on `chat.status` — block input while `streaming`.
+- Respect the `disabled` prop everywhere a component accepts user input.
+
+## Testing
+
+- `ink-testing-library@4` does **not** route stdin through `ink@7`'s input pipeline. Keyboard-input tests must mock `useInput` directly:
+
+  ```tsx
+  let captured: ((input: string, key: Key) => void) | undefined
+  vi.mock('ink', async () => {
+    const actual = await vi.importActual<typeof import('ink')>('ink')
+    return {
+      ...actual,
+      useInput: (handler) => { captured = handler },
+    }
+  })
+
+  // In tests, call captured!(input, key) directly.
+  ```
+
+- Rendering-only tests work fine with `ink-testing-library`.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Writing ANSI codes manually | Use `Text color={...}` |
+| Reading stdin directly | Use `useInput` |
+| Forgetting to gate input on `streaming` | Check `chat.status !== 'streaming'` before every action |
+| Assuming 80 columns | Use `useStdout` and `rows`/`columns` from it |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (60% lines)
+- [ ] Uses `ink` primitives only (no raw ANSI)
+- [ ] Keyboard tests mock `useInput` per the pattern above
+- [ ] Works in narrow terminals (test at 40 columns)

--- a/packages/memory/CONVENTIONS.md
+++ b/packages/memory/CONVENTIONS.md
@@ -1,0 +1,63 @@
+# Conventions — `@agentskit/memory`
+
+Memory backends implementing the two contracts from [ADR 0003](../../docs/architecture/adrs/0003-memory-contract.md): `ChatMemory` and `VectorMemory`.
+
+## Scope
+
+- **ChatMemory implementations**: `fileChatMemory`, `sqliteChatMemory`, `redisChatMemory`
+- **VectorMemory implementations**: `fileVectorMemory`, `redisVectorMemory`
+- Shared client helpers where reuse is genuine (`redis-client.ts`, `vector-store.ts`)
+
+## Adding a new ChatMemory backend
+
+1. Create `src/<name>-chat.ts`.
+2. Export a factory: `export function sqliteChatMemory(opts): ChatMemory`.
+3. Implement the six invariants CM1–CM6:
+   - `load()` returns a snapshot
+   - `save()` is **replace-all**, not append
+   - Ordering preserved, atomic from consumer view
+   - Empty state returns `[]`
+   - `clear` optional
+4. Re-export from `src/index.ts`.
+
+## Adding a new VectorMemory backend
+
+1. Create `src/<name>-vector.ts`.
+2. Export a factory: `export function fileVectorMemory(opts): VectorMemory`.
+3. Implement the eight invariants VM1–VM8:
+   - `store` is **upsert by id**
+   - Dimensionality is a constructor concern — reject mismatches
+   - `search` returns descending-scored
+   - `threshold` is exclusive from below
+   - `topK` is an upper bound, not a floor
+4. Re-export from `src/index.ts`.
+
+## Configuration
+
+- Connection details (file path, URL, credentials) taken at construction.
+- Do not open connections until first use — defer to `load()` / `save()` / `store()` / `search()`.
+- Provide a `close()` escape hatch for long-lived processes; the contracts don't require it but consumers appreciate it.
+
+## Testing
+
+- **In-memory fake** per contract for fast tests of consumers (`memory/fakes.ts` — not yet present, welcome to add).
+- **Integration tests** for each backend using real storage (SQLite file, Redis testcontainer).
+- **Invariant tests**: a shared test suite that every backend must pass (`MemoryContractSuite` — tracked for future).
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Implementing `save` as append | Replace-all (CM2). Consumers send full state. |
+| Returning `null` from `load` on empty | Return `[]` |
+| Mixing embedding dimensions in one vector store | Reject mismatches at `store()` time |
+| Padding `search` results to reach `topK` | Return fewer documents; `topK` is an upper bound |
+| Opening connections at import time | Defer to first method call |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (80% lines)
+- [ ] New backend tested against all relevant invariants
+- [ ] Config accepted at construction; no env reads in the factory
+- [ ] Documentation for the backend's quirks in package README

--- a/packages/observability/CONVENTIONS.md
+++ b/packages/observability/CONVENTIONS.md
@@ -1,0 +1,58 @@
+# Conventions — `@agentskit/observability`
+
+Observers and integrations for logging, tracing, and metric emission. Pairs with the `Observer` primitives in `@agentskit/core`.
+
+## Stability tier: `beta`
+
+Observer shape is stable; provider integrations (LangSmith, OpenTelemetry, PostHog, console) are growing. Breaking changes to integrations may land in minor bumps.
+
+## Scope
+
+- **Console observer** — default local-dev logger
+- **Provider integrations** — LangSmith, OpenTelemetry, PostHog (as they land)
+- **Tracing helpers** — span wrappers, trace-id generation
+
+## Observers are read-only
+
+Per runtime RT9: observers **cannot** mutate messages, tool calls, or results. Side effects (log, metric emission, trace span) are fine; state mutation is not.
+
+If you're tempted to write an observer that rewrites a tool call or redacts a prompt, it's not an observer — it's a wrapper runtime. Build it as such.
+
+## Adding a new observer
+
+1. Create `src/<name>.ts`.
+2. Export a factory: `export function consoleObserver(opts): Observer`.
+3. Implement only the events you care about — all observer methods are optional.
+4. Catch and log observer-internal errors. Never throw out of an observer — the runtime swallows it but you lose context.
+5. Re-export from `src/index.ts`.
+
+## Adding a provider integration
+
+1. Create `src/integrations/<provider>.ts`.
+2. Export a factory that returns an `Observer`.
+3. Accept configuration at construction (`apiKey`, `projectId`, etc.).
+4. Batch if the provider requires it; don't block the runtime on network calls.
+5. Document the provider-specific fields used from `chunk.metadata`.
+
+## Testing
+
+- Observers are tested via a mock runtime that fires events and asserts observer side effects.
+- Do not reach out to real provider APIs in unit tests. Mock the HTTP client or SDK.
+- Integration tests against real providers run separately and are not blocking.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Mutating a message or result in an observer | Wrap the runtime; observers are read-only |
+| Blocking the runtime on slow API calls | Fire-and-forget with batching |
+| Throwing on missing optional fields | Check for presence; metadata is opaque |
+| Logging at every chunk in production | Sample or aggregate |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 10KB gzipped
+- [ ] Coverage threshold holds (55% lines, climbing)
+- [ ] Observer does not mutate any runtime state
+- [ ] Errors caught and logged, never thrown out
+- [ ] Provider integration documented in package README

--- a/packages/rag/CONVENTIONS.md
+++ b/packages/rag/CONVENTIONS.md
@@ -1,0 +1,54 @@
+# Conventions — `@agentskit/rag`
+
+Plug-and-play RAG. One factory (`createRAG`) returning a `RAG` that satisfies the `Retriever` contract from [ADR 0004](../../docs/architecture/adrs/0004-retriever-contract.md).
+
+## Scope
+
+- `createRAG({ store, embed, chunkSize, topK, threshold })`
+- Simple chunker (`chunker.ts`) — paragraph-based splits with configurable size
+- Types linking `RAG` to `Retriever`
+
+## What does NOT belong here
+
+- Vector store implementations → `@agentskit/memory`
+- Embedders → `@agentskit/adapters`
+- Document loaders (URL, PDF, Notion, etc.) → a future `@agentskit/loaders` package
+
+## Adding a capability
+
+Before adding:
+
+1. Can this be done by **composition**? Wrapping `createRAG`'s output in another `Retriever` is almost always the answer.
+2. Is this actually about chunking? Put it next to the existing chunker and add a `split` option to `createRAG` if it's reusable.
+3. Is this re-ranking? That's a composite `Retriever` — probably belongs in a separate package, not here.
+
+The core `createRAG` is intentionally small. Keep it that way.
+
+## Chunking
+
+- The default chunker splits on paragraphs, respecting `chunkSize`.
+- Custom chunkers implement `(text: string) => string[]`.
+- Do not make chunking async — if loading is async, load first then chunk synchronously.
+
+## Testing
+
+- The RAG factory must satisfy the Retriever contract (R1–R11).
+- Test ingest + retrieve as an end-to-end: `ingest([docs]) → retrieve({ query })` returns relevant documents in descending score order.
+- Test empty ingest → empty retrieve (returns `[]`, not an error).
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Letting `RAG` depend on a specific vector store | Inject via `store` option; `RAG` is store-agnostic |
+| Splitting by exact character count mid-word | Prefer paragraph boundaries with size as a soft cap |
+| Returning unordered results | Sort descending by score (R6) |
+| Padding to `topK` when fewer match | `topK` is an upper bound |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 10KB gzipped
+- [ ] Coverage threshold holds (95% lines)
+- [ ] `RAG` still extends `Retriever`
+- [ ] New features added by composition where possible
+- [ ] Chunker changes are backward-compatible (existing indexed docs still retrieve)

--- a/packages/react/CONVENTIONS.md
+++ b/packages/react/CONVENTIONS.md
@@ -1,0 +1,76 @@
+# Conventions — `@agentskit/react`
+
+React hooks and headless UI components for AgentsKit. Everything here runs in a browser.
+
+## Scope
+
+- **Hooks** — `useChat`, `useStream`, `useReactive`, and any future reactive primitives
+- **Headless UI components** — `ChatContainer`, `Message`, `InputBar`, `ThinkingIndicator`, `ToolCallView`, `Confirmation`, `CodeBlock`
+- **Theme CSS** — a single opinionated default theme at `@agentskit/react/theme`
+
+## What does NOT belong here
+
+- Any non-React framework wrapper → its own package (`@agentskit/vue`, `@agentskit/svelte`, etc.)
+- Provider adapters → `@agentskit/adapters`
+- Autonomous runtime — `@agentskit/runtime`
+- Anything that only runs on Node → `@agentskit/memory`, `@agentskit/tools`, etc.
+
+## Adding a new component
+
+1. Create `src/components/<Name>.tsx`. Name the file and the component in PascalCase.
+2. The component must be **headless** — no hardcoded styles beyond what's needed for layout. Use `data-ak-*` attributes for styling hooks.
+3. Props interface: `<Name>Props`, exported.
+4. Accept a `className` prop always.
+5. Accept `children` where composition is useful; otherwise keep the surface minimal.
+6. Re-export from `src/components/index.ts` and from `src/index.ts`.
+
+## Adding a new hook
+
+1. Create `src/<hookName>.ts` or a subdir if there are supporting files.
+2. Return a typed object — never tuples for more than 2 values.
+3. Name fields clearly: `messages`, `status`, `send`, `stop`, `retry` are conventions already in use.
+4. Do not introduce global state. Hooks are self-contained.
+5. Re-export from `src/index.ts`.
+
+## Styling conventions
+
+- Use `data-ak-*` attributes, not class names, for targeting:
+  ```tsx
+  <div data-ak-message data-ak-message-role={role}>
+  ```
+- The theme at `src/theme.css` provides defaults. Consumers can override via CSS variables.
+- Do not import CSS inside a component file. Let consumers opt in via `import '@agentskit/react/theme'`.
+
+## Testing
+
+- Use `@testing-library/react` + `happy-dom` (already configured).
+- Test observable behavior: what the user sees, not what the component does internally.
+- Use a mock `AdapterFactory` (see [Recipe: Custom adapter](../../apps/docs-next/content/docs/recipes/custom-adapter.mdx)) for hook tests.
+- Snapshot tests for components are acceptable; snapshot tests for LLM output are not.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Hardcoding colors in component styles | Use CSS variables defined in the theme |
+| Pulling in a UI library (MUI, Chakra, etc.) as a dep | Keep components headless; let consumers wire their own UI |
+| Reaching into `@agentskit/core` internals | Use only the public exports |
+| Making a hook that returns a 5-tuple | Return an object |
+| Side effects in render | Move to `useEffect` |
+
+## Accessibility
+
+Every interactive component must:
+
+- Be keyboard-reachable (Tab focus, Enter activation)
+- Expose ARIA attributes for role and state
+- Not trap focus unless explicitly modal
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (80% lines)
+- [ ] No hardcoded colors or fonts
+- [ ] `data-ak-*` attributes for styling hooks
+- [ ] Works with a mock adapter in tests
+- [ ] Keyboard and screen-reader accessible

--- a/packages/runtime/CONVENTIONS.md
+++ b/packages/runtime/CONVENTIONS.md
@@ -1,0 +1,73 @@
+# Conventions — `@agentskit/runtime`
+
+The conductor. Implements the Runtime contract ([ADR 0006](../../docs/architecture/adrs/0006-runtime-contract.md)) with all fourteen invariants.
+
+## Scope
+
+- `createRuntime(config)` factory and the `run(task, options?)` method
+- Delegation materialized as dynamic tools
+- Shared context passed down to delegates
+- The agent loop implementation (actual ReAct cycle)
+
+## What does NOT belong here
+
+- LLM provider code → `@agentskit/adapters`
+- Tool implementations → `@agentskit/tools`
+- Skill definitions → `@agentskit/skills`
+- UI → `@agentskit/react` or `@agentskit/ink`
+
+## Adding a new capability
+
+The runtime surface is deliberately small. Before adding anything:
+
+1. Can this be an **Observer**? Prefer that — observers are read-only and composable.
+2. Can this be a **wrapper runtime**? Wrap `createRuntime` and expose the same `run()` method.
+3. Is this a new contract? Open an RFC and an ADR first.
+
+If you still need to change the runtime internals, keep the RT invariants intact.
+
+## The fourteen invariants
+
+Every change in this package is reviewed against RT1–RT14 in [ADR 0006](../../docs/architecture/adrs/0006-runtime-contract.md):
+
+- RT1 Pure config, no I/O in `createRuntime`
+- RT2 One method: `run(task, options?)`
+- RT3 Options override config, never silent merge
+- RT4 Hard `maxSteps` cap
+- RT5 Tool resolution order well-defined
+- RT6 Confirmation refuse-by-default
+- RT7 Memory atomic at run boundary
+- RT8 Retrieval per-turn, not per-step
+- RT9 Observers read-only
+- RT10 Delegation as tool
+- RT11 Bounded delegation depth
+- RT12 Deterministic `RunResult` shape
+- RT13 Abort prompt and clean
+- RT14 Errors categorized
+
+Any PR that touches the loop must argue why each invariant still holds.
+
+## Testing
+
+- Unit tests for isolated primitives (`delegates`, `shared-context`)
+- Integration tests use mock adapters (no real network)
+- Every observer event has a test asserting it fires at the right time
+- Abort tests are mandatory for any change to the loop
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Silent array merging between config and options | Explicit override; document the resolution order (RT3) |
+| Soft `maxSteps` cap (user-overridable at runtime) | Hard cap. Document generous defaults instead. |
+| Catching tool errors and treating them as adapter errors | Feed back to the model; don't terminate the loop (RT14) |
+| Saving memory on failure "for audit" | Use an observer for audit; memory saves only on success (RT7) |
+| Throwing from observers | Catch inside the runtime; observer failures don't break the loop (RT9) |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (90% lines — this is the conductor)
+- [ ] Each of RT1–RT14 still holds (argue in PR description if a change touches them)
+- [ ] New public API has a test for happy path + error path + abort path
+- [ ] No new runtime primitive without an RFC

--- a/packages/sandbox/CONVENTIONS.md
+++ b/packages/sandbox/CONVENTIONS.md
@@ -1,0 +1,51 @@
+# Conventions — `@agentskit/sandbox`
+
+Secure code execution for tools that run untrusted code.
+
+## Stability tier: `beta`
+
+E2B backend works. WebContainer fallback is still experimental. The shape of `createSandbox` and the wrapping pattern may evolve.
+
+## Scope
+
+- `createSandbox({ backend })` factory — returns a sandbox instance
+- `sandbox.run(code)` — executes code and returns output
+- `wrapWithSandbox(tool, sandbox)` — wraps an existing `ToolDefinition` so its `execute` runs in the sandbox
+
+## Security posture
+
+- Default to **denying** network access. Opt in only when the tool explicitly needs it.
+- Default to a small filesystem slice (`/tmp` equivalent) — not the host.
+- Resource limits (memory, CPU seconds, wall time) enforced at the backend.
+- Never expose the host's API keys or env vars to sandboxed code. Pass only what's needed.
+
+## Adding a backend
+
+1. Create `src/backends/<name>.ts`.
+2. Implement the internal `SandboxBackend` interface (local to this package).
+3. Respect the security defaults above.
+4. Provide a `close()` that cleans up resources.
+5. Re-export via `src/index.ts`.
+
+## Testing
+
+- Unit test the wrapping and dispatch logic with a mock backend.
+- Integration test against a real E2B session in CI (behind an env flag — don't run on every PR).
+- Test the denial paths: attempting network when disabled fails cleanly.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Leaking host env vars into the sandbox | Explicit allowlist at sandbox creation |
+| Trusting the sandbox for data integrity | The sandbox is for blast-radius, not correctness |
+| Long-running sandbox sessions | Enforce wall time; dispose after each run |
+| Allowing arbitrary filesystem paths | Pin to a sandboxed dir |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 10KB gzipped
+- [ ] Coverage threshold holds (30% lines, growing)
+- [ ] Security defaults preserved
+- [ ] New backend has a denial-path test
+- [ ] `close()` cleans up resources deterministically

--- a/packages/skills/CONVENTIONS.md
+++ b/packages/skills/CONVENTIONS.md
@@ -1,0 +1,71 @@
+# Conventions — `@agentskit/skills`
+
+Pre-built personas (prompts + behavioral rules) that satisfy the Skill contract ([ADR 0005](../../docs/architecture/adrs/0005-skill-contract.md)).
+
+## Scope
+
+- General-purpose skills: researcher, critic, summarizer, coder, planner, debater
+- Skill composition helpers when a pattern shows up repeatedly
+
+## What does NOT belong here
+
+- Skill implementations that require custom code paths beyond a prompt → they're probably not skills, they're runtimes or tools
+- UI to edit skills → a future skill marketplace package
+
+## Adding a new skill
+
+1. Create `src/<skill-name>.ts`.
+2. Export a `SkillDefinition` as a named constant: `export const summarizer: SkillDefinition = { ... }`.
+3. Required fields: `name`, `description` (one line), `systemPrompt` (the soul of the skill).
+4. Optional: `examples` (single-turn), `tools` (array of tool **names**, not definitions), `delegates`, `temperature`, `metadata`.
+5. Re-export from `src/index.ts`.
+
+## Writing the system prompt
+
+The system prompt is the contract with the model. Invest here.
+
+- **State the role clearly** in the first line: "You are a meticulous code reviewer."
+- **Describe the workflow** as numbered steps. Models follow structure.
+- **Specify the output format** — markdown? JSON? prose?
+- **Include constraints** that would otherwise be forgotten (terse, cite sources, no speculation).
+- **Avoid adjectives**. "Excellent senior engineer" adds nothing.
+
+Real skills in this package are the best reference. Read `researcher.ts`, `critic.ts`, `coder.ts` before writing a new one.
+
+## Pure declarative — no execute
+
+Skills do **not** have a `run` or `execute` method. Confusing them with tools is the most common mistake. If you want a function the model calls, it's a Tool. If you want a persona the model becomes, it's a Skill.
+
+The only function on a `SkillDefinition` is `onActivate`, and it's used **only** for per-user/per-tenant dynamic tool construction. General initialization belongs elsewhere.
+
+## Naming
+
+- Snake_case for `name` field (matches Tool convention).
+- File name matches the skill: `code_reviewer.ts` exports `codeReviewer`.
+- Keep names short — used in delegation tool names (`delegate_code_reviewer`).
+
+## Testing
+
+- Skills are mostly prompts; traditional unit tests don't apply.
+- Provide a small **golden dataset** of `{ input, expected }` pairs per skill.
+- Use `@agentskit/eval` to score the skill periodically. Don't block PRs on eval scores; do flag regressions.
+- Schema-check that `name` matches the regex and that `systemPrompt` is non-empty.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Inline tool definitions inside a skill | Reference tools by name; let the runtime resolve |
+| Multi-turn examples encoded as one input/output | Single-turn only in v1; encode multi-turn patterns in the prompt itself |
+| Using `onActivate` for general init | Reserved for per-user dynamic tools; move general init elsewhere |
+| Side effects at definition time (top-level `await`) | Move to `onActivate` or out of the skill |
+| Pretending a skill can be invoked like a function | It's activated, not invoked. Pass to `runtime.run({ skill })` |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 10KB gzipped
+- [ ] Coverage threshold holds (95% lines — mostly structural checks)
+- [ ] Every new skill has at least one example in `examples`
+- [ ] Prompt reviewed by a second set of eyes for clarity
+- [ ] Name matches the regex `^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$`
+- [ ] No inline tool implementations; names only

--- a/packages/templates/CONVENTIONS.md
+++ b/packages/templates/CONVENTIONS.md
@@ -1,0 +1,43 @@
+# Conventions — `@agentskit/templates`
+
+Authoring toolkit for custom skills, tools, and runtimes. The package consumers reach for when they want to publish their own assets.
+
+## Scope
+
+- **Scaffold helpers** — `createSkill`, `createTool`, `createRuntime` wrappers that apply sensible defaults
+- **Template strings / prompts** — reusable prompt fragments (role setup, output format directives, citation patterns)
+- **Validation helpers** — confirm a `ToolDefinition` or `SkillDefinition` satisfies its contract before shipping
+
+## Adding a helper
+
+1. Create `src/<helper>.ts` with a single focused export.
+2. Prefer pure functions. Avoid classes.
+3. Document the happy path in JSDoc above the export.
+4. If the helper is generic enough to move into `@agentskit/core`, consider that first — only add here if it's authoring-specific.
+
+## Adding prompt fragments
+
+- Organize by purpose: `src/prompts/<category>.ts` → `roles.ts`, `formats.ts`, `citations.ts`.
+- Export as named constants: `export const citeBracketedNumbers = '...'`.
+- No templating DSL. Plain strings with placeholder comments.
+
+## Testing
+
+- Unit-test every helper for at least one happy path and one error path.
+- Schema validators must round-trip a known-good definition without changes.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Exporting a giant `create*` that does everything | Split into small composable helpers |
+| Hiding defaults inside the helper | Document defaults in JSDoc; accept overrides via options |
+| Validating tools with a custom schema validator | Use JSON Schema 7 — aligned with the Tool contract |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (95% lines)
+- [ ] Helpers are pure functions
+- [ ] Defaults documented
+- [ ] Schema validators round-trip correctly

--- a/packages/tools/CONVENTIONS.md
+++ b/packages/tools/CONVENTIONS.md
@@ -1,0 +1,58 @@
+# Conventions — `@agentskit/tools`
+
+Ready-made tools that satisfy the Tool contract ([ADR 0002](../../docs/architecture/adrs/0002-tool-contract.md)).
+
+## Scope
+
+- General-purpose tools: web search, filesystem, shell, discovery helpers
+- Factory functions (`webSearch()`, `filesystem({ basePath })`, `shell({ allowedCommands })`) that return `ToolDefinition` or arrays of them
+- Small surface helpers used by multiple tools — only if truly shared
+
+## What does NOT belong here
+
+- Provider-specific tools → a separate package (e.g., `@agentskit/tools-github`, `@agentskit/tools-slack` — future)
+- Tool execution sandboxes → `@agentskit/sandbox`
+- MCP bridge → future `@agentskit/mcp` (Phase 3)
+
+## Adding a new tool
+
+1. Create `src/<tool-name>.ts`.
+2. Export a factory function (not a raw `ToolDefinition`) so users can pass configuration: `webSearch({ apiKey })`, `filesystem({ basePath })`.
+3. The factory returns `ToolDefinition` or `ToolDefinition[]` (for tools that come as a group, like filesystem read/write/list).
+4. Define the JSON Schema 7 as a typed object literal. No Zod in this package (see `zod-to-json-schema` in consumer projects if they prefer Zod).
+5. Include a concise `description` — this is what the model reads.
+6. Set `requiresConfirmation: true` for any destructive operation. Non-negotiable.
+7. Return **JSON-serializable** data from `execute` — Dates become ISO strings, Buffers become base64.
+8. Handle errors by returning `{ error: '...' }`. Only throw for programmer bugs.
+9. Re-export from `src/index.ts`.
+
+## Naming
+
+- Tool names match the factory name: `webSearch()` → `{ name: 'web_search' }`, `filesystem()` → `{ name: 'filesystem_read' }`, etc.
+- Use snake_case for `name` (matches every major provider's convention and the JSON Schema ecosystem).
+- Keep names short — the model sees them repeatedly.
+
+## Testing
+
+- Mock the external I/O (fetch, fs, child_process). Test only the tool's shape and dispatch logic.
+- Test schema validation: passing a malformed args object should produce a tool error, not an execute call.
+- Test confirmation flow when `requiresConfirmation: true`.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Returning a Buffer or Date directly | Serialize: base64 or ISO string |
+| Forgetting `requiresConfirmation` on a destructive op | Default to true; reviewers flag this |
+| Side effects at import time (top-level `await`) | Move to `init()` or `execute()` (invariant T10) |
+| Tool names with spaces or hyphens in positions the regex rejects | Match `^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$` |
+| Shared state between tools (globals) | Encapsulate in the factory closure |
+
+## Review checklist for this package
+
+- [ ] Bundle size under 15KB gzipped
+- [ ] Coverage threshold holds (70% lines)
+- [ ] Every new tool has its own schema validation test
+- [ ] Destructive tools set `requiresConfirmation: true`
+- [ ] `execute` returns JSON-serializable data only
+- [ ] Factory accepts configuration; no hardcoded secrets


### PR DESCRIPTION
## Summary

One focused CONVENTIONS.md per package explaining:

- **Scope** — what belongs here
- **What does NOT belong here** — routing to sibling packages
- **How to add a new X** — step-by-step for adapters, tools, skills, memory backends, components, observers, etc.
- **Testing conventions** specific to that package
- **Common pitfalls** as a lookup table
- **Review checklist** reviewers run when approving PRs

Closes #232.

## Highlights per package

- **core** — strictest rules. Zero deps, <10KB, no `any`, named exports only. Explicit list of what triggers an ADR.
- **adapters** — step-by-step for a new chat adapter + embedder, naming rules, contract-test pointer (10 invariants).
- **react** — headless components, `data-ak-*` attributes for styling hooks, accessibility requirements.
- **ink** — documents the ink@7 / ink-testing-library@4 test harness workaround so new contributors don't rediscover it.
- **cli** — `--help` fits one screen, stdout vs stderr discipline, exit code conventions.
- **runtime** — enforces RT1–RT14 as the review gate. Any PR touching the loop must argue why each invariant still holds.
- **tools** — JSON Schema 7 (not Zod), `requiresConfirmation: true` for destructive ops, snake_case naming.
- **skills** — how to write the system prompt, pure-declarative no-execute principle, `onActivate` only for dynamic per-user tools.
- **memory** — separate sections for ChatMemory and VectorMemory backends, invariant lists.
- **rag** — composition-first ("can this be done by wrapping Retriever?"), keep `createRAG` small.
- **observability** — observers are read-only; mutation belongs in a wrapper runtime.
- **sandbox** — deny-by-default network/filesystem, security posture non-negotiable.
- **eval** — scores in `[0, 1]`, every metric optional, replay-first design.
- **templates** — helpers as pure functions, defaults in JSDoc.

## Why this matters for Fase 3 onboarding

Fase 3 adds ~10 new adapters, ~15 new tools, 8 memory backends, 4 UI frameworks. Without CONVENTIONS.md per package, every contributor relitigates the same design questions. These docs are **the** reference for 'how do I add X to Y?'.

## Test plan

- [x] 14 CONVENTIONS.md files created
- [x] Each links to the relevant ADRs and sibling packages
- [x] Each ends with a package-specific review checklist
- [ ] Reviewer: spot-check the rules against real patterns in each `src/`
- [ ] Reviewer: confirm the stability-tier notes match what was declared in #279
- [ ] Reviewer: any pitfall missing from your experience that should land now?

## Follow-up

The linked 'contract test suites' (AdapterContractSuite, MemoryContractSuite) referenced in several CONVENTIONS don't exist yet — they're tracked for Phase 2 work.

Refs #232 #211