### PR TITLE
fix(docs-next): eliminate horizontal overflow on mobile landing

### DIFF
--- a/apps/docs-next/app/(home)/_components/social-proof-bar.tsx
+++ b/apps/docs-next/app/(home)/_components/social-proof-bar.tsx
@@ -91,8 +91,8 @@ export function SocialProofBar() {
   }, [])
 
   return (
-    <section className="border-b border-ak-border bg-ak-surface/50 px-6 py-10">
-      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-10 gap-y-4">
+    <section className="border-b border-ak-border bg-ak-surface/50 px-4 py-8 sm:px-6 sm:py-10">
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-6 gap-y-3 sm:gap-x-10 sm:gap-y-4">
         <Metric
           href={NPM_ORG}
           label="weekly downloads"

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -88,7 +88,7 @@ const JSON_LD = {
 
 export default function HomePage() {
   return (
-    <main className="flex flex-1 flex-col">
+    <main className="flex w-full max-w-full flex-1 flex-col overflow-x-clip">
       <JsonLd data={JSON_LD} />
       <Hero />
       <SocialProofBar />
@@ -300,12 +300,12 @@ function SolutionSection() {
           your code survives provider changes, UI changes, and scale.
         </p>
 
-        <div className="overflow-hidden rounded-xl border border-ak-border bg-ak-midnight p-8">
+        <div className="overflow-hidden rounded-xl border border-ak-border bg-ak-midnight p-5 sm:p-8">
           <div className="mx-auto max-w-3xl">
-            <div className="mb-6 text-center">
+            <div className="mb-5 text-center sm:mb-6">
               <Link
                 href="/docs/packages/core"
-                className="inline-block rounded-md border border-ak-blue/30 bg-ak-blue/10 px-4 py-2 font-mono text-sm text-ak-blue transition hover:bg-ak-blue/20"
+                className="inline-block rounded-md border border-ak-blue/30 bg-ak-blue/10 px-3 py-2 font-mono text-[12px] text-ak-blue transition hover:bg-ak-blue/20 sm:px-4 sm:text-sm"
               >
                 @agentskit/core · 10KB · zero deps
               </Link>
@@ -314,16 +314,16 @@ function SolutionSection() {
             <p className="mb-4 text-center font-mono text-[11px] uppercase tracking-[0.2em] text-ak-graphite">
               ↓ click any package to open its docs
             </p>
-            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
               {PACKAGE_CARDS.map(pkg => (
                 <Link
                   key={pkg.name}
                   href={pkg.href}
-                  className="group flex items-center justify-between gap-2 rounded-md border border-ak-border bg-ak-surface px-3 py-2 text-center font-mono text-sm text-ak-foam transition hover:border-ak-blue hover:text-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)]"
+                  className="group flex min-w-0 items-center justify-between gap-1.5 rounded-md border border-ak-border bg-ak-surface px-2.5 py-2 text-center font-mono text-[12px] text-ak-foam transition hover:border-ak-blue hover:text-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)] sm:gap-2 sm:px-3 sm:text-sm"
                   aria-label={`Open docs for ${pkg.name}`}
                 >
-                  <span className="flex-1 text-left">{pkg.name}</span>
-                  <span className="text-xs opacity-0 transition group-hover:opacity-100" aria-hidden="true">
+                  <span className="min-w-0 flex-1 truncate text-left">{pkg.name}</span>
+                  <span className="shrink-0 text-xs opacity-0 transition group-hover:opacity-100" aria-hidden="true">
                     →
                   </span>
                 </Link>

--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -89,7 +89,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${inter.variable} ${jetbrainsMono.variable}`}
       suppressHydrationWarning
     >
-      <body className="flex flex-col min-h-screen font-sans">
+      <body className="flex min-h-screen flex-col overflow-x-clip font-sans">
         <RootProvider>{children}</RootProvider>
         <Analytics />
         <SpeedInsights />


### PR DESCRIPTION
## Summary

Mobile landing still showed a ~8px black gutter on the left of the viewport after #320 — something was overflowing horizontally and shifting the body right. This fixes the three confirmed sources plus adds a viewport-level safety net.

## Root causes found

1. **SolutionSection package cards** — `grid-cols-2` at 375px gave each card ~160px, but monospace `text-sm` labels like `@agentskit/observability` (20 chars ≈ 180px) did not shrink and pushed the grid wider than the viewport. The card's `flex-1` span had no `min-w-0`, so the label could not shrink.
2. **SolutionSection card shell** — `p-8` on mobile pushed the inner grid tight against the viewport edge.
3. **SocialProofBar** — hard-coded `px-6` with `gap-x-10` on the metric row forced metrics past the viewport edge on narrow screens.

## Fixes

- Package cards grid: `grid-cols-2 sm:grid-cols-3 md:grid-cols-4` (more columns earlier), `min-w-0 flex-1 truncate` on the label span so it cannot overflow its slot, `text-[12px] sm:text-sm` for a calmer mobile footprint, tighter inner padding.
- SolutionSection card shell: `p-5 sm:p-8`.
- Core badge inside SolutionSection: `px-3 sm:px-4`, `text-[12px] sm:text-sm`.
- SocialProofBar: `px-4 sm:px-6`, `gap-x-6 sm:gap-x-10`, `py-8 sm:py-10`.

## Safety net (viewport-level)

- `<body>` (root layout) gains `overflow-x-clip`.
- `<main>` on the home route gains `w-full max-w-full overflow-x-clip`.

Modern CSS `overflow-x: clip` is the correct primitive here — it prevents horizontal scroll and the resulting left-shift without clipping `sticky`/`fixed` descendants the way `overflow-x: hidden` does. If any future element accidentally overflows, it gets clipped at the viewport edge instead of shifting the whole page right.

## Test plan

- [ ] `pnpm --filter @agentskit/docs-next dev` → open `http://localhost:3000` → DevTools responsive mode:
  - [ ] iPhone SE (375×667) — no black gutter on left, content centered, no horizontal scroll.
  - [ ] Pixel 7 (412×915) — same.
  - [ ] iPad (768×1024) — unchanged visually.
- [ ] `pnpm --filter @agentskit/docs-next exec tsc --noEmit` — passes clean locally.
- [ ] Scroll entire page on mobile: Hero → SocialProofBar → ProblemSection → SolutionSection (package cards) → BenefitsSection → ProviderStrip → ContributorWall → FinalCta. Zero horizontal scroll anywhere.