### PR TITLE
fix(ink): restore ink@7 test harness + Phase 1 review report

### DIFF
--- a/docs/PHASE-1-REVIEW.md
+++ b/docs/PHASE-1-REVIEW.md
@@ -1,0 +1,166 @@
+# Phase 1 — Review Report
+
+> Generated 2026-04-15. Run before officially closing Phase 1.
+
+## 1. Audit — build + test + lint + size
+
+| Check | Status | Detail |
+|---|---|---|
+| `pnpm install` | ✅ | Clean |
+| `pnpm build` (packages) | ✅ | All 14 packages built |
+| `pnpm test` | ✅ | 22 / 22 tasks passing after cherry-picking the ink test fix that was lost in an earlier merge (included in `fix/ink-test-suite`) |
+| `pnpm lint` | ✅ | 28 / 28 tasks passing (tsc --noEmit across packages) |
+| `pnpm exec size-limit` | ✅ | Every package under budget |
+| `@agentskit/docs` (legacy Docusaurus) | ❌ | Broken on Node 25 — known, will be retired by the Fumadocs migration |
+
+### Blocker found during audit
+
+**Ink test regression**. Commit `e8416bf` (from PR #265 timeline) that rewrote ink tests to work around ink@7 / ink-testing-library@4 incompat never made it to `main`. Fixed in this review via cherry-pick to `fix/ink-test-suite`. **This branch should merge before closing Phase 1.**
+
+---
+
+## 2. Tour — new code shipped
+
+| Module | Lines | What it does |
+|---|---|---|
+| `packages/cli/src/init.ts` | 539 | 4 templates (react, ink, runtime, multi-agent) with full wiring |
+| `packages/cli/src/init-interactive.ts` | 151 | @inquirer prompts + summary + confirm |
+| `packages/cli/src/doctor.ts` | 295 | Node / pm / packages / config / env keys / reachability |
+| `packages/cli/src/dev.ts` | 180 | chokidar watch + tsx spawn + keyboard shortcuts |
+| `packages/cli/src/tunnel.ts` | 115 | localtunnel wrapper |
+| `packages/adapters/src/utils.ts` | +232 | `fetchWithRetry`, `simulateStream`, `chunkText` |
+| `packages/adapters/src/mock.ts` | 198 | `mockAdapter`, `recordingAdapter`, `replayAdapter`, `inMemorySink` |
+| `packages/observability/src/cost-guard.ts` | 191 | Pricing table + observer + abort |
+| `packages/core/src/types/adapter.ts` | +32 | `AdapterCapabilities` interface |
+| `packages/core/src/types/chat.ts` | +20 | `EditOptions` + `edit` / `regenerate` in ChatController |
+| `packages/core/src/controller.ts` | +70 | `edit` + `regenerate` implementations |
+
+---
+
+## 3. Smoke test — end-to-end
+
+```bash
+node packages/cli/dist/bin.js init --dir /tmp/smoke-runtime --template runtime --provider demo -y
+# → Created runtime starter
+```
+
+Generated files match expectations: `package.json`, `tsconfig.json`, `src/index.ts`, `.env.example`, `.gitignore`, `README.md`. `package.json` declares only the packages actually used (no `@agentskit/adapters` when provider is `demo`).
+
+```bash
+node packages/cli/dist/bin.js doctor --no-network
+# → 2 pass · 1 warn · 3 fail · 2 skip
+```
+
+Doctor correctly warns about Node 25 + flags missing API keys (no crash, proper exit code).
+
+---
+
+## 4. Metrics
+
+### Test counts (14 packages)
+
+| Package | Tests |
+|---|---|
+| @agentskit/adapters | 90 |
+| @agentskit/core | 79 |
+| @agentskit/cli | 58 |
+| @agentskit/skills | 44 |
+| @agentskit/react | 41 |
+| @agentskit/observability | 40 |
+| @agentskit/runtime | 39 |
+| @agentskit/tools | 28 |
+| @agentskit/memory | 26 |
+| @agentskit/ink | 23 |
+| @agentskit/rag | 22 |
+| @agentskit/templates | 21 |
+| @agentskit/sandbox | 14 |
+| @agentskit/eval | 13 |
+| **Total** | **538** |
+
+### Bundle sizes (gzipped, against budget)
+
+| Package | Size | Limit | Headroom |
+|---|---|---|---|
+| `@agentskit/core` (ESM) | 5.17 KB | 10 KB | 48% |
+| `@agentskit/core` (CJS) | 5.26 KB | 10 KB | 47% |
+| `@agentskit/adapters` | 6.3 KB | 20 KB | 69% |
+| `@agentskit/react` | 2.59 KB | 15 KB | 83% |
+| `@agentskit/runtime` | 2.34 KB | 15 KB | 84% |
+| `@agentskit/memory` | 2.84 KB | 15 KB | 81% |
+| `@agentskit/rag` | 852 B | 10 KB | 92% |
+| `@agentskit/tools` | 2.27 KB | 15 KB | 85% |
+| `@agentskit/skills` | 5.19 KB | 10 KB | 48% |
+| `@agentskit/observability` | 3.83 KB | 10 KB | 62% |
+| `@agentskit/eval` | 556 B | 10 KB | 95% |
+| `@agentskit/sandbox` | 1.53 KB | 10 KB | 85% |
+| `@agentskit/ink` | 1.34 KB | 15 KB | 91% |
+| `@agentskit/cli` | 210 B | 20 KB | 99% |
+| `@agentskit/templates` | 2.89 KB | 15 KB | 81% |
+
+**Manifesto principle 1 holds**: core is 5.17 KB gzipped, 48% under budget despite Phase 1 adding capabilities + retry + simulate-stream + edit/regenerate to its surface.
+
+---
+
+## 5. Docs coverage — Phase 1 features
+
+| Feature | Doc hits | Status |
+|---|---|---|
+| `agentskit init` | 5 pages | ✅ Recipe + README |
+| `agentskit doctor` | 1 page | ⚠️ Changelog only |
+| `agentskit dev` | 1 page | ⚠️ Changelog only |
+| `agentskit tunnel` | 1 page | ⚠️ Changelog only |
+| retry (adapters) | 7 pages | ✅ Covered |
+| `mockAdapter` | 1 page | ⚠️ Recipe reference only |
+| capabilities | 2 pages | ✅ |
+| `simulateStream` | 0 pages | ❌ Undocumented |
+| `costGuard` | 0 pages | ❌ Undocumented (recipe mentions manual version) |
+| `edit(` | 0 pages | ❌ Undocumented |
+| `regenerate(` | 0 pages | ❌ Undocumented |
+
+**Action required before closing Phase 1**: create a single "Phase 1 features" doc page (or per-feature recipes) for the 4 items at 0 hits: `simulateStream`, `costGuard`, `edit`, `regenerate`.
+
+### Changeset coverage
+
+10 pending changesets, all paired with Phase 1 PRs:
+
+```
+adapter-capabilities.md   adapter-retry.md         chat-edit-regenerate.md
+core-browser-compat.md    cost-guard.md            dev-command.md
+doctor-command.md         dry-run-mode.md          init-interactive.md
+tunnel-command.md
+```
+
+---
+
+## 6. Release dry-run
+
+`pnpm changeset status` summarizes what the next release will ship:
+
+| Package | Bump | Reason |
+|---|---|---|
+| `@agentskit/core` | **major** | `createFileMemory` + `loadConfig` removed (browser-compat) — ADR 0001 still valid, APIs changed |
+| `@agentskit/adapters` | minor | retry + capabilities + mock/recording/replay + simulateStream |
+| `@agentskit/cli` | minor | init (interactive) + doctor + dev + tunnel + loadConfig moved in |
+| `@agentskit/react` | minor | `edit` + `regenerate` on useChat; `createFileMemory` re-export dropped |
+| `@agentskit/ink` | minor | same as react |
+| `@agentskit/memory` | minor | `fileChatMemory` added |
+| `@agentskit/observability` | minor | `costGuard` + `priceFor` + `DEFAULT_PRICES` |
+| `@agentskit/eval` | patch | no surface changes |
+| `@agentskit/rag` | patch | no surface changes |
+| `@agentskit/runtime` | patch | no surface changes |
+| `@agentskit/sandbox` | patch | no surface changes |
+| `@agentskit/skills` | patch | no surface changes |
+| `@agentskit/templates` | patch | no surface changes |
+| `@agentskit/tools` | patch | no surface changes |
+
+**Release path**: `pnpm changeset version` → review generated version bumps & CHANGELOGs → commit → `pnpm changeset publish`.
+
+---
+
+## Gates before officially closing Phase 1
+
+- [ ] Merge `fix/ink-test-suite` (cherry-pick of the ink@7 test fix that was lost)
+- [ ] Add doc pages for `simulateStream`, `costGuard`, `edit`, `regenerate`
+- [ ] Consider whether the `@agentskit/core` major bump is the moment to publish v1.0 on core, or defer
+- [ ] Run `pnpm changeset version` locally and review the generated CHANGELOGs before `changeset publish`
+- [ ] Announce the release publicly (HN / Twitter / Discord) — per the pre-launch plan in `docs/MASTER-EXECUTION-PLAN.md`

--- a/packages/ink/tests/InputBar.test.tsx
+++ b/packages/ink/tests/InputBar.test.tsx
@@ -1,10 +1,48 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from 'ink-testing-library'
 import { InputBar } from '../src/components/InputBar'
 import type { ChatReturn } from '@agentskit/core'
 
-const delay = (ms = 50) => new Promise(r => setTimeout(r, ms))
+// ink-testing-library@4 does not route stdin through ink@7's new raw-mode
+// input pipeline, so useInput callbacks never fire. To test InputBar's
+// keyboard behavior we mock the useInput hook and capture its handler,
+// then invoke it directly with the same (input, key) shape ink would pass.
+//
+// This validates the actual InputBar logic (setInput/send/guards) without
+// depending on the broken test harness. See #266.
+
+type Key = Parameters<Parameters<typeof import('ink').useInput>[0]>[1]
+
+let capturedHandler: ((input: string, key: Key) => void) | undefined
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual<typeof import('ink')>('ink')
+  return {
+    ...actual,
+    useInput: (handler: (input: string, key: Key) => void) => {
+      capturedHandler = handler
+    },
+  }
+})
+
+const key = (overrides: Partial<Key> = {}): Key => ({
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  escape: false,
+  ctrl: false,
+  shift: false,
+  tab: false,
+  backspace: false,
+  delete: false,
+  meta: false,
+  ...overrides,
+} as Key)
 
 function mockChat(overrides?: Partial<ChatReturn>): ChatReturn {
   return {
@@ -22,6 +60,10 @@ function mockChat(overrides?: Partial<ChatReturn>): ChatReturn {
 }
 
 describe('InputBar', () => {
+  beforeEach(() => {
+    capturedHandler = undefined
+  })
+
   it('renders placeholder text', () => {
     const chat = mockChat()
     const { lastFrame } = render(<InputBar chat={chat} />)
@@ -40,87 +82,91 @@ describe('InputBar', () => {
     expect(lastFrame()).toContain('hello world')
   })
 
-  it('typing characters calls setInput with appended text', async () => {
+  it('typing characters calls setInput with appended text', () => {
     const setInput = vi.fn()
     const chat = mockChat({ input: 'hel', setInput })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('l')
-    await delay()
+    capturedHandler!('l', key())
     expect(setInput).toHaveBeenCalledWith('hell')
   })
 
-  it('backspace calls setInput with trimmed text', async () => {
+  it('backspace calls setInput with trimmed text', () => {
     const setInput = vi.fn()
     const chat = mockChat({ input: 'hello', setInput })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('\x7F')
-    await delay()
+    capturedHandler!('', key({ backspace: true }))
     expect(setInput).toHaveBeenCalledWith('hell')
   })
 
-  it('enter sends the message when input is not empty', async () => {
+  it('enter sends the message when input is not empty', () => {
     const send = vi.fn()
     const chat = mockChat({ input: 'hello', send })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('\r')
-    await delay()
+    capturedHandler!('', key({ return: true }))
     expect(send).toHaveBeenCalledWith('hello')
   })
 
-  it('enter does nothing when input is empty', async () => {
+  it('enter does nothing when input is empty', () => {
     const send = vi.fn()
     const chat = mockChat({ input: '', send })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('\r')
-    await delay()
+    capturedHandler!('', key({ return: true }))
     expect(send).not.toHaveBeenCalled()
   })
 
-  it('enter does nothing when input is whitespace only', async () => {
+  it('enter does nothing when input is whitespace only', () => {
     const send = vi.fn()
     const chat = mockChat({ input: '   ', send })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('\r')
-    await delay()
+    capturedHandler!('', key({ return: true }))
     expect(send).not.toHaveBeenCalled()
   })
 
-  it('blocks input while streaming (prevents double-send)', async () => {
+  it('blocks input while streaming (prevents double-send)', () => {
     const setInput = vi.fn()
     const send = vi.fn()
     const chat = mockChat({ input: 'hello', status: 'streaming', setInput, send })
-    const { stdin } = render(<InputBar chat={chat} />)
+    render(<InputBar chat={chat} />)
 
-    await delay()
-    stdin.write('\r')
-    stdin.write('x')
-    await delay()
+    capturedHandler!('', key({ return: true }))
+    capturedHandler!('x', key())
     expect(send).not.toHaveBeenCalled()
     expect(setInput).not.toHaveBeenCalled()
   })
 
-  it('disabled prop blocks all input', async () => {
+  it('disabled prop blocks all input', () => {
     const setInput = vi.fn()
     const send = vi.fn()
     const chat = mockChat({ input: 'test', setInput, send })
-    const { stdin } = render(<InputBar chat={chat} disabled />)
+    render(<InputBar chat={chat} disabled />)
 
-    await delay()
-    stdin.write('x')
-    stdin.write('\r')
-    stdin.write('\x7F')
-    await delay()
+    capturedHandler!('x', key())
+    capturedHandler!('', key({ return: true }))
+    capturedHandler!('', key({ backspace: true }))
     expect(setInput).not.toHaveBeenCalled()
     expect(send).not.toHaveBeenCalled()
+  })
+
+  it('ignores ctrl key combinations', () => {
+    const setInput = vi.fn()
+    const chat = mockChat({ input: 'hi', setInput })
+    render(<InputBar chat={chat} />)
+
+    capturedHandler!('c', key({ ctrl: true }))
+    expect(setInput).not.toHaveBeenCalled()
+  })
+
+  it('ignores meta key combinations', () => {
+    const setInput = vi.fn()
+    const chat = mockChat({ input: 'hi', setInput })
+    render(<InputBar chat={chat} />)
+
+    capturedHandler!('v', key({ meta: true }))
+    expect(setInput).not.toHaveBeenCalled()
   })
 })

--- a/packages/ink/tests/integration.test.tsx
+++ b/packages/ink/tests/integration.test.tsx
@@ -1,9 +1,56 @@
 import React from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from 'ink-testing-library'
 import { ChatContainer, Message, InputBar, ThinkingIndicator } from '../src/components'
 import { useChat } from '../src/useChat'
 import type { AdapterFactory, AdapterRequest, StreamChunk, Message as MessageType } from '@agentskit/core'
+
+// Same strategy as InputBar.test.tsx: ink-testing-library@4 does not trigger
+// useInput under ink@7. We intercept the handler and drive keyboard input
+// directly. See #266.
+
+type Key = Parameters<Parameters<typeof import('ink').useInput>[0]>[1]
+
+let capturedHandler: ((input: string, key: Key) => void) | undefined
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual<typeof import('ink')>('ink')
+  return {
+    ...actual,
+    useInput: (handler: (input: string, key: Key) => void) => {
+      capturedHandler = handler
+    },
+  }
+})
+
+const key = (overrides: Partial<Key> = {}): Key => ({
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  escape: false,
+  ctrl: false,
+  shift: false,
+  tab: false,
+  backspace: false,
+  delete: false,
+  meta: false,
+  ...overrides,
+} as Key)
+
+const flush = () => new Promise(r => setTimeout(r, 0))
+
+const typeText = async (text: string) => {
+  for (const char of text) {
+    capturedHandler!(char, key())
+    await flush()
+  }
+}
+
+const pressEnter = () => capturedHandler!('', key({ return: true }))
 
 const delay = (ms = 50) => new Promise(r => setTimeout(r, ms))
 
@@ -39,6 +86,10 @@ function ChatApp({ adapter }: { adapter: AdapterFactory }) {
 }
 
 describe('Ink chat integration', () => {
+  beforeEach(() => {
+    capturedHandler = undefined
+  })
+
   it('renders empty chat with input bar', () => {
     const adapter = createMockAdapter([])
     const { lastFrame } = render(<ChatApp adapter={adapter} />)
@@ -53,31 +104,18 @@ describe('Ink chat integration', () => {
       { type: 'done' },
     ])
 
-    const { lastFrame, stdin } = render(<ChatApp adapter={adapter} />)
+    const { lastFrame, rerender } = render(<ChatApp adapter={adapter} />)
 
-    // Wait for Ink to set up useInput
-    await delay()
-
-    // Type "Hi"
-    stdin.write('H')
-    await delay()
-    stdin.write('i')
-    await delay()
-
-    // Verify input appears
+    await typeText('Hi')
+    rerender(<ChatApp adapter={adapter} />)
     expect(lastFrame()).toContain('Hi')
 
-    // Press enter to send
-    stdin.write('\r')
-
-    // Wait for streaming to complete
+    pressEnter()
     await delay(200)
+    rerender(<ChatApp adapter={adapter} />)
 
     const output = lastFrame()
-
-    // User message should be visible
     expect(output).toContain('USER')
-    // Assistant response should be fully streamed
     expect(output).toContain('Hello from AgentsKit!')
     expect(output).toContain('ASSISTANT')
   })
@@ -88,7 +126,6 @@ describe('Ink chat integration', () => {
       createSource: () => ({
         stream: async function* () {
           yield { type: 'text' as const, content: 'partial' }
-          // Block until resolved
           await new Promise<void>(r => { resolveStream = r })
           yield { type: 'done' as const }
         },
@@ -96,22 +133,19 @@ describe('Ink chat integration', () => {
       }),
     }
 
-    const { lastFrame, stdin } = render(<ChatApp adapter={adapter} />)
-    await delay()
+    const { lastFrame, rerender } = render(<ChatApp adapter={adapter} />)
 
-    stdin.write('go')
-    await delay()
-    stdin.write('\r')
+    await typeText('go')
+    pressEnter()
     await delay(100)
+    rerender(<ChatApp adapter={adapter} />)
 
-    // Should show thinking indicator during streaming
     expect(lastFrame()).toContain('Thinking...')
 
-    // Resolve the stream
     resolveStream?.()
     await delay(100)
+    rerender(<ChatApp adapter={adapter} />)
 
-    // Thinking indicator should be gone
     expect(lastFrame()).not.toContain('Thinking...')
   })
 })


### PR DESCRIPTION
## Summary

Two things in one PR — both part of the Phase 1 close-out audit:

### 1. Ink test fix restored

Commit `e8416bf` (rewrote the ink test suite to mock `useInput` for ink@7 + ink-testing-library@4 compat) landed on a branch during Phase 0 but **never reached main** when the squash merges collapsed history. `pnpm test` has been failing on \`@agentskit/ink\` ever since.

Cherry-picked here. Result: `@agentskit/ink` goes from 5 failing → **23 passing**. `pnpm test` now green across all 22 turbo tasks.

### 2. `docs/PHASE-1-REVIEW.md`

The full Phase 1 close-out audit in one doc:

- **Build / test / lint / size** — all green (minus the legacy Docusaurus build which is known broken on Node 25 and being retired)
- **Tour** of every new module with line counts and role
- **End-to-end smoke** using `init` → `doctor` against a fresh starter
- **Metrics**: 538 total tests across 14 packages, bundle sizes (core at 5.17 KB — 48% under the 10 KB manifesto budget)
- **Docs coverage gaps** — 4 features (`simulateStream`, `costGuard`, `edit`, `regenerate`) shipped code but no doc page yet
- **Release dry-run**: `core` = major, 6 packages = minor, 7 = patch

Includes the gates list to clear before publishing the Phase 1 release.

## Test plan

- [x] `pnpm test` now green (538 tests across 14 packages)
- [x] `pnpm lint` green (28 / 28)
- [x] `pnpm exec size-limit` green (all packages under budget)
- [x] Ink package: 23 / 23 passing, no skips
- [ ] Reviewer: read `docs/PHASE-1-REVIEW.md` and agree with the gates list

Refs #211 #266