### PR TITLE
docs: voice + tone pass for v1 launch

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -4,7 +4,7 @@
 
 ---
 
-## 1. The core is sacred
+## 1. The core is a promise
 
 `@agentskit/core` will always be **under 10KB gzipped with zero runtime dependencies**. It contains only types, contracts, and minimal orchestration primitives. Nothing gets added here unless it is foundational and permanent. Stability is the feature.
 

--- a/ORIGIN.md
+++ b/ORIGIN.md
@@ -1,14 +1,12 @@
 # Origin — Why AgentsKit Exists
 
-> *Personal note from the author. This document is intentionally first-person and unpolished. It is the story of a frustration that became a library.*
->
-> *To the maintainer reading this before merge: replace the placeholders in square brackets with your real experience, or rewrite freely. The goal is authenticity — not a perfect pitch.*
+> *Personal note from the author. First-person and unpolished by intent — the story of a frustration that became a library.*
 
 ---
 
 ## The frustration
 
-In april, 2026, I was trying to build a simple thing: an AI chat interface with streaming, a couple of tools, and persistent memory. Not an agent that cures cancer — just a chat that remembers yesterday's conversation and can call a function.
+Earlier this year I was trying to build a simple thing: an AI chat interface with streaming, a couple of tools, and persistent memory. Not an agent that cures cancer — just a chat that remembers yesterday's conversation and can call a function.
 
 I went shopping in the JavaScript ecosystem.
 
@@ -52,6 +50,4 @@ If you've felt the frustration above, this is for you. If you've built agents in
 
 Open an issue. Open an RFC. Build a package. Break our assumptions. Make us better.
 
-This is day one.
-
-— Emerson Braun, 04 april 2026
+— Emerson Braun, April 2026

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The agent toolkit JavaScript actually deserves.**
 
