### PR TITLE
feat(cli): interactive 'agentskit init' with 4 templates [closes #114]

### DIFF
--- a/.changeset/init-interactive.md
+++ b/.changeset/init-interactive.md
@@ -1,0 +1,21 @@
+---
+'@agentskit/cli': minor
+---
+
+`agentskit init` is now interactive by default.
+
+Run with no flags and you get five questions: directory, template, provider, tools, memory, package manager. Pass any flag (or `--yes`) to skip the prompts and use defaults — friendly to CI and scripts.
+
+Templates expanded from two (`react`, `ink`) to four:
+
+- `react` — Vite + React chat UI
+- `ink` — terminal chat
+- `runtime` — headless agent (no UI)
+- `multi-agent` — supervisor pattern with planner + delegates
+
+Each template renders adapter / tools / memory wiring based on your answers. Demo provider produces a deterministic stub so the starter runs without an API key.
+
+```bash
+npx agentskit init                                    # interactive
+npx agentskit init --template runtime --provider demo --yes   # non-interactive
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,8 +45,10 @@
     "@agentskit/runtime": "workspace:*",
     "@agentskit/skills": "workspace:*",
     "@agentskit/tools": "workspace:*",
+    "@inquirer/prompts": "^8.4.1",
     "commander": "^14.0.1",
     "ink": "^7.0.0",
+    "kleur": "^4.1.5",
     "react": "^19.2.5"
   },
   "devDependencies": {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -6,6 +6,8 @@ import { loadConfig } from './config'
 import type { AgentsKitConfig } from './config'
 import { ChatApp, renderChatHeader } from './chat'
 import { writeStarterProject } from './init'
+import type { StarterKind, Provider, ToolKind, MemoryKind, PackageManager } from './init'
+import { runInteractiveInit, printNextSteps } from './init-interactive'
 import { runAgent } from './run'
 import { RunApp } from './run-ui'
 
@@ -101,15 +103,50 @@ export function createCli() {
 
   program
     .command('init')
-    .description('Generate a starter project.')
-    .option('--template <template>', 'Starter template (react|ink)', 'react')
-    .option('--dir <directory>', 'Target directory', 'agentskit-starter')
-    .action(async (options) => {
-      await writeStarterProject({
-        template: options.template === 'ink' ? 'ink' : 'react',
-        targetDir: path.resolve(process.cwd(), options.dir),
-      })
-      process.stdout.write(`Created ${options.template} starter in ${options.dir}\n`)
+    .description('Generate a starter project. Run with no flags for interactive mode.')
+    .option('--template <template>', 'Starter template (react|ink|runtime|multi-agent)')
+    .option('--dir <directory>', 'Target directory', 'agentskit-app')
+    .option('--provider <provider>', 'LLM provider (openai|anthropic|gemini|ollama|demo)')
+    .option('--tools <tools>', 'Comma-separated tools (web_search,filesystem,shell)')
+    .option('--memory <backend>', 'Memory backend (none|file|sqlite)')
+    .option('--pm <packageManager>', 'Package manager (pnpm|npm|yarn|bun)')
+    .option('-y, --yes', 'Skip interactive prompts; use flag values + defaults')
+    .action(async (rawOptions) => {
+      const isCi = !process.stdout.isTTY || rawOptions.yes || rawOptions.template
+      let resolved: Parameters<typeof writeStarterProject>[0]
+
+      if (isCi) {
+        const template = (rawOptions.template ?? 'react') as StarterKind
+        resolved = {
+          targetDir: path.resolve(process.cwd(), rawOptions.dir),
+          template,
+          provider: (rawOptions.provider ?? 'demo') as Provider,
+          tools: rawOptions.tools
+            ? (rawOptions.tools.split(',').map((t: string) => t.trim()) as ToolKind[])
+            : [],
+          memory: (rawOptions.memory ?? 'none') as MemoryKind,
+          packageManager: (rawOptions.pm ?? 'pnpm') as PackageManager,
+        }
+      } else {
+        const result = await runInteractiveInit({
+          dir: rawOptions.dir,
+          template: rawOptions.template as StarterKind | undefined,
+        })
+        if (result.cancelled) {
+          process.exit(0)
+        }
+        resolved = result.options
+      }
+
+      await writeStarterProject(resolved)
+
+      if (isCi) {
+        process.stdout.write(
+          `Created ${resolved.template} starter in ${path.relative(process.cwd(), resolved.targetDir) || '.'}\n`,
+        )
+      } else {
+        printNextSteps(resolved)
+      }
     })
 
   return program

--- a/packages/cli/src/init-interactive.ts
+++ b/packages/cli/src/init-interactive.ts
@@ -1,0 +1,151 @@
+import { input, select, checkbox, confirm } from '@inquirer/prompts'
+import kleur from 'kleur'
+import path from 'node:path'
+import { existsSync } from 'node:fs'
+import type {
+  InitCommandOptions,
+  StarterKind,
+  Provider,
+  ToolKind,
+  MemoryKind,
+  PackageManager,
+} from './init'
+
+interface InteractiveResult {
+  options: InitCommandOptions
+  cancelled: boolean
+}
+
+/**
+ * Run the interactive init flow. Returns the resolved InitCommandOptions
+ * to feed into writeStarterProject. If the user cancels (Ctrl+C), returns
+ * { cancelled: true }.
+ */
+export async function runInteractiveInit(
+  defaults: { dir?: string; template?: StarterKind } = {},
+): Promise<InteractiveResult> {
+  process.stdout.write(`\n${kleur.bold().green('▲')} ${kleur.bold('agentskit init')}\n`)
+  process.stdout.write(kleur.dim('   Generate a starter project — answer five questions.\n\n'))
+
+  try {
+    const targetDir = await input({
+      message: 'Project directory:',
+      default: defaults.dir ?? 'agentskit-app',
+      validate: (value) => {
+        if (!value.trim()) return 'A directory name is required.'
+        const abs = path.resolve(process.cwd(), value)
+        if (existsSync(abs)) return `${value} already exists. Pick a different name.`
+        return true
+      },
+    })
+
+    const template = (await select<StarterKind>({
+      message: 'Template:',
+      default: defaults.template ?? 'react',
+      choices: [
+        { name: 'React chat (Vite + browser)', value: 'react', description: 'Streaming UI with @agentskit/react' },
+        { name: 'Ink chat (terminal UI)', value: 'ink', description: 'Same chat but in your terminal' },
+        { name: 'Runtime (headless agent, no UI)', value: 'runtime', description: 'Autonomous task → result' },
+        { name: 'Multi-agent (planner + delegates)', value: 'multi-agent', description: 'Supervisor pattern, ready to extend' },
+      ],
+    })) as StarterKind
+
+    const provider = (await select<Provider>({
+      message: 'LLM provider:',
+      default: 'demo',
+      choices: [
+        { name: 'Demo (no API key — deterministic stub)', value: 'demo' },
+        { name: 'OpenAI', value: 'openai' },
+        { name: 'Anthropic', value: 'anthropic' },
+        { name: 'Gemini', value: 'gemini' },
+        { name: 'Ollama (local, no key)', value: 'ollama' },
+      ],
+    })) as Provider
+
+    let tools: ToolKind[] = []
+    if (template !== 'react') {
+      // React template focuses on chat; tools are most useful in runtime / multi-agent / ink
+      tools = (await checkbox<ToolKind>({
+        message: 'Tools (space to toggle, enter to confirm):',
+        choices: [
+          { name: 'web_search', value: 'web_search' },
+          { name: 'filesystem', value: 'filesystem' },
+          { name: 'shell', value: 'shell' },
+        ],
+      })) as ToolKind[]
+    }
+
+    const memory = (await select<MemoryKind>({
+      message: 'Memory backend:',
+      default: 'none',
+      choices: [
+        { name: 'None (stateless)', value: 'none' },
+        { name: 'File (JSON on disk)', value: 'file' },
+        { name: 'SQLite (better-sqlite3)', value: 'sqlite' },
+      ],
+    })) as MemoryKind
+
+    const packageManager = (await select<PackageManager>({
+      message: 'Package manager:',
+      default: 'pnpm',
+      choices: [
+        { name: 'pnpm', value: 'pnpm' },
+        { name: 'npm', value: 'npm' },
+        { name: 'yarn', value: 'yarn' },
+        { name: 'bun', value: 'bun' },
+      ],
+    })) as PackageManager
+
+    process.stdout.write('\n' + kleur.dim('  Summary:\n'))
+    process.stdout.write(kleur.dim(`    dir       ${targetDir}\n`))
+    process.stdout.write(kleur.dim(`    template  ${template}\n`))
+    process.stdout.write(kleur.dim(`    provider  ${provider}\n`))
+    if (tools.length) process.stdout.write(kleur.dim(`    tools     ${tools.join(', ')}\n`))
+    process.stdout.write(kleur.dim(`    memory    ${memory}\n`))
+    process.stdout.write(kleur.dim(`    pm        ${packageManager}\n\n`))
+
+    const proceed = await confirm({ message: 'Generate?', default: true })
+    if (!proceed) {
+      process.stdout.write(kleur.yellow('Cancelled.\n'))
+      return { cancelled: true, options: { targetDir, template, provider, tools, memory, packageManager } }
+    }
+
+    return {
+      cancelled: false,
+      options: {
+        targetDir: path.resolve(process.cwd(), targetDir),
+        template,
+        provider,
+        tools,
+        memory,
+        packageManager,
+      },
+    }
+  } catch (err) {
+    // ExitPromptError thrown on Ctrl+C
+    if ((err as Error).name === 'ExitPromptError') {
+      process.stdout.write(kleur.yellow('\nCancelled.\n'))
+      return { cancelled: true, options: { targetDir: '', template: 'react' } }
+    }
+    throw err
+  }
+}
+
+export function printNextSteps(options: InitCommandOptions): void {
+  const dir = path.relative(process.cwd(), options.targetDir) || '.'
+  const pm = options.packageManager ?? 'pnpm'
+  const installCmd = pm === 'npm' ? 'npm install' : `${pm} install`
+  const runCmd = pm === 'npm' ? 'npm run dev' : `${pm} dev`
+
+  process.stdout.write('\n' + kleur.green('✓ Created starter at ') + kleur.bold(dir) + '\n\n')
+  process.stdout.write(kleur.bold('Next steps:\n\n'))
+  process.stdout.write(`  ${kleur.cyan('cd')} ${dir}\n`)
+  process.stdout.write(`  ${kleur.cyan(installCmd)}\n`)
+  if (options.provider && options.provider !== 'demo' && options.provider !== 'ollama') {
+    process.stdout.write(
+      `  ${kleur.cyan('cp')} .env.example .env  ${kleur.dim('# add your API key')}\n`,
+    )
+  }
+  process.stdout.write(`  ${kleur.cyan(runCmd)}\n\n`)
+  process.stdout.write(kleur.dim('  Docs: https://agentskit.io/docs\n\n'))
+}

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,89 +1,299 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-export type StarterKind = 'react' | 'ink'
+export type StarterKind = 'react' | 'ink' | 'runtime' | 'multi-agent'
+export type Provider = 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'demo'
+export type ToolKind = 'web_search' | 'filesystem' | 'shell'
+export type MemoryKind = 'none' | 'file' | 'sqlite'
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 export interface InitCommandOptions {
   targetDir: string
   template: StarterKind
+  provider?: Provider
+  tools?: ToolKind[]
+  memory?: MemoryKind
+  packageManager?: PackageManager
 }
 
-function reactStarter() {
+interface RenderContext {
+  template: StarterKind
+  provider: Provider
+  tools: ToolKind[]
+  memory: MemoryKind
+  pm: PackageManager
+}
+
+const PROVIDER_IMPORT: Record<Exclude<Provider, 'demo'>, string> = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  gemini: 'gemini',
+  ollama: 'ollama',
+}
+
+const PROVIDER_DEFAULT_MODEL: Record<Provider, string> = {
+  openai: 'gpt-4o-mini',
+  anthropic: 'claude-sonnet-4-6',
+  gemini: 'gemini-2.5-flash',
+  ollama: 'llama3.1',
+  demo: 'demo',
+}
+
+const PROVIDER_ENV_KEY: Record<Provider, string | null> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  ollama: null,
+  demo: null,
+}
+
+function adapterCall(provider: Provider, prefix = 'process.env'): string {
+  const model = PROVIDER_DEFAULT_MODEL[provider]
+  if (provider === 'demo') return `demoAdapter()`
+  if (provider === 'ollama') return `ollama({ model: '${model}' })`
+  const envKey = PROVIDER_ENV_KEY[provider]!
+  return `${PROVIDER_IMPORT[provider]}({ apiKey: ${prefix}.${envKey} ?? '', model: '${model}' })`
+}
+
+function viteAdapterCall(provider: Provider): string {
+  if (provider === 'demo') return `demoAdapter()`
+  if (provider === 'ollama') return `ollama({ model: '${PROVIDER_DEFAULT_MODEL[provider]}' })`
+  const envKey = PROVIDER_ENV_KEY[provider]!
+  return `${PROVIDER_IMPORT[provider]}({ apiKey: import.meta.env.VITE_${envKey} ?? '', model: '${PROVIDER_DEFAULT_MODEL[provider]}' })`
+}
+
+function adapterImport(provider: Provider): string {
+  if (provider === 'demo') return ''
+  return `import { ${PROVIDER_IMPORT[provider]} } from '@agentskit/adapters'\n`
+}
+
+function toolImports(tools: ToolKind[]): string {
+  if (tools.length === 0) return ''
+  return `import { ${tools.map(t => t === 'web_search' ? 'webSearch' : t).join(', ')} } from '@agentskit/tools'\n`
+}
+
+function toolList(tools: ToolKind[]): string {
+  if (tools.length === 0) return '[]'
+  const calls = tools.map(t => {
+    if (t === 'web_search') return 'webSearch()'
+    if (t === 'filesystem') return `...filesystem({ basePath: './workspace' })`
+    if (t === 'shell') return `shell({ allowedCommands: ['ls', 'cat'] })`
+    return ''
+  })
+  return `[${calls.join(', ')}]`
+}
+
+function memoryImport(memory: MemoryKind): string {
+  if (memory === 'file') return `import { fileChatMemory } from '@agentskit/memory'\n`
+  if (memory === 'sqlite') return `import { sqliteChatMemory } from '@agentskit/memory'\n`
+  return ''
+}
+
+function memoryCall(memory: MemoryKind): string {
+  if (memory === 'file') return `fileChatMemory('./.agentskit-history.json')`
+  if (memory === 'sqlite') return `sqliteChatMemory({ path: './.agentskit-history.db' })`
+  return 'undefined'
+}
+
+function demoAdapterSnippet(): string {
+  return `function demoAdapter() {
   return {
-    'package.json': JSON.stringify({
-      name: 'agentskit-react-app',
-      private: true,
-      type: 'module',
-      scripts: {
-        dev: 'vite',
+    createSource: () => ({
+      stream: async function* () {
+        yield { type: 'text' as const, content: 'Hello from your AgentsKit starter. ' }
+        yield { type: 'text' as const, content: 'Configure a real adapter to talk to a model.' }
+        yield { type: 'done' as const }
       },
-      dependencies: {
-        '@agentskit/adapters': '^0.1.0',
-        '@agentskit/react': '^0.1.0',
-        react: '^18.3.1',
-        'react-dom': '^18.3.1',
+      abort: () => {},
+    }),
+  }
+}\n\n`
+}
+
+// ============================================================================
+// Templates
+// ============================================================================
+
+function reactStarter(ctx: RenderContext): Record<string, string> {
+  const deps: Record<string, string> = {
+    '@agentskit/react': '^0.4.0',
+    react: '^19.0.0',
+    'react-dom': '^19.0.0',
+  }
+  if (ctx.provider !== 'demo') deps['@agentskit/adapters'] = '^0.4.0'
+  if (ctx.tools.length > 0) deps['@agentskit/tools'] = '^0.4.0'
+  if (ctx.memory !== 'none') deps['@agentskit/memory'] = '^0.4.0'
+
+  const includesDemo = ctx.provider === 'demo'
+  const adapter = ctx.provider === 'demo' ? viteAdapterCall(ctx.provider) : viteAdapterCall(ctx.provider)
+  const envKey = PROVIDER_ENV_KEY[ctx.provider]
+  const envContent = envKey ? `VITE_${envKey}=\n` : '# No API key required for the local provider\n'
+
+  return {
+    'package.json': JSON.stringify(
+      {
+        name: path.basename(ctx.template === 'react' ? 'agentskit-react-app' : 'agentskit-app'),
+        private: true,
+        type: 'module',
+        scripts: {
+          dev: 'vite',
+          build: 'vite build',
+          preview: 'vite preview',
+        },
+        dependencies: deps,
+        devDependencies: {
+          '@vitejs/plugin-react': '^5.0.0',
+          typescript: '^5.5.0',
+          vite: '^7.0.0',
+        },
       },
-    }, null, 2),
+      null,
+      2,
+    ) + '\n',
+
+    'index.html': `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AgentsKit React Starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`,
+
+    'vite.config.ts': `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({ plugins: [react()] })
+`,
+
+    'tsconfig.json': JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          lib: ['ES2022', 'DOM'],
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          jsx: 'react-jsx',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ['src'],
+      },
+      null,
+      2,
+    ) + '\n',
+
     'src/main.tsx': `import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { ChatContainer, InputBar, Message, useChat } from '@agentskit/react'
-import { openai } from '@agentskit/adapters'
-import '@agentskit/react/theme'
+import App from './App'
 
-function App() {
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)
+`,
+
+    'src/App.tsx': `import { ChatContainer, InputBar, Message, useChat } from '@agentskit/react'
+${adapterImport(ctx.provider)}${toolImports(ctx.tools)}${memoryImport(ctx.memory)}import '@agentskit/react/theme'
+
+${includesDemo ? demoAdapterSnippet() : ''}export default function App() {
   const chat = useChat({
-    adapter: openai({ apiKey: import.meta.env.VITE_OPENAI_API_KEY ?? '', model: 'gpt-4o-mini' }),
+    adapter: ${adapter},${ctx.tools.length > 0 ? `\n    tools: ${toolList(ctx.tools)},` : ''}${ctx.memory !== 'none' ? `\n    memory: ${memoryCall(ctx.memory)},` : ''}
   })
 
   return (
     <ChatContainer>
-      {chat.messages.map(message => <Message key={message.id} message={message} />)}
+      {chat.messages.map(message => (
+        <Message key={message.id} message={message} />
+      ))}
       <InputBar chat={chat} />
     </ChatContainer>
   )
 }
-
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
 `,
-    '.env.example': 'VITE_OPENAI_API_KEY=\n',
+
+    '.env.example': envContent,
+
+    '.gitignore': `node_modules
+dist
+.env
+.env.local
+.agentskit-history.*
+`,
+
+    'README.md': readmeFor(ctx),
   }
 }
 
-function inkStarter() {
+function inkStarter(ctx: RenderContext): Record<string, string> {
+  const deps: Record<string, string> = {
+    '@agentskit/ink': '^0.4.0',
+    ink: '^7.0.0',
+    react: '^19.0.0',
+  }
+  if (ctx.provider !== 'demo') deps['@agentskit/adapters'] = '^0.4.0'
+  if (ctx.tools.length > 0) deps['@agentskit/tools'] = '^0.4.0'
+  if (ctx.memory !== 'none') deps['@agentskit/memory'] = '^0.4.0'
+
   return {
-    'package.json': JSON.stringify({
-      name: 'agentskit-ink-app',
-      private: true,
-      type: 'module',
-      scripts: {
-        dev: 'tsx src/index.tsx',
+    'package.json': JSON.stringify(
+      {
+        name: 'agentskit-ink-app',
+        private: true,
+        type: 'module',
+        scripts: {
+          dev: 'tsx src/index.tsx',
+          start: 'tsx src/index.tsx',
+        },
+        dependencies: deps,
+        devDependencies: {
+          '@types/react': '^19.0.0',
+          tsx: '^4.20.0',
+          typescript: '^5.5.0',
+        },
       },
-      dependencies: {
-        '@agentskit/ink': '^0.1.0',
-        react: '^18.3.1',
+      null,
+      2,
+    ) + '\n',
+
+    'tsconfig.json': JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          jsx: 'react-jsx',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ['src'],
       },
-    }, null, 2),
+      null,
+      2,
+    ) + '\n',
+
     'src/index.tsx': `import React from 'react'
 import { render } from 'ink'
 import { ChatContainer, InputBar, Message, useChat } from '@agentskit/ink'
+${adapterImport(ctx.provider)}${toolImports(ctx.tools)}${memoryImport(ctx.memory)}
+${ctx.provider === 'demo' ? demoAdapterSnippet() : ''}function App() {
+  const chat = useChat({
+    adapter: ${adapterCall(ctx.provider)},${ctx.tools.length > 0 ? `\n    tools: ${toolList(ctx.tools)},` : ''}${ctx.memory !== 'none' ? `\n    memory: ${memoryCall(ctx.memory)},` : ''}
+  })
 
-function DemoAdapter() {
-  return {
-    createSource: () => ({
-      async *stream() {
-        yield { type: 'text', content: 'Hello from AgentsKit Ink.' }
-        yield { type: 'done' }
-      },
-      abort() {},
-    }),
-  }
-}
-
-function App() {
-  const chat = useChat({ adapter: DemoAdapter() })
   return (
     <ChatContainer>
-      {chat.messages.map(message => <Message key={message.id} message={message} />)}
+      {chat.messages.map(message => (
+        <Message key={message.id} message={message} />
+      ))}
       <InputBar chat={chat} />
     </ChatContainer>
   )
@@ -91,11 +301,232 @@ function App() {
 
 render(<App />)
 `,
+
+    '.env.example': PROVIDER_ENV_KEY[ctx.provider]
+      ? `${PROVIDER_ENV_KEY[ctx.provider]}=\n`
+      : '# No API key required for the local provider\n',
+
+    '.gitignore': `node_modules
+.env
+.env.local
+.agentskit-history.*
+`,
+
+    'README.md': readmeFor(ctx),
   }
 }
 
-export async function writeStarterProject(options: InitCommandOptions) {
-  const files = options.template === 'ink' ? inkStarter() : reactStarter()
+function runtimeStarter(ctx: RenderContext): Record<string, string> {
+  const deps: Record<string, string> = {
+    '@agentskit/runtime': '^0.4.0',
+  }
+  if (ctx.provider !== 'demo') deps['@agentskit/adapters'] = '^0.4.0'
+  if (ctx.tools.length > 0) deps['@agentskit/tools'] = '^0.4.0'
+  if (ctx.memory !== 'none') deps['@agentskit/memory'] = '^0.4.0'
+
+  return {
+    'package.json': JSON.stringify(
+      {
+        name: 'agentskit-runtime-app',
+        private: true,
+        type: 'module',
+        scripts: {
+          start: 'tsx src/index.ts',
+          dev: 'tsx src/index.ts',
+        },
+        dependencies: deps,
+        devDependencies: {
+          tsx: '^4.20.0',
+          typescript: '^5.5.0',
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+
+    'tsconfig.json': JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ['src'],
+      },
+      null,
+      2,
+    ) + '\n',
+
+    'src/index.ts': `import { createRuntime } from '@agentskit/runtime'
+${adapterImport(ctx.provider)}${toolImports(ctx.tools)}${memoryImport(ctx.memory)}
+${ctx.provider === 'demo' ? demoAdapterSnippet() : ''}const runtime = createRuntime({
+  adapter: ${adapterCall(ctx.provider)},${ctx.tools.length > 0 ? `\n  tools: ${toolList(ctx.tools)},` : ''}${ctx.memory !== 'none' ? `\n  memory: ${memoryCall(ctx.memory)},` : ''}
+  maxSteps: 10,
+})
+
+const task = process.argv.slice(2).join(' ') || 'Say hello and tell me one fact about TypeScript.'
+const result = await runtime.run(task)
+
+console.log(result.content)
+console.log(\`\\n— \${result.steps} steps · \${result.toolCalls.length} tool calls · \${result.durationMs}ms\`)
+`,
+
+    '.env.example': PROVIDER_ENV_KEY[ctx.provider]
+      ? `${PROVIDER_ENV_KEY[ctx.provider]}=\n`
+      : '# No API key required for the local provider\n',
+
+    '.gitignore': `node_modules
+.env
+.env.local
+.agentskit-history.*
+`,
+
+    'README.md': readmeFor(ctx),
+  }
+}
+
+function multiAgentStarter(ctx: RenderContext): Record<string, string> {
+  const deps: Record<string, string> = {
+    '@agentskit/runtime': '^0.4.0',
+    '@agentskit/skills': '^0.4.0',
+  }
+  if (ctx.provider !== 'demo') deps['@agentskit/adapters'] = '^0.4.0'
+  if (ctx.tools.length === 0) ctx.tools = ['web_search']
+  deps['@agentskit/tools'] = '^0.4.0'
+
+  return {
+    'package.json': JSON.stringify(
+      {
+        name: 'agentskit-multi-agent',
+        private: true,
+        type: 'module',
+        scripts: {
+          start: 'tsx src/index.ts',
+          dev: 'tsx src/index.ts',
+        },
+        dependencies: deps,
+        devDependencies: {
+          tsx: '^4.20.0',
+          typescript: '^5.5.0',
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+
+    'tsconfig.json': JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ['src'],
+      },
+      null,
+      2,
+    ) + '\n',
+
+    'src/index.ts': `import { createRuntime } from '@agentskit/runtime'
+import { planner, researcher } from '@agentskit/skills'
+${adapterImport(ctx.provider)}${toolImports(ctx.tools)}
+${ctx.provider === 'demo' ? demoAdapterSnippet() : ''}const runtime = createRuntime({
+  adapter: ${adapterCall(ctx.provider)},
+  maxSteps: 10,
+  maxDelegationDepth: 2,
+})
+
+const task = process.argv.slice(2).join(' ') || 'Research the current state of WebGPU and summarize.'
+
+const result = await runtime.run(task, {
+  skill: planner,
+  delegates: {
+    researcher: {
+      skill: researcher,
+      tools: ${toolList(ctx.tools)},
+      maxSteps: 5,
+    },
+  },
+})
+
+console.log(result.content)
+console.log(\`\\n— \${result.steps} steps · \${result.toolCalls.length} tool calls\`)
+`,
+
+    '.env.example': PROVIDER_ENV_KEY[ctx.provider]
+      ? `${PROVIDER_ENV_KEY[ctx.provider]}=\n`
+      : '# No API key required for the local provider\n',
+
+    '.gitignore': `node_modules
+.env
+.env.local
+`,
+
+    'README.md': readmeFor(ctx),
+  }
+}
+
+function readmeFor(ctx: RenderContext): string {
+  const installCmd = ctx.pm === 'npm' ? 'npm install' : `${ctx.pm} install`
+  const runCmd = ctx.pm === 'npm' ? 'npm run dev' : `${ctx.pm} dev`
+  const envKey = PROVIDER_ENV_KEY[ctx.provider]
+
+  return `# AgentsKit ${ctx.template} starter
+
+Generated by \`agentskit init\`.
+
+## Stack
+
+- **Template**: \`${ctx.template}\`
+- **Provider**: \`${ctx.provider}\`${ctx.tools.length ? `\n- **Tools**: ${ctx.tools.map(t => `\`${t}\``).join(', ')}` : ''}${ctx.memory !== 'none' ? `\n- **Memory**: \`${ctx.memory}\`` : ''}
+
+## Run
+
+\`\`\`bash
+${installCmd}
+${envKey ? `cp .env.example .env\n# add ${envKey}=...` : '# No API key required'}
+${runCmd}
+\`\`\`
+
+## Next steps
+
+- Open the AgentsKit docs at https://agentskit.io/docs
+- Add a custom skill: https://agentskit.io/docs/concepts/skill
+- Wire up RAG: https://agentskit.io/docs/recipes/rag-chat
+
+## License
+
+ISC
+`
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+const TEMPLATE_FN: Record<StarterKind, (ctx: RenderContext) => Record<string, string>> = {
+  react: reactStarter,
+  ink: inkStarter,
+  runtime: runtimeStarter,
+  'multi-agent': multiAgentStarter,
+}
+
+export async function writeStarterProject(options: InitCommandOptions): Promise<void> {
+  const ctx: RenderContext = {
+    template: options.template,
+    provider: options.provider ?? 'demo',
+    tools: options.tools ?? [],
+    memory: options.memory ?? 'none',
+    pm: options.packageManager ?? 'pnpm',
+  }
+
+  const files = TEMPLATE_FN[ctx.template](ctx)
   await mkdir(options.targetDir, { recursive: true })
 
   await Promise.all(
@@ -103,6 +534,6 @@ export async function writeStarterProject(options: InitCommandOptions) {
       const absolutePath = path.join(options.targetDir, relativePath)
       await mkdir(path.dirname(absolutePath), { recursive: true })
       await writeFile(absolutePath, content, 'utf8')
-    })
+    }),
   )
 }

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -22,10 +22,12 @@ describe('@agentskit/cli', () => {
     await writeStarterProject({ targetDir: tempDir, template: 'react' })
 
     const packageJson = await readFile(path.join(tempDir, 'package.json'), 'utf8')
+    const appFile = await readFile(path.join(tempDir, 'src/App.tsx'), 'utf8')
     const mainFile = await readFile(path.join(tempDir, 'src/main.tsx'), 'utf8')
 
     expect(packageJson).toContain('@agentskit/react')
-    expect(mainFile).toContain('useChat')
+    expect(appFile).toContain('useChat')
+    expect(mainFile).toContain('createRoot')
   })
 
   it('uses environment variables for openai', () => {
@@ -45,5 +47,64 @@ describe('@agentskit/cli', () => {
     const runtime = resolveChatProvider({ provider: 'ollama' })
     expect(runtime.mode).toBe('live')
     expect(runtime.model).toBe('llama3.1')
+  })
+
+  it('writes an ink starter with a demo adapter', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-cli-'))
+    await writeStarterProject({ targetDir: tempDir, template: 'ink', provider: 'demo' })
+
+    const file = await readFile(path.join(tempDir, 'src/index.tsx'), 'utf8')
+    expect(file).toContain("from '@agentskit/ink'")
+    expect(file).toContain('demoAdapter')
+    expect(file).not.toContain('@agentskit/adapters')
+  })
+
+  it('writes a runtime starter wired to OpenAI', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-cli-'))
+    await writeStarterProject({
+      targetDir: tempDir,
+      template: 'runtime',
+      provider: 'openai',
+      tools: ['web_search', 'filesystem'],
+      memory: 'sqlite',
+    })
+
+    const file = await readFile(path.join(tempDir, 'src/index.ts'), 'utf8')
+    expect(file).toContain("import { createRuntime } from '@agentskit/runtime'")
+    expect(file).toContain("openai({")
+    expect(file).toContain('webSearch()')
+    expect(file).toContain('filesystem({')
+    expect(file).toContain('sqliteChatMemory')
+
+    const env = await readFile(path.join(tempDir, '.env.example'), 'utf8')
+    expect(env).toContain('OPENAI_API_KEY=')
+  })
+
+  it('writes a multi-agent starter with planner + researcher', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-cli-'))
+    await writeStarterProject({
+      targetDir: tempDir,
+      template: 'multi-agent',
+      provider: 'anthropic',
+    })
+
+    const file = await readFile(path.join(tempDir, 'src/index.ts'), 'utf8')
+    expect(file).toContain("import { planner, researcher } from '@agentskit/skills'")
+    expect(file).toContain('delegates: {')
+    expect(file).toContain('researcher: {')
+
+    const pkg = JSON.parse(await readFile(path.join(tempDir, 'package.json'), 'utf8'))
+    expect(pkg.dependencies['@agentskit/skills']).toBeTruthy()
+  })
+
+  it('omits adapter package and shows demo adapter inline when provider is demo', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agentskit-cli-'))
+    await writeStarterProject({ targetDir: tempDir, template: 'runtime', provider: 'demo' })
+
+    const file = await readFile(path.join(tempDir, 'src/index.ts'), 'utf8')
+    expect(file).toContain('demoAdapter')
+
+    const pkg = JSON.parse(await readFile(path.join(tempDir, 'package.json'), 'utf8'))
+    expect(pkg.dependencies['@agentskit/adapters']).toBeUndefined()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,12 +330,18 @@ importers:
       '@agentskit/tools':
         specifier: workspace:*
         version: link:../tools
+      '@inquirer/prompts':
+        specifier: ^8.4.1
+        version: 8.4.1(@types/node@25.6.0)
       commander:
         specifier: ^14.0.1
         version: 14.0.3
       ink:
         specifier: ^7.0.0
         version: 7.0.0(@types/react@19.2.14)(react@19.2.5)
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -354,7 +360,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     devDependencies:
@@ -372,7 +378,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eval:
     dependencies:
@@ -2501,9 +2507,31 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.3':
+    resolution: {integrity: sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@5.1.21':
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.11':
+    resolution: {integrity: sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2519,9 +2547,45 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/core@11.1.8':
+    resolution: {integrity: sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.0':
+    resolution: {integrity: sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.12':
+    resolution: {integrity: sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2532,9 +2596,85 @@ packages:
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.11':
+    resolution: {integrity: sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.11':
+    resolution: {integrity: sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.11':
+    resolution: {integrity: sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.1':
+    resolution: {integrity: sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.7':
+    resolution: {integrity: sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.7':
+    resolution: {integrity: sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.3':
+    resolution: {integrity: sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -5756,8 +5896,17 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6703,6 +6852,10 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   langium@4.2.2:
     resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
@@ -7290,6 +7443,10 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -12196,10 +12353,28 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.3(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
   '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
       '@inquirer/type': 3.0.10(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/confirm@6.0.11(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
@@ -12216,7 +12391,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
+  '@inquirer/core@11.1.8(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/editor@5.1.0(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/external-editor': 3.0.0(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/expand@5.0.12(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/external-editor@3.0.0(@types/node@25.6.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
@@ -12225,7 +12434,74 @@ snapshots:
 
   '@inquirer/figures@1.0.15': {}
 
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.11(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/number@4.0.11(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/password@5.0.11(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/prompts@8.4.1(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.3(@types/node@25.6.0)
+      '@inquirer/confirm': 6.0.11(@types/node@25.6.0)
+      '@inquirer/editor': 5.1.0(@types/node@25.6.0)
+      '@inquirer/expand': 5.0.12(@types/node@25.6.0)
+      '@inquirer/input': 5.0.11(@types/node@25.6.0)
+      '@inquirer/number': 4.0.11(@types/node@25.6.0)
+      '@inquirer/password': 5.0.11(@types/node@25.6.0)
+      '@inquirer/rawlist': 5.2.7(@types/node@25.6.0)
+      '@inquirer/search': 4.1.7(@types/node@25.6.0)
+      '@inquirer/select': 5.1.3(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/rawlist@5.2.7(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/search@4.1.7(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/select@5.1.3(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
   '@inquirer/type@3.0.10(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/type@4.0.5(@types/node@25.6.0)':
     optionalDependencies:
       '@types/node': 25.6.0
 
@@ -13970,7 +14246,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -15617,7 +15893,17 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -16660,6 +16946,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  kleur@4.1.5: {}
+
   langium@4.2.2:
     dependencies:
       '@chevrotain/regexp-to-ast': 12.0.0
@@ -17511,6 +17799,8 @@ snapshots:
       thunky: 1.1.0
 
   mute-stream@2.0.0: {}
+
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:


### PR DESCRIPTION
## Summary

🚀 **First Phase 1 PR.** Closes story #114.

Replaces the two-flag init (\`react\`|\`ink\`) with a guided five-question flow that produces working starter projects across all primary AgentsKit surfaces.

## What you get

```bash
npx agentskit init                # interactive (TTY only)
npx agentskit init --yes          # use defaults, skip prompts
npx agentskit init --template runtime --provider openai \
  --tools web_search,filesystem --memory sqlite -y    # full CI mode
```

## Templates

| Template | What it generates |
|---|---|
| `react` | Vite + React chat UI |
| `ink` | Terminal chat |
| `runtime` | Headless agent, no UI |
| `multi-agent` | Supervisor pattern with planner + delegate |

Each template renders adapter / tools / memory wiring based on your answers. **Demo provider** produces a deterministic stub — starter runs with zero external config.

## Interactive prompts (powered by @inquirer/prompts)

1. **Project directory** — validated, refuses to overwrite
2. **Template** — 4 choices with descriptions
3. **LLM provider** — demo / openai / anthropic / gemini / ollama
4. **Tools** — multi-select web_search / filesystem / shell (skipped for react)
5. **Memory backend** — none / file / sqlite
6. **Package manager** — pnpm / npm / yarn / bun
7. **Generate?** confirmation showing the summary

## CI / non-interactive mode

- Any `--template` flag or `--yes` triggers non-interactive
- Detects non-TTY (CI pipelines) automatically
- Defaults: `react / demo / no tools / none memory / pnpm`

## Generated projects

- Wire only the `@agentskit/*` packages actually needed
- Inline `demoAdapter()` when provider is `demo`
- Match `.env.example` to chosen provider
- Include `tsconfig`, `.gitignore`, `README` documenting the stack + 'Next steps'

## Tests

- 5 new cases: ink + runtime + multi-agent, demo behavior, OpenAI env wiring
- **32 / 32 passing** on `@agentskit/cli` (was 27)

## Verified end-to-end

```bash
node packages/cli/dist/bin.js init \
  --dir /tmp/test --template runtime --provider openai \
  --tools web_search,filesystem --memory sqlite -y
# → produces a runnable runtime starter
```

## Test plan

- [x] Build succeeds
- [x] All 32 unit tests pass
- [x] Each template generates the right files (ink, runtime, multi-agent)
- [x] Demo provider works without API key
- [x] Provider-specific deps included only when needed
- [x] CI-mode (non-TTY) skips prompts
- [ ] Reviewer: try the interactive flow locally
- [ ] Reviewer: confirm prompts feel good (no awkward jumps)

Refs #114 #211