### PR TITLE
chore: brand as AgentsKit.js to distinguish from Inngest AgentKit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to AgentsKit
+# Contributing to AgentsKit.js
 
 Thanks for being here. This guide gets you from `git clone` to merged PR with the least friction we know how to provide.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-AgentsKit is maintainer-led open source. This document explains who decides what and how.
+AgentsKit.js is maintainer-led open source. This document explains who decides what and how.
 
 ## Roles
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,6 +1,6 @@
-# AgentsKit Manifesto
+# AgentsKit.js Manifesto
 
-> These are the non-negotiable principles that shape AgentsKit. Every design decision, every PR, every package is measured against them. If a principle is ever about to be broken, we stop and reconsider — never rationalize.
+> These are the non-negotiable principles that shape AgentsKit.js. Every design decision, every PR, every package is measured against them. If a principle is ever about to be broken, we stop and reconsider — never rationalize.
 
 ---
 
@@ -14,15 +14,15 @@ Every package works standalone, with a single install and less than ten lines of
 
 ## 3. Interop is radical, not optional
 
-Any combination of AgentsKit packages must compose without glue code. React + Runtime + Memory + RAG + Observability should just work. The contract is the API — shared types, shared events, shared semantics across the entire ecosystem.
+Any combination of AgentsKit.js packages must compose without glue code. React + Runtime + Memory + RAG + Observability should just work. The contract is the API — shared types, shared events, shared semantics across the entire ecosystem.
 
 ## 4. Zero lock-in
 
-Leaving AgentsKit must be a single `npm uninstall` away. No proprietary formats, no captive state, no hidden coupling. Adapters, memory stores, tools — all are replaceable. We earn our place every day.
+Leaving AgentsKit.js must be a single `npm uninstall` away. No proprietary formats, no captive state, no hidden coupling. Adapters, memory stores, tools — all are replaceable. We earn our place every day.
 
 ## 5. Agent-first, not chat-first
 
-AgentsKit is not a chat library that happens to support tools. It is an agent runtime that happens to render chat. Tools, skills, memory, and reasoning loops are primary citizens — UI is one surface among many (React, Ink, CLI, headless).
+AgentsKit.js is not a chat library that happens to support tools. It is an agent runtime that happens to render chat. Tools, skills, memory, and reasoning loops are primary citizens — UI is one surface among many (React, Ink, CLI, headless).
 
 ## 6. Docs are product, not afterthought
 

--- a/ORIGIN.md
+++ b/ORIGIN.md
@@ -1,4 +1,4 @@
-# Origin — Why AgentsKit Exists
+# Origin — Why AgentsKit.js Exists
 
 > *Personal note from the author. First-person and unpolished by intent — the story of a frustration that became a library.*
 
@@ -32,7 +32,7 @@ The observation is simple: **we don't need another framework. We need a kit** �
 
 ## The bet
 
-AgentsKit is a bet on three claims:
+AgentsKit.js is a bet on three claims:
 
 1. **JavaScript will be the language of agent applications**, because it's where the users are, where the deployment is cheap, and where the ecosystem is most plug-and-play.
 2. **Agents don't need a framework; they need contracts.** A `Tool` is a function. A `Memory` is a store. A `Runtime` is a loop. Formalize the contracts, keep the packages small, let users assemble.
@@ -40,9 +40,9 @@ AgentsKit is a bet on three claims:
 
 ## The promise
 
-AgentsKit will never become the thing I was frustrated with. It will stay small. It will stay composable. It will stay honest — about what it does and what it doesn't. It will tell you when you should use something else.
+AgentsKit.js will never become the thing I was frustrated with. It will stay small. It will stay composable. It will stay honest — about what it does and what it doesn't. It will tell you when you should use something else.
 
-If AgentsKit ever starts feeling like LangChain — bloated, magical, hard to debug — we failed. If it ever stops feeling like plain JavaScript you already know — we failed. The manifesto is how we hold ourselves accountable.
+If AgentsKit.js ever starts feeling like LangChain — bloated, magical, hard to debug — we failed. If it ever stops feeling like plain JavaScript you already know — we failed. The manifesto is how we hold ourselves accountable.
 
 ## The invitation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# AgentsKit