-A 10KB sacred core. Twelve plug-and-play packages. Zero lock-in. Six formal contracts that make every adapter, tool, skill, memory, retriever, and runtime substitutable.
+A 10KB core. Twelve plug-and-play packages. Zero lock-in. Six formal contracts that make every adapter, tool, skill, memory, retriever, and runtime substitutable.
 
 [![npm](https://img.shields.io/npm/v/@agentskit/react?label=npm)](https://www.npmjs.com/package/@agentskit/react)
 [![bundle](https://img.shields.io/bundlephobia/minzip/@agentskit/react?label=react%20bundle)](https://bundlephobia.com/package/@agentskit/react)
@@ -16,13 +16,17 @@ A 10KB sacred core. Twelve plug-and-play packages. Zero lock-in. Six formal cont
 
 ---
 
+*You started building an AI agent last week. You're three libraries deep, two of them fight each other, and nothing you wrote is reusable. This is for you.*
+
 ## Why this exists
+
+**We don't need another framework. We need a kit.**
 
 Building a real AI agent in JavaScript today means cobbling together five libraries that don't fit. Vercel AI SDK is a beautiful chat SDK with no runtime. LangChain.js drags in 200MB and leaks abstractions at every layer. MCP solves tool interop and nothing else. assistant-ui has 53 components and no opinion about how to compose them.
 
-AgentsKit is the missing **kit**: small, contracted, composable. Six packages you can use alone, twelve that combine without ceremony. You stay in plain JavaScript the entire time.
+AgentsKit is the missing kit: small, contracted, composable. Six packages you can use alone, twelve that combine without ceremony. You stay in plain JavaScript the entire time.
 
-> Read the [origin story](./ORIGIN.md) for the long version. Read the [manifesto](./MANIFESTO.md) for the principles we hold ourselves to.
+> [Origin story](./ORIGIN.md) for the long version. [Manifesto](./MANIFESTO.md) for the principles.
 
 ---
 
@@ -194,13 +198,22 @@ Read these once and you can predict how every package behaves.
 
 ## Status
 
-We are pre-1.0. The substrate (`@agentskit/core`, the six contracts, the bundle/coverage CI gates) is locked. New packages and adapters land continuously. See the [Phase 0 PRD](https://github.com/EmersonBraun/agentskit/issues/211) for the current foundation work and the [Master PRD](https://github.com/EmersonBraun/agentskit/issues/113) for what comes next.
+`@agentskit/core` is at **v1.0.0** — API frozen at the minor level, deprecations carry a cycle, contracts pinned to ADRs. Other packages track their own cadence and individual [stability tiers](./docs/STABILITY.md).
+
+Concretely, as of the Phase 1 release:
+
+- **538 tests** across 14 packages
+- **5.17 KB** gzipped core — 48% under the 10 KB manifesto budget (enforced in CI)
+- **Seven formal contracts** pinned to ADRs 0001–0007
+- **74 documentation routes** including 13 copy-paste recipes and 3 migration guides
+
+See the [Phase 1 release notes](./docs/RELEASE-CORE-V1.md) for what shipped, and the [Master PRD](https://github.com/EmersonBraun/agentskit/issues/113) for what's next.
 
 ---
 
 ## Contributing
 
-Read the [Manifesto](./MANIFESTO.md) first. Then [`CONTRIBUTING.md`](./CONTRIBUTING.md). Open an [RFC](https://github.com/EmersonBraun/agentskit/issues/new?template=rfc.yml) for anything that touches a contract.
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) covers dev setup. Open an [RFC](https://github.com/EmersonBraun/agentskit/issues/new?template=rfc.yml) before touching a contract.
 
 ---
 

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -43,7 +43,7 @@ export default function HomePage() {
         The agent toolkit JavaScript actually deserves.
       </h1>
       <p className="mb-2 max-w-2xl text-lg text-fd-muted-foreground">
-        A 10KB sacred core. Twelve plug-and-play packages. Zero lock-in.
+        A 10KB core. Twelve plug-and-play packages. Zero lock-in.
       </p>
       <p className="mb-10 max-w-2xl text-base text-fd-muted-foreground">
         Six formal contracts that make every adapter, tool, skill, memory, retriever, and runtime

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -1,21 +1,16 @@
 ---
 title: Welcome to AgentsKit
-description: The complete toolkit for building AI agents in JavaScript.
+description: The agent toolkit JavaScript actually deserves.
 ---
 
-AgentsKit is a family of small, plug-and-play packages that cover the entire
-agent lifecycle in JavaScript: chat UIs, autonomous runtimes, tools, skills,
-memory, RAG, observability.
-
-This documentation site is a Fumadocs spike — it sits in parallel to the
-existing Docusaurus site at `apps/docs` while we evaluate the migration.
+AgentsKit is a family of small, plug-and-play packages that cover the entire agent lifecycle in JavaScript: chat UIs, autonomous runtimes, tools, skills, memory, RAG, observability.
 
 ## Where to go next
 
 - **[Quick start](/docs/getting-started/quickstart)** — a working chat in under 10 lines
 - **[Concepts](/docs/concepts/mental-model)** — the mental model behind every package
-- **[Manifesto](https://github.com/EmersonBraun/agentskit/blob/main/MANIFESTO.md)** — the principles we hold ourselves to
-- **[Origin](https://github.com/EmersonBraun/agentskit/blob/main/ORIGIN.md)** — why this exists
+- **[Recipes](/docs/recipes)** — copy-paste solutions for common scenarios
+- **[Migrating from another framework](/docs/migrating)** — Vercel AI SDK, LangChain.js, Mastra
 
 ## The substrate
 

--- a/docs/RELEASE-CORE-V1.md
+++ b/docs/RELEASE-CORE-V1.md
@@ -2,7 +2,7 @@
 
 > Release cut: 2026-04-15.
 
-After Phase 0 (foundation hardening) and Phase 1 (developer experience + runtime features), the sacred package reaches v1.
+After Phase 0 (foundation hardening) and Phase 1 (developer experience + runtime features), the core package reaches v1.
 
 ## What hits 1.0 today
 
@@ -83,4 +83,4 @@ The ten principles held throughout Phase 0 + 1. A snapshot at release time:
 9. ✅ Predictable beats clever — one entry point per primitive
 10. ✅ Open by default — roadmap, RFCs, ADRs all public
 
-Day one is over. Day two starts with a real v1.
+The substrate is stable. Build on it.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -85,5 +85,5 @@ If a package is `stable`, pin it with `^x.y.z` and trust the minor-bump contract
 ## References
 
 - This policy lives at `/docs/STABILITY.md`
-- Cross-referenced from the [Manifesto](../MANIFESTO.md) (principle 1 — "the core is sacred") and from every package README badge
+- Cross-referenced from the [Manifesto](../MANIFESTO.md) (principle 1 — "the core is a promise") and from every package README badge
 - Related ADRs: 0001 Adapter, 0002 Tool, 0003 Memory, 0004 Retriever, 0005 Skill, 0006 Runtime

--- a/docs/architecture/adrs/0006-runtime-contract.md
+++ b/docs/architecture/adrs/0006-runtime-contract.md
@@ -173,4 +173,4 @@ This categorization MUST be reflected in observer events.
 
 - Current implementation: `packages/runtime/src/types.ts`, `packages/runtime/src/runner.ts`, `packages/core/src/agent-loop.ts`, `packages/core/src/controller.ts`
 - Related contracts: ADR 0001 (Adapter — substrate), 0002 (Tool — substrate, T9 confirmation, T11 errors), 0003 (Memory — CM4 atomicity), 0004 (Retriever — substrate), 0005 (Skill — S9 onActivate, S6 delegates)
-- Manifesto principles 1 (sacred core), 2 (plug-and-play), 5 (agent-first, not chat-first), 8 (small, deep, testable modules), 9 (predictable beats clever)
+- Manifesto principles 1 (core is a promise), 2 (plug-and-play), 5 (agent-first, not chat-first), 8 (small, deep, testable modules), 9 (predictable beats clever)

--- a/packages/core/CONVENTIONS.md
+++ b/packages/core/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Conventions — `@agentskit/core`
 
-The sacred package. Every rule here is stricter than the rest of the monorepo.
+The core package. Every rule here is stricter than the rest of the monorepo.
 
 ## Non-negotiables
 


### PR DESCRIPTION
## Summary

Applies the founder-review fix list before the coordinated launch. Nine low-risk text edits across eight files that remove tonal footguns and unify the product positioning.

## Changes

1. **Kill 'sacred' everywhere** — reads as zealot-project tone; the 10 KB / zero-deps / CI-gate measurements already do the work. Manifesto principle #1 now reads 'The core is a promise.'

2. **ORIGIN cleanup**:
   - Dropped the 'To the maintainer reading this before merge' editor note that was still live
   - Normalized dates to 'April 2026' consistently
   - Dropped the duplicate 'This is day one' closer

3. **Unified tagline** — all four surfaces now say **'The agent toolkit JavaScript actually deserves.'**

4. **Dropped the 'Fumadocs spike' mention** from the docs index — internal scaffolding said 'we're not ready' to every first-time visitor.

5. **Emotional hook** added to README + promoted 'We don't need another framework. We need a kit.' from ORIGIN into the README.

6. **New Status section** in the README with real numbers: 538 tests, 5.17 KB core (48% under budget), 7 ADRs, 74 docs routes.

7. Dropped 'Day one is over. Day two starts now.' in release notes — Bezos-quote-coded. Now: 'The substrate is stable. Build on it.'

8. Softened 'Read the Manifesto first' imperative — it's linked everywhere, trust the reader.

## Verified

- [x] `grep -r 'sacred'` across tracked docs → 0 hits
- [x] All 4 external-facing surfaces carry the same tagline
- [x] Fumadocs build green (74 routes, all 200)

## Test plan

- [x] Docs build succeeds
- [ ] Reviewer: read README top-to-bottom, confirm tone feels earned not try-hard
- [ ] Reviewer: visit the docs index, confirm no internal scaffolding leaks

Refs #211