### PR TITLE
fix(docs-next): correct install command + mobile-responsive landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Pick what you need. Every package works alone. Combinations work without glue co
 | [`@agentskit/eval`](packages/eval) | Agent evaluation and benchmarking | beta |
 | [`@agentskit/templates`](packages/templates) | Authoring toolkit for skills/tools | stable |
 
-The whole catalog is one `pnpm dlx agentskit init` away.
+The whole catalog is one `npx @agentskit/cli init` away.
 
 ---
 

--- a/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
+++ b/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
@@ -170,7 +170,7 @@ export function HeroDemo() {
         </span>
       </div>
 
-      <div className="flex h-[460px] min-w-0 flex-col overflow-hidden bg-ak-midnight font-sans text-sm">
+      <div className="flex h-[380px] min-w-0 flex-col overflow-hidden bg-ak-midnight font-sans text-sm sm:h-[440px] md:h-[460px]">
         <div
           ref={scrollRef}
           className="flex min-w-0 flex-1 flex-col gap-3 overflow-y-auto p-4"

--- a/apps/docs-next/app/(home)/_components/install-command.tsx
+++ b/apps/docs-next/app/(home)/_components/install-command.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-const SCAFFOLD = 'npx agentskit init'
+const SCAFFOLD = 'npx @agentskit/cli init'
 const ADD = 'npm install @agentskit/core @agentskit/adapters'
 
 export function InstallCommand() {
@@ -62,12 +62,14 @@ function Card({
       <button
         type="button"
         onClick={copy}
-        className="group inline-flex items-center gap-3 rounded-md border border-ak-border bg-ak-midnight px-3 py-2 font-mono text-sm text-ak-foam transition hover:border-ak-blue"
+        className="group flex w-full items-center gap-2 rounded-md border border-ak-border bg-ak-midnight px-3 py-2 text-left font-mono text-[13px] text-ak-foam transition hover:border-ak-blue sm:gap-3 sm:text-sm"
       >
-        <span className="text-ak-green">$</span>
-        <span className="flex-1 truncate">{command}</span>
+        <span className="shrink-0 text-ak-green">$</span>
+        <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {command}
+        </span>
         <span
-          className={`rounded border border-ak-border px-2 py-0.5 text-xs transition ${
+          className={`shrink-0 rounded border border-ak-border px-2 py-0.5 text-[11px] transition sm:text-xs ${
             copied ? 'border-ak-green text-ak-green' : 'text-ak-graphite'
           }`}
         >

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -103,29 +103,29 @@ export default function HomePage() {
 
 function Hero() {
   return (
-    <section className="relative overflow-hidden border-b border-ak-border bg-ak-midnight px-6 pt-20 pb-24 md:pt-28 md:pb-32">
-      <div className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.1fr_1fr] lg:items-center">
-        <div>
-          <div className="mb-6 flex items-center gap-3">
+    <section className="relative overflow-hidden border-b border-ak-border bg-ak-midnight px-4 pt-14 pb-16 sm:px-6 sm:pt-20 sm:pb-24 md:pt-28 md:pb-32">
+      <div className="mx-auto grid max-w-6xl gap-8 sm:gap-10 md:gap-12 lg:grid-cols-[1.1fr_1fr] lg:items-center">
+        <div className="min-w-0">
+          <div className="mb-5 flex items-center gap-3 sm:mb-6">
             <AnimatedLogo variant="hero" size={44} loop />
-            <span className="font-mono text-xl font-bold tracking-tight text-ak-foam">
+            <span className="font-mono text-lg font-bold tracking-tight text-ak-foam sm:text-xl">
               agentskit
             </span>
           </div>
 
-          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-ak-border bg-ak-surface px-3 py-1 font-mono text-xs text-ak-graphite">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-ak-border bg-ak-surface px-3 py-1 font-mono text-[11px] text-ak-graphite sm:mb-5 sm:text-xs">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-ak-green" />
             v1.0 · MIT · Built for the agent era
           </div>
 
-          <h1 className="mb-6 max-w-2xl text-4xl font-bold leading-[1.05] tracking-tight text-ak-foam md:text-6xl">
+          <h1 className="mb-5 max-w-2xl text-[2rem] font-bold leading-[1.08] tracking-tight text-ak-foam sm:mb-6 sm:text-4xl md:text-5xl lg:text-6xl">
             Ship AI agents in JavaScript.
             <span className="block text-ak-graphite">
               Without gluing 8 libraries together.
             </span>
           </h1>
 
-          <p className="mb-8 max-w-xl text-lg leading-relaxed text-ak-graphite">
+          <p className="mb-7 max-w-xl text-base leading-relaxed text-ak-graphite sm:mb-8 sm:text-lg">
             AgentsKit gives you chat UI, tools, memory, RAG, and runtime — one
             toolkit, zero lock-in. Swap{' '}
             <span className="text-ak-foam">OpenAI for Claude</span>, React for
@@ -135,30 +135,30 @@ function Hero() {
 
           <InstallCommand />
 
-          <div className="mt-6 flex flex-wrap items-center gap-3">
+          <div className="mt-5 flex flex-wrap items-center gap-2.5 sm:mt-6 sm:gap-3">
             <Link
               href="/docs"
-              className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-5 py-2.5 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+              className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-4 py-2.5 text-sm font-semibold text-ak-midnight transition hover:bg-white sm:px-5"
             >
               Install in 30 seconds →
             </Link>
             <Link
               href="/docs/examples"
-              className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-5 py-2.5 text-sm font-medium text-ak-foam transition hover:border-ak-blue"
+              className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-4 py-2.5 text-sm font-medium text-ak-foam transition hover:border-ak-blue sm:px-5"
             >
               See a live agent
             </Link>
           </div>
 
-          <p className="mt-4 font-mono text-xs text-ak-graphite">
+          <p className="mt-4 font-mono text-[11px] leading-relaxed text-ak-graphite sm:text-xs">
             MIT · Works with OpenAI, Anthropic, Gemini, Ollama, Vercel AI SDK,
             LangChain
           </p>
         </div>
 
-        <div>
+        <div className="min-w-0">
           <HeroDemo />
-          <p className="mt-3 text-center font-mono text-xs text-ak-graphite">
+          <p className="mt-3 text-center font-mono text-[11px] leading-relaxed text-ak-graphite sm:text-xs">
             Agent renders real React components — not markdown.{' '}
             <Link href="/docs/examples/agent-actions" className="text-ak-blue hover:underline">
               See how →
@@ -224,15 +224,15 @@ function _HeroCodeDemo() {
 
 function ProblemSection() {
   return (
-    <section className="border-b border-ak-border bg-ak-midnight px-6 py-24">
+    <section className="border-b border-ak-border bg-ak-midnight px-4 py-16 sm:px-6 sm:py-20 md:py-24">
       <div className="mx-auto max-w-4xl">
-        <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em] text-ak-red">
+        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-red sm:mb-4 sm:text-xs">
           The problem
         </p>
-        <h2 className="mb-8 text-3xl font-bold leading-tight text-ak-foam md:text-5xl">
+        <h2 className="mb-6 text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-8 sm:text-3xl md:text-4xl lg:text-5xl">
           Building agents in JS today is a glue job.
         </h2>
-        <div className="grid gap-4 text-lg leading-relaxed text-ak-graphite md:grid-cols-2 md:gap-6">
+        <div className="grid gap-4 text-base leading-relaxed text-ak-graphite sm:text-lg md:grid-cols-2 md:gap-6">
           <Pain>
             LangChain is bloated. Vercel AI SDK hits walls past a chat box.
           </Pain>
@@ -263,15 +263,15 @@ function Pain({ children }: { children: React.ReactNode }) {
 
 function SolutionSection() {
   return (
-    <section className="border-b border-ak-border bg-ak-surface/40 px-6 py-24">
+    <section className="border-b border-ak-border bg-ak-surface/40 px-4 py-16 sm:px-6 sm:py-20 md:py-24">
       <div className="mx-auto max-w-5xl">
-        <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em] text-ak-green">
+        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-green sm:mb-4 sm:text-xs">
           The fix
         </p>
-        <h2 className="mb-5 max-w-3xl text-3xl font-bold leading-tight text-ak-foam md:text-5xl">
+        <h2 className="mb-4 max-w-3xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-5 sm:text-3xl md:text-4xl lg:text-5xl">
           One toolkit. Twelve packages. Pick what you need.
         </h2>
-        <p className="mb-12 max-w-2xl text-lg text-ak-graphite">
+        <p className="mb-8 max-w-2xl text-base text-ak-graphite sm:mb-12 sm:text-lg">
           A 10KB zero-dependency core defines six contracts. Every adapter,
           tool, skill, memory, retriever, and runtime is substitutable — so
           your code survives provider changes, UI changes, and scale.
@@ -353,15 +353,15 @@ function BenefitsSection() {
     },
   ]
   return (
-    <section className="border-b border-ak-border bg-ak-midnight px-6 py-24">
+    <section className="border-b border-ak-border bg-ak-midnight px-4 py-16 sm:px-6 sm:py-20 md:py-24">
       <div className="mx-auto max-w-6xl">
-        <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">
+        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-blue sm:mb-4 sm:text-xs">
           Why teams ship with it
         </p>
-        <h2 className="mb-14 max-w-2xl text-3xl font-bold leading-tight text-ak-foam md:text-5xl">
+        <h2 className="mb-10 max-w-2xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-14 sm:text-3xl md:text-4xl lg:text-5xl">
           Built for the code you&apos;ll still want to own in 12 months.
         </h2>
-        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:gap-5 md:grid-cols-2 lg:grid-cols-3">
           {benefits.map(b => (
             <div
               key={b.title}
@@ -396,12 +396,12 @@ function ProviderStrip() {
     'Vercel AI SDK',
   ]
   return (
-    <section className="border-b border-ak-border bg-ak-surface/30 px-6 py-16">
+    <section className="border-b border-ak-border bg-ak-surface/30 px-4 py-12 sm:px-6 sm:py-16">
       <div className="mx-auto max-w-6xl text-center">
-        <p className="mb-8 font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+        <p className="mb-6 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-graphite sm:mb-8 sm:text-xs">
           Works with what you already use
         </p>
-        <div className="flex flex-wrap justify-center gap-x-8 gap-y-3">
+        <div className="flex flex-wrap justify-center gap-x-5 gap-y-3 sm:gap-x-8">
           {providers.map(p => (
             <span
               key={p}
@@ -418,7 +418,7 @@ function ProviderStrip() {
 
 function BuiltInOpenSection() {
   return (
-    <section className="border-b border-ak-border bg-ak-midnight px-6 py-20">
+    <section className="border-b border-ak-border bg-ak-midnight px-4 py-14 sm:px-6 sm:py-20">
       <div className="mx-auto max-w-5xl">
         <ContributorWall />
       </div>
@@ -428,16 +428,16 @@ function BuiltInOpenSection() {
 
 function FinalCta() {
   return (
-    <section className="bg-ak-midnight px-6 py-28">
+    <section className="bg-ak-midnight px-4 py-20 sm:px-6 sm:py-24 md:py-28">
       <div className="mx-auto max-w-3xl text-center">
-        <div className="mb-6 flex justify-center">
+        <div className="mb-5 flex justify-center sm:mb-6">
           <AnimatedLogo variant="hero" size={56} loop />
         </div>
-        <h2 className="mb-5 text-4xl font-bold leading-tight text-ak-foam md:text-6xl">
+        <h2 className="mb-4 text-[2rem] font-bold leading-[1.1] text-ak-foam sm:mb-5 sm:text-4xl md:text-5xl lg:text-6xl">
           Build the agent.{' '}
           <span className="text-ak-graphite">Skip the plumbing.</span>
         </h2>
-        <p className="mx-auto mb-10 max-w-xl text-lg text-ak-graphite">
+        <p className="mx-auto mb-8 max-w-xl text-base text-ak-graphite sm:mb-10 sm:text-lg">
           30 seconds to install. First streaming agent in under 10 lines. No
           credit card, no signup, no lock-in.
         </p>
@@ -446,10 +446,10 @@ function FinalCta() {
           <InstallCommand />
         </div>
 
-        <div className="flex flex-wrap justify-center gap-3">
+        <div className="flex flex-wrap justify-center gap-2.5 sm:gap-3">
           <Link
             href="/docs"
-            className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-6 py-3 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+            className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-5 py-3 text-sm font-semibold text-ak-midnight transition hover:bg-white sm:px-6"
           >
             Read the docs →
           </Link>
@@ -457,13 +457,13 @@ function FinalCta() {
             href={GITHUB}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-6 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue"
+            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-5 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue sm:px-6"
           >
             Star on GitHub
           </a>
           <Link
             href="/docs/contribute"
-            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-6 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue"
+            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-5 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue sm:px-6"
           >
             Contribute →
           </Link>

--- a/docs/MASTER-EXECUTION-PLAN.md
+++ b/docs/MASTER-EXECUTION-PLAN.md
@@ -111,7 +111,7 @@ Sprints de **2 semanas**. Ao longo dos 12 meses, ~26 sprints.
 
 ### Gate Fase 1 → Fase 2
 - [ ] 20 stories da Fase 1 done ou explicitamente descopadas
-- [ ] `npx agentskit init` com ≥1000 downloads/mês
+- [ ] `npx @agentskit/cli init` com ≥1000 downloads/mês
 - [ ] Discord com ≥200 membros
 - [ ] ≥3 usuários externos compartilhando projetos publicamente
 

--- a/docs/ROADMAP-PRD.md
+++ b/docs/ROADMAP-PRD.md
@@ -54,7 +54,7 @@ Objetivo: camada comercial sustentável sem comprometer open-source.
 
 ### Fase 1 — Fundação
 
-1. Como dev novato no AgentsKit, quero rodar `npx agentskit init` e escolher template interativamente, para ter um projeto funcionando em menos de 2 minutos.
+1. Como dev novato no AgentsKit, quero rodar `npx @agentskit/cli init` e escolher template interativamente, para ter um projeto funcionando em menos de 2 minutos.
 2. Como dev, quero rodar `agentskit doctor` e ver env vars faltando, versões incompatíveis e keys inválidas, para não perder tempo debugando config.
 3. Como dev, quero `agentskit dev` com hot-reload de prompts/tools/memory, para iterar rápido sem reiniciar.
 4. Como dev, quero `agentskit tunnel` para expor meu agente local com URL pública temporária, para testar webhooks.


### PR DESCRIPTION
## Summary

**Critical:** the landing + docs shipped `npx agentskit init` as the bootstrap command. No unscoped `agentskit` package exists on npm — the CLI is published as `@agentskit/cli` with bin `agentskit`, so `npx agentskit init` throws E404 before executing. Every visitor who copy-pastes the hero command today hits a failing npx. This PR corrects every invocation and fixes three mobile layout regressions on the landing while touching adjacent code.

## Command fix

`npx agentskit init` → `npx @agentskit/cli init` in:

- `README.md` (the "whole catalog is one command away" line)
- `apps/docs-next/app/(home)/_components/install-command.tsx` (hero CTA)
- `docs/ROADMAP-PRD.md` (story 1)
- `docs/MASTER-EXECUTION-PLAN.md` (gate criterion)

Left alone: bare `agentskit init` (post-install invocation after `npm install -g @agentskit/cli`) — that's still correct.

## Mobile fixes

1. **Install card no longer truncates the command.** Was `flex-1 truncate` → ellipsis clipped `$ npx @agentskit/cli init` mid-command on narrow screens, so the copy button returned an incomplete command. Now uses `overflow-x-auto whitespace-nowrap` on the command span with the scrollbar hidden.
2. **Hero typography scale smoothed.** Was `text-4xl` → `md:text-6xl` with no intermediate step. Now `text-[2rem] sm:text-4xl md:text-5xl lg:text-6xl`. Applied the same smoothing to every H2 (`text-3xl`/`text-5xl` jumps) and the Final CTA.
3. **Hero demo fixed height was dominating above-the-fold on phones.** Was `h-[460px]`. Now `h-[380px] sm:h-[440px] md:h-[460px]`.
4. **Section padding scale.** `py-24` → `py-16 sm:py-20 md:py-24` across ProblemSection, SolutionSection, BenefitsSection; ProviderStrip `py-16` → `py-12 sm:py-16`; BuiltInOpen `py-20` → `py-14 sm:py-20`; FinalCta `py-28` → `py-20 sm:py-24 md:py-28`.
5. **Hero padding + gap + min-w-0.** Horizontal padding `px-6` → `px-4 sm:px-6`; vertical `pt-20 pb-24` → `pt-14 pb-16 sm:pt-20 sm:pb-24 md:pt-28 md:pb-32`; grid gap `gap-12` → `gap-8 sm:gap-10 md:gap-12`. Added `min-w-0` to both columns to stop flex children overflowing horizontally.
6. **Button padding responsive.** Hero + Final CTA buttons use `px-4 py-2.5 sm:px-5` so tap targets stay thumb-friendly on phones without looking chunky on desktop.

## Merge conflict note

This branch was cut from `main` and overlaps with EmersonBraun/agentskit#317 (Discord + PH additions to the same Hero). Whichever merges second needs a trivial rebase — the additions are additive, no semantic conflict.

## Test plan

- [ ] Run `pnpm --filter @agentskit/docs-next dev`, open `http://localhost:3000`, DevTools responsive mode:
  - [ ] iPhone SE (375×667) — hero fits above fold, install command fully visible + copyable, no horizontal scroll anywhere.
  - [ ] iPad (768×1024) — hero stacks sensibly, demo does not dominate.
  - [ ] Desktop (1440×900) — unchanged visual.
- [ ] Copy the hero install command, paste into terminal, run: `npx @agentskit/cli init` — expect the CLI to fetch from npm and run the interactive prompts.
- [ ] `pnpm --filter @agentskit/docs-next exec tsc --noEmit` — passes clean locally.
- [ ] Spot-check README preview on GitHub for the corrected command.