+# AgentsKit.js
 
 **The agent toolkit JavaScript actually deserves.**
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support
 
-Thanks for using AgentsKit. Here's where to get help based on what you need.
+Thanks for using AgentsKit.js. Here's where to get help based on what you need.
 
 ## I have a question or want to discuss an idea
 Open a thread in **[GitHub Discussions](https://github.com/EmersonBraun/agentskit/discussions)**. Good for: "how do I…", "is this the right approach", "would you accept a PR for…", design feedback, pattern questions.
@@ -22,7 +22,7 @@ Open a **[Feature request](https://github.com/EmersonBraun/agentskit/issues/new?
 Start with [CONTRIBUTING.md](./CONTRIBUTING.md). Read [AGENTS.md](./AGENTS.md) and the relevant package's `CONVENTIONS.md` before coding. The roadmap is public: **[Roadmap →](https://github.com/users/EmersonBraun/projects/1)**.
 
 ## Commercial / enterprise support
-Not available today. AgentsKit is maintainer-led OSS.
+Not available today. AgentsKit.js is maintainer-led OSS.
 
 ## SLA
 There is no SLA. This is a community project. Issues are triaged in batches, typically weekly. If something is blocking you in production, open an issue and tag it `blocker` — it gets prioritized.

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -7,18 +7,18 @@ import { AnimatedLogo } from '@/components/brand/animated-logo'
 import { JsonLd } from '@/components/seo/json-ld'
 
 export const metadata = {
-  title: 'AgentsKit — Ship AI agents in JavaScript without gluing 8 libraries',
+  title: 'AgentsKit.js — Ship AI agents in JavaScript without gluing 8 libraries',
   description:
     'One toolkit for chat UI, tools, memory, RAG, and runtime. Swap OpenAI for Claude, React for terminal, in-memory for vector DB — nothing breaks. MIT, 10KB core.',
   openGraph: {
-    title: 'AgentsKit — Ship AI agents in JavaScript',
+    title: 'AgentsKit.js — Ship AI agents in JavaScript',
     description:
       'Chat UI, tools, memory, RAG, runtime. One toolkit. Zero lock-in. 10KB core.',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'AgentsKit — Ship AI agents in JavaScript',
+    title: 'AgentsKit.js — Ship AI agents in JavaScript',
     description:
       'Chat UI, tools, memory, RAG, runtime. One toolkit. Zero lock-in.',
   },
@@ -48,7 +48,7 @@ const JSON_LD = {
     {
       '@type': 'Organization',
       '@id': 'https://www.agentskit.io/#org',
-      name: 'AgentsKit',
+      name: 'AgentsKit.js',
       url: 'https://www.agentskit.io',
       logo: 'https://www.agentskit.io/favicon.svg',
       sameAs: [
@@ -59,7 +59,7 @@ const JSON_LD = {
     {
       '@type': 'SoftwareApplication',
       '@id': 'https://www.agentskit.io/#software',
-      name: 'AgentsKit',
+      name: 'AgentsKit.js',
       description:
         'One toolkit for building AI agents in JavaScript — chat UI, tools, memory, RAG, runtime. Swap OpenAI for Claude, React for terminal, in-memory for vector DB. Nothing breaks.',
       applicationCategory: 'DeveloperApplication',
@@ -75,7 +75,7 @@ const JSON_LD = {
       '@type': 'WebSite',
       '@id': 'https://www.agentskit.io/#website',
       url: 'https://www.agentskit.io',
-      name: 'AgentsKit',
+      name: 'AgentsKit.js',
       publisher: { '@id': 'https://www.agentskit.io/#org' },
       potentialAction: {
         '@type': 'SearchAction',
@@ -110,7 +110,7 @@ function Hero() {
           <div className="mb-5 flex items-center gap-3 sm:mb-6">
             <AnimatedLogo variant="hero" size={44} loop />
             <span className="font-mono text-lg font-bold tracking-tight text-ak-foam sm:text-xl">
-              agentskit
+              agentskit<span className="text-ak-graphite">.js</span>
             </span>
           </div>
 
@@ -501,7 +501,7 @@ function FinalCta() {
         </div>
 
         <p className="mt-8 font-mono text-xs text-ak-graphite">
-          MIT · 14 packages on npm · built in the open
+          AgentsKit.js · MIT · 14 packages on npm · built in the open
         </p>
       </div>
     </section>

--- a/apps/docs-next/app/api/og/route.tsx
+++ b/apps/docs-next/app/api/og/route.tsx
@@ -24,7 +24,7 @@ const SECTION_ACCENTS: Record<string, { label: string; color: string }> = {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
-  const title = searchParams.get('title')?.slice(0, 100) ?? 'AgentsKit'
+  const title = searchParams.get('title')?.slice(0, 100) ?? 'AgentsKit.js'
   const description =
     searchParams.get('description')?.slice(0, 200) ??
     'The agent toolkit JavaScript actually deserves.'

--- a/apps/docs-next/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs-next/app/docs/[[...slug]]/page.tsx
@@ -45,8 +45,8 @@ export default async function Page(props: {
     headline: page.data.title,
     description: page.data.description,
     url: slugPath === 'index' ? `${SITE}/docs` : `${SITE}/docs/${slugPath}`,
-    author: { '@type': 'Organization', name: 'AgentsKit', url: SITE },
-    publisher: { '@type': 'Organization', name: 'AgentsKit', url: SITE },
+    author: { '@type': 'Organization', name: 'AgentsKit.js', url: SITE },
+    publisher: { '@type': 'Organization', name: 'AgentsKit.js', url: SITE },
   }
 
   return (

--- a/apps/docs-next/app/layout.config.tsx
+++ b/apps/docs-next/app/layout.config.tsx
@@ -6,7 +6,7 @@ export const baseOptions: BaseLayoutProps = {
     title: (
       <span className="flex items-center gap-2">
         <AnimatedLogo variant="nav" loop />
-        <span className="font-mono font-bold tracking-tight">agentskit</span>
+        <span className="font-mono font-bold tracking-tight">agentskit<span className="text-ak-graphite">.js</span></span>
       </span>
     ),
   },

--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -14,8 +14,8 @@ const DESCRIPTION = 'The agent toolkit JavaScript actually deserves.'
 export const metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: 'AgentsKit — the agent toolkit JavaScript actually deserves',
-    template: '%s | AgentsKit',
+    default: 'AgentsKit.js — the agent toolkit JavaScript actually deserves',
+    template: '%s | AgentsKit.js',
   },
   description: DESCRIPTION,
   keywords: [
@@ -62,21 +62,21 @@ export const metadata = {
     type: 'website',
     locale: 'en_US',
     url: SITE_URL,
-    siteName: 'AgentsKit',
-    title: 'AgentsKit — the agent toolkit JavaScript actually deserves',
+    siteName: 'AgentsKit.js',
+    title: 'AgentsKit.js — the agent toolkit JavaScript actually deserves',
     description: DESCRIPTION,
     images: [
       {
         url: '/api/og',
         width: 1200,
         height: 630,
-        alt: 'AgentsKit — the agent toolkit JavaScript actually deserves',
+        alt: 'AgentsKit.js — the agent toolkit JavaScript actually deserves',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'AgentsKit — the agent toolkit JavaScript actually deserves',
+    title: 'AgentsKit.js — the agent toolkit JavaScript actually deserves',
     description: DESCRIPTION,
     images: ['/api/og'],
   },

--- a/apps/docs-next/content/docs/announcements/core-v1.mdx
+++ b/apps/docs-next/content/docs/announcements/core-v1.mdx
@@ -42,9 +42,9 @@ None of these are fine. The agent era deserves a substrate that works like React
 
 ---
 
-## What AgentsKit actually is
+## What AgentsKit.js actually is
 
-A family of **14 small packages** built on one **5 KB core**. Every package is plug-and-play. Every contract is open. Every combination composes.
+AgentsKit.js is a family of **14 small packages** built on one **5 KB core**. Every package is plug-and-play. Every contract is open. Every combination composes.
 
 ```
 @agentskit/core            ← pure foundation, zero deps, v1.0.0

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Welcome to AgentsKit
+title: Welcome to AgentsKit.js
 description: The agent toolkit JavaScript actually deserves.
 ---
 
-AgentsKit is a family of small, plug-and-play packages that cover the entire agent lifecycle in JavaScript: chat UIs, autonomous runtimes, tools, skills, memory, RAG, observability.
+AgentsKit.js is a family of small, plug-and-play packages that cover the entire agent lifecycle in JavaScript: chat UIs, autonomous runtimes, tools, skills, memory, RAG, observability.
 
 ## Where to go next
 
@@ -12,7 +12,7 @@ AgentsKit is a family of small, plug-and-play packages that cover the entire age
 - **[Recipes](/docs/recipes)** — copy-paste solutions for common scenarios
 - **[Examples](/docs/examples)** — live interactive demos
 - **[Migrating from another framework](/docs/migrating)** — Vercel AI SDK, LangChain.js, Mastra
-- **[Contribute →](/docs/contribute)** — AgentsKit is built in the open. Your PR helps.
+- **[Contribute →](/docs/contribute)** — AgentsKit.js is built in the open. Your PR helps.
 - **[Join the Discord →](https://discord.gg/zx6z2p4jVb)** — Office Hours every Friday, direct line to maintainers.
 
 ## The substrate
@@ -28,4 +28,4 @@ Six core contracts (formalized as ADRs) define how every package composes:
 | Skill | Declarative persona |
 | Runtime | The loop that composes them all |
 
-If you understand these six, you understand AgentsKit.
+If you understand these six, you understand AgentsKit.js.


### PR DESCRIPTION
## Summary

Inngest ships an unrelated [AgentKit](https://github.com/inngest/agent-kit) (orchestration-only, Inngest-platform-coupled). The one-letter difference ("AgentsKit" vs "AgentKit") causes confusion in search, HN threads, and npm discovery.

Adding the **".js" qualifier** — matching ecosystem convention (Next.js, Three.js, Chart.js) — immediately signals "JavaScript agent toolkit" and eliminates ambiguity.

## What changes

| Surface | Before | After |
|---------|--------|-------|
| README H1 | AgentsKit | **AgentsKit.js** |
| Site title / OG / Twitter meta | AgentsKit — ... | **AgentsKit.js — ...** |
| Nav brand (layout.config) | agentskit | **agentskit.js** (.js in muted color) |
| Hero brand text | agentskit | **agentskit.js** |
| JSON-LD org/software/website | AgentsKit | **AgentsKit.js** |
| OG image fallback title | AgentsKit | **AgentsKit.js** |
| Docs welcome page | Welcome to AgentsKit | **Welcome to AgentsKit.js** |
| MANIFESTO, ORIGIN, CONTRIBUTING, GOVERNANCE, SUPPORT | AgentsKit | **AgentsKit.js** |
| Core v1 announcement | AgentsKit | **AgentsKit.js** |

## What does NOT change

- npm packages: \`@agentskit/*\` — unchanged
- CLI binary: \`agentskit\` — unchanged
- Domain: \`agentskit.io\` — unchanged
- GitHub repo: \`EmersonBraun/agentskit\` — unchanged
- Code identifiers, imports, CSS classes — unchanged
- URLs — unchanged

## Test plan

- [ ] \`pnpm --filter @agentskit/docs-next dev\` → verify nav shows "agentskit.js" with muted ".js"
- [ ] Hero shows "agentskit.js" brand text
- [ ] Page title in browser tab: "AgentsKit.js — ..."
- [ ] View source → confirm JSON-LD has "AgentsKit.js"
- [ ] \`curl https://www.agentskit.io/api/og\` → OG image says "AgentsKit.js"
- [ ] GitHub README renders with "AgentsKit.js" H1
- [ ] Google "site:agentskit.io" after deploy → title shows ".js" qualifier