### PR TITLE
fix(ci): authenticate npm publish with NODE_AUTH_TOKEN in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,8 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # setup-node's registry-url writes .npmrc referencing
+          # ${NODE_AUTH_TOKEN}; that is the name npm publish reads.
+          # Pass the secret under both names so changeset publish works.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The Release workflow has been failing every publish with E404 for every `@agentskit/*` package, even after the NPM_TOKEN was recreated with full publish rights. Root cause: **env var name mismatch**.

\`actions/setup-node@v4\` with \`registry-url: https://registry.npmjs.org\` writes a \`.npmrc\` that looks like:

\`\`\`
always-auth=true
registry=https://registry.npmjs.org/
//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}
\`\`\`

\`npm publish\` reads this file and expands \`\${NODE_AUTH_TOKEN}\`. Our workflow only passed \`NPM_TOKEN\` into the changesets step env, so \`\$NODE_AUTH_TOKEN\` expanded to empty, publish ran **unauthenticated**, and npm returned E404 (npm intentionally returns E404 instead of 403 when auth is missing for scoped package writes).

## Fix

Pass the same secret under both names so any consumer finds it:

\`\`\`yaml
env:
  GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
  NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}  # ← new
  NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
\`\`\`

One-line change. Zero impact on anything else.

## Test plan

- [ ] Merge this PR.
- [ ] Re-run the failed Release workflow (or merge any other PR to main, which will trigger it).
- [ ] Confirm in the run log that \`pnpm changeset publish\` succeeds and publishes the 14 bumped versions:
  - \`@agentskit/core@1.0.1\`
  - \`@agentskit/adapters@0.5.1\`
  - \`@agentskit/cli@0.5.1\`
  - \`@agentskit/eval@0.2.4\`
  - \`@agentskit/ink@0.5.1\`
  - \`@agentskit/memory@0.5.1\`
  - \`@agentskit/observability@0.3.1\`
  - \`@agentskit/rag@0.1.4\`
  - \`@agentskit/react@0.5.1\`
  - \`@agentskit/runtime@0.4.4\`
  - \`@agentskit/sandbox@0.2.4\`
  - \`@agentskit/skills@0.4.4\`
  - \`@agentskit/templates@0.1.3\`
  - \`@agentskit/tools@0.4.4\`
- [ ] Verify on npm: \`npm view @agentskit/core version\` → expect \`1.0.1\`.