### PR TITLE
docs: translate planning docs from Portuguese to English

### DIFF
--- a/docs/MASTER-EXECUTION-PLAN.md
+++ b/docs/MASTER-EXECUTION-PLAN.md
@@ -1,231 +1,231 @@
 # AgentsKit — Master Execution Plan
 
-> Plano mestre de execução dos 149 issues (Phase 0 + Fases 1-4).
-> Sequência, dependências, sprints, gates e ordem sugerida.
+> Master execution plan for the 149 issues (Phase 0 + Phases 1–4).
+> Sequence, dependencies, sprints, gates, and suggested order.
 >
-> **Documentos relacionados:**
-> - [Master PRD #113](https://github.com/EmersonBraun/agentskit/issues/113) — 97 issues do roadmap de produto
-> - [Phase 0 PRD #211](https://github.com/EmersonBraun/agentskit/issues/211) — 52 issues de foundation hardening
-> - [`PHASE-0-EXECUTION-PLAN.md`](./PHASE-0-EXECUTION-PLAN.md) — plano detalhado P0→P2
+> **Related documents:**
+> - [Master PRD #113](https://github.com/EmersonBraun/agentskit/issues/113) — 97 product roadmap issues
+> - [Phase 0 PRD #211](https://github.com/EmersonBraun/agentskit/issues/211) — 52 foundation-hardening issues
+> - [`PHASE-0-EXECUTION-PLAN.md`](./PHASE-0-EXECUTION-PLAN.md) — detailed P0→P2 plan
 > - [Project Board](https://github.com/users/EmersonBraun/projects/1)
 
 ---
 
-## Visão geral
+## Overview
 
-| Período | Fase | Issues | Objetivo |
+| Period | Phase | Issues | Goal |
 |---|---|---|---|
-| **Semanas 1-6** | **Phase 0** (Foundation) | 52 (#212-#263) | Base sólida: contratos, narrativa, Fumadocs, agentskit.io, qualidade |
-| **Meses 2-4** | **Fase 1** (Foundation UX) | 20 (#114-#133) | DX que vira viral — init, doctor, dev, devtools, recipes |
-| **Meses 4-7** | **Fase 2** (Evolução) | 31 (#134-#164) | Diferenciação técnica real — replay, router, memory, security |
-| **Meses 7-10** | **Fase 3** (Expansão) | 34 (#165-#198) | Adapters, tools, MCP bridge, multi-framework, verticais |
-| **Meses 10-12** | **Fase 4** (Business) | 12 (#199-#210) | Cloud, marketplace, enterprise, parcerias |
+| **Weeks 1–6** | **Phase 0** (Foundation) | 52 (#212–#263) | Solid base: contracts, narrative, Fumadocs, agentskit.io, quality |
+| **Months 2–4** | **Phase 1** (Foundation UX) | 20 (#114–#133) | DX that goes viral — init, doctor, dev, devtools, recipes |
+| **Months 4–7** | **Phase 2** (Evolution) | 31 (#134–#164) | Real technical differentiation — replay, router, memory, security |
+| **Months 7–10** | **Phase 3** (Expansion) | 34 (#165–#198) | Adapters, tools, MCP bridge, multi-framework, verticals |
+| **Months 10–12** | **Phase 4** (Business) | 12 (#199–#210) | Cloud, marketplace, enterprise, partnerships |
 
-**Total**: ~12 meses de roadmap claro. Revisão trimestral obrigatória pra recalibrar.
+**Total**: ~12 months of a clear roadmap. Mandatory quarterly review to recalibrate.
 
 ---
 
-## Estrutura de Sprints
+## Sprint structure
 
-Sprints de **2 semanas**. Ao longo dos 12 meses, ~26 sprints.
+Sprints of **2 weeks**. Over 12 months, ~26 sprints.
 
-### Mapeamento Fase → Sprints → Issues
+### Phase → Sprint → Issue mapping
 
-| Sprint | Semanas | Fase | Foco | Issues-alvo |
+| Sprint | Weeks | Phase | Focus | Target issues |
 |---|---|---|---|---|
-| **S1** | 1-2 | Phase 0 | Narrativa + CI gates | P0: #225, #226, #235, #217, #218, #224 |
-| **S2** | 3-4 | Phase 0 | Contratos + Fumadocs início | P0/P1: #214, #225→#238 (Fumadocs spike) |
-| **S3** | 5-6 | Phase 0 | Fumadocs full + Concepts + READMEs pacotes | P1/P2: #238, #239, #228, READMEs |
-| **S4** | 7-8 | Phase 0 wrap | Migration guides + E2E + Discord + LICENSE | #241, #242, #243, #255, #261 |
-| **S5** | 9-10 | **🚀 Launch + Fase 1 início** | Anúncio coordenado + init/doctor | #263 (launch) + #114 #115 #116 |
-| **S6** | 11-12 | Fase 1 | Dev server + tunnel + streaming | #117 #118 #121 |
-| **S7** | 13-14 | Fase 1 | useChat + cost guard + hot-swap | #119 #120 #121 #122 #123 |
-| **S8** | 15-16 | Fase 1 | Docs chat + decision tree + migration guides | #124 #125 #126 #127 #128 |
-| **S9** | 17-18 | Fase 1 wrap | Error didáticos + tipos + roadmap público | #129 #130 #131 #132 #133 |
-| **S10** | 19-20 | Fase 2 | Deterministic replay + snapshot + diff | #134 #135 #136 |
-| **S11** | 21-22 | Fase 2 | Time travel + token budget + speculative | #137 #138 #139 |
-| **S12** | 23-24 | Fase 2 | Streaming progressivo + context + multi-modal | #140 #141 #142 |
-| **S13** | 25-26 | Fase 2 | Schema-first + agentskit ai + router adapter | #143 #144 #145 |
-| **S14** | 27-28 | Fase 2 | Ensemble + fallback + devtools | #146 #147 #148 |
-| **S15** | 29-30 | Fase 2 | Trace viewer + evals CI + A/B | #149 #150 #151 |
-| **S16** | 31-32 | Fase 2 | Hierarchical memory + summarization + RAG reranking | #152 #153 #154 #155 |
-| **S17** | 33-34 | Fase 2 wrap | Durable + multi-agent + HITL + background | #156 #157 #158 #159 |
-| **S18** | 35-36 | Fase 2 security | PII + prompt injection + audit + rate-limit + sandbox | #160 #161 #162 #163 #164 |
-| **S19** | 37-38 | Fase 3 | Major adapters (10+ providers) | #165 #166 |
-| **S20** | 39-40 | Fase 3 | MCP bridge + tool composer | #167 #168 |
-| **S21** | 41-42 | Fase 3 | Tools dev ecosystem (GitHub, Linear, Slack) | #169 #170 #171 |
-| **S22** | 43-44 | Fase 3 | Tools scraping/image/voice/maps | #172 #173 #174 #175 |
-| **S23** | 45-46 | Fase 3 | Browser agent + self-debug + memory adapters | #176 #177 #178 |
-| **S24** | 47-48 | Fase 3 | Memory graph + encryption + skills | #179 #180 #181 #182 #183 |
-| **S25** | 49-50 | Fase 3 | UI multi-framework (Vue/Svelte/Solid) + RN | #184 #185 #186 |
-| **S26** | 51-52 | Fase 3 wrap | Edge + Browser-only + verticais + A2A | #187 #188 #189 #190 #191 #192 #193 #194 #195 #196 #197 #198 |
-| **S27+** | 53+ | **Fase 4** | Cloud, marketplace, enterprise | #199-#210 |
+| **S1** | 1–2 | Phase 0 | Narrative + CI gates | P0: #225, #226, #235, #217, #218, #224 |
+| **S2** | 3–4 | Phase 0 | Contracts + Fumadocs start | P0/P1: #214, #225→#238 (Fumadocs spike) |
+| **S3** | 5–6 | Phase 0 | Full Fumadocs + Concepts + package READMEs | P1/P2: #238, #239, #228, READMEs |
+| **S4** | 7–8 | Phase 0 wrap | Migration guides + E2E + Discord + LICENSE | #241, #242, #243, #255, #261 |
+| **S5** | 9–10 | **🚀 Launch + start of Phase 1** | Coordinated announcement + init/doctor | #263 (launch) + #114 #115 #116 |
+| **S6** | 11–12 | Phase 1 | Dev server + tunnel + streaming | #117 #118 #121 |
+| **S7** | 13–14 | Phase 1 | useChat + cost guard + hot-swap | #119 #120 #121 #122 #123 |
+| **S8** | 15–16 | Phase 1 | Docs chat + decision tree + migration guides | #124 #125 #126 #127 #128 |
+| **S9** | 17–18 | Phase 1 wrap | Didactic errors + types + public roadmap | #129 #130 #131 #132 #133 |
+| **S10** | 19–20 | Phase 2 | Deterministic replay + snapshot + diff | #134 #135 #136 |
+| **S11** | 21–22 | Phase 2 | Time travel + token budget + speculative | #137 #138 #139 |
+| **S12** | 23–24 | Phase 2 | Progressive streaming + context + multi-modal | #140 #141 #142 |
+| **S13** | 25–26 | Phase 2 | Schema-first + agentskit ai + router adapter | #143 #144 #145 |
+| **S14** | 27–28 | Phase 2 | Ensemble + fallback + devtools | #146 #147 #148 |
+| **S15** | 29–30 | Phase 2 | Trace viewer + evals CI + A/B | #149 #150 #151 |
+| **S16** | 31–32 | Phase 2 | Hierarchical memory + summarization + RAG reranking | #152 #153 #154 #155 |
+| **S17** | 33–34 | Phase 2 wrap | Durable + multi-agent + HITL + background | #156 #157 #158 #159 |
+| **S18** | 35–36 | Phase 2 security | PII + prompt injection + audit + rate-limit + sandbox | #160 #161 #162 #163 #164 |
+| **S19** | 37–38 | Phase 3 | Major adapters (10+ providers) | #165 #166 |
+| **S20** | 39–40 | Phase 3 | MCP bridge + tool composer | #167 #168 |
+| **S21** | 41–42 | Phase 3 | Dev ecosystem tools (GitHub, Linear, Slack) | #169 #170 #171 |
+| **S22** | 43–44 | Phase 3 | Scraping/image/voice/maps tools | #172 #173 #174 #175 |
+| **S23** | 45–46 | Phase 3 | Browser agent + self-debug + memory adapters | #176 #177 #178 |
+| **S24** | 47–48 | Phase 3 | Memory graph + encryption + skills | #179 #180 #181 #182 #183 |
+| **S25** | 49–50 | Phase 3 | Multi-framework UI (Vue/Svelte/Solid) + RN | #184 #185 #186 |
+| **S26** | 51–52 | Phase 3 wrap | Edge + Browser-only + verticals + A2A | #187 #188 #189 #190 #191 #192 #193 #194 #195 #196 #197 #198 |
+| **S27+** | 53+ | **Phase 4** | Cloud, marketplace, enterprise | #199–#210 |
 
-> Nota: capacidade assumida = **1-2 devs**. Com mais gente, compactar sprints.
+> Note: assumed capacity = **1–2 devs**. With more people, compress sprints.
 
 ---
 
-## Dependências críticas
+## Critical dependencies
 
-### Antes de qualquer coisa da Fase 1
-- ✅ ADRs dos contratos (#214) concluídos
-- ✅ Bundle/coverage gates (#217 #218) ativos
-- ✅ agentskit.io no ar (#235)
-- ✅ Fumadocs migrado (#238)
-- ✅ README + Manifesto + Origin (#224 #225 #226) publicados
-- ✅ E2E Playwright nos exemplos (#251)
+### Before anything in Phase 1
+- ✅ Contract ADRs (#214) completed
+- ✅ Bundle/coverage gates (#217 #218) active
+- ✅ agentskit.io live (#235)
+- ✅ Fumadocs migrated (#238)
+- ✅ README + Manifesto + Origin (#224 #225 #226) published
+- ✅ E2E Playwright on the examples (#251)
 
-### Dependências entre features
+### Feature-to-feature dependencies
 
 ```
-#3 ADRs contratos ─────┬──> toda Fase 1 (precisa de contrato estável)
-                        └──> toda Fase 3 (novos adapters/tools)
+#3 Contract ADRs ─────┬──> all of Phase 1 (needs a stable contract)
+                       └──> all of Phase 3 (new adapters/tools)
 
-#54 MCP bridge (F3) ──> #31 agentskit ai (F2) — precisa MCP tools
-#21 Deterministic replay (F2) ──> #39 Replay sessões + #43 Fixtures testes
-#77 AgentsKit Edge (F3) ──> #86 Cloud free tier (F4) — runtime edge
-#69 Skill marketplace (F3) ──> #91 Revenue share (F4)
-#81 A2A Protocol (F3) ──> parcerias estratégicas (F4)
+#54 MCP bridge (P3) ──> #31 agentskit ai (P2) — needs MCP tools
+#21 Deterministic replay (P2) ──> #39 Session replay + #43 Test fixtures
+#77 AgentsKit Edge (P3) ──> #86 Cloud free tier (P4) — edge runtime
+#69 Skill marketplace (P3) ──> #91 Revenue share (P4)
+#81 A2A Protocol (P3) ──> strategic partnerships (P4)
 ```
 
 ### Capacity warnings
-- **S16-S18** (memory + security + durability) são **pesadas** — considerar 3 sprints ao invés de 2
-- **S19 adapters major** requer chaves API de 10+ providers — preparar orçamento/credenciais antes
-- **S20 MCP bridge** é arquitetural pesado — alocar dev sênior
+- **S16–S18** (memory + security + durability) are **heavy** — consider 3 sprints instead of 2
+- **S19 major adapters** requires API keys for 10+ providers — line up budget/credentials first
+- **S20 MCP bridge** is architecturally heavy — allocate a senior dev
 
 ---
 
-## Gates por fase (não pular)
+## Gates per phase (do not skip)
 
-### Gate Phase 0 → Fase 1
-- [ ] 6 ADRs core merged
-- [ ] Bundle/coverage gates bloqueando PRs
-- [ ] agentskit.io resolvendo + docs.agentskit.io no ar
-- [ ] README raiz reescrito + Manifesto + Origin publicados
-- [ ] Fumadocs com Concepts section + ≥5 recipes
-- [ ] Migration guides LangChain + Vercel AI publicados
-- [ ] E2E Playwright rodando nos 4 exemplos
-- [ ] Discord com ≥20 membros + CODEOWNERS ativo
-- [ ] LICENSING.md decidido
-- [ ] **Lançamento coordenado executado** (HN/Twitter/PH/Reddit)
+### Gate Phase 0 → Phase 1
+- [ ] 6 core ADRs merged
+- [ ] Bundle/coverage gates blocking PRs
+- [ ] agentskit.io resolving + docs.agentskit.io live
+- [ ] Root README rewritten + Manifesto + Origin published
+- [ ] Fumadocs with Concepts section + ≥5 recipes
+- [ ] LangChain + Vercel AI migration guides published
+- [ ] E2E Playwright running on the 4 examples
+- [ ] Discord with ≥20 members + CODEOWNERS active
+- [ ] LICENSING.md decided
+- [ ] **Coordinated launch executed** (HN/Twitter/PH/Reddit)
 
-### Gate Fase 1 → Fase 2
-- [ ] 20 stories da Fase 1 done ou explicitamente descopadas
-- [ ] `npx @agentskit/cli init` com ≥1000 downloads/mês
-- [ ] Discord com ≥200 membros
-- [ ] ≥3 usuários externos compartilhando projetos publicamente
+### Gate Phase 1 → Phase 2
+- [ ] 20 Phase 1 stories done or explicitly de-scoped
+- [ ] `npx @agentskit/cli init` at ≥1000 downloads/month
+- [ ] Discord with ≥200 members
+- [ ] ≥3 external users sharing projects publicly
 
-### Gate Fase 2 → Fase 3
-- [ ] Deterministic replay + devtools funcionais (diferenciação técnica real)
-- [ ] Security layer completa
-- [ ] Memoria hierárquica + RAG reranking shipped
-- [ ] ≥10 stars/semana crescimento consistente
-- [ ] 1+ case study publicado
+### Gate Phase 2 → Phase 3
+- [ ] Deterministic replay + devtools working (real technical differentiation)
+- [ ] Full security layer
+- [ ] Hierarchical memory + RAG reranking shipped
+- [ ] ≥10 stars/week of consistent growth
+- [ ] 1+ case study published
 
-### Gate Fase 3 → Fase 4
-- [ ] 10+ adapters estáveis
-- [ ] MCP bridge bidirecional funcional
-- [ ] ≥1 parceria estratégica anunciada (Vercel, Cloudflare, provider)
-- [ ] Base de usuários ≥5k DAU
+### Gate Phase 3 → Phase 4
+- [ ] 10+ stable adapters
+- [ ] Bidirectional MCP bridge functional
+- [ ] ≥1 strategic partnership announced (Vercel, Cloudflare, provider)
+- [ ] User base ≥5k DAU
 
 ---
 
-## Ritmo & cerimônias
+## Cadence & ceremonies
 
-### Diário
-- Status update no Discord `#maintainers` (2 linhas — done/doing/blocked)
+### Daily
+- Status update in Discord `#maintainers` (2 lines — done/doing/blocked)
 
-### Semanal — toda sexta 17h
-- **Sprint Review** (30min): demo do que ficou pronto
-- **Planning** próxima semana (30min): ajustar prioridades
+### Weekly — every Friday at 5pm
+- **Sprint Review** (30 min): demo what shipped
+- **Planning** for next week (30 min): adjust priorities
 
-### Quinzenal — fim de cada sprint
-- **Retro** (30min): o que funcionou, o que não, o que mudar
-- Atualizar Project board: mover concluídos, reestimar pending
+### Bi-weekly — end of each sprint
+- **Retro** (30 min): what worked, what didn't, what to change
+- Update the Project board: move completed, re-estimate pending
 
-### Mensal
+### Monthly
 - **Community update** — blog post / newsletter
-- **Review do roadmap completo** — alguma Fase precisa recalibrar?
+- **Full roadmap review** — does any phase need recalibrating?
 
-### Trimestral
-- **Roadmap review público** — RFC de ajustes
-- **Eval de métricas** — stars, downloads, Discord, contribuidores
-
----
-
-## Métricas de sucesso
-
-### Phase 0 (3 meses)
-- agentskit.io indexado no Google
-- Launch coordenado com ≥1000 visitas na semana
-- ≥500 stars no repo
-- ≥20 membros no Discord
-
-### Fase 1 (fim do mês 4)
-- ≥1000 downloads/mês npm
-- ≥200 membros Discord
-- ≥5 contribuidores externos com PRs merged
-
-### Fase 2 (fim do mês 7)
-- ≥5000 downloads/mês
-- ≥1 post em Hacker News front page
-- Cobertura em ≥3 newsletters tech (Node Weekly, JS Weekly, etc.)
-
-### Fase 3 (fim do mês 10)
-- ≥20k downloads/mês
-- 10+ adapters maduros
-- ≥10 projetos open-source públicos usando AgentsKit
-
-### Fase 4 (fim do ano 1)
-- Cloud com ≥100 usuários ativos
-- Primeiro cliente enterprise
-- Break-even no custo de infra
+### Quarterly
+- **Public roadmap review** — RFC of adjustments
+- **Metrics eval** — stars, downloads, Discord, contributors
 
 ---
 
-## Project Board — configuração recomendada
+## Success metrics
 
-Adicionar campo **Iteration** (sprint tracker) com:
-- Sprints S1 a S27 como opções
-- Preenchido antecipadamente para issues das próximas 2-3 iterations
+### Phase 0 (3 months)
+- agentskit.io indexed on Google
+- Coordinated launch with ≥1000 visits in the week
+- ≥500 stars on the repo
+- ≥20 Discord members
 
-Criar **Views**:
-1. **🔥 Current Sprint** — filtro: `iteration = current`, group by Status
+### Phase 1 (end of month 4)
+- ≥1000 npm downloads/month
+- ≥200 Discord members
+- ≥5 external contributors with merged PRs
+
+### Phase 2 (end of month 7)
+- ≥5000 downloads/month
+- ≥1 Hacker News front-page post
+- Coverage in ≥3 tech newsletters (Node Weekly, JS Weekly, etc.)
+
+### Phase 3 (end of month 10)
+- ≥20k downloads/month
+- 10+ mature adapters
+- ≥10 public open-source projects using AgentsKit
+
+### Phase 4 (end of year 1)
+- Cloud with ≥100 active users
+- First enterprise customer
+- Break-even on infra cost
+
+---
+
+## Project Board — recommended configuration
+
+Add an **Iteration** field (sprint tracker) with:
+- Sprints S1 through S27 as options
+- Pre-filled for the next 2–3 iterations
+
+Create **Views**:
+1. **🔥 Current Sprint** — filter: `iteration = current`, group by Status
 2. **📅 Roadmap Timeline** — layout: Roadmap, group by Phase
-3. **🎯 By Priority** — filtro: `iteration = current or next`, group by Priority
-4. **🧭 Backlog Planning** — filtro: `iteration is empty`, group by Phase
+3. **🎯 By Priority** — filter: `iteration = current or next`, group by Priority
+4. **🧭 Backlog Planning** — filter: `iteration is empty`, group by Phase
 5. **📦 By Package** — group by Category/Package
 
 ---
 
-## Próximas ações concretas (começar hoje)
+## Concrete next actions (start today)
 
-### Esta semana (Sprint 1 start)
-1. **Criar branch `foundation/manifesto-origin`** — rascunhar MANIFESTO.md + ORIGIN.md
-2. **Comprar serviço DNS + Cloudflare pro agentskit.io** — apontar `CNAME` provisório
-3. **Setup `size-limit` em um package de teste** (core) — validar fluxo antes de replicar
-4. **Criar issue/PR templates na `.github/`** — desbloqueio pra tudo que virá
-5. **Decidir hoster da doc nova**: Vercel vs Cloudflare Pages (recomendo Vercel pela integração Fumadocs/Next.js)
+### This week (Sprint 1 start)
+1. **Create branch `foundation/manifesto-origin`** — draft MANIFESTO.md + ORIGIN.md
+2. **Buy DNS service + Cloudflare for agentskit.io** — point a provisional `CNAME`
+3. **Set up `size-limit` on a test package** (core) — validate the flow before replicating
+4. **Create issue/PR templates in `.github/`** — unblocks everything that follows
+5. **Decide the new docs host**: Vercel vs Cloudflare Pages (we recommend Vercel for the Fumadocs/Next.js integration)
 
-### Próxima semana
-1. Finalizar MANIFESTO + ORIGIN em PR aprovado
-2. Começar reescrita do README raiz (bloco por bloco)
-3. Spike Fumadocs em branch separado
-4. Abrir primeiro ADR (`0001-adapter-contract.md`) como RFC público
+### Next week
+1. Finalize MANIFESTO + ORIGIN in an approved PR
+2. Start the root README rewrite (block by block)
+3. Spike Fumadocs in a separate branch
+4. Open the first ADR (`0001-adapter-contract.md`) as a public RFC
 
-### Semana 3
+### Week 3
 1. Parity check Docusaurus vs Fumadocs
-2. Continuar ADRs (meta: 1/dia)
+2. Continue ADRs (target: 1/day)
 3. CODEOWNERS + issue templates merged
-4. Ativar bundle/coverage gates em main
+4. Activate bundle/coverage gates on main
 
 ---
 
-## Princípios de execução
+## Execution principles
 
-1. **Done é melhor que perfeito** — aceitar v0.1 das coisas e iterar
-2. **Publicar em público** — RFCs, ADRs, decisões tudo aberto
-3. **Time-box agressivo** — toda tarefa tem limite; se estourar, re-avaliar
-4. **Diariamente fazer pelo menos 1 issue mover** — momentum importa
-5. **Nunca iniciar uma fase com a anterior incompleta** — gates existem por motivo
-6. **Dogfood** — AgentsKit deve ser usado pra construir AgentsKit (chat da doc, agente de release, etc.)
+1. **Done is better than perfect** — accept v0.1 of things and iterate
+2. **Publish in public** — RFCs, ADRs, decisions all open
+3. **Aggressive time-boxing** — every task has a limit; if it overruns, re-evaluate
+4. **Move at least 1 issue every day** — momentum matters
+5. **Never start a phase with the previous one incomplete** — gates exist for a reason
+6. **Dogfood** — AgentsKit should be used to build AgentsKit (docs chat, release agent, etc.)

--- a/docs/PHASE-0-EXECUTION-PLAN.md
+++ b/docs/PHASE-0-EXECUTION-PLAN.md
@@ -1,121 +1,121 @@
 # Phase 0 — Execution Plan (P0 → P2)
 
-> Plano tático para as 12 tarefas prioritárias da Phase 0. Cobre 3-4 semanas.
-> Ligado ao [Phase 0 PRD #211](https://github.com/EmersonBraun/agentskit/issues/211).
+> Tactical plan for the 12 top-priority Phase 0 tasks. Covers 3–4 weeks.
+> Linked to the [Phase 0 PRD #211](https://github.com/EmersonBraun/agentskit/issues/211).
 
 ---
 
 ## Sprint Overview
 
-| Sprint | Duração | Objetivo | Entregáveis |
+| Sprint | Duration | Goal | Deliverables |
 |---|---|---|---|
-| **Sprint 1** (P0) | 5 dias úteis | Narrativa + infra-base | README, Manifesto, Origin, DNS, Bundle/Coverage gates, início dos ADRs |
-| **Sprint 2** (P1) | 5-7 dias úteis | Contratos formalizados + migração de docs | 6 ADRs completos, Fumadocs migrado, Concepts section |
-| **Sprint 3** (P2) | 5-7 dias úteis | Polimento externo + qualidade | READMEs dos 14 packages, migration guide Vercel AI, E2E Playwright |
+| **Sprint 1** (P0) | 5 business days | Narrative + infra foundation | README, Manifesto, Origin, DNS, bundle/coverage gates, first ADRs |
+| **Sprint 2** (P1) | 5–7 business days | Formalized contracts + docs migration | 6 complete ADRs, Fumadocs migrated, Concepts section |
+| **Sprint 3** (P2) | 5–7 business days | External polish + quality | Rewritten READMEs for the 14 packages, Vercel AI migration guide, Playwright E2E |
 
-**Gate para Fase 1 começar**: todos os P0+P1 concluídos + ≥80% dos P2.
+**Gate to start Phase 1**: all P0+P1 done + ≥80% of P2.
 
 ---
 
-## Sprint 1 — P0 (Semana 1)
+## Sprint 1 — P0 (Week 1)
 
-### Dia 1 — Narrativa base (baixo esforço, alta visibilidade)
+### Day 1 — Base narrative (low effort, high visibility)
 
-**Manhã — #14 MANIFESTO.md** (2-3h)
-- Criar `MANIFESTO.md` na raiz
-- 5-7 princípios não-negociáveis, 1 parágrafo cada:
-  1. Core < 10KB gzip, zero deps (estabilidade eterna)
-  2. Plug-and-play: todo package funciona sozinho
-  3. Interop radical: combinação arbitrária = zero atrito
-  4. Zero lock-in: sair é `npm uninstall`
-  5. Agent-first (não chat-first)
-  6. TypeScript rigoroso, sem `any`
-  7. Docs são produto, não afterthought
-- Link no topo do README
+**Morning — #14 MANIFESTO.md** (2–3h)
+- Create `MANIFESTO.md` at the root
+- 5–7 non-negotiable principles, 1 paragraph each:
+  1. Core < 10KB gzip, zero deps (eternal stability)
+  2. Plug-and-play: every package works on its own
+  3. Radical interop: arbitrary combination = zero friction
+  4. Zero lock-in: leaving is `npm uninstall`
+  5. Agent-first (not chat-first)
+  6. Strict TypeScript, no `any`
+  7. Docs are product, not an afterthought
+- Link at the top of the README
 
-**Tarde — #15 ORIGIN.md** (2-3h)
-- Criar `ORIGIN.md` na raiz
-- 500-800 palavras, tom pessoal
-- Estrutura sugerida:
-  - "Em [data], tentei construir [X]. Descobri que..."
-  - Dor concreta (não abstrata): "LangChain tinha 200MB, Vercel AI SDK não tinha runtime, MCP não tinha UI"
-  - Decisão: "Criei AgentsKit porque..."
-  - Visão: "Minha aposta é que JavaScript vai ser a linguagem dos agentes porque..."
+**Afternoon — #15 ORIGIN.md** (2–3h)
+- Create `ORIGIN.md` at the root
+- 500–800 words, personal tone
+- Suggested structure:
+  - "On [date], I tried to build [X]. I found that…"
+  - Concrete pain (not abstract): "LangChain was 200MB, Vercel AI SDK had no runtime, MCP had no UI"
+  - Decision: "I created AgentsKit because…"
+  - Vision: "My bet is JavaScript will be the language of agents because…"
 
-### Dia 2 — Domínio no ar
+### Day 2 — Domain live
 
-**#24 Configurar agentskit.io** (4-6h)
-- Adicionar `CNAME` no repo apontando pro domínio
+**#24 Configure agentskit.io** (4–6h)
+- Add `CNAME` in the repo pointing at the domain
 - DNS:
-  - `agentskit.io` → Vercel/Cloudflare Pages (landing futura) OU GitHub Pages temporário
-  - `docs.agentskit.io` → reservado pra Fumadocs (Sprint 2)
-- SSL automático via Cloudflare
-- Redirect `emersonbraun.github.io/agentskit/*` → `agentskit.io/*` (manter SEO)
-- Atualizar README com novo domínio
-- Verificar meta tags OG (title, description, image) apontando pro domínio correto
+  - `agentskit.io` → Vercel/Cloudflare Pages (future landing) OR temporary GitHub Pages
+  - `docs.agentskit.io` → reserved for Fumadocs (Sprint 2)
+- Automatic SSL via Cloudflare
+- Redirect `emersonbraun.github.io/agentskit/*` → `agentskit.io/*` (preserve SEO)
+- Update the README with the new domain
+- Verify OG meta tags (title, description, image) pointing at the correct domain
 
-### Dia 3-4 — Reescrita do README raiz
+### Days 3–4 — Root README rewrite
 
-**#13 README raiz reescrito** (2 dias)
-- Estrutura nova (baseada em Next.js, Vercel AI SDK, Bun):
+**#13 Rewritten root README** (2 days)
+- New structure (inspired by Next.js, Vercel AI SDK, Bun):
   ```
-  [Logo + tagline emocional 1 linha]
-  [Badges: npm, bundle, license, discord futuro]
+  [Logo + emotional tagline — 1 line]
+  [Badges: npm, bundle, license, future Discord]
 
-  > One-liner pitch (25 palavras máx)
+  > One-liner pitch (25 words max)
 
   ## Why AgentsKit?
-  [4 bullets com contraste claro]
+  [4 bullets with clear contrast]
 
-  ## Quick Start (60 segundos)
-  [Código ≤15 linhas rodando chat streaming]
+  ## Quick Start (60 seconds)
+  [Code ≤15 lines running streaming chat]
 
   ## Before / After
-  [Código Vercel AI SDK vs AgentsKit lado a lado]
+  [Vercel AI SDK vs AgentsKit code, side by side]
 
   ## When NOT to use AgentsKit
-  [Honestidade — 3 cenários]
+  [Honesty — 3 scenarios]
 
   ## Ecosystem
-  [Diagrama Mermaid dos packages]
+  [Mermaid diagram of the packages]
 
   ## Links
   [Docs, Manifesto, Origin, Discord, Twitter]
   ```
-- Validar lendo em voz alta — tem que bater em 90s de leitura
+- Validate by reading it aloud — it must hit under 90 seconds of reading
 
-### Dia 5 — Gates no CI (destrava qualidade futura)
+### Day 5 — CI gates (unlocks future quality)
 
-**Manhã — #6 Bundle size budget** (3-4h)
-- Instalar `size-limit` + plugin gzip
-- Criar `.size-limit.json` na raiz com entrada por package:
+**Morning — #6 Bundle-size budget** (3–4h)
+- Install `size-limit` + the gzip plugin
+- Create `.size-limit.json` at the root with one entry per package:
   ```json
   [
     { "path": "packages/core/dist/index.js", "limit": "10 KB" },
     { "path": "packages/adapters/dist/index.js", "limit": "20 KB" }
   ]
   ```
-- Workflow `.github/workflows/size.yml` rodando em cada PR
-- Bloquear merge se exceder
+- Workflow `.github/workflows/size.yml` running on every PR
+- Block merge on overrun
 
-**Tarde — #7 Coverage gate** (2-3h)
-- Configurar `vitest --coverage` com threshold por package
-- Mínimos: core 85%, adapters 70%, outros 60%
-- Publicar badge + relatório via Codecov ou CodeClimate (grátis pra OSS)
-- Workflow falha se não atingir
+**Afternoon — #7 Coverage gate** (2–3h)
+- Configure `vitest --coverage` with a per-package threshold
+- Minimums: core 85%, adapters 70%, others 60%
+- Publish a badge + report via Codecov or CodeClimate (free for OSS)
+- The workflow fails if the threshold isn't met
 
 ---
 
-## Sprint 2 — P1 (Semanas 2-3)
+## Sprint 2 — P1 (Weeks 2–3)
 
-### Contratos formalizados — 6 ADRs
+### Formalized contracts — 6 ADRs
 
-**#3 ADRs dos contratos core** (5-7 dias, 1 ADR/dia)
+**#3 Core contract ADRs** (5–7 days, 1 ADR/day)
 
-Criar pasta `docs/architecture/adrs/`. Template padrão por ADR:
+Create folder `docs/architecture/adrs/`. Standard ADR template:
 
 ```markdown
-# ADR 000N — <Contrato>
+# ADR 000N — <Contract>
 
 ## Status: Accepted | Proposed | Superseded
 ## Date: YYYY-MM-DD
@@ -127,7 +127,7 @@ Criar pasta `docs/architecture/adrs/`. Template padrão por ADR:
 ## Open Questions
 ```
 
-Ordem sugerida (do mais estável pro mais volátil):
+Suggested order (most stable to most volatile):
 - `0001-adapter-contract.md` — `Adapter`, streaming, tool calling
 - `0002-tool-contract.md` — `Tool` schema, execute, validation
 - `0003-memory-contract.md` — `Memory`, read/write, serialization
@@ -135,60 +135,60 @@ Ordem sugerida (do mais estável pro mais volátil):
 - `0005-skill-contract.md` — `Skill` manifest, prompt, examples
 - `0006-runtime-contract.md` — `Runtime`, loop, lifecycle hooks
 
-Cada ADR vira um PR separado → forçar discussão.
+Each ADR ships as a separate PR → forces discussion.
 
-### Migração Fumadocs
+### Fumadocs migration
 
-**#25 Migração Docusaurus → Fumadocs** (5-7 dias)
+**#25 Docusaurus → Fumadocs migration** (5–7 days)
 
-Plano:
-1. **Dia 1**: Spike técnico — scaffolding Fumadocs em branch `docs-fumadocs`, porting do index
-2. **Dia 2-3**: Migrar conteúdo das 12 seções existentes (`adapters`, `agents`, `chat-uis`, `components`, `data-layer`, `examples`, `getting-started`, `hooks`, `infrastructure`, `packages`, `theming`, `contributing`)
-3. **Dia 4**: Decidir estratégia i18n (Crowdin? congelar? LLM?) — RFC rápido
-4. **Dia 5**: Redirects, sidebar, tema custom (paleta + tipografia alinhadas à Manifesto)
-5. **Dia 6**: Deploy em `docs.agentskit.io` via Vercel
-6. **Dia 7**: Publicar, arquivar Docusaurus antigo
+Plan:
+1. **Day 1**: Technical spike — Fumadocs scaffolding in branch `docs-fumadocs`, port the index
+2. **Days 2–3**: Migrate content from the 12 existing sections (`adapters`, `agents`, `chat-uis`, `components`, `data-layer`, `examples`, `getting-started`, `hooks`, `infrastructure`, `packages`, `theming`, `contributing`)
+3. **Day 4**: Decide the i18n strategy (Crowdin? freeze? LLM?) — short RFC
+4. **Day 5**: Redirects, sidebar, custom theme (palette + typography aligned to the Manifesto)
+5. **Day 6**: Deploy at `docs.agentskit.io` via Vercel
+6. **Day 7**: Publish, archive the old Docusaurus
 
 ### Concepts Section
 
-**#26 Concepts section** (2-3 dias)
-- Criar em `docs/concepts/`:
-  - `mental-model.mdx` — diagrama único mostrando Agent ↔ Adapter ↔ Tool ↔ Memory ↔ Skill
-  - `agent.mdx` — o que é um Agent
-  - `adapter.mdx` — abstração do provider
-  - `tool.mdx` — função executável
+**#26 Concepts section** (2–3 days)
+- Create under `docs/concepts/`:
+  - `mental-model.mdx` — single diagram showing Agent ↔ Adapter ↔ Tool ↔ Memory ↔ Skill
+  - `agent.mdx` — what an Agent is
+  - `adapter.mdx` — provider abstraction
+  - `tool.mdx` — executable function
   - `skill.mdx` — prompt + behavior + examples
-  - `memory.mdx` — persistência
-  - `react-loop.mdx` — como ReAct funciona no AgentsKit
-  - `streaming.mdx` — modelo de streaming unificado
-- Linguagem consistente (glossário vive aqui)
-- Cada conceito ≤600 palavras + exemplo mínimo + "quando usar" / "quando não usar"
+  - `memory.mdx` — persistence
+  - `react-loop.mdx` — how ReAct works in AgentsKit
+  - `streaming.mdx` — the unified streaming model
+- Consistent language (the glossary lives here)
+- Each concept ≤600 words + minimal example + "when to use" / "when not to use"
 
 ---
 
-## Sprint 3 — P2 (Semanas 3-4)
+## Sprint 3 — P2 (Weeks 3–4)
 
-### READMEs dos 14 packages
+### READMEs for the 14 packages
 
-**#17 Rewrite de todos os READMEs** (2-3 dias, paralelizável)
+**#17 Rewrite of every README** (2–3 days, parallelizable)
 
-Estrutura padrão por package:
+Standard structure per package:
 ```
 # @agentskit/<name>
-> <tagline única — 1 linha, emoção + função>
+> <unique tagline — 1 line, emotion + function>
 
-<Pitch de 2-3 linhas>
+<2–3 line pitch>
 
 ## Install
 ## When to use this
 ## When NOT to use this
-## Quick example (≤10 linhas)
+## Quick example (≤10 lines)
 ## Contracts this implements
 ## Stability: stable | beta | experimental
 ## Links: Docs | Changelog | ADR
 ```
 
-Taglines sugeridas:
+Suggested taglines:
 - `@agentskit/core` — *"The 10KB soul of every AgentsKit app"*
 - `@agentskit/runtime` — *"Agents that survive crashes"*
 - `@agentskit/adapters` — *"Swap providers in one line"*
@@ -204,63 +204,63 @@ Taglines sugeridas:
 - `@agentskit/cli` — *"From idea to agent in 60 seconds"*
 - `@agentskit/templates` — *"Start with something real"*
 
-### Migration Guide Vercel AI SDK
+### Vercel AI SDK migration guide
 
-**#30 Migration guide** (2 dias)
-- Doc em `docs/migrating/vercel-ai-sdk.mdx`
-- Estrutura:
-  1. TL;DR (5 linhas)
-  2. Tabela de equivalências (`streamText` → ?, `useChat` → ?, `tool()` → ?)
-  3. 5 exemplos de migração lado a lado (basic chat, tool calling, streaming, multi-modal, RAG)
-  4. O que AgentsKit adiciona que Vercel AI não tem
-  5. Casos em que Vercel AI é melhor (honestidade)
-- Tweet-size summary para divulgação
+**#30 Migration guide** (2 days)
+- Doc at `docs/migrating/vercel-ai-sdk.mdx`
+- Structure:
+  1. TL;DR (5 lines)
+  2. Equivalence table (`streamText` → ?, `useChat` → ?, `tool()` → ?)
+  3. 5 side-by-side migration examples (basic chat, tool calling, streaming, multi-modal, RAG)
+  4. What AgentsKit adds that Vercel AI doesn't have
+  5. Cases where Vercel AI is better (honesty)
+- Tweet-size summary for distribution
 
-### E2E Playwright
+### Playwright E2E
 
-**#40 E2E nos 4 exemplos** (2-3 dias)
-- Setup Playwright compartilhado em `tests/e2e/`
-- Um test file por `apps/example-*`:
-  - `example-react.spec.ts` — chat streaming + tool call + memory persistindo
-  - `example-ink.spec.ts` — usar `ink-testing-library`
-  - `example-runtime.spec.ts` — agent loop completo com replay
-  - `example-multi-agent.spec.ts` — delegação funcionando
-- Workflow `.github/workflows/e2e.yml` rodando em PR e main
-- Fixture de adapter determinístico pra evitar flakiness
+**#40 E2E on the 4 examples** (2–3 days)
+- Shared Playwright setup in `tests/e2e/`
+- One test file per `apps/example-*`:
+  - `example-react.spec.ts` — streaming chat + tool call + memory persisting
+  - `example-ink.spec.ts` — use `ink-testing-library`
+  - `example-runtime.spec.ts` — full agent loop with replay
+  - `example-multi-agent.spec.ts` — delegation working
+- Workflow `.github/workflows/e2e.yml` running on PR and main
+- Deterministic adapter fixture to avoid flakiness
 
 ---
 
 ## Tracking
 
-### Definition of Done por tarefa
+### Definition of Done per task
 
-Cada issue dos P0-P2 é "done" quando:
-- [ ] Código/conteúdo implementado
-- [ ] Testes adicionados/atualizados (se aplicável)
-- [ ] Changeset criado (se aplicável)
-- [ ] PR revisado e merged
-- [ ] Documentação atualizada (se afeta API)
-- [ ] Item marcado no Project board
+Every P0–P2 issue is "done" when:
+- [ ] Code/content implemented
+- [ ] Tests added/updated (if applicable)
+- [ ] Changeset created (if applicable)
+- [ ] PR reviewed and merged
+- [ ] Docs updated (if it affects the API)
+- [ ] Item marked on the Project board
 
-### Checkpoint semanal
+### Weekly checkpoint
 
-Toda sexta-feira:
-- Status das issues P0-P2 (done / in-progress / blocked)
-- Demo curta do que ficou pronto
-- Ajuste de prioridades para semana seguinte
+Every Friday:
+- Status of the P0–P2 issues (done / in-progress / blocked)
+- Short demo of what shipped
+- Priority adjustment for the next week
 
-### Riscos conhecidos
+### Known risks
 
-1. **Migração Fumadocs pode quebrar i18n** — mitigação: manter Docusaurus vivo em branch até nova doc ter paridade
-2. **ADRs podem virar bikeshed** — mitigação: time-box de 1 dia por ADR, merge e itera depois
-3. **Bundle/coverage gates podem bloquear PRs existentes** — mitigação: baseline relaxado no início, apertar em 2 semanas
-4. **README reescrito pode perder info técnica** — mitigação: mover detalhes pro docs, README é porta de entrada
+1. **Fumadocs migration may break i18n** — mitigation: keep Docusaurus alive in a branch until the new docs reach parity
+2. **ADRs may turn into bikeshedding** — mitigation: 1-day time-box per ADR, merge and iterate later
+3. **Bundle/coverage gates may block existing PRs** — mitigation: relaxed baseline at the start, tighten in 2 weeks
+4. **A rewritten README may lose technical info** — mitigation: move details into the docs, the README is the entry point
 
 ---
 
-## Após Phase 0
+## After Phase 0
 
-Quando todos os gates do PRD #211 estiverem verdes:
-1. Anunciar publicamente (HN + Twitter + Reddit + ProductHunt) — **evento único**
-2. Abrir as 20 issues da Fase 1 (stories #1-20 do Master PRD #113)
-3. Setup de Discord ativo + primeira newsletter mensal
+When all gates in PRD #211 are green:
+1. Announce publicly (HN + Twitter + Reddit + ProductHunt) — **single event**
+2. Open the 20 Phase 1 issues (stories #1–20 from Master PRD #113)
+3. Active Discord setup + first monthly newsletter

--- a/docs/PHASE-0-FOUNDATION-PRD.md
+++ b/docs/PHASE-0-FOUNDATION-PRD.md
@@ -1,223 +1,223 @@
 # AgentsKit — Phase 0: Foundation Hardening PRD
 
-> Pré-roadmap. Antes de executar as 97 issues do Master PRD (#113), solidificar bases técnicas, narrativa e infraestrutura pública. 4–6 semanas de trabalho focado.
+> Pre-roadmap. Before executing the 97 Master PRD issues (#113), solidify technical bases, narrative, and public infrastructure. 4–6 weeks of focused work.
 >
-> **Decisões já tomadas:**
-> - Migração de **Docusaurus → Fumadocs** (Next.js-native, MDX rico, visual moderno, ideal pra lib JS)
-> - Domínio próprio **agentskit.io** (já adquirido) substituindo `emersonbraun.github.io/agentskit`
+> **Decisions already made:**
+> - Migration from **Docusaurus → Fumadocs** (Next.js-native, rich MDX, modern look, ideal for a JS library)
+> - Own domain **agentskit.io** (already acquired) replacing `emersonbraun.github.io/agentskit`
 
 ---
 
 ## Problem Statement
 
-O AgentsKit tem 14 packages funcionais, CI, changesets, Docusaurus com i18n em 3 línguas e um Master PRD com 97 user stories roadmap-ed. Mas executar esse roadmap sobre a base atual vai gerar dívida técnica e inconsistência porque:
+AgentsKit has 14 functional packages, CI, changesets, Docusaurus with i18n in 3 languages, and a Master PRD with 97 user stories roadmap-ed. But executing that roadmap on the current base will create technical debt and inconsistency because:
 
-- **Contratos não são formalmente versionados** (Adapter, Tool, Memory, Retriever). 10 adapters novos divergindo em sutilezas quebram a promessa "plug-and-play".
-- **Sem stability tiers** — dev externo não sabe quais packages são seguros adotar.
-- **Bundle size budget não é enforced no CI** — promessa de core <10KB pode ser quebrada silenciosamente.
-- **Narrativa externa é técnica e genérica** — "complete toolkit for AI agents" não vende produto revolucionário; falta manifesto, origin story, identidade visual forte, comparação honesta incluindo quando NÃO usar.
-- **Documentação é ampla e rasa** — 12 seções no Docusaurus sem "Concepts" section, sem Recipes/Cookbook profundos, sem troubleshooting, sem migration guides de LangChain/Vercel AI.
-- **READMEs dos 14 packages são uniformemente genéricos (~50 linhas)** — cada package é um produto e precisa de pitch próprio.
-- **Docusaurus é decisão default nunca decidida** — existe alternativa superior (Fumadocs) pra ecossistema Next/React. Já decidido migrar.
-- **Domínio fraco** (`emersonbraun.github.io/agentskit`) prejudica positioning. `agentskit.io` já adquirido.
-- **Governança imatura** — sem CODEOWNERS, sem Discord, sem maintainers plurais, sem RFC process, sem issue/PR templates específicos.
-- **Gaps legais/business** — licença MIT ok pra OSS mas ambígua pra Cloud futuro; trademark não registrado; analytics ausente na doc.
+- **Contracts are not formally versioned** (Adapter, Tool, Memory, Retriever). 10 new adapters diverging on subtleties break the "plug-and-play" promise.
+- **No stability tiers** — external developers don't know which packages are safe to adopt.
+- **Bundle-size budget is not enforced in CI** — the core <10KB promise can be silently broken.
+- **External narrative is technical and generic** — "complete toolkit for AI agents" doesn't sell a revolutionary product; there's no manifesto, origin story, strong visual identity, or honest comparison including when NOT to use.
+- **Documentation is broad and shallow** — 12 Docusaurus sections with no "Concepts" section, no deep Recipes/Cookbook, no troubleshooting, no migration guides from LangChain/Vercel AI.
+- **READMEs of the 14 packages are uniformly generic (~50 lines)** — each package is a product and needs its own pitch.
+- **Docusaurus is an un-decided default** — a better alternative exists (Fumadocs) for the Next/React ecosystem. Already decided to migrate.
+- **Weak domain** (`emersonbraun.github.io/agentskit`) hurts positioning. `agentskit.io` already acquired.
+- **Immature governance** — no CODEOWNERS, no Discord, no plural maintainers, no RFC process, no specific issue/PR templates.
+- **Legal / business gaps** — MIT license is fine for OSS but ambiguous for a future Cloud offering; trademark not registered; analytics missing from the docs.
 
 ## Solution
 
-Executar **Phase 0 — Foundation Hardening** em 4 frentes paralelas antes de iniciar a Fase 1 do Master PRD:
+Execute **Phase 0 — Foundation Hardening** across 4 parallel tracks before starting Phase 1 of the Master PRD:
 
-1. **Contratos & governança técnica** — ADRs, stability tiers, CI gates, RFC process.
-2. **Narrativa & identidade** — manifesto, origin story, visual identity mínima, landing independente em `agentskit.io`, READMEs por pacote com pitch próprio.
-3. **Documentação profunda** — migração para **Fumadocs**, Concepts section, Recipes cookbook, troubleshooting/FAQ, migration guides de LangChain e Vercel AI, exemplos linkados.
-4. **Infraestrutura de qualidade e comunidade** — coverage/bundle gates, E2E dos exemplos, CODEOWNERS, Discord, analytics, sponsors.
+1. **Contracts & technical governance** — ADRs, stability tiers, CI gates, RFC process.
+2. **Narrative & identity** — manifesto, origin story, minimum visual identity, independent landing at `agentskit.io`, per-package READMEs with their own pitch.
+3. **Deep documentation** — migration to **Fumadocs**, Concepts section, Recipes cookbook, troubleshooting/FAQ, LangChain and Vercel AI migration guides, linked examples.
+4. **Quality & community infrastructure** — coverage/bundle gates, E2E for examples, CODEOWNERS, Discord, analytics, sponsors.
 
-Resultado esperado: ao final da Phase 0, o projeto está **pronto pra crescer 10x sem dívida**, com narrativa que "se vende sozinha" e base técnica que suporta 97 issues sem caos.
+Expected outcome: at the end of Phase 0, the project is **ready to 10x without debt**, with a narrative that "sells itself" and a technical base that supports 97 issues without chaos.
 
 ---
 
 ## User Stories
 
-### Frente 1 — Contratos & Governança Técnica
+### Track 1 — Contracts & Technical Governance
 
-1. Como maintainer, quero um **ARCHITECTURE.md raiz** explicando decisões fundadoras (core zero-deps, packages independentes, por que não LangChain-style), para alinhar contribuidores.
-2. Como maintainer, quero um **processo RFC aberto** com template (`.github/RFC-TEMPLATE.md` + pasta `rfcs/`), para propostas técnicas serem discutidas antes de virarem código.
-3. Como dev externo, quero um **ADR versionado por contrato core** (Adapter, Tool, Memory, Retriever, Skill, Runtime), para adotar sem medo de breaking change silencioso.
-4. Como dev, quero **stability tiers documentados** (stable / beta / experimental) em cada `package.json` e README, para saber o que posso usar em produção.
-5. Como maintainer, quero **semver policy escrita** — o que é breaking vs patch, quando bumpa major — para aplicar consistente.
-6. Como maintainer, quero **bundle size budget enforced no CI** (ex: `size-limit` ou `bundlewatch`) bloqueando PRs que quebrem core <10KB, adapters <20KB, etc.
-7. Como maintainer, quero **coverage gate no CI** (mínimo 70% por package, 85% no core), para regressões em teste serem bloqueadas.
-8. Como maintainer, quero **changeset lint** bloqueando PR que não declara mudança de versão.
-9. Como maintainer, quero **CONVENTIONS.md por package** (`packages/adapters/CONVENTIONS.md`, etc.) descrevendo como adicionar novo adapter/tool/skill — passo-a-passo.
-10. Como maintainer, quero **diagrama visual das dependências** entre packages (Mermaid no ARCHITECTURE.md) atualizado automaticamente.
-11. Como maintainer, quero **CODEOWNERS** configurado por package pra auto-assign de review.
-12. Como maintainer, quero **issue templates** (bug, feature request, RFC, docs) e **PR template** forçando checklist (testes, changeset, docs).
+1. As a maintainer, I want a **root ARCHITECTURE.md** explaining founding decisions (zero-deps core, independent packages, why not LangChain-style) to align contributors.
+2. As a maintainer, I want an **open RFC process** with a template (`.github/RFC-TEMPLATE.md` + `rfcs/` folder), so technical proposals are discussed before becoming code.
+3. As an external developer, I want a **versioned ADR per core contract** (Adapter, Tool, Memory, Retriever, Skill, Runtime), so I can adopt without fear of silent breaking changes.
+4. As a developer, I want **documented stability tiers** (stable / beta / experimental) in each `package.json` and README, so I know what I can use in production.
+5. As a maintainer, I want a **written semver policy** — what counts as breaking vs patch, when to bump major — so I can apply it consistently.
+6. As a maintainer, I want a **bundle-size budget enforced in CI** (e.g. `size-limit` or `bundlewatch`) blocking PRs that break core <10KB, adapters <20KB, etc.
+7. As a maintainer, I want a **coverage gate in CI** (minimum 70% per package, 85% on core), so test regressions are blocked.
+8. As a maintainer, I want **changeset linting** blocking any PR that doesn't declare a version change.
+9. As a maintainer, I want **per-package CONVENTIONS.md** (`packages/adapters/CONVENTIONS.md`, etc.) describing how to add a new adapter/tool/skill — step by step.
+10. As a maintainer, I want a **visual dependency diagram** between packages (Mermaid in ARCHITECTURE.md) updated automatically.
+11. As a maintainer, I want **CODEOWNERS** configured per package for review auto-assign.
+12. As a maintainer, I want **issue templates** (bug, feature request, RFC, docs) and a **PR template** enforcing a checklist (tests, changeset, docs).
 
-### Frente 2 — Narrativa & Identidade
+### Track 2 — Narrative & Identity
 
-13. Como visitante, quero um **README raiz reescrito** com: tagline emocional, origin story resumida, "before/after" em código, comparativo honesto (incluindo quando NÃO usar), quickstart ≤15 linhas, link pra agentskit.io.
-14. Como leitor técnico, quero um **MANIFESTO.md** público (core <10KB, plug-and-play, zero lock-in, agent-first, interop radical) explicando princípios não-negociáveis.
-15. Como visitante, quero uma **ORIGIN.md** — por que AgentsKit existe, que dor o autor sentiu, contexto do ecossistema JS de agentes — para criar conexão humana.
-16. Como dev avaliando, quero ver na home uma **tabela de comparação honesta** vs Vercel AI SDK, LangChain.js, Mastra, assistant-ui — incluindo pontos onde outros ganham.
-17. Como dev, quero um **pitch próprio no README de cada package** (`@agentskit/core — the 10KB soul`, `@agentskit/runtime — agents that survive crashes`, etc.) substituindo os READMEs genéricos atuais.
-18. Como visitante, quero uma **identidade visual mínima**: logo, favicon, paleta de 3-5 cores, tipografia escolhida, social card (OG image), tema Fumadocs customizado.
-19. Como visitante, quero acessar **agentskit.io** com landing page independente (Next.js) separada da documentação — públicos diferentes (marketing vs referência técnica).
-20. Como dev descobrindo a lib, quero um **vídeo de 60 segundos** embedado na home mostrando "zero → chat streaming em 10 linhas" visualmente.
-21. Como visitante, quero ver **social proof** na landing (GitHub stars, downloads npm, "used by", testimonials quando existirem, showcase).
-22. Como maintainer, quero **conta oficial no X/Twitter** (`@agentskit` ou `@agentskitdev`) ativa com tips semanais, changelog, release notes.
-23. Como dev, quero um **changelog público com narrativa** (não só CHANGELOG.md técnico) — "This month we shipped X, learned Y" — como blog/newsletter mensal.
-24. Como visitante, quero **domínio agentskit.io configurado** com DNS, SSL, redirects do GitHub Pages antigo.
+13. As a visitor, I want a **rewritten root README** with: emotional tagline, summarized origin story, a "before/after" code block, honest comparison (including when NOT to use), quickstart ≤15 lines, link to agentskit.io.
+14. As a technical reader, I want a public **MANIFESTO.md** (core <10KB, plug-and-play, zero lock-in, agent-first, radical interop) explaining non-negotiable principles.
+15. As a visitor, I want an **ORIGIN.md** — why AgentsKit exists, what pain the author felt, JS-agent ecosystem context — to create human connection.
+16. As an evaluating developer, I want to see an **honest comparison table** on the home page vs Vercel AI SDK, LangChain.js, Mastra, assistant-ui — including points where the others win.
+17. As a developer, I want a **dedicated pitch in each package README** (`@agentskit/core — the 10KB soul`, `@agentskit/runtime — agents that survive crashes`, etc.) replacing the current generic READMEs.
+18. As a visitor, I want a **minimum visual identity**: logo, favicon, 3–5 color palette, chosen typography, social card (OG image), customized Fumadocs theme.
+19. As a visitor, I want to access **agentskit.io** with an independent landing page (Next.js) separate from the documentation — different audiences (marketing vs technical reference).
+20. As a developer discovering the library, I want a **60-second video** embedded on the home page showing "zero → streaming chat in 10 lines" visually.
+21. As a visitor, I want to see **social proof** on the landing (GitHub stars, npm downloads, "used by", testimonials when available, showcase).
+22. As a maintainer, I want an **official X/Twitter account** (`@agentskit` or `@agentskitdev`) active with weekly tips, changelog, release notes.
+23. As a developer, I want a **public changelog with narrative** (not only a technical CHANGELOG.md) — "This month we shipped X, learned Y" — as a monthly blog/newsletter.
+24. As a visitor, I want **agentskit.io configured** with DNS, SSL, and redirects from the old GitHub Pages.
 
-### Frente 3 — Documentação Profunda (migração pra Fumadocs)
+### Track 3 — Deep Documentation (Fumadocs migration)
 
-25. Como maintainer, quero **migrar `apps/docs` de Docusaurus pra Fumadocs** (Next.js 15, MDX, tema moderno), preservando conteúdo existente.
-26. Como dev, quero uma **seção "Concepts"** nova explicando mental model (Agent, Adapter, Skill, Tool, Memory, ReAct, Streaming) com diagrama único e linguagem consistente — antes de API reference.
-27. Como dev, quero um **"Decision Tree"** de 5 perguntas ("Vai usar React? Quer terminal? Precisa de RAG?") que me diz qual combinação de packages instalar.
-28. Como dev novo, quero um **Quickstart em 3 minutos** que entrega chat funcionando com streaming, tool call e memory básica.
-29. Como dev, quero uma **seção "Recipes" / Cookbook** com ≥10 receitas curtas e completas (Chat com RAG em 30 linhas; Agente que lê Gmail; Discord bot; PDF Q&A; Code reviewer; Multi-agent; etc.), cada uma com Stackblitz link.
-30. Como dev, quero **Migration Guide de Vercel AI SDK → AgentsKit** com code-diff lado a lado.
-31. Como dev, quero **Migration Guide de LangChain.js → AgentsKit** com code-diff lado a lado.
-32. Como dev, quero uma **seção "Troubleshooting / FAQ"** resolvendo os 20 erros/dúvidas mais comuns.
-33. Como dev, quero **exemplos em `apps/example-*` linkados da doc** com "Edit on Stackblitz" e screenshots.
-34. Como dev, quero **API reference gerada por TypeDoc** exposta dentro da Fumadocs, tipada e sempre atualizada.
-35. Como dev de outra língua, quero **estratégia clara de i18n** na Fumadocs: ou manter pt-BR/es/zh-Hans com tradução automatizada (Crowdin/LLM) ou congelar até EN estabilizar — decisão documentada.
-36. Como dev, quero um **Glossário** (ReAct, Tool Calling, RAG, Embedding, Adapter, Skill) linkado inline na doc.
-37. Como maintainer, quero **versionamento de docs** (v0.x, v1.x) nativo na Fumadocs para não quebrar links quando bumpar major.
-38. Como visitante, quero **busca full-text rápida** (Algolia DocSearch grátis pra OSS ou built-in Fumadocs).
-39. Como maintainer, quero **PostHog/Plausible analytics** na doc + landing para entender quais páginas convertem, onde devs saem.
+25. As a maintainer, I want to **migrate `apps/docs` from Docusaurus to Fumadocs** (Next.js 15, MDX, modern theme), preserving existing content.
+26. As a developer, I want a new **"Concepts" section** explaining the mental model (Agent, Adapter, Skill, Tool, Memory, ReAct, Streaming) with a single diagram and consistent language — before the API reference.
+27. As a developer, I want a 5-question **"Decision Tree"** ("Using React? Want terminal? Need RAG?") that tells me which combination of packages to install.
+28. As a new developer, I want a **3-minute Quickstart** that delivers a working chat with streaming, a tool call, and basic memory.
+29. As a developer, I want a **"Recipes" / Cookbook section** with ≥10 short, complete recipes (Chat with RAG in 30 lines; Agent that reads Gmail; Discord bot; PDF Q&A; Code reviewer; Multi-agent; etc.), each with a Stackblitz link.
+30. As a developer, I want a **Vercel AI SDK → AgentsKit Migration Guide** with side-by-side code diffs.
+31. As a developer, I want a **LangChain.js → AgentsKit Migration Guide** with side-by-side code diffs.
+32. As a developer, I want a **"Troubleshooting / FAQ" section** solving the 20 most common errors/questions.
+33. As a developer, I want **examples in `apps/example-*` linked from the docs** with "Edit on Stackblitz" and screenshots.
+34. As a developer, I want a **TypeDoc-generated API reference** embedded inside Fumadocs, typed and always up to date.
+35. As a developer in another language, I want a **clear i18n strategy** in Fumadocs: either keep pt-BR/es/zh-Hans with automated translation (Crowdin/LLM) or freeze until EN stabilizes — decision documented.
+36. As a developer, I want a **Glossary** (ReAct, Tool Calling, RAG, Embedding, Adapter, Skill) linked inline in the docs.
+37. As a maintainer, I want **docs versioning** (v0.x, v1.x) native to Fumadocs so links don't break when bumping major.
+38. As a visitor, I want **fast full-text search** (Algolia DocSearch free for OSS or Fumadocs built-in).
+39. As a maintainer, I want **PostHog/Plausible analytics** on docs + landing to understand which pages convert and where developers leave.
 
-### Frente 4 — Qualidade & Comunidade
+### Track 4 — Quality & Community
 
-40. Como maintainer, quero **E2E Playwright** nos 4 `apps/example-*` rodando no CI garantindo que demos reais nunca quebram.
-41. Como maintainer, quero **contract tests por adapter** — suite comum rodada contra OpenAI, Anthropic, Gemini, Ollama — detectando regressão quando provider muda API.
-42. Como dev, quero **visual regression tests** (Playwright screenshots) nos componentes React e Ink.
-43. Como maintainer, quero **fixtures de replay gravadas** (adapter calls mockados deterministicamente) para testes rápidos sem tokens reais.
-44. Como comunidade, quero um **Discord oficial** (ou GitHub Discussions bem curado) com canais por package + #help + #showcase.
-45. Como contribuidor, quero um **CONTRIBUTING.md expandido** com dev setup em 5 minutos, troubleshooting de build, como rodar tests, fluxo de PR.
-46. Como contribuidor, quero **labels de issue bem definidas** (`good first issue`, `help wanted`, `area:adapters`, `area:docs`) aplicadas nas 97 issues existentes.
-47. Como maintainer, quero **GitHub Sponsors / OpenCollective** configurado para aceitar apoio financeiro e dar credibilidade.
-48. Como dev avaliando, quero ver **múltiplos maintainers** listados no README — mesmo que 2-3 no início, muda percepção de "side-project" para "projeto sério".
-49. Como maintainer, quero **registro de trademark "AgentsKit"** iniciado (USPTO ou INPI) antes da visibilidade aumentar.
-50. Como maintainer, quero **decisão documentada sobre licenciamento** — manter MIT? Dual-license MIT + comercial pra Cloud? BSL? — escrita em `LICENSING.md` antes de começar Fase 4 (Business).
-51. Como maintainer, quero **auditoria externa paga de DX** (1 dev sênior, 2-5k reais) reviewing narrativa e primeira experiência do dev — objetividade que o autor não consegue ter sozinho.
-52. Como maintainer, quero **lançamento coordenado (HN + Twitter + ProductHunt + Reddit)** planejado como evento único quando Phase 0 terminar — uma chance só, tem que ser com tudo pronto.
+40. As a maintainer, I want **Playwright E2E** on the 4 `apps/example-*` running in CI, guaranteeing that real demos never break.
+41. As a maintainer, I want **per-adapter contract tests** — one shared suite run against OpenAI, Anthropic, Gemini, Ollama — catching regressions when a provider changes its API.
+42. As a developer, I want **visual regression tests** (Playwright screenshots) for React and Ink components.
+43. As a maintainer, I want **recorded replay fixtures** (deterministically mocked adapter calls) for fast tests without burning real tokens.
+44. As the community, I want an **official Discord** (or well-curated GitHub Discussions) with per-package channels + #help + #showcase.
+45. As a contributor, I want an **expanded CONTRIBUTING.md** with dev setup in 5 minutes, build troubleshooting, how to run tests, PR flow.
+46. As a contributor, I want **well-defined issue labels** (`good first issue`, `help wanted`, `area:adapters`, `area:docs`) applied to the 97 existing issues.
+47. As a maintainer, I want **GitHub Sponsors / OpenCollective** configured to accept financial support and add credibility.
+48. As an evaluating developer, I want to see **multiple maintainers** listed in the README — even 2–3 at the start changes the perception from "side project" to "serious project".
+49. As a maintainer, I want **"AgentsKit" trademark registration** started (USPTO or INPI) before visibility grows.
+50. As a maintainer, I want a **documented licensing decision** — keep MIT? Dual-license MIT + commercial for Cloud? BSL? — written in `LICENSING.md` before Phase 4 (Business) starts.
+51. As a maintainer, I want a **paid external DX audit** (1 senior dev, $400–1000) reviewing narrative and first developer experience — the objectivity the author can't have alone.
+52. As a maintainer, I want a **coordinated launch (HN + Twitter + ProductHunt + Reddit)** planned as a single event when Phase 0 ends — you only get one shot, everything must be ready.
 
 ---
 
 ## Implementation Decisions
 
-### Decisões já fechadas
+### Closed decisions
 
-- **Fumadocs** substituirá Docusaurus em `apps/docs`. Next.js 15 + MDX. Tema customizado alinhado à identidade visual.
-- **Domínio oficial: agentskit.io** — configurar DNS apontando para Vercel/Cloudflare Pages, com subdomínios previstos: `agentskit.io` (landing), `docs.agentskit.io` (Fumadocs), `play.agentskit.io` (playground futuro).
-- **Landing separada da doc** — Next.js independente em `apps/landing` ou hospedada no root do domínio; docs em subdomínio `docs.agentskit.io`.
-- **Manter monorepo pnpm + Turborepo** — sem reorganização estrutural nesta fase.
+- **Fumadocs** will replace Docusaurus in `apps/docs`. Next.js 15 + MDX. Custom theme aligned with the visual identity.
+- **Official domain: agentskit.io** — configure DNS pointing to Vercel/Cloudflare Pages, with planned subdomains: `agentskit.io` (landing), `docs.agentskit.io` (Fumadocs), `play.agentskit.io` (future playground).
+- **Landing separate from docs** — standalone Next.js in `apps/landing` or hosted at the domain root; docs on subdomain `docs.agentskit.io`.
+- **Keep pnpm + Turborepo monorepo** — no structural reorganization in this phase.
 
-### Módulos a criar/modificar
+### Modules to create/modify
 
-- **`apps/docs`** — migração completa para Fumadocs preservando estrutura de conteúdo; i18n revisado.
-- **`apps/landing`** (novo) — Next.js pro marketing, SEO, conversão.
-- **`.github/`** — issue templates, PR template, RFC template, CODEOWNERS, workflows extras (size-limit, coverage gate, e2e).
-- **`rfcs/`** (novo) — pasta de RFCs versionados.
-- **`docs/architecture/`** — ADRs numerados (`0001-adapter-contract.md`, `0002-tool-contract.md`, etc.).
-- **`ARCHITECTURE.md`, `MANIFESTO.md`, `ORIGIN.md`, `LICENSING.md`** (novos na raiz).
-- **`packages/*/CONVENTIONS.md`** (novos) — um por pacote com regras de contribuição específicas.
-- **`packages/*/README.md`** — reescritos com pitch próprio + stability tier + link pra doc.
-- **README.md raiz** — reescrito com narrativa forte, comparativos honestos, link pra agentskit.io.
+- **`apps/docs`** — full migration to Fumadocs preserving content structure; i18n reviewed.
+- **`apps/landing`** (new) — Next.js for marketing, SEO, conversion.
+- **`.github/`** — issue templates, PR template, RFC template, CODEOWNERS, extra workflows (size-limit, coverage gate, e2e).
+- **`rfcs/`** (new) — folder of versioned RFCs.
+- **`docs/architecture/`** — numbered ADRs (`0001-adapter-contract.md`, `0002-tool-contract.md`, etc.).
+- **`ARCHITECTURE.md`, `MANIFESTO.md`, `ORIGIN.md`, `LICENSING.md`** (new, at root).
+- **`packages/*/CONVENTIONS.md`** (new) — one per package with specific contribution rules.
+- **`packages/*/README.md`** — rewritten with dedicated pitch + stability tier + link to the docs.
+- **Root README.md** — rewritten with a strong narrative, honest comparisons, link to agentskit.io.
 
-### Módulos profundos candidatos a teste isolado
+### Deep modules — candidates for isolated tests
 
-- **ContractValidator** (nasce aqui) — valida em runtime que um adapter/tool/skill implementa contrato vigente. Interface: `validate(impl, contract) → Report`.
-- **BundleBudgetCheck** — wrapper sobre `size-limit` com config por package. Interface: `check(package) → Pass|Fail`.
-- **AdapterContractSuite** — suite de testes que roda a mesma bateria contra qualquer adapter. Interface: `run(adapter, opts) → Report`.
+- **ContractValidator** (born here) — validates at runtime that an adapter/tool/skill implements the current contract. Interface: `validate(impl, contract) → Report`.
+- **BundleBudgetCheck** — wrapper over `size-limit` with per-package config. Interface: `check(package) → Pass|Fail`.
+- **AdapterContractSuite** — test suite that runs the same battery against any adapter. Interface: `run(adapter, opts) → Report`.
 
-### Contratos/APIs
+### Contracts / APIs
 
-- **ADRs serão o formato canônico** para contratos core. Mudança de contrato = novo ADR + bump major do package afetado.
-- **Stability tier** declarado em `package.json` via campo custom `"stability": "stable" | "beta" | "experimental"`.
-- **RFC process**: PR em `rfcs/` com template, discussão aberta, aprovação de 2+ maintainers antes de virar issue de implementação.
+- **ADRs will be the canonical format** for core contracts. A contract change = new ADR + major bump of the affected package.
+- **Stability tier** declared in `package.json` via a custom field `"stability": "stable" | "beta" | "experimental"`.
+- **RFC process**: PR in `rfcs/` with a template, open discussion, approval from 2+ maintainers before becoming an implementation issue.
 
-### Priorização sugerida (dentro dos 4-6 semanas)
+### Suggested prioritization (within 4–6 weeks)
 
-- **Semana 1-2**: Frente 1 (contratos/governança) + início Frente 2 (manifesto, origin, README raiz)
-- **Semana 2-4**: Frente 3 (migração Fumadocs, Concepts, Recipes) paralelo a Frente 2 (identidade visual, landing)
-- **Semana 4-5**: Frente 4 (qualidade, Discord, CODEOWNERS, analytics) + migration guides
-- **Semana 6**: Auditoria externa de DX + ajustes + ensaio de lançamento coordenado
+- **Weeks 1–2**: Track 1 (contracts/governance) + start Track 2 (manifesto, origin, root README)
+- **Weeks 2–4**: Track 3 (Fumadocs migration, Concepts, Recipes) parallel to Track 2 (visual identity, landing)
+- **Weeks 4–5**: Track 4 (quality, Discord, CODEOWNERS, analytics) + migration guides
+- **Week 6**: External DX audit + adjustments + coordinated-launch rehearsal
 
 ### Breaking changes
 
-- Phase 0 **não pode introduzir breaking changes** em packages publicados. É hardening, não refactor.
-- READMEs reescritos, docs migradas, CI apertado — tudo ortogonal ao runtime.
+- Phase 0 **cannot introduce breaking changes** in published packages. It's hardening, not refactoring.
+- Rewritten READMEs, migrated docs, tightened CI — all orthogonal to the runtime.
 
 ---
 
 ## Testing Decisions
 
-### O que faz bom teste aqui
+### What makes a good test here
 
-- **Contract tests reutilizáveis** por categoria (adapter, tool, skill) — uma bateria que qualquer implementação futura roda automaticamente.
-- **E2E dos exemplos é o teste mais importante** — se `example-react` funciona com chat streaming + tool call + memory, a lib funciona.
-- **Evitar snapshot de strings de LLM** — usar matchers estruturais ou tolerância semântica quando necessário.
+- **Reusable contract tests** per category (adapter, tool, skill) — one battery any future implementation runs automatically.
+- **E2E of the examples is the most important test** — if `example-react` works with chat streaming + tool call + memory, the library works.
+- **Avoid LLM-string snapshots** — use structural matchers or semantic tolerance when needed.
 
-### Módulos com teste
+### Modules with tests
 
-- **ContractValidator, BundleBudgetCheck, AdapterContractSuite** — módulos profundos criados nesta fase.
-- **E2E Playwright** em `apps/example-react`, `apps/example-ink`, `apps/example-runtime`, `apps/example-multi-agent`.
-- **Visual regression** em componentes críticos do `@agentskit/react` (ChatContainer, Message, InputBar) e `@agentskit/ink`.
+- **ContractValidator, BundleBudgetCheck, AdapterContractSuite** — deep modules created in this phase.
+- **Playwright E2E** in `apps/example-react`, `apps/example-ink`, `apps/example-runtime`, `apps/example-multi-agent`.
+- **Visual regression** on critical components of `@agentskit/react` (ChatContainer, Message, InputBar) and `@agentskit/ink`.
 
 ### Prior art
 
-- Vitest já é o runner. Manter.
-- `size-limit` ou `bundlewatch` tem template pronto pra CI GitHub Actions.
-- Playwright setup de monorepo: usar um `playwright.config.ts` compartilhado.
+- Vitest is already the runner. Keep it.
+- `size-limit` or `bundlewatch` has a ready-made GitHub Actions template.
+- Playwright monorepo setup: use a shared `playwright.config.ts`.
 
 ---
 
 ## Out of Scope
 
-- **Implementação de qualquer story do Master PRD (#113 e filhas #114-#210)** — fica para Fase 1 em diante.
-- **AgentsKit Cloud** e qualquer trabalho comercial — Fase 4.
-- **Novos packages** — Phase 0 só hardeniza os 14 existentes, não adiciona (exceto `apps/landing`).
-- **Rebranding de nome** — "AgentsKit" fica; só ganha identidade visual forte.
-- **Reescrita de core** — core tá ok, só precisa de contratos formalizados.
-- **Criar Python SDK** — permanece fora do escopo.
+- **Implementation of any Master PRD story (#113 and children #114–#210)** — left for Phase 1 onward.
+- **AgentsKit Cloud** and any commercial work — Phase 4.
+- **New packages** — Phase 0 only hardens the existing 14; no additions (except `apps/landing`).
+- **Name rebranding** — "AgentsKit" stays; only gains a strong visual identity.
+- **Core rewrite** — core is fine, only needs formalized contracts.
+- **Python SDK** — stays out of scope.
 
 ---
 
 ## Further Notes
 
-### Como este PRD vira issues
+### How this PRD becomes issues
 
-Cada user story (1-52) vira 1 issue GitHub com:
-- Título: `[Phase 0] Story NN — <resumo>`
-- Label: `phase-0-foundation` + label de frente (`frente-contratos`, `frente-narrativa`, `frente-docs`, `frente-qualidade`)
-- Link de volta para este PRD.
+Every user story (1–52) becomes 1 GitHub issue with:
+- Title: `[Phase 0] Story NN — <summary>`
+- Label: `phase-0-foundation` + track label (`track-contracts`, `track-narrative`, `track-docs`, `track-quality`)
+- Link back to this PRD.
 
-### Gates pra Phase 1 começar
+### Gates for Phase 1 to start
 
-Nenhuma issue do Master PRD deve ser iniciada até que **todas estas** sejam verdade:
+No Master PRD issue should be started until **all of these** are true:
 
-- [ ] ADRs dos 6 contratos core publicados (Adapter, Tool, Memory, Retriever, Skill, Runtime)
-- [ ] Bundle budget e coverage gate ativos e bloqueando PRs
-- [ ] README raiz reescrito + MANIFESTO + ORIGIN publicados
-- [ ] agentskit.io no ar com landing básica
-- [ ] Migração para Fumadocs concluída com Concepts section e ≥5 Recipes
-- [ ] Migration guides LangChain e Vercel AI publicados
-- [ ] E2E Playwright rodando nos 4 exemplos
-- [ ] Discord + CODEOWNERS + issue/PR templates ativos
-- [ ] Decisão sobre licenciamento documentada
+- [ ] ADRs for the 6 core contracts published (Adapter, Tool, Memory, Retriever, Skill, Runtime)
+- [ ] Bundle budget and coverage gate active and blocking PRs
+- [ ] Root README rewritten + MANIFESTO + ORIGIN published
+- [ ] agentskit.io live with a basic landing
+- [ ] Fumadocs migration complete with Concepts section and ≥5 Recipes
+- [ ] LangChain and Vercel AI migration guides published
+- [ ] Playwright E2E running on the 4 examples
+- [ ] Discord + CODEOWNERS + issue/PR templates active
+- [ ] Licensing decision documented
 
-### Apostas não-negociáveis da fase
+### Non-negotiable bets of the phase
 
-1. **Formalizar contratos** antes de adicionar 10 adapters novos.
-2. **Reescrever narrativa** antes de lançar publicamente.
-3. **Fumadocs + agentskit.io** antes de aumentar tráfego.
-4. **E2E dos exemplos** antes de aceitar 97 PRs de features.
+1. **Formalize contracts** before adding 10 new adapters.
+2. **Rewrite the narrative** before launching publicly.
+3. **Fumadocs + agentskit.io** before growing traffic.
+4. **E2E for examples** before accepting 97 feature PRs.
 
-### Princípios (já no CLAUDE.md, reforçados)
+### Principles (already in CLAUDE.md, reinforced)
 
 - Core <10KB gzip, zero deps.
-- Todo package plug-and-play.
-- Interop total entre packages.
+- Every package plug-and-play.
+- Total interop across packages.
 - Named exports only, no default exports.
-- TypeScript strict, sem `any`.
+- TypeScript strict, no `any`.

--- a/docs/ROADMAP-PRD.md
+++ b/docs/ROADMAP-PRD.md
@@ -1,255 +1,255 @@
 # AgentsKit — Master PRD & Roadmap
 
-> Documento base consolidando ~160 ideias do brainstorm em um roadmap faseado.
-> Cada item é uma **semente de issue** — deve virar issue GitHub independente na fase de execução.
+> Base document consolidating ~160 ideas from the brainstorm into a phased roadmap.
+> Each item is an **issue seed** — should become an independent GitHub issue at execution time.
 
 ---
 
 ## Problem Statement
 
-Desenvolvedores JavaScript/TypeScript que querem construir aplicações com agentes de IA hoje enfrentam um ecossistema fragmentado:
+JavaScript/TypeScript developers who want to build applications with AI agents today face a fragmented ecosystem:
 
-- **Vercel AI SDK** é ótimo pra chat em Next.js, mas fraco em runtime de agentes, memória, multi-agent e terminal.
-- **LangChain.js** é pesado, difícil de debugar, com abstrações vazando e bundle gigante.
-- **Mastra** e similares são promissores mas ainda limitados em UI, adapters e tooling.
-- **MCP** resolve tool interop mas não dá UI, runtime ou orquestração.
+- **Vercel AI SDK** is great for chat in Next.js, but weak on agent runtime, memory, multi-agent, and terminal.
+- **LangChain.js** is heavy, hard to debug, with leaky abstractions and a giant bundle.
+- **Mastra** and similar tools are promising but still limited in UI, adapters, and tooling.
+- **MCP** solves tool interop but does not provide UI, runtime, or orchestration.
 
-O resultado: pra construir um agente JS "de verdade" (com UI React/terminal, memória persistente, RAG, multi-agent, observability, deploy em edge), o dev precisa juntar 5-8 libs incompatíveis, gastar semanas em integração e ainda assim fica sem debugging decente, sem eval, sem replay.
+The result: to build a "real" JS agent (with React/terminal UI, persistent memory, RAG, multi-agent, observability, edge deploy), developers have to glue 5–8 incompatible libraries together, spend weeks on integration, and still end up without decent debugging, evals, or replay.
 
-Faltam também: experiência inicial (scaffolding), docs dogfooded, marketplace de tools/skills, e padrões abertos de interop entre ecossistemas.
+Also missing: initial experience (scaffolding), dogfooded docs, a tools/skills marketplace, and open interop standards across ecosystems.
 
 ## Solution
 
-**AgentsKit** — toolkit modular e plug-and-play que cobre o ciclo de vida completo do agente JS:
+**AgentsKit** — a modular, plug-and-play toolkit that covers the full JS agent lifecycle:
 
-- **Core leve** (<10KB gzip, zero deps) como fundação estável
-- **Packages independentes** e combináveis (React, Ink, CLI, runtime, tools, skills, memory, RAG, sandbox, observability, eval)
-- **DX de primeira classe**: scaffolding, hot-reload, devtools, deterministic replay
-- **Marketplace** aberto de tools e skills com versionamento
-- **Interop radical**: MCP bidirecional, Agent-to-Agent protocol, migração 1-comando de LangChain/Vercel AI
-- **Edge-ready**: roda em Cloudflare Workers, Deno Deploy, browser puro (WebLLM)
-- **Cloud opcional** (free tier generoso) + enterprise self-hosted como camada de monetização
+- **Lightweight core** (<10KB gzip, zero deps) as a stable foundation
+- **Independent packages** that compose freely (React, Ink, CLI, runtime, tools, skills, memory, RAG, sandbox, observability, eval)
+- **First-class DX**: scaffolding, hot-reload, devtools, deterministic replay
+- **Open marketplace** for tools and skills with versioning
+- **Radical interop**: bidirectional MCP, Agent-to-Agent protocol, one-command migration from LangChain/Vercel AI
+- **Edge-ready**: runs on Cloudflare Workers, Deno Deploy, pure browser (WebLLM)
+- **Optional Cloud** (generous free tier) + self-hosted enterprise as a monetization layer
 
-Meta: ser **o Vercel/Next.js da era dos agentes** — opinionado onde importa, extensível onde necessário, o default recomendado por providers (OpenAI, Anthropic, xAI).
+Goal: be **the Vercel/Next.js of the agent era** — opinionated where it matters, extensible where needed, the default recommended by providers (OpenAI, Anthropic, xAI).
 
 ---
 
-## Fases
+## Phases
 
-### Fase 1 — Fundação & Melhorias do Ecossistema (0–3 meses)
-Objetivo: solidificar o core, eliminar atrito de onboarding, tornar a lib "usável por estranho numa tarde".
+### Phase 1 — Foundation & Ecosystem Improvements (0–3 months)
+Goal: solidify the core, remove onboarding friction, make the library "usable by a stranger in an afternoon".
 
-### Fase 2 — Evolução Técnica (3–6 meses)
-Objetivo: diferenciação técnica real — features que ninguém mais tem bem feito. É o que vira post no Hacker News.
+### Phase 2 — Technical Evolution (3–6 months)
+Goal: real technical differentiation — features nobody else ships well. This is what becomes a Hacker News post.
 
-### Fase 3 — Expansão do Ecossistema (6–9 meses)
-Objetivo: ampliar superfície — multi-framework, marketplaces, verticais, protocolos abertos.
+### Phase 3 — Ecosystem Expansion (6–9 months)
+Goal: widen the surface — multi-framework, marketplaces, verticals, open protocols.
 
-### Fase 4 — Business & Monetização (9–12 meses)
-Objetivo: camada comercial sustentável sem comprometer open-source.
+### Phase 4 — Business & Monetization (9–12 months)
+Goal: a sustainable commercial layer that does not compromise open source.
 
 ---
 
 ## User Stories
 
-### Fase 1 — Fundação
+### Phase 1 — Foundation
 
-1. Como dev novato no AgentsKit, quero rodar `npx @agentskit/cli init` e escolher template interativamente, para ter um projeto funcionando em menos de 2 minutos.
-2. Como dev, quero rodar `agentskit doctor` e ver env vars faltando, versões incompatíveis e keys inválidas, para não perder tempo debugando config.
-3. Como dev, quero `agentskit dev` com hot-reload de prompts/tools/memory, para iterar rápido sem reiniciar.
-4. Como dev, quero `agentskit tunnel` para expor meu agente local com URL pública temporária, para testar webhooks.
-5. Como dev, quero retry com backoff e circuit breaker automáticos nos adapters, para não escrever esse boilerplate.
-6. Como dev em dev/teste, quero modo "dry run" que simula respostas LLM mockadas, para rodar testes sem gastar tokens.
-7. Como dev, quero streaming zero-config (detectado por capability do provider), para não configurar manualmente.
-8. Como dev frontend, quero `useChat` com optimistic UI, edição e regeneração de mensagens nativos.
-9. Como dev que paga a conta, quero cost guard com limite por sessão/usuário e alerta, para não tomar susto no fim do mês.
-10. Como dev, quero contador de tokens universal antes do envio, abstraído do tokenizer de cada provider.
-11. Como dev, quero poder trocar de provider (OpenAI ↔ Anthropic) em runtime sem reiniciar, para fallback e A/B.
-12. Como dev visitando a doc, quero um chat embutido que responde sobre a própria lib usando RAG na doc.
-13. Como dev avaliando, quero um "decision tree" de 5 perguntas que me diz qual package eu preciso.
-14. Como dev vindo de LangChain/Vercel AI, quero um migration guide concreto com code-diff lado a lado.
-15. Como dev lendo a doc, quero Stackblitz "Edit on..." em cada exemplo, para testar sem clonar.
-16. Como dev, quero ver recipes curtas ("chat com RAG em 30 linhas", "agente que lê Gmail") antes de ler referência completa.
-17. Como dev, quero ver um comparativo honesto AgentsKit vs Vercel AI SDK vs LangChain vs Mastra.
-18. Como dev, quero error messages didáticos estilo Rust compiler — com link pra doc + sugestão de fix.
-19. Como dev escrevendo tool, quero que o schema Zod/JSON do tool vire tipo TypeScript do retorno automaticamente.
-20. Como maintainer, quero public roadmap + processo RFC aberto no GitHub, para alinhar comunidade.
+1. As a developer new to AgentsKit, I want to run `npx @agentskit/cli init` and pick a template interactively, so I have a working project in under 2 minutes.
+2. As a developer, I want to run `agentskit doctor` and see missing env vars, incompatible versions, and invalid keys, so I don't waste time debugging config.
+3. As a developer, I want `agentskit dev` with hot-reload for prompts/tools/memory, so I can iterate fast without restarting.
+4. As a developer, I want `agentskit tunnel` to expose my local agent at a temporary public URL, so I can test webhooks.
+5. As a developer, I want automatic retry with backoff and circuit breaker in adapters, so I don't have to write that boilerplate.
+6. As a developer in dev/test, I want a "dry run" mode that simulates mocked LLM responses, so I can run tests without spending tokens.
+7. As a developer, I want zero-config streaming (detected from provider capability), so I don't have to configure it manually.
+8. As a frontend developer, I want `useChat` with native optimistic UI, message editing, and regeneration.
+9. As a developer paying the bill, I want a cost guard with per-session/per-user limits and alerts, so I don't get a shock at the end of the month.
+10. As a developer, I want a universal pre-send token counter, abstracted from each provider's tokenizer.
+11. As a developer, I want to swap providers (OpenAI ↔ Anthropic) at runtime without a restart, for fallback and A/B.
+12. As a developer visiting the docs, I want an embedded chat that answers questions about the library itself using RAG over the docs.
+13. As an evaluating developer, I want a 5-question "decision tree" that tells me which package I need.
+14. As a developer coming from LangChain/Vercel AI, I want a concrete migration guide with side-by-side code diffs.
+15. As a developer reading the docs, I want a Stackblitz "Edit on..." link in every example, so I can try without cloning.
+16. As a developer, I want short recipes ("chat with RAG in 30 lines", "agent that reads Gmail") before I read the full reference.
+17. As a developer, I want an honest comparison: AgentsKit vs Vercel AI SDK vs LangChain vs Mastra.
+18. As a developer, I want didactic error messages in the Rust compiler style — with a link to the docs plus a fix suggestion.
+19. As a developer writing a tool, I want the tool's Zod/JSON schema to become the TypeScript return type automatically.
+20. As a maintainer, I want a public roadmap and an open RFC process on GitHub, to align with the community.
 
-### Fase 2 — Evolução Técnica
+### Phase 2 — Technical Evolution
 
-21. Como dev debugando, quero **deterministic replay**: gravar seed + todas as chamadas LLM e reproduzir bit-a-bit, para debugar flakiness.
-22. Como dev, quero **snapshot testing de prompts** com tolerância semântica, estilo Jest snapshot.
-23. Como dev, quero **prompt diff tool** que mostra qual mudança causou qual mudança de output (git blame pra prompts).
-24. Como dev, quero **time travel debug** no trace viewer — voltar no tempo, alterar output de tool, re-rodar.
-25. Como dev, quero **token budget compiler** — declaro "esse agente tem 10k tokens" e o framework otimiza prompts/memória.
-26. Como dev, quero **speculative execution** — rodar N caminhos em paralelo com modelos baratos, escolher o melhor.
-27. Como dev, quero **streaming tool calls progressivos** — tool começa executar antes do LLM terminar args (quando schema permite).
-28. Como dev, quero **context window virtualization** transparente, para suportar conversas gigantes.
-29. Como dev, quero **multi-modal unificado** — mesma API pra texto/imagem/áudio/vídeo independente do provider.
-30. Como dev, quero **schema-first agents** — definir agente em YAML/JSON e gerar TS tipado.
-31. Como dev, quero **`npx agentskit ai`** — descrevo agente em português e gera config + tools + skill.
-32. Como dev, quero **adapter "router"** — escolhe modelo automaticamente por custo/latência/task.
-33. Como dev, quero **adapter "ensemble"** — manda pra N modelos e agrega (voting/best-of).
-34. Como dev, quero **adapter "fallback chain"** declarativa com scores de confiança.
-35. Como dev, quero **devtools browser extension** que inspeciona mensagens, tool calls, tokens e custos em tempo real.
-36. Como dev, quero **trace viewer local** estilo Jaeger pra debug offline.
-37. Como dev, quero rodar **evals em CI** via GitHub Action com datasets templates.
-38. Como dev, quero **A/B testing de prompts** integrado com feature flags (PostHog/GrowthBook).
-39. Como dev, quero **replay de sessões** re-rodando com outro modelo pra comparar.
-40. Como dev, quero **hierarchical memory** (working/episodic/semantic) estilo MemGPT out-of-the-box.
-41. Como dev, quero **auto-summarization** quando context window enche.
-42. Como dev, quero **RAG com re-ranking** (Cohere Rerank, BGE) e **hybrid search** (BM25 + vector).
-43. Como dev, quero **durable execution** estilo Temporal — agente sobrevive a crash.
-44. Como dev, quero **multi-agent topologies** prontas (supervisor, swarm, hierarchical, blackboard).
-45. Como dev, quero **human-in-the-loop primitives** — pause/resume/approve persistido.
-46. Como dev, quero **background agents** que rodam em cron ou reagem a webhooks.
-47. Como dev preocupado com segurança, quero **PII redaction middleware** antes do envio.
-48. Como dev, quero **prompt injection detector** built-in (ex: Llama Guard local).
-49. Como dev enterprise, quero **audit log assinado** pra compliance SOC2/HIPAA.
-50. Como dev, quero **rate limiting** por user/IP/key.
-51. Como dev, quero **tool sandbox obrigatório** (WebContainer/isolated-vm) pra tools que executam código.
+21. As a debugging developer, I want **deterministic replay**: record the seed plus every LLM call and reproduce bit-for-bit, to debug flakiness.
+22. As a developer, I want **prompt snapshot testing** with semantic tolerance, Jest snapshot style.
+23. As a developer, I want a **prompt diff tool** that shows which change caused which output change (git blame for prompts).
+24. As a developer, I want **time-travel debugging** in the trace viewer — go back in time, change a tool output, re-run.
+25. As a developer, I want a **token budget compiler** — I declare "this agent has 10k tokens" and the framework optimizes prompts/memory.
+26. As a developer, I want **speculative execution** — run N paths in parallel with cheap models, pick the best.
+27. As a developer, I want **progressive streaming tool calls** — the tool starts executing before the LLM finishes the args (when the schema allows it).
+28. As a developer, I want transparent **context window virtualization**, so I can support huge conversations.
+29. As a developer, I want **unified multi-modal** — the same API for text/image/audio/video regardless of the provider.
+30. As a developer, I want **schema-first agents** — define an agent in YAML/JSON and generate typed TS.
+31. As a developer, I want **`npx agentskit ai`** — describe an agent in natural language and generate config + tools + skill.
+32. As a developer, I want a **router adapter** — picks a model automatically by cost/latency/task.
+33. As a developer, I want an **ensemble adapter** — sends to N models and aggregates (voting/best-of).
+34. As a developer, I want a declarative **fallback-chain adapter** with confidence scores.
+35. As a developer, I want a **devtools browser extension** that inspects messages, tool calls, tokens, and costs in real time.
+36. As a developer, I want a **local trace viewer** in the Jaeger style for offline debugging.
+37. As a developer, I want to run **evals in CI** via a GitHub Action with dataset templates.
+38. As a developer, I want **prompt A/B testing** integrated with feature flags (PostHog/GrowthBook).
+39. As a developer, I want **session replay** that re-runs with a different model for comparison.
+40. As a developer, I want **hierarchical memory** (working/episodic/semantic) in the MemGPT style, out of the box.
+41. As a developer, I want **auto-summarization** when the context window fills up.
+42. As a developer, I want **RAG with re-ranking** (Cohere Rerank, BGE) and **hybrid search** (BM25 + vector).
+43. As a developer, I want **durable execution** in the Temporal style — the agent survives a crash.
+44. As a developer, I want ready-made **multi-agent topologies** (supervisor, swarm, hierarchical, blackboard).
+45. As a developer, I want **human-in-the-loop primitives** — persisted pause/resume/approve.
+46. As a developer, I want **background agents** that run on cron or react to webhooks.
+47. As a security-conscious developer, I want **PII redaction middleware** before sending.
+48. As a developer, I want a built-in **prompt injection detector** (e.g., Llama Guard local).
+49. As an enterprise developer, I want a **signed audit log** for SOC2/HIPAA compliance.
+50. As a developer, I want **rate limiting** per user/IP/key.
+51. As a developer, I want a **mandatory tool sandbox** (WebContainer/isolated-vm) for tools that execute code.
 
-### Fase 3 — Expansão
+### Phase 3 — Expansion
 
-52. Como dev, quero adapters para **Mistral, Cohere, Together, Groq, Fireworks, Replicate, OpenRouter, Bedrock, Azure OpenAI, Vertex AI, xAI/Grok, HuggingFace**.
-53. Como dev, quero adapter para **modelos locais** (llama.cpp, LM Studio, vLLM, Ollama).
-54. Como dev, quero **MCP bridge bidirecional** — consumir qualquer MCP server E publicar tools AgentsKit como MCP.
-55. Como dev, quero **tool composer** pra encadear N tools em uma macro tool.
-56. Como dev, quero tools prontos: **GitHub, Linear, Jira, Notion, Asana, Slack, Discord, Teams, WhatsApp**.
-57. Como dev, quero tools: **Google Workspace (Drive, Docs, Sheets, Calendar, Gmail), Microsoft 365**.
-58. Como dev, quero tools: **Stripe, Supabase, Postgres, MySQL, Mongo (com safe-mode), S3/R2/GCS**.
-59. Como dev, quero tools: **web scraping (Playwright + Firecrawl + Reader), PDF/DOCX/XLSX parsing**.
-60. Como dev, quero tools: **image gen (DALL-E, Flux, SD, Recraft), TTS/STT (ElevenLabs, Whisper, Deepgram)**.
-61. Como dev, quero tools: **Maps, Weather, CoinGecko, Yahoo Finance**.
-62. Como dev, quero **Browser Agent tool** (Playwright + visão, clicar e preencher forms) em sandbox isolado.
-63. Como dev, quero **self-debug tool** — agente recebe erro de tool call e tenta corrigir sozinho.
-64. Como dev, quero **memory adapters**: Postgres+pgvector, Pinecone, Qdrant, Chroma, Weaviate, Turso, Cloudflare Vectorize, Upstash.
-65. Como usuário final, quero **memória com criptografia client-side** onde eu controlo a chave.
-66. Como dev, quero **memory graph** (grafo não-linear de relações).
-67. Como dev, quero **personalization layer** — perfil de user persistido entre sessões.
-68. Como dev, quero **doc loaders prontos**: URL, PDF, GitHub repo, Notion, Confluence, Drive.
-69. Como dev, quero **skill marketplace** com versionamento e ratings (estilo npm).
-70. Como dev, quero skills prontos: **code reviewer, test writer, PR describer, commit gen, SQL gen, translator, email triager, meeting summarizer, lead qualifier, debate agents, agent auditor**.
-71. Como dev frontend, quero **shadcn/ui registry** — `npx shadcn add agentskit-chat`.
-72. Como dev frontend, quero componentes pra **Vue, Svelte, Solid, Qwik**.
-73. Como dev mobile, quero **React Native + Expo** package.
-74. Como dev, quero **generative UI** — modelo retorna JSON estruturado e componentes renderizam.
-75. Como dev, quero **voice mode** component (push-to-talk, VAD, barge-in).
-76. Como dev, quero **artifact rendering** (code, charts, markdown, HTML sandbox) estilo Claude.ai.
-77. Como dev de edge, quero **AgentsKit Edge** — runtime mínimo <50KB com cold start <10ms em Cloudflare Workers/Deno Deploy.
-78. Como dev, quero **AgentsKit Browser-only** com WebLLM/WebGPU (100% client-side).
-79. Como dev de extensão, quero **AgentsKit for VS Code**, **Raycast/Alfred**, **embedded/IoT**.
-80. Como dev de verticais, quero **templates: Healthcare (HIPAA), Finance (SOX), E-commerce (Shopify), DevRel/Support, Education, Gaming**.
-81. Como dev, quero **Agent-to-Agent Protocol (A2A)** — spec aberta pra agentes de ecossistemas diferentes conversarem.
-82. Como dev, quero **Skill Manifest Spec** e **Tool Manifest compatível com MCP** — interop com LangChain/Mastra.
-83. Como dev, quero **Open Eval Format** — datasets e resultados trocáveis entre AgentsKit/Braintrust/LangSmith.
-84. Como dev, quero **`agentskit flow`** — editor visual YAML que compila pra DAG durável.
-85. Como maintainer da comunidade, quero **awesome-agentskit** curado, **Agent of the Week**, **AgentsKit University** (curso em vídeo), **hackathons mensais**, **bounty program**.
+52. As a developer, I want adapters for **Mistral, Cohere, Together, Groq, Fireworks, Replicate, OpenRouter, Bedrock, Azure OpenAI, Vertex AI, xAI/Grok, HuggingFace**.
+53. As a developer, I want an adapter for **local models** (llama.cpp, LM Studio, vLLM, Ollama).
+54. As a developer, I want a **bidirectional MCP bridge** — consume any MCP server AND publish AgentsKit tools as MCP.
+55. As a developer, I want a **tool composer** to chain N tools into a single macro tool.
+56. As a developer, I want ready-made tools: **GitHub, Linear, Jira, Notion, Asana, Slack, Discord, Teams, WhatsApp**.
+57. As a developer, I want tools: **Google Workspace (Drive, Docs, Sheets, Calendar, Gmail), Microsoft 365**.
+58. As a developer, I want tools: **Stripe, Supabase, Postgres, MySQL, Mongo (with safe-mode), S3/R2/GCS**.
+59. As a developer, I want tools: **web scraping (Playwright + Firecrawl + Reader), PDF/DOCX/XLSX parsing**.
+60. As a developer, I want tools: **image gen (DALL-E, Flux, SD, Recraft), TTS/STT (ElevenLabs, Whisper, Deepgram)**.
+61. As a developer, I want tools: **Maps, Weather, CoinGecko, Yahoo Finance**.
+62. As a developer, I want a **Browser Agent tool** (Playwright + vision, click and fill forms) in an isolated sandbox.
+63. As a developer, I want a **self-debug tool** — the agent receives a tool-call error and tries to fix it on its own.
+64. As a developer, I want **memory adapters**: Postgres+pgvector, Pinecone, Qdrant, Chroma, Weaviate, Turso, Cloudflare Vectorize, Upstash.
+65. As an end user, I want **client-side encrypted memory** where I control the key.
+66. As a developer, I want a **memory graph** (non-linear graph of relationships).
+67. As a developer, I want a **personalization layer** — a user profile persisted across sessions.
+68. As a developer, I want ready-made **doc loaders**: URL, PDF, GitHub repo, Notion, Confluence, Drive.
+69. As a developer, I want a **skill marketplace** with versioning and ratings (npm style).
+70. As a developer, I want ready-made skills: **code reviewer, test writer, PR describer, commit gen, SQL gen, translator, email triager, meeting summarizer, lead qualifier, debate agents, agent auditor**.
+71. As a frontend developer, I want a **shadcn/ui registry** — `npx shadcn add agentskit-chat`.
+72. As a frontend developer, I want components for **Vue, Svelte, Solid, Qwik**.
+73. As a mobile developer, I want a **React Native + Expo** package.
+74. As a developer, I want **generative UI** — the model returns structured JSON and components render it.
+75. As a developer, I want a **voice mode** component (push-to-talk, VAD, barge-in).
+76. As a developer, I want **artifact rendering** (code, charts, markdown, HTML sandbox) in the Claude.ai style.
+77. As an edge developer, I want **AgentsKit Edge** — minimal runtime <50KB with <10ms cold start on Cloudflare Workers/Deno Deploy.
+78. As a developer, I want **AgentsKit Browser-only** with WebLLM/WebGPU (100% client-side).
+79. As an extension developer, I want **AgentsKit for VS Code**, **Raycast/Alfred**, **embedded/IoT**.
+80. As a verticals developer, I want **templates: Healthcare (HIPAA), Finance (SOX), E-commerce (Shopify), DevRel/Support, Education, Gaming**.
+81. As a developer, I want an **Agent-to-Agent Protocol (A2A)** — an open spec for agents from different ecosystems to talk.
+82. As a developer, I want a **Skill Manifest Spec** and a **Tool Manifest compatible with MCP** — interop with LangChain/Mastra.
+83. As a developer, I want an **Open Eval Format** — datasets and results interchangeable between AgentsKit/Braintrust/LangSmith.
+84. As a developer, I want **`agentskit flow`** — a visual YAML editor that compiles to a durable DAG.
+85. As a community maintainer, I want a curated **awesome-agentskit**, **Agent of the Week**, **AgentsKit University** (video course), **monthly hackathons**, a **bounty program**.
 
-### Fase 4 — Business & Monetização
+### Phase 4 — Business & Monetization
 
-86. Como dev hobbyista, quero **AgentsKit Cloud Free Tier** generoso (agentes + 1 vector store pequeno) — para testar sem cartão.
-87. Como dev profissional, quero **AgentsKit Cloud** com hosted runtime, observability, vector store e deploy 1-click.
-88. Como dev, quero **Pro Marketplace** com tools premium licenciados por usuário.
-89. Como empresa enterprise, quero **self-hosted air-gapped + SOC2/HIPAA** com suporte dedicado.
-90. Como empresa, quero **SSO (SAML/OIDC), audit log completo, multi-tenant isolation**.
-91. Como autor de skill/tool popular, quero **revenue share** quando meu asset é usado no marketplace.
-92. Como empresa, quero **AgentsKit Certification** program — selo oficial pra projetos e devs.
-93. Como comunidade, quero **AI Agent Conference** anual organizada pelo AgentsKit.
-94. Como cliente enterprise, quero **parceria com Vercel** (deploy button oficial), **Cloudflare Workers** (runtime edge otimizado), **Bun/Deno** (first-class).
-95. Como dev, quero **co-marketing com providers** — Anthropic/OpenAI/xAI recomendando AgentsKit como caminho JS oficial.
-96. Como ops team, quero **Carbon-aware + cost-aware routing** com selo "green agent" público.
-97. Como dev de produção crítica, quero **Agent Insurance** — garantia de output via ensemble + validator com reembolso em falha.
+86. As a hobbyist developer, I want a generous **AgentsKit Cloud Free Tier** (agents + 1 small vector store) — to try without a credit card.
+87. As a professional developer, I want **AgentsKit Cloud** with hosted runtime, observability, vector store, and 1-click deploy.
+88. As a developer, I want a **Pro Marketplace** with premium tools licensed per user.
+89. As an enterprise, I want **self-hosted air-gapped + SOC2/HIPAA** with dedicated support.
+90. As a company, I want **SSO (SAML/OIDC), full audit log, multi-tenant isolation**.
+91. As a popular skill/tool author, I want **revenue share** when my asset is used in the marketplace.
+92. As a company, I want an **AgentsKit Certification** program — an official seal for projects and developers.
+93. As a community, I want an annual **AI Agent Conference** organized by AgentsKit.
+94. As an enterprise customer, I want **partnership with Vercel** (official deploy button), **Cloudflare Workers** (optimized edge runtime), **Bun/Deno** (first-class).
+95. As a developer, I want **co-marketing with providers** — Anthropic/OpenAI/xAI recommending AgentsKit as the official JS path.
+96. As an ops team, I want **carbon-aware + cost-aware routing** with a public "green agent" badge.
+97. As a critical-production developer, I want **Agent Insurance** — output guarantee via ensemble + validator with refund on failure.
 
 ---
 
 ## Implementation Decisions
 
-### Arquitetura geral
-- **Monorepo pnpm + Turborepo** já existente — manter.
-- `@agentskit/core` permanece zero-deps, <10KB gzip. Tudo novo vai em pacotes separados.
-- Novos packages sugeridos: `@agentskit/devtools`, `@agentskit/edge`, `@agentskit/replay`, `@agentskit/eval`, `@agentskit/cloud-sdk`, `@agentskit/vue`, `@agentskit/svelte`, `@agentskit/native`.
-- Cada adapter novo é um subpath: `@agentskit/adapters/mistral`, etc.
+### Overall architecture
+- **Existing pnpm + Turborepo monorepo** — keep it.
+- `@agentskit/core` stays zero-deps, <10KB gzip. Everything new ships in separate packages.
+- Suggested new packages: `@agentskit/devtools`, `@agentskit/edge`, `@agentskit/replay`, `@agentskit/eval`, `@agentskit/cloud-sdk`, `@agentskit/vue`, `@agentskit/svelte`, `@agentskit/native`.
+- Each new adapter is a subpath: `@agentskit/adapters/mistral`, etc.
 
-### Módulos profundos (candidatos a testes isolados)
-- **ReplayEngine** — grava/reproduz sessões deterministicamente. Interface: `record(session)`, `replay(id, patches?)`. Encapsula seed mgmt, serialização de LLM calls, diff semântico.
-- **TokenBudgetCompiler** — recebe prompt tree + budget, retorna prompt otimizado. Interface: `compile(tree, budget) → OptimizedPrompt`.
-- **RouterAdapter** — seleciona provider por policy. Interface: `route(request, policy) → Adapter`.
-- **MemoryGraph** — grafo de entidades/episódios/goals. Interface: `add(node, edges)`, `query(traversal)`.
-- **ToolSandbox** — executa código untrusted. Interface: `run(code, limits) → Result`.
-- **PromptDiffer** — compara outputs semanticamente. Interface: `diff(outputA, outputB) → DiffReport`.
-- **EvalRunner** — roda test suite contra agente. Interface: `run(agent, dataset, metrics) → Report`.
+### Deep modules (candidates for isolated tests)
+- **ReplayEngine** — deterministically records/reproduces sessions. Interface: `record(session)`, `replay(id, patches?)`. Encapsulates seed management, LLM call serialization, semantic diff.
+- **TokenBudgetCompiler** — takes a prompt tree + budget, returns an optimized prompt. Interface: `compile(tree, budget) → OptimizedPrompt`.
+- **RouterAdapter** — selects a provider by policy. Interface: `route(request, policy) → Adapter`.
+- **MemoryGraph** — graph of entities/episodes/goals. Interface: `add(node, edges)`, `query(traversal)`.
+- **ToolSandbox** — runs untrusted code. Interface: `run(code, limits) → Result`.
+- **PromptDiffer** — compares outputs semantically. Interface: `diff(outputA, outputB) → DiffReport`.
+- **EvalRunner** — runs a test suite against an agent. Interface: `run(agent, dataset, metrics) → Report`.
 
-### Contratos/APIs
-- **A2A Protocol** — spec JSON-RPC sobre HTTP/WebSocket, versionada. Manter compat com MCP onde possível.
-- **Skill Manifest** — JSON schema público com `name`, `description`, `systemPrompt`, `examples`, `version`, `compatible: ["agentskit@^1", "langchain@^0.3"]`.
-- **Tool Manifest** — superset do MCP tool manifest; se só usar subset MCP, deve rodar em MCP clients sem modificação.
-- **Open Eval Format** — OpenAI evals + extensões (latency, cost, carbon).
+### Contracts / APIs
+- **A2A Protocol** — versioned JSON-RPC spec over HTTP/WebSocket. Stay compatible with MCP where possible.
+- **Skill Manifest** — public JSON schema with `name`, `description`, `systemPrompt`, `examples`, `version`, `compatible: ["agentskit@^1", "langchain@^0.3"]`.
+- **Tool Manifest** — a superset of the MCP tool manifest; if it only uses the MCP subset, it should run on MCP clients unmodified.
+- **Open Eval Format** — OpenAI evals + extensions (latency, cost, carbon).
 
-### Priorização dentro de cada fase
-Dentro de uma fase, priorizar por: (1) impacto na narrativa pública, (2) desbloqueio de outras features, (3) esforço. Matriz detalhada em issue separada quando a fase começar.
+### Prioritization inside each phase
+Within a phase, prioritize by: (1) impact on the public narrative, (2) unblocking of other features, (3) effort. Detailed matrix in a separate issue when the phase starts.
 
 ### Breaking changes
-- Fases 1-2 não introduzem breaking changes no core.
-- Fase 3 pode bumpar `@agentskit/react` pra v2 se necessário (generative UI).
-- Changesets obrigatório em todo PR.
+- Phases 1–2 introduce no breaking changes in the core.
+- Phase 3 may bump `@agentskit/react` to v2 if necessary (generative UI).
+- Changesets required on every PR.
 
 ---
 
 ## Testing Decisions
 
-### O que faz um bom teste aqui
-- Testa **comportamento externo**, não implementação. Ex: "quando LLM retorna tool_call, tool é invocado com args corretos" — não "o método `_parseToolCall` é chamado".
-- Usa **adapters mock determinísticos** (gravados via ReplayEngine) em vez de mocks manuais frágeis.
-- Evita snapshot testing de strings cruas de LLM — usa tolerância semântica ou matchers estruturados.
+### What makes a good test here
+- Tests **external behavior**, not implementation. Example: "when the LLM returns a tool_call, the tool is invoked with the correct args" — not "the `_parseToolCall` method is called".
+- Uses **deterministic mock adapters** (recorded via ReplayEngine) instead of fragile hand-written mocks.
+- Avoids snapshot testing of raw LLM strings — uses semantic tolerance or structured matchers.
 
-### Módulos que devem ter testes
-- **ReplayEngine, TokenBudgetCompiler, RouterAdapter, MemoryGraph, ToolSandbox, EvalRunner, PromptDiffer** — módulos profundos, alta alavancagem de teste.
-- Cada **adapter** novo: teste de contract (streaming, tool calling, multi-modal se aplicável) rodando contra gravação real + mock.
-- Cada **tool** novo: teste de schema validation + execução mockada.
+### Modules that must have tests
+- **ReplayEngine, TokenBudgetCompiler, RouterAdapter, MemoryGraph, ToolSandbox, EvalRunner, PromptDiffer** — deep modules with high test leverage.
+- Every new **adapter**: contract test (streaming, tool calling, multi-modal when applicable) running against a real recording + mock.
+- Every new **tool**: schema validation + mocked execution test.
 
 ### Prior art
-- Vitest já é o runner padrão.
-- Usar `@agentskit/adapters` teste existente como template.
-- E2E com Playwright pra componentes React/Ink e devtools extension.
+- Vitest is already the default runner.
+- Use the existing `@agentskit/adapters` test as a template.
+- E2E with Playwright for React/Ink components and the devtools extension.
 
 ### Skills/Tools (asset marketplace)
-- Cada skill publicado deve vir com **golden dataset** (10-50 exemplos input/expected) rodado no CI do marketplace.
+- Every published skill must ship with a **golden dataset** (10–50 input/expected examples) run in the marketplace CI.
 
 ---
 
-## Out of Scope (pra esse documento master)
+## Out of Scope (for this master document)
 
-- **Priorização final detalhada** (impacto × esforço × diferenciação) — sai em documento/issue separado quando cada fase começar.
-- **Pricing do Cloud** — definido mais perto da Fase 4.
-- **Go-to-market e marketing** — complementar, não PRD técnico.
-- **Implementação de Python SDK** — AgentsKit é JS-first; Python fica fora.
-- **Treinamento de modelos próprios** — AgentsKit é layer de integração, não foundation model.
-- **Hosting de modelos** — delegado a providers (OpenRouter, Together, etc.).
+- **Final detailed prioritization** (impact × effort × differentiation) — lives in a separate document/issue when each phase starts.
+- **Cloud pricing** — defined closer to Phase 4.
+- **Go-to-market and marketing** — complementary, not a technical PRD.
+- **Python SDK implementation** — AgentsKit is JS-first; Python is out.
+- **Training our own models** — AgentsKit is an integration layer, not a foundation model.
+- **Model hosting** — delegated to providers (OpenRouter, Together, etc.).
 
 ---
 
 ## Further Notes
 
-### Como este doc vira issues
-Cada user story (1-97) deve virar **1 issue GitHub** com:
-- Título: "`[Fase X] Story NN — <resumo>`"
+### How this doc becomes issues
+Every user story (1–97) should become **1 GitHub issue** with:
+- Title: "`[Phase X] Story NN — <summary>`"
 - Label: `phase-1-foundation` | `phase-2-evolution` | `phase-3-expansion` | `phase-4-business`
-- Label de pacote: `pkg:core`, `pkg:adapters`, `pkg:react`, etc.
-- Label de tipo: `type:feature`, `type:dx`, `type:docs`, `type:tool`, `type:adapter`, `type:infra`.
-- Link de volta pra esse PRD.
+- Package label: `pkg:core`, `pkg:adapters`, `pkg:react`, etc.
+- Type label: `type:feature`, `type:dx`, `type:docs`, `type:tool`, `type:adapter`, `type:infra`.
+- Link back to this PRD.
 
-Stories grandes (ex: #54 MCP bridge, #77 AgentsKit Edge, #84 agentskit flow) viram **epics** com sub-issues.
+Large stories (e.g., #54 MCP bridge, #77 AgentsKit Edge, #84 agentskit flow) become **epics** with sub-issues.
 
-### Apostas estratégicas (se precisar cortar)
-Se tudo mais falhar, estas 3 apostas são o mínimo pra AgentsKit se diferenciar:
-1. **Deterministic replay + prompt diff + time travel debug** (stories 21-24) — narrativa "finalmente dá pra debugar agentes".
-2. **AgentsKit Edge** (story 77) — território vazio, Vercel AI SDK não cobre bem.
-3. **MCP bridge bidirecional + A2A Protocol** (stories 54, 81-83) — AgentsKit como camada de interop.
+### Strategic bets (if we need to cut)
+If everything else fails, these 3 bets are the minimum for AgentsKit to differentiate:
+1. **Deterministic replay + prompt diff + time-travel debug** (stories 21–24) — the "finally you can debug agents" narrative.
+2. **AgentsKit Edge** (story 77) — empty territory, Vercel AI SDK does not cover it well.
+3. **Bidirectional MCP bridge + A2A Protocol** (stories 54, 81–83) — AgentsKit as the interop layer.
 
-### Princípios não-negociáveis (já no CLAUDE.md)
+### Non-negotiable principles (already in CLAUDE.md)
 - Core <10KB gzip, zero deps.
-- Todo package plug-and-play.
-- Interop total entre packages.
+- Every package plug-and-play.
+- Total interop across packages.
 - Named exports only, no default exports.
-- TypeScript strict, sem `any`.
+- TypeScript strict, no `any`.


### PR DESCRIPTION
## Summary

The four planning docs under \`docs/\` were authored in Portuguese and not meant for public consumption at the time, but they are linked from open issues #113, #211, #264, and indexed by Google. English-only repo policy means they have to be EN too.

Translations are faithful: structure, links, code blocks, tables, priority lists, sprint numbers, and gate criteria are unchanged. Portuguese sentences are translated to their direct English equivalents; technical terms are kept (\`adapter\`, \`runtime\`, \`ReAct\`, \`ReAct loop\`, etc.).

## Files

- \`docs/ROADMAP-PRD.md\` — Master PRD & Roadmap (97 user stories across 4 phases)
- \`docs/MASTER-EXECUTION-PLAN.md\` — 149-issue sprint plan with gates and cadence
- \`docs/PHASE-0-FOUNDATION-PRD.md\` — 52 foundation-hardening stories across 4 tracks
- \`docs/PHASE-0-EXECUTION-PLAN.md\` — P0 tactical plan (Sprints 1–3)

## Issue titles

Already fixed via \`gh issue edit\` before this PR:
- #264 \`em 12 meses\` → \`in 12 months\`
- #220 \`por package\` → \`per package\`
- #211 \`antes da Fase 1\` → \`before Phase 1\`
- #175 \`visão\` → \`vision\`

## Follow-up

Issue bodies of #264 and #211 mirror the content of these docs. After this PR merges, I'll sync those issue bodies to the translated text. No action required here.

## Test plan

- [ ] Spot-check each doc renders correctly on GitHub (tables, code blocks, checkboxes).
- [ ] Search the 4 files for any residual Portuguese: \`grep -E "(ão|çã|çõ)" docs/*.md\` — expect no matches.