### PR TITLE
chore: refresh npm READMEs to point at www.agentskit.io

### DIFF
--- a/.changeset/refresh-npm-readme.md
+++ b/.changeset/refresh-npm-readme.md
@@ -1,0 +1,20 @@
+---
+'@agentskit/core': patch
+'@agentskit/adapters': patch
+'@agentskit/react': patch
+'@agentskit/ink': patch
+'@agentskit/cli': patch
+'@agentskit/runtime': patch
+'@agentskit/tools': patch
+'@agentskit/skills': patch
+'@agentskit/memory': patch
+'@agentskit/rag': patch
+'@agentskit/sandbox': patch
+'@agentskit/observability': patch
+'@agentskit/eval': patch
+'@agentskit/templates': patch
+---
+
+docs: refresh npm READMEs to point at www.agentskit.io (retire legacy emersonbraun.github.io URL)
+
+No code changes. Re-publish only — every package's README was migrated to www.agentskit.io in the Fumadocs rollout (#286, #313, #314) but the packages were never republished, so npmjs.com still surfaces the legacy GitHub Pages URL. This patch bump refreshes the published READMEs in one sweep.


### PR DESCRIPTION
## Summary

- Re-publish-only changeset that patch-bumps all 14 packages so npmjs.com picks up the already-updated READMEs.
- The Fumadocs migration (#286, #313, #314) migrated every package README to point at `www.agentskit.io`, but no release was cut afterwards. As a result, npm still shows the legacy `emersonbraun.github.io/agentskit` URL on every package page.
- Verified on npm: `npm view @agentskit/core readme | grep github.io` still returns `[Full documentation](https://emersonbraun.github.io/agentskit/)`.

## What ships

- Patch bump on: `core`, `adapters`, `react`, `ink`, `cli`, `runtime`, `tools`, `skills`, `memory`, `rag`, `sandbox`, `observability`, `eval`, `templates`.
- Zero code changes. Zero behavior changes.

## Release plan

Merge → the Release workflow opens a `chore: version packages` PR (changesets action) → merge that PR → `pnpm changeset publish` republishes all 14 packages with the correct README content.

## Test plan

- [ ] After final publish, run `npm view @agentskit/core readme | grep -i 'github.io\\|agentskit.io'` — expect only `agentskit.io` matches.
- [ ] Spot-check the npmjs.com page for `@agentskit/core`, `@agentskit/react`, `@agentskit/adapters` — Discord badge, PH badge (if present), and `www.agentskit.io` links all render correctly.