### PR TITLE
feat(adapters): mock + recording + replay adapters [closes #119]

### DIFF
--- a/.changeset/dry-run-mode.md
+++ b/.changeset/dry-run-mode.md
@@ -1,0 +1,56 @@
+---
+'@agentskit/adapters': minor
+---
+
+New dry-run primitives — test agents without burning tokens.
+
+```ts
+import { mockAdapter, recordingAdapter, replayAdapter, inMemorySink } from '@agentskit/adapters'
+```
+
+### `mockAdapter` — deterministic adapter
+
+Three call shapes:
+
+```ts
+// 1. Static chunks
+mockAdapter({ response: [
+  { type: 'text', content: 'hello' },
+  { type: 'done' },
+]})
+
+// 2. Request-aware
+mockAdapter({ response: req => [
+  { type: 'text', content: 'echo: ' + req.messages[0].content },
+  { type: 'done' },
+]})
+
+// 3. Sequenced — different output per call
+mockAdapter({ response: [
+  [{ type: 'text', content: 'first' },  { type: 'done' }],
+  [{ type: 'text', content: 'second' }, { type: 'done' }],
+]})
+```
+
+Conforms to ADR 0001 — the terminal `done` chunk is appended automatically if the response doesn't include one. Optional `delayMs` between chunks for streaming UX testing.
+
+### `recordingAdapter` + `replayAdapter` — capture once, replay forever
+
+```ts
+import { openai, recordingAdapter, replayAdapter, inMemorySink } from '@agentskit/adapters'
+
+// Dev: wrap the real adapter and capture every turn
+const sink = inMemorySink()
+const adapter = recordingAdapter(
+  openai({ apiKey: KEY, model: 'gpt-4o' }),
+  sink,
+)
+// ...run the agent...
+
+// Test: feed the recorded fixture back
+const replay = replayAdapter(sink.fixture)
+```
+
+`RecordedTurn` includes `recordedAt`, the original `request`, and every chunk yielded — JSON-serializable so you can save fixtures to disk and replay them in CI.
+
+These are the substrate for the deterministic-replay feature tracked in #134 (Phase 2).

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -24,6 +24,15 @@ export type { VercelAIConfig } from './vercel-ai'
 export { fetchWithRetry } from './utils'
 export type { RetryOptions } from './utils'
 
+export { mockAdapter, recordingAdapter, replayAdapter, inMemorySink } from './mock'
+export type {
+  MockAdapterOptions,
+  MockResponse,
+  RecordedTurn,
+  RecordingFixture,
+  RecordingSink,
+} from './mock'
+
 export {
   openaiEmbedder,
   geminiEmbedder,

--- a/packages/adapters/src/mock.ts
+++ b/packages/adapters/src/mock.ts
@@ -1,0 +1,191 @@
+import type {
+  AdapterFactory,
+  AdapterRequest,
+  StreamChunk,
+  StreamSource,
+} from '@agentskit/core'
+
+export type MockResponse = StreamChunk[] | ((request: AdapterRequest) => StreamChunk[])
+
+export interface MockAdapterOptions {
+  /**
+   * Static chunks, a request-aware function, or a sequence of responses
+   * (the i-th call returns the i-th item, looping when exhausted).
+   */
+  response: MockResponse | MockResponse[]
+  /** ms between yielded chunks. Default 0 (synchronous). */
+  delayMs?: number
+  /** Track every request the adapter received. Useful for assertions. */
+  history?: AdapterRequest[]
+}
+
+/**
+ * A deterministic adapter for tests, demos, and dry-run experiments.
+ *
+ * Conforms to ADR 0001 — Adapter contract:
+ * - createSource is pure (A1) — no work until stream() runs
+ * - Always emits a terminal chunk (A3)
+ * - abort() is safe (A6)
+ * - Does not mutate input messages (A7)
+ *
+ * Examples:
+ *
+ *   // Static
+ *   const adapter = mockAdapter({
+ *     response: [
+ *       { type: 'text', content: 'Hello!' },
+ *       { type: 'done' },
+ *     ],
+ *   })
+ *
+ *   // Request-aware
+ *   const adapter = mockAdapter({
+ *     response: req => {
+ *       const last = req.messages[req.messages.length - 1]?.content ?? ''
+ *       return [
+ *         { type: 'text', content: 'Echo: ' + last },
+ *         { type: 'done' },
+ *       ]
+ *     },
+ *   })
+ *
+ *   // Sequenced — different output each call
+ *   const adapter = mockAdapter({
+ *     response: [
+ *       [{ type: 'text', content: 'first' }, { type: 'done' }],
+ *       [{ type: 'text', content: 'second' }, { type: 'done' }],
+ *     ],
+ *   })
+ */
+export function mockAdapter(options: MockAdapterOptions): AdapterFactory {
+  const { response, delayMs = 0, history } = options
+  let callIndex = 0
+
+  return {
+    createSource: (request: AdapterRequest): StreamSource => {
+      history?.push(request)
+      const myCall = callIndex++
+      let cancelled = false
+
+      return {
+        stream: async function* (): AsyncIterableIterator<StreamChunk> {
+          const chunks = resolve(response, myCall, request)
+          let endedExplicitly = false
+
+          for (const chunk of chunks) {
+            if (cancelled) return
+            if (delayMs > 0) await new Promise(r => setTimeout(r, delayMs))
+            yield chunk
+            if (chunk.type === 'done' || chunk.type === 'error') {
+              endedExplicitly = true
+            }
+          }
+
+          // ADR 0001 A3 — every stream ends with a terminal chunk.
+          if (!endedExplicitly) yield { type: 'done' }
+        },
+        abort: () => {
+          cancelled = true
+        },
+      }
+    },
+  }
+}
+
+function resolve(
+  response: MockResponse | MockResponse[],
+  callIndex: number,
+  request: AdapterRequest,
+): StreamChunk[] {
+  if (Array.isArray(response) && response.length > 0 && Array.isArray(response[0])) {
+    // Sequenced responses
+    const sequence = response as StreamChunk[][]
+    const item = sequence[callIndex % sequence.length]
+    return item
+  }
+  if (Array.isArray(response) && response.length > 0 && typeof response[0] === 'function') {
+    // Sequenced functions
+    const sequence = response as Array<(req: AdapterRequest) => StreamChunk[]>
+    return sequence[callIndex % sequence.length](request)
+  }
+  if (typeof response === 'function') {
+    return response(request)
+  }
+  return response as StreamChunk[]
+}
+
+// ============================================================================
+// Recording / replay
+// ============================================================================
+
+export interface RecordedTurn {
+  /** ISO timestamp when this turn was recorded. */
+  recordedAt: string
+  /** The request that produced this turn. */
+  request: AdapterRequest
+  /** Every chunk yielded by the wrapped adapter. */
+  chunks: StreamChunk[]
+}
+
+export type RecordingFixture = RecordedTurn[]
+
+export interface RecordingSink {
+  push(turn: RecordedTurn): void | Promise<void>
+}
+
+/**
+ * Wrap a real adapter so every turn is captured to a sink. Use this in
+ * dev to build up a fixture, then replay with replayAdapter() in tests.
+ */
+export function recordingAdapter(
+  inner: AdapterFactory,
+  sink: RecordingSink,
+): AdapterFactory {
+  return {
+    createSource: (request: AdapterRequest): StreamSource => {
+      const innerSource = inner.createSource(request)
+      const captured: StreamChunk[] = []
+      const recordedAt = new Date().toISOString()
+
+      return {
+        stream: async function* (): AsyncIterableIterator<StreamChunk> {
+          try {
+            for await (const chunk of innerSource.stream()) {
+              captured.push(chunk)
+              yield chunk
+            }
+          } finally {
+            await sink.push({ recordedAt, request, chunks: captured })
+          }
+        },
+        abort: () => innerSource.abort(),
+      }
+    },
+  }
+}
+
+/**
+ * In-memory recording sink — useful for tests and ephemeral capture.
+ */
+export function inMemorySink(): RecordingSink & { fixture: RecordingFixture } {
+  const fixture: RecordingFixture = []
+  return {
+    fixture,
+    push(turn) {
+      fixture.push(turn)
+    },
+  }
+}
+
+/**
+ * Replay an adapter from a recorded fixture. Each turn maps 1:1 to a
+ * recorded entry by index — call N replays fixture[N % fixture.length].
+ */
+export function replayAdapter(fixture: RecordingFixture): AdapterFactory {
+  if (fixture.length === 0) {
+    throw new Error('replayAdapter: fixture is empty')
+  }
+  return mockAdapter({
+    response: fixture.map(turn => turn.chunks),
+  })
+}

--- a/packages/adapters/tests/mock.test.ts
+++ b/packages/adapters/tests/mock.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest'
+import type { AdapterRequest, StreamChunk } from '@agentskit/core'
+import {
+  mockAdapter,
+  recordingAdapter,
+  replayAdapter,
+  inMemorySink,
+} from '../src/mock'
+
+const sampleRequest: AdapterRequest = {
+  messages: [
+    {
+      id: '1',
+      role: 'user',
+      content: 'hi',
+      status: 'complete',
+      createdAt: new Date('2026-04-15T00:00:00Z'),
+    },
+  ],
+}
+
+async function collect(source: ReturnType<ReturnType<typeof mockAdapter>['createSource']>): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = []
+  for await (const chunk of source.stream()) out.push(chunk)
+  return out
+}
+
+describe('mockAdapter — static response', () => {
+  it('yields the chunks in order', async () => {
+    const adapter = mockAdapter({
+      response: [
+        { type: 'text', content: 'hello' },
+        { type: 'text', content: ' world' },
+        { type: 'done' },
+      ],
+    })
+
+    const chunks = await collect(adapter.createSource(sampleRequest))
+    expect(chunks).toHaveLength(3)
+    expect(chunks[0]).toEqual({ type: 'text', content: 'hello' })
+    expect(chunks[1]).toEqual({ type: 'text', content: ' world' })
+    expect(chunks[2]).toEqual({ type: 'done' })
+  })
+
+  it('appends a done chunk if the response did not include one', async () => {
+    const adapter = mockAdapter({
+      response: [{ type: 'text', content: 'hi' }],
+    })
+
+    const chunks = await collect(adapter.createSource(sampleRequest))
+    expect(chunks).toEqual([
+      { type: 'text', content: 'hi' },
+      { type: 'done' },
+    ])
+  })
+
+  it('does not duplicate done if response already terminates', async () => {
+    const adapter = mockAdapter({
+      response: [{ type: 'done' }],
+    })
+    const chunks = await collect(adapter.createSource(sampleRequest))
+    expect(chunks).toEqual([{ type: 'done' }])
+  })
+
+  it('terminates with error and does not append done', async () => {
+    const adapter = mockAdapter({
+      response: [{ type: 'error', content: 'kaboom' }],
+    })
+    const chunks = await collect(adapter.createSource(sampleRequest))
+    expect(chunks).toEqual([{ type: 'error', content: 'kaboom' }])
+  })
+
+  it('does not start work until stream() is called (ADR 0001 A1)', () => {
+    let started = false
+    const adapter = mockAdapter({
+      response: () => {
+        started = true
+        return [{ type: 'done' }]
+      },
+    })
+    adapter.createSource(sampleRequest)
+    expect(started).toBe(false)
+  })
+
+  it('records request history when sink is supplied', () => {
+    const history: AdapterRequest[] = []
+    const adapter = mockAdapter({
+      response: [{ type: 'done' }],
+      history,
+    })
+    adapter.createSource(sampleRequest)
+    adapter.createSource(sampleRequest)
+    expect(history).toHaveLength(2)
+  })
+})
+
+describe('mockAdapter — request-aware', () => {
+  it('passes the request to the response function', async () => {
+    const adapter = mockAdapter({
+      response: req => [
+        { type: 'text', content: 'echo: ' + req.messages[0].content },
+        { type: 'done' },
+      ],
+    })
+    const chunks = await collect(adapter.createSource(sampleRequest))
+    expect(chunks[0]).toEqual({ type: 'text', content: 'echo: hi' })
+  })
+})
+
+describe('mockAdapter — sequenced', () => {
+  it('returns each item per call, looping when exhausted', async () => {
+    const adapter = mockAdapter({
+      response: [
+        [{ type: 'text', content: 'first' }, { type: 'done' }],
+        [{ type: 'text', content: 'second' }, { type: 'done' }],
+      ],
+    })
+
+    const a = await collect(adapter.createSource(sampleRequest))
+    const b = await collect(adapter.createSource(sampleRequest))
+    const c = await collect(adapter.createSource(sampleRequest))   // loops back to first
+
+    expect(a[0]).toEqual({ type: 'text', content: 'first' })
+    expect(b[0]).toEqual({ type: 'text', content: 'second' })
+    expect(c[0]).toEqual({ type: 'text', content: 'first' })
+  })
+})
+
+describe('mockAdapter — abort', () => {
+  it('stops yielding chunks after abort', async () => {
+    const adapter = mockAdapter({
+      response: [
+        { type: 'text', content: 'a' },
+        { type: 'text', content: 'b' },
+        { type: 'text', content: 'c' },
+        { type: 'done' },
+      ],
+      delayMs: 5,
+    })
+
+    const source = adapter.createSource(sampleRequest)
+    const chunks: StreamChunk[] = []
+    const reader = (async () => {
+      for await (const chunk of source.stream()) chunks.push(chunk)
+    })()
+
+    await new Promise(r => setTimeout(r, 8))
+    source.abort()
+    await reader
+
+    expect(chunks.length).toBeLessThan(4)
+  })
+})
+
+describe('recordingAdapter + replayAdapter', () => {
+  it('records every chunk an inner adapter yields', async () => {
+    const inner = mockAdapter({
+      response: [
+        { type: 'text', content: 'recorded' },
+        { type: 'done' },
+      ],
+    })
+    const sink = inMemorySink()
+    const wrapped = recordingAdapter(inner, sink)
+
+    const source = wrapped.createSource(sampleRequest)
+    for await (const _ of source.stream()) { /* drain */ }
+
+    expect(sink.fixture).toHaveLength(1)
+    expect(sink.fixture[0].chunks).toHaveLength(2)
+    expect(sink.fixture[0].request).toBe(sampleRequest)
+    expect(sink.fixture[0].recordedAt).toBeTruthy()
+  })
+
+  it('replays a recorded fixture deterministically', async () => {
+    const sink = inMemorySink()
+    const recordedInner = mockAdapter({
+      response: [
+        [{ type: 'text', content: 'turn1' }, { type: 'done' }],
+        [{ type: 'text', content: 'turn2' }, { type: 'done' }],
+      ],
+    })
+    const wrapped = recordingAdapter(recordedInner, sink)
+
+    // Record two turns
+    for await (const _ of wrapped.createSource(sampleRequest).stream()) {}
+    for await (const _ of wrapped.createSource(sampleRequest).stream()) {}
+
+    expect(sink.fixture).toHaveLength(2)
+
+    // Replay
+    const replay = replayAdapter(sink.fixture)
+    const a = await collect(replay.createSource(sampleRequest))
+    const b = await collect(replay.createSource(sampleRequest))
+
+    expect(a[0]).toEqual({ type: 'text', content: 'turn1' })
+    expect(b[0]).toEqual({ type: 'text', content: 'turn2' })
+  })
+
+  it('replayAdapter throws on empty fixture', () => {
+    expect(() => replayAdapter([])).toThrow(/empty/)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 #119. Three testing primitives for adapters — write fast, deterministic tests without burning tokens.

```ts
import {
  mockAdapter, recordingAdapter, replayAdapter, inMemorySink,
} from '@agentskit/adapters'
```

## `mockAdapter` — deterministic stub

Three call shapes:

```ts
// 1. Static chunks
mockAdapter({ response: [
  { type: 'text', content: 'hello' },
  { type: 'done' },
]})

// 2. Request-aware
mockAdapter({ response: req => [
  { type: 'text', content: 'echo: ' + req.messages[0].content },
  { type: 'done' },
]})

// 3. Sequenced — different output per call
mockAdapter({ response: [
  [{ type: 'text', content: 'first' },  { type: 'done' }],
  [{ type: 'text', content: 'second' }, { type: 'done' }],
]})
```

Conforms to **ADR 0001** — auto-appends terminal `done` if the response doesn't include one, pure factory, abort-safe.

## `recordingAdapter` + `replayAdapter` — capture once, replay forever

```ts
import { openai, recordingAdapter, replayAdapter, inMemorySink } from '@agentskit/adapters'

// Dev: record real sessions
const sink = inMemorySink()
const adapter = recordingAdapter(
  openai({ apiKey: KEY, model: 'gpt-4o' }),
  sink,
)
// ... run the agent ...
// sink.fixture is JSON-serializable — save to disk

// Test: replay
const replay = replayAdapter(savedFixture)
```

`RecordedTurn` includes `recordedAt`, original `request`, and every chunk yielded.

This is the **substrate for the deterministic-replay feature** tracked in #134 (Phase 2).

## Use cases unlocked

- Unit-test agent flows without API keys or rate limits
- Snapshot-test prompts: record a real session, replay forever in CI
- Demo apps that need deterministic output for screenshots
- Cost-free CI runs of `@agentskit/eval` test suites

## Tests

12 new cases — **75 / 75 passing** on `@agentskit/adapters` (was 63):

- Static / request-aware / sequenced response shapes
- Auto-done append behavior
- Error termination (no double done)
- Pure factory invariant (no work until stream())
- Request history capture
- Abort cooperation
- recordingAdapter end-to-end
- replay determinism
- Empty fixture error

## Test plan

- [x] Build succeeds
- [x] All 75 tests pass
- [x] All exports threaded through `src/index.ts`
- [x] No type leaks — `RecordedTurn` is JSON-serializable
- [ ] Reviewer: try recording a real session and replaying it

Refs #119 #134 #211