### PR TITLE
chore(community): add Discord invite and Product Hunt badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ playwright-report/
 test-results/
 *.tsbuildinfo
 .DS_Store
+
+# Local launch + setup tooling (not for public repo)
+tools/
+docs/launch/

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ A 10KB core. Twelve plug-and-play packages. Zero lock-in. Six formal contracts t
 [![npm](https://img.shields.io/npm/v/@agentskit/react?label=npm)](https://www.npmjs.com/package/@agentskit/react)
 [![bundle](https://img.shields.io/bundlephobia/minzip/@agentskit/react?label=react%20bundle)](https://bundlephobia.com/package/@agentskit/react)
 [![license](https://img.shields.io/npm/l/@agentskit/react?label=license)](./LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/zx6z2p4jVb)
 [![GitHub stars](https://img.shields.io/github/stars/EmersonBraun/agentskit?style=social)](https://github.com/EmersonBraun/agentskit)
 [![GitHub issues](https://img.shields.io/github/issues/EmersonBraun/agentskit)](https://github.com/EmersonBraun/agentskit/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/EmersonBraun/agentskit)](https://github.com/EmersonBraun/agentskit/pulls)
 [![Last commit](https://img.shields.io/github/last-commit/EmersonBraun/agentskit)](https://github.com/EmersonBraun/agentskit/commits)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/core?label=core%20downloads)](https://www.npmjs.com/package/@agentskit/core)
 
-[**Documentation**](https://www.agentskit.io) · [**Manifesto**](./MANIFESTO.md) · [**Origin**](./ORIGIN.md) · [**Architecture**](./docs/architecture/adrs)
+[**Documentation**](https://www.agentskit.io) · [**Discord**](https://discord.gg/zx6z2p4jVb) · [**Manifesto**](./MANIFESTO.md) · [**Origin**](./ORIGIN.md) · [**Architecture**](./docs/architecture/adrs)
+
+<a href="https://www.producthunt.com/products/agentskit?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agentskit" target="_blank" rel="noopener noreferrer"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1125539&theme=light" alt="AgentsKit — The most complete ecosystem to create AI agents | Product Hunt" width="250" height="54" /></a>
 
 </div>
 

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -25,6 +25,7 @@ export const metadata = {
 }
 
 const GITHUB = 'https://github.com/EmersonBraun/agentskit'
+const DISCORD = 'https://discord.gg/zx6z2p4jVb'
 
 const PACKAGE_CARDS = [
   { name: 'adapters', href: '/docs/data-layer/adapters' },
@@ -148,12 +149,34 @@ function Hero() {
             >
               See a live agent
             </Link>
+            <a
+              href={DISCORD}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-5 py-2.5 text-sm font-medium text-ak-foam transition hover:border-[#5865F2]"
+            >
+              Join Discord →
+            </a>
           </div>
 
           <p className="mt-4 font-mono text-xs text-ak-graphite">
             MIT · Works with OpenAI, Anthropic, Gemini, Ollama, Vercel AI SDK,
             LangChain
           </p>
+
+          <a
+            href="https://www.producthunt.com/products/agentskit?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agentskit"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-5 inline-block"
+          >
+            <img
+              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1125539&theme=dark"
+              alt="AgentsKit — The most complete ecosystem to create AI agents | Product Hunt"
+              width={250}
+              height={54}
+            />
+          </a>
         </div>
 
         <div>
@@ -460,6 +483,14 @@ function FinalCta() {
             className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-6 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue"
           >
             Star on GitHub
+          </a>
+          <a
+            href={DISCORD}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-6 py-3 text-sm font-medium text-ak-foam transition hover:border-[#5865F2]"
+          >
+            Join Discord
           </a>
           <Link
             href="/docs/contribute"

--- a/apps/docs-next/app/layout.config.tsx
+++ b/apps/docs-next/app/layout.config.tsx
@@ -14,6 +14,7 @@ export const baseOptions: BaseLayoutProps = {
     { text: 'Documentation', url: '/docs' },
     { text: 'Examples', url: '/docs/examples' },
     { text: 'Contribute', url: '/docs/contribute' },
+    { text: 'Discord', url: 'https://discord.gg/zx6z2p4jVb' },
     { text: 'GitHub', url: 'https://github.com/EmersonBraun/agentskit' },
     { text: 'Manifesto', url: 'https://github.com/EmersonBraun/agentskit/blob/main/MANIFESTO.md' },
   ],

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -13,6 +13,7 @@ AgentsKit is a family of small, plug-and-play packages that cover the entire age
 - **[Examples](/docs/examples)** — live interactive demos
 - **[Migrating from another framework](/docs/migrating)** — Vercel AI SDK, LangChain.js, Mastra
 - **[Contribute →](/docs/contribute)** — AgentsKit is built in the open. Your PR helps.
+- **[Join the Discord →](https://discord.gg/zx6z2p4jVb)** — Office Hours every Friday, direct line to maintainers.
 
 ## The substrate
 


### PR DESCRIPTION
## Summary

- Surfaces the newly-opened Discord community (`discord.gg/zx6z2p4jVb`) across the primary entry points so evaluators and contributors land somewhere with activity instead of a dead end.
- Adds the Product Hunt featured badge (light on README, dark on docs hero) ahead of launch so the launch-day traffic loop back-propagates.
- Ignores local-only launch tooling (`tools/`, `docs/launch/`) so the private setup scripts, PH gallery mockups, and stargazer helpers stay off the public repo.

## Changes

- `README.md` — Discord Shields.io badge, top-line Discord link, PH launch badge below the doc-links row.
- `apps/docs-next/app/layout.config.tsx` — new `Discord` nav link between `Contribute` and `GitHub`.
- `apps/docs-next/app/(home)/page.tsx` — hero CTA row gets a `Join Discord →` button; final CTA row gets a `Join Discord` button alongside GitHub + Contribute; PH featured badge rendered in the hero (dark theme).
- `apps/docs-next/content/docs/index.mdx` — Discord entry in the "Where to go next" list.
- `.gitignore` — excludes `tools/` and `docs/launch/` (local setup scripts, launch gallery, stargazer helpers — not intended for public consumption).

## Test plan

- [ ] Run `pnpm --filter @agentskit/docs-next dev` and verify Discord nav link, hero CTA, hero PH badge, final CTA Discord button all render and open the correct URLs in a new tab.
- [ ] Run `pnpm --filter @agentskit/docs-next exec tsc --noEmit` (passes clean locally).
- [ ] Render the README on GitHub and confirm the Discord shield + PH badge render correctly.
- [ ] Spot-check docs index page shows new Discord bullet.
- [ ] Retire the PH badge 2–4 weeks after launch.