### PR TITLE
docs: fix all stale APIs + add new feature docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Standalone agent runtime (no UI required). Supports ReAct loop, reflection, plan
 Marketplace of reusable executable tools. Includes: browser (Puppeteer), filesystem, telegram, resend, web search, calendar, code execution, etc. Each tool follows strict contract (`name`, `description`, `schema`, `execute`). Auto-discovery and registration in runtime and chat. Supports parallel tool calling and human confirmation.
 
 ### @agentskit/skills
-Collection of ready-made skills (prompts + behavioral instructions). Each skill contains: `name`, `description`, `systemPrompt`, few-shot examples, best practices. Examples: researcher, critic, writer, planner, coder, summarizer, analyst. Easy to combine, override, or extend. Designed for use with runtime and multi-agent setups.
+Collection of ready-made skills (prompts + behavioral instructions). Each skill contains: `name`, `description`, `systemPrompt`, few-shot examples, best practices. Examples: researcher, critic, planner, coder, summarizer. Easy to combine, override, or extend. Designed for use with runtime and multi-agent setups.
 
 ### @agentskit/memory
 Persistent and vector memory layer. Implementations: in-memory, localStorage, file, SQLite, Redis, LanceDB (vector). Clear contract for custom memory adapters. Supports hydration, serialization, and long-term storage. Works across React, Ink, runtime, and CLI.

--- a/apps/docs-next/content/docs/announcements/core-v1.mdx
+++ b/apps/docs-next/content/docs/announcements/core-v1.mdx
@@ -54,7 +54,7 @@ AgentsKit.js is a family of **14 small packages** built on one **5 KB core**. Ev
   ├── cli                  ← agentskit init / chat / dev / doctor / tunnel
   ├── runtime              ← standalone agent loop (ReAct, reflection, multi-agent)
   ├── tools                ← browser, fs, web search, code exec, email, calendar
-  ├── skills               ← researcher, critic, writer, planner, coder
+  ├── skills               ← researcher, critic, planner, coder, summarizer
   ├── memory               ← in-memory, file, SQLite, Redis, vector
   ├── rag                  ← plug-and-play retrieval in 3 lines
   ├── sandbox              ← E2B + WebContainer code execution

--- a/apps/docs-next/content/docs/components/overview.mdx
+++ b/apps/docs-next/content/docs/components/overview.mdx
@@ -15,6 +15,7 @@ AgentsKit ships headless components that render semantic HTML with `data-ak-*` a
 | `CodeBlock` | Syntax-highlighted code with copy button |
 | `ToolCallView` | Expandable tool invocation display |
 | `ThinkingIndicator` | Animated thinking/loading state |
+| `ToolConfirmation` | UI for human-in-the-loop tool approval/denial |
 | `InputBar` | Text input with send button |
 
 ## Headless Philosophy

--- a/apps/docs-next/content/docs/concepts/errors.mdx
+++ b/apps/docs-next/content/docs/concepts/errors.mdx
@@ -1,0 +1,148 @@
+---
+title: Error Handling
+description: AgentsKit's didactic error system — Rust-compiler-style errors with codes, hints, and doc links baked in.
+---
+
+AgentsKit uses a **didactic error system** inspired by the Rust compiler. Every error carries a machine-readable `code`, a human-readable `hint` explaining how to fix the problem, and a `docsUrl` pointing directly to the relevant documentation — so you know what went wrong and how to fix it without searching.
+
+## The base class
+
+```ts
+import { AgentsKitError } from '@agentskit/core'
+
+class AgentsKitError extends Error {
+  readonly code: string         // e.g. 'AK_TOOL_EXEC_FAILED'
+  readonly hint: string | undefined    // actionable fix suggestion
+  readonly docsUrl: string | undefined // direct link to relevant docs
+  readonly cause: unknown       // original error, if any
+}
+```
+
+`toString()` formats like a compiler diagnostic:
+
+```
+error[AK_ADAPTER_MISSING]: No adapter provided
+  --> Hint: Pass an adapter when creating the chat controller, e.g.
+            createChatController({ adapter: openaiAdapter() })
+  --> Docs: https://agentskit.dev/docs/adapters
+```
+
+## Error subclasses
+
+All errors extend `AgentsKitError`. The subclasses set a default `docsUrl` for their domain:
+
+| Class | Default docs link | Thrown when |
+|-------|-------------------|-------------|
+| `AdapterError` | `/docs/adapters` | Adapter is missing or a stream call fails |
+| `ToolError` | `/docs/tools` | A tool is not found or `execute` throws |
+| `MemoryError` | `/docs/memory` | Memory load, save, or deserialization fails |
+| `ConfigError` | `/docs/configuration` | Required configuration is absent or invalid |
+
+## ErrorCodes
+
+All code strings live in the `ErrorCodes` constant so you never use bare string literals:
+
+```ts
+import { ErrorCodes } from '@agentskit/core'
+
+// Adapter errors
+ErrorCodes.AK_ADAPTER_MISSING       // adapter not provided to the controller
+ErrorCodes.AK_ADAPTER_STREAM_FAILED // provider streaming call failed
+
+// Tool errors
+ErrorCodes.AK_TOOL_NOT_FOUND        // tool name not registered
+ErrorCodes.AK_TOOL_EXEC_FAILED      // execute() threw
+
+// Memory errors
+ErrorCodes.AK_MEMORY_LOAD_FAILED          // memory.load() failed
+ErrorCodes.AK_MEMORY_SAVE_FAILED          // memory.save() failed
+ErrorCodes.AK_MEMORY_DESERIALIZE_FAILED   // persisted state is corrupt
+
+// Config errors
+ErrorCodes.AK_CONFIG_INVALID        // missing or wrong type in config
+```
+
+## Catching and narrowing
+
+```ts
+import { AgentsKitError, AdapterError, ToolError, MemoryError, ErrorCodes } from '@agentskit/core'
+
+try {
+  await runtime.run(task)
+} catch (err) {
+  if (err instanceof AdapterError) {
+    console.error('Adapter problem:', err.hint)
+    console.error('Docs:', err.docsUrl)
+  } else if (err instanceof ToolError) {
+    if (err.code === ErrorCodes.AK_TOOL_NOT_FOUND) {
+      console.error(`Tool not registered: ${err.message}`)
+    } else {
+      // AK_TOOL_EXEC_FAILED — execution threw
+      console.error('Tool failed:', err.toString())
+      if (err.cause instanceof Error) {
+        console.error('Caused by:', err.cause.message)
+      }
+    }
+  } else if (err instanceof AgentsKitError) {
+    // any other AgentsKit-originating error
+    console.error(err.toString())
+  } else {
+    throw err // re-throw — not an AgentsKit error
+  }
+}
+```
+
+## Throwing in custom code
+
+When you author custom tools, memory adapters, or adapters, use the matching subclass so consumers can catch by type:
+
+```ts
+import { ToolError, MemoryError, ErrorCodes } from '@agentskit/core'
+
+// In a custom tool
+export const fetchRecord = {
+  name: 'fetch_record',
+  async execute(args: { id: string }) {
+    const record = await db.find(args.id)
+    if (!record) {
+      throw new ToolError({
+        code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+        message: `Record "${args.id}" not found in database`,
+        hint: 'Ensure the record exists before calling fetch_record.',
+        cause: undefined,
+      })
+    }
+    return record
+  },
+}
+
+// In a custom memory adapter
+async function load(): Promise<Message[]> {
+  try {
+    return JSON.parse(await fs.readFile(path, 'utf8'))
+  } catch (cause) {
+    throw new MemoryError({
+      code: ErrorCodes.AK_MEMORY_LOAD_FAILED,
+      message: `Failed to load messages from ${path}`,
+      hint: 'Check that the file exists and is valid JSON.',
+      cause,
+    })
+  }
+}
+```
+
+## Why not plain `Error`?
+
+| | Plain `Error` | `AgentsKitError` |
+|---|---|---|
+| Machine-readable identity | no | `code` |
+| Actionable fix in the error | no | `hint` |
+| Docs link in the error | no | `docsUrl` |
+| Original cause preserved | manual | `cause` |
+| Console output | stack trace | compiler-style diagnostic |
+
+Using plain `Error` in ecosystem packages forces every caller to parse `message` strings — brittle and untyped. `AgentsKitError` subclasses give callers a stable, typed interface to react to specific failure modes without string parsing.
+
+## See also
+
+[@agentskit/core exports](../packages/core) · [Tools](./tool) · [Memory](./memory) · [Adapters](./adapter)

--- a/apps/docs-next/content/docs/concepts/errors.mdx
+++ b/apps/docs-next/content/docs/concepts/errors.mdx
@@ -24,7 +24,7 @@ class AgentsKitError extends Error {
 error[AK_ADAPTER_MISSING]: No adapter provided
   --> Hint: Pass an adapter when creating the chat controller, e.g.
             createChatController({ adapter: openaiAdapter() })
-  --> Docs: https://agentskit.dev/docs/adapters
+  --> Docs: https://www.agentskit.io/docs/adapters
 ```
 
 ## Error subclasses

--- a/apps/docs-next/content/docs/concepts/memory.mdx
+++ b/apps/docs-next/content/docs/concepts/memory.mdx
@@ -55,10 +55,10 @@ export interface VectorMemory {
 
 ```ts
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 
 const store = fileVectorMemory({ path: './embeddings.json' })
-const embed = openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' })
+const embed = openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' })
 
 await store.store([
   { id: 'doc-1', content: 'AgentsKit core is 10KB gzipped.', embedding: await embed('AgentsKit core is 10KB gzipped.') },
@@ -80,9 +80,9 @@ A pure function. Same input + same model = same output. No randomness allowed.
 Built-in embedders:
 
 ```ts
-import { openaiEmbed, ollamaEmbed, geminiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder, ollamaEmbedder, geminiEmbedder } from '@agentskit/adapters'
 
-const embed = openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' })
+const embed = openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' })
 ```
 
 ## Built-in backends

--- a/apps/docs-next/content/docs/concepts/meta.json
+++ b/apps/docs-next/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["mental-model", "adapter", "tool", "skill", "memory", "retriever", "runtime"]
+  "pages": ["mental-model", "adapter", "tool", "skill", "memory", "retriever", "runtime", "errors"]
 }

--- a/apps/docs-next/content/docs/concepts/retriever.mdx
+++ b/apps/docs-next/content/docs/concepts/retriever.mdx
@@ -39,11 +39,11 @@ export interface RetrievedDocument {
 ```ts
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
   topK: 5,
 })
 

--- a/apps/docs-next/content/docs/concepts/runtime.mdx
+++ b/apps/docs-next/content/docs/concepts/runtime.mdx
@@ -92,12 +92,16 @@ This is a deliberate v1 simplification. ReAct-style per-step retrieval is possib
 ## Observers (read-only telemetry)
 
 ```ts
+import type { AgentEvent, Observer } from '@agentskit/core'
+
 const consoleObserver: Observer = {
-  onModelStart: (req) => console.log('→ model'),
-  onChunk: (chunk) => process.stdout.write(chunk.content ?? ''),
-  onToolStart: (call) => console.log(`  ⚙ ${call.name}(${JSON.stringify(call.args)})`),
-  onToolEnd: (call) => console.log(`  ✓ ${call.name}`),
-  onRunEnd: (result) => console.log(`done in ${result.steps} steps`),
+  name: 'console',
+  on(event: AgentEvent) {
+    if (event.type === 'llm:start') console.log('→ model')
+    if (event.type === 'llm:end') console.log(`done in ${event.durationMs}ms`)
+    if (event.type === 'tool:start') console.log(`  ⚙ ${event.name}(${JSON.stringify(event.args)})`)
+    if (event.type === 'tool:end') console.log(`  ✓ ${event.name}`)
+  },
 }
 
 createRuntime({ adapter, tools, observers: [consoleObserver] })

--- a/apps/docs-next/content/docs/concepts/tool.mdx
+++ b/apps/docs-next/content/docs/concepts/tool.mdx
@@ -63,7 +63,7 @@ createRuntime({
   tools: [
     webSearch(),
     ...filesystem({ basePath: './workspace' }),
-    shell({ allowedCommands: ['ls', 'cat'] }),
+    shell({ allowed: ['ls', 'cat'] }),
   ],
 })
 ```
@@ -123,6 +123,106 @@ const remoteTool: ToolDefinition = {
   // no execute — runs elsewhere
 }
 ```
+
+## Type-safe tools with `defineTool`
+
+Writing `ToolDefinition` objects directly types `args` as `Record<string, unknown>`, which means you must cast inside `execute`. The `defineTool` factory infers the args type directly from the JSON Schema so you get full type-safety and autocomplete at zero runtime cost.
+
+```ts
+import { defineTool } from '@agentskit/core'
+
+const createTask = defineTool({
+  name: 'create_task',
+  description: 'Create a task in the project tracker.',
+  schema: {
+    type: 'object',
+    properties: {
+      title:    { type: 'string' },
+      priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+      dueDate:  { type: 'string' },
+    },
+    required: ['title', 'priority'],
+  } as const,  // <-- required for inference
+  async execute(args) {
+    // args.title    → string           (required, inferred)
+    // args.priority → string           (required, inferred)
+    // args.dueDate  → string | undefined  (optional, inferred)
+    return await tracker.create({ title: args.title, priority: args.priority, dueDate: args.dueDate })
+  },
+})
+```
+
+The `as const` assertion on `schema` narrows the literal types so `InferSchemaType` can map them to TypeScript. Without it, `args` falls back to `Record<string, unknown>`.
+
+### Using the inferred type standalone
+
+```ts
+import type { InferSchemaType } from '@agentskit/core'
+
+const schema = {
+  type: 'object',
+  properties: {
+    query: { type: 'string' },
+    limit: { type: 'integer' },
+  },
+  required: ['query'],
+} as const
+
+type SearchArgs = InferSchemaType<typeof schema>
+// → { query: string; limit?: number }
+```
+
+## Zod-based tools with `defineZodTool`
+
+If you already use [Zod](https://zod.dev) in your project, `@agentskit/tools` ships `defineZodTool` — a factory that types `execute` args from a Zod schema and also validates them at runtime via `schema.parse`.
+
+Zod is **not bundled** — it must be installed as a peer dependency. You also supply the JSON Schema conversion yourself (e.g. via `zod-to-json-schema`), which keeps the Zod dependency fully optional.
+
+```ts
+import { z } from 'zod'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import { defineZodTool } from '@agentskit/tools'
+import type { JSONSchema7 } from 'json-schema'
+
+const sendEmail = defineZodTool({
+  name: 'send_email',
+  description: 'Send an email to a recipient.',
+  schema: z.object({
+    to:      z.string().email(),
+    subject: z.string(),
+    body:    z.string(),
+    cc:      z.string().email().optional(),
+  }),
+  toJsonSchema: (s) => zodToJsonSchema(s) as JSONSchema7,
+  async execute(args) {
+    // args.to      → string  (Zod-validated at runtime)
+    // args.subject → string
+    // args.body    → string
+    // args.cc      → string | undefined
+    await mailer.send({ to: args.to, subject: args.subject, body: args.body, cc: args.cc })
+    return { sent: true }
+  },
+})
+```
+
+`defineZodTool` wraps `execute` to call `schema.parse(args)` before your function runs. Invalid input raises a Zod `ZodError` — the runtime surfaces it as a tool error rather than crashing the agent.
+
+### Install peer dependencies
+
+```bash
+npm install zod zod-to-json-schema
+```
+
+### When to use `defineTool` vs `defineZodTool`
+
+| | `defineTool` | `defineZodTool` |
+|---|---|---|
+| **Deps** | none (core only) | zod + zod-to-json-schema |
+| **Runtime validation** | no | yes (via `schema.parse`) |
+| **Schema authoring** | JSON Schema (`as const`) | Zod API |
+| **JSON Schema for adapter** | you write it | converted automatically |
+
+Use `defineTool` when you want zero extra dependencies and are comfortable with JSON Schema. Use `defineZodTool` when Zod is already in your stack and you want runtime validation as a safety net.
 
 ## Common pitfalls
 

--- a/apps/docs-next/content/docs/data-layer/adapters.mdx
+++ b/apps/docs-next/content/docs/data-layer/adapters.mdx
@@ -236,6 +236,98 @@ Pass any embedder directly to `createRAG` — see [RAG](./rag.md).
 | Tool JSON errors | Provider-specific tool schema limits; trim `description` length or simplify schema. |
 | Embedder dimension mismatch | Vector index `dimensions` must match the model (e.g. 1536 for many OpenAI embeddings). |
 
+## Testing Adapters
+
+`@agentskit/adapters` ships three utilities for deterministic testing — no real LLM calls needed.
+
+### `mockAdapter`
+
+A deterministic adapter that returns pre-defined chunks. Supports static responses, request-aware functions, and sequenced multi-turn responses.
+
+```ts
+import { mockAdapter } from '@agentskit/adapters'
+
+// Static response
+const adapter = mockAdapter({
+  response: [
+    { type: 'text', content: 'Hello!' },
+    { type: 'done' },
+  ],
+})
+
+// Request-aware — inspect the incoming messages
+const adapter = mockAdapter({
+  response: req => {
+    const last = req.messages[req.messages.length - 1]?.content ?? ''
+    return [
+      { type: 'text', content: 'Echo: ' + last },
+      { type: 'done' },
+    ]
+  },
+})
+
+// Sequenced — first call returns "first", second returns "second"
+const adapter = mockAdapter({
+  response: [
+    [{ type: 'text', content: 'first' }, { type: 'done' }],
+    [{ type: 'text', content: 'second' }, { type: 'done' }],
+  ],
+})
+
+// Optional: capture every request for assertions
+const history: AdapterRequest[] = []
+const adapter = mockAdapter({ response: [...], history })
+// after chat.send(...):
+expect(history[0].messages[0].content).toBe('Hello')
+```
+
+Options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `response` | `StreamChunk[] \| ((req) => StreamChunk[]) \| Array<...>` | Chunks to yield per call |
+| `delayMs` | `number` | Milliseconds between yielded chunks (default: `0`) |
+| `history` | `AdapterRequest[]` | Array to push each incoming request into |
+
+### `recordingAdapter` and `inMemorySink`
+
+Wrap a real adapter to capture every turn into a fixture. Use in development to record real responses, then replay them in tests.
+
+```ts
+import { recordingAdapter, inMemorySink } from '@agentskit/adapters'
+import { anthropic } from '@agentskit/adapters'
+
+const sink = inMemorySink()
+const adapter = recordingAdapter(
+  anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  sink,
+)
+
+// Run your agent — turns are captured to sink.fixture
+await runtime.run('Hello')
+
+// Inspect or serialize the fixture
+console.log(JSON.stringify(sink.fixture, null, 2))
+```
+
+### `replayAdapter`
+
+Replay a previously recorded fixture. Each call maps 1:1 to a recorded turn by index (cycles when exhausted).
+
+```ts
+import { replayAdapter } from '@agentskit/adapters'
+import fixture from './my-fixture.json'
+
+const adapter = replayAdapter(fixture)
+// Now use adapter in useChat or createRuntime — no network calls
+```
+
+Typical workflow:
+
+1. In development, wrap the real adapter with `recordingAdapter` + `inMemorySink`.
+2. Save `sink.fixture` to a JSON file.
+3. In tests, load the JSON and pass it to `replayAdapter`.
+
 ## See also
 
 [Start here](../getting-started/read-this-first) · [Packages](../packages/overview) · [TypeDoc](pathname:///agentskit/api-reference/) (`@agentskit/adapters`) · [Memory](./memory) · [RAG](./rag) · [useChat](../hooks/use-chat) · [@agentskit/core](../packages/core)

--- a/apps/docs-next/content/docs/data-layer/rag.mdx
+++ b/apps/docs-next/content/docs/data-layer/rag.mdx
@@ -39,7 +39,7 @@ await rag.ingest([
 ])
 
 // Retrieve relevant context
-const docs = await rag.retrieve('How does AgentsKit work?', { topK: 3 })
+const docs = await rag.retrieve({ query: 'How does AgentsKit work?', messages: [] })
 ```
 
 ## With Runtime
@@ -56,23 +56,11 @@ const runtime = createRuntime({
 const result = await runtime.run('Explain the AgentsKit architecture')
 ```
 
-## With React
-
-```ts
-import { useRAGChat } from '@agentskit/rag'
-import { openai } from '@agentskit/adapters'
-
-const chat = useRAGChat({
-  adapter: openai({ apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o' }),
-  rag,
-})
-```
-
 ## Lifecycle: ingest vs retrieve
 
 1. **`ingest(documents)`** — splits text into chunks (see Chunking), embeds each chunk, upserts into `VectorMemory`. Duplicate `id`s are overwritten per backend semantics.
-2. **`retrieve(query, { topK, threshold? })`** — embeds the query, runs vector search, returns ranked chunks for prompting.
-3. **Runtime / `useRAGChat`** — call `retrieve` (or equivalent) on your behalf each turn so the model sees fresh context.
+2. **`retrieve({ query, messages })`** — embeds the query, runs vector search, returns ranked chunks for prompting.
+3. **Runtime** — calls `retrieve` on your behalf each turn so the model sees fresh context.
 
 Re-ingest when source documents change; there is no automatic filesystem watcher.
 
@@ -80,8 +68,7 @@ Re-ingest when source documents change; there is no automatic filesystem watcher
 
 | Export | Role |
 |--------|------|
-| `createRAG(config)` | Factory returning RAG instance with `ingest`, `retrieve`, and retriever-compatible surface |
-| `useRAGChat` | React hook: chat + automatic retrieval wiring |
+| `createRAG(config)` | Factory returning RAG instance with `ingest`, `retrieve`, and `search` |
 
 ## Chunking
 

--- a/apps/docs-next/content/docs/hooks/use-chat.mdx
+++ b/apps/docs-next/content/docs/hooks/use-chat.mdx
@@ -40,19 +40,34 @@ const chat = useChat(config)
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `adapter` | `AdapterFactory` | AI provider adapter |
-| `onMessage` | `(msg: Message) => void` | Called when assistant message completes |
-| `onError` | `(err: Error) => void` | Called on stream error |
+| `adapter` | `AdapterFactory` | AI provider adapter (required) |
+| `systemPrompt` | `string` | System prompt injected at the start of every request |
+| `temperature` | `number` | Model temperature (provider-dependent) |
+| `maxTokens` | `number` | Maximum tokens the model may generate |
+| `tools` | `ToolDefinition[]` | Executable tools the model can call |
+| `skills` | `SkillDefinition[]` | Ready-made skills (prompts + tool bundles) |
+| `memory` | `ChatMemory` | Persistent memory backend (e.g. `createLocalStorageMemory()`) |
+| `retriever` | `Retriever` | RAG retriever — context is injected before each request |
 | `initialMessages` | `Message[]` | Pre-populate chat history |
+| `onMessage` | `(msg: Message) => void` | Called when an assistant message completes |
+| `onError` | `(err: Error) => void` | Called on stream error |
+| `onToolCall` | `(toolCall: ToolCall, ctx: ToolCallHandlerContext) => void` | Called when the model invokes a tool |
+| `observers` | `Observer[]` | Lifecycle observers for logging / tracing |
 
 ### Returns
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `messages` | `Message[]` | All messages in the conversation |
-| `send` | `(text: string) => void` | Send a user message and stream response |
-| `stop` | `() => void` | Abort current stream |
-| `retry` | `() => void` | Retry last assistant message |
-| `status` | `StreamStatus` | Current streaming status |
+| `status` | `StreamStatus` | Current streaming status (`idle`, `streaming`, `error`) |
 | `input` | `string` | Current input value |
-| `setInput` | `(value: string) => void` | Update input value |
+| `error` | `Error \| null` | Last error, or `null` |
+| `send` | `(text: string) => Promise<void>` | Send a user message and stream the response |
+| `stop` | `() => void` | Abort the current stream |
+| `retry` | `() => Promise<void>` | Retry the last assistant message |
+| `edit` | `(messageId: string, newContent: string, opts?: EditOptions) => Promise<void>` | Edit a message by id; re-generates the response for user messages |
+| `regenerate` | `(messageId?: string) => Promise<void>` | Regenerate a specific assistant message (or the last one) |
+| `setInput` | `(value: string) => void` | Update the controlled input value |
+| `clear` | `() => Promise<void>` | Clear all messages and reset chat state |
+| `approve` | `(toolCallId: string) => Promise<void>` | Approve a pending tool call (human-in-the-loop) |
+| `deny` | `(toolCallId: string, reason?: string) => Promise<void>` | Deny a pending tool call with an optional reason |

--- a/apps/docs-next/content/docs/infrastructure/eval.mdx
+++ b/apps/docs-next/content/docs/infrastructure/eval.mdx
@@ -29,8 +29,9 @@ const results = await runEval({
 })
 
 console.log(results.accuracy)    // 0.92
-console.log(results.avgLatencyMs) // 1240
-console.log(results.totalTokens)  // 8432
+console.log(results.passed)      // 11
+console.log(results.failed)      // 1
+console.log(results.totalCases)  // 12
 ```
 
 ## Defining a Suite
@@ -97,16 +98,15 @@ const agent: AgentFn = async (input) => {
 
 ## Metrics
 
-`runEval` returns an `EvalReport` with the following fields:
+`runEval` returns an `EvalResult` with the following fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `accuracy` | `number` | Fraction of cases that passed (0–1) |
 | `passed` | `number` | Count of passing cases |
 | `failed` | `number` | Count of failing cases |
-| `avgLatencyMs` | `number` | Mean time per agent call |
-| `totalTokens` | `number \| null` | Combined input + output tokens (null if not reported) |
-| `cases` | `CaseResult[]` | Per-case breakdown |
+| `totalCases` | `number` | Total number of test cases run |
+| `results` | `CaseResult[]` | Per-case breakdown (input, output, passed, latencyMs, tokenUsage?, error?) |
 
 ## Error Handling
 

--- a/apps/docs-next/content/docs/infrastructure/observability.mdx
+++ b/apps/docs-next/content/docs/infrastructure/observability.mdx
@@ -126,6 +126,70 @@ const myObserver: Observer = {
 }
 ```
 
+## Token counting
+
+`@agentskit/observability` exports a standalone token-counting API that is useful for context-window budget checks, cost estimation, and trimming old messages before they exceed a model's limit.
+
+### Quick approximate count
+
+```ts
+import { approximateCounter, countTokens } from '@agentskit/observability'
+
+// Using the convenience function (falls back to approximateCounter)
+const total = await countTokens(messages)
+if (total > 120_000) trimOldMessages(messages)
+
+// Using the counter object directly (synchronous)
+const syncTotal = approximateCounter.count(messages)
+```
+
+`approximateCounter` uses a `chars / 4 + 4` heuristic (4 tokens per message for structural framing). It is zero-dependency, synchronous, and slightly over-estimates — which is intentional when checking budgets.
+
+### Per-message breakdown
+
+```ts
+import { countTokensDetailed } from '@agentskit/observability'
+
+const result = await countTokensDetailed(messages)
+// result.total       → number    (sum across all messages)
+// result.perMessage  → number[]  (token count per message, same order)
+
+result.perMessage.forEach((count, i) => {
+  console.log(`Message ${i}: ${count} tokens`)
+})
+```
+
+### Provider-specific counter with a real tokenizer
+
+The built-in heuristic is good for budget guards but not exact. Use `createProviderCounter` to plug in a real tokenizer (tiktoken, Anthropic's tokenizer, etc.) while conforming to the `TokenCounter` contract:
+
+```ts
+import { createProviderCounter, countTokens } from '@agentskit/observability'
+import { encoding_for_model } from 'tiktoken'
+
+const enc = encoding_for_model('gpt-4o')
+
+const tiktokenCounter = createProviderCounter({
+  name: 'tiktoken',
+  tokenize: (text) => [...enc.encode(text)],
+  // perMessageOverhead defaults to 4
+})
+
+const exact = await countTokens(messages, { counter: tiktokenCounter, model: 'gpt-4o' })
+console.log(`Exact token count: ${exact}`)
+```
+
+### API reference
+
+| Export | Description |
+|--------|-------------|
+| `approximateCounter` | `TokenCounter` using `chars/4` heuristic — zero deps, synchronous |
+| `countTokens(messages, options?)` | Async convenience: returns total token count; uses `approximateCounter` by default |
+| `countTokensDetailed(messages, options?)` | Same as `countTokens` but returns `{ total, perMessage }` |
+| `createProviderCounter(options)` | Factory — wraps any `tokenize` function in a `TokenCounter` |
+
+`countTokens` and `countTokensDetailed` accept an optional `{ counter, model }` options object — pass a counter from `createProviderCounter` for exact counts, or omit it for the fast heuristic.
+
 ## Troubleshooting
 
 | Issue | Mitigation |

--- a/apps/docs-next/content/docs/migrating/from-langchain.mdx
+++ b/apps/docs-next/content/docs/migrating/from-langchain.mdx
@@ -335,13 +335,13 @@ const res = await chain.invoke({ query: 'What was said about X?' })
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 await rag.ingest(texts.map((content, i) => ({ id: String(i), content })))

--- a/apps/docs-next/content/docs/migrating/from-langchain.mdx
+++ b/apps/docs-next/content/docs/migrating/from-langchain.mdx
@@ -335,13 +335,13 @@ const res = await chain.invoke({ query: 'What was said about X?' })
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 await rag.ingest(texts.map((content, i) => ({ id: String(i), content })))
@@ -415,11 +415,12 @@ const model = new ChatOpenAI({
 import type { Observer } from '@agentskit/core'
 
 const telemetry: Observer = {
-  onModelStart: () => console.log('→ model'),
-  onChunk: (chunk) => {
-    if (chunk.metadata?.usage) console.log('usage:', chunk.metadata.usage)
+  name: 'telemetry',
+  on(event) {
+    if (event.type === 'llm:start') console.log('→ model')
+    if (event.type === 'llm:end') console.log(`${event.durationMs}ms`, event.usage)
+    if (event.type === 'agent:step') console.log(`step ${event.step}: ${event.action}`)
   },
-  onRunEnd: (result) => console.log(`${result.steps} steps, ${result.durationMs}ms`),
 }
 
 createRuntime({ adapter, tools, observers: [telemetry] })

--- a/apps/docs-next/content/docs/migrating/from-mastra.mdx
+++ b/apps/docs-next/content/docs/migrating/from-mastra.mdx
@@ -174,13 +174,13 @@ const agent = new Agent({ name: 'assistant', memory, /* ... */ })
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { sqliteChatMemory, fileVectorMemory } from '@agentskit/memory'
 import { createRAG } from '@agentskit/rag'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
   topK: 3,
 })
 
@@ -212,13 +212,13 @@ RAG is just a `Retriever`. Any `Runtime` accepts one.
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 await rag.ingest([
@@ -316,10 +316,14 @@ OpenTelemetry auto-wired via `telemetry: { serviceName, enabled }` on the `Mastr
 import type { Observer } from '@agentskit/core'
 
 const telemetry: Observer = {
-  onModelStart: () => console.time('model'),
-  onRunEnd: (result) => {
-    console.timeEnd('model')
-    console.log(`${result.steps} steps, ${result.toolCalls.length} tools`)
+  name: 'telemetry',
+  on(event) {
+    if (event.type === 'llm:start') console.time('model')
+    if (event.type === 'llm:end') {
+      console.timeEnd('model')
+      console.log(`${event.durationMs}ms`)
+    }
+    if (event.type === 'agent:step') console.log(`step ${event.step}: ${event.action}`)
   },
 }
 

--- a/apps/docs-next/content/docs/migrating/from-mastra.mdx
+++ b/apps/docs-next/content/docs/migrating/from-mastra.mdx
@@ -174,13 +174,13 @@ const agent = new Agent({ name: 'assistant', memory, /* ... */ })
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { sqliteChatMemory, fileVectorMemory } from '@agentskit/memory'
 import { createRAG } from '@agentskit/rag'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
   topK: 3,
 })
 
@@ -212,13 +212,13 @@ RAG is just a `Retriever`. Any `Runtime` accepts one.
 
 ```ts
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 await rag.ingest([

--- a/apps/docs-next/content/docs/migrating/from-vercel-ai-sdk.mdx
+++ b/apps/docs-next/content/docs/migrating/from-vercel-ai-sdk.mdx
@@ -238,11 +238,11 @@ import { webSearch, filesystem } from '@agentskit/tools'
 import { sqliteChatMemory } from '@agentskit/memory'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 const runtime = createRuntime({

--- a/apps/docs-next/content/docs/migrating/from-vercel-ai-sdk.mdx
+++ b/apps/docs-next/content/docs/migrating/from-vercel-ai-sdk.mdx
@@ -238,11 +238,11 @@ import { webSearch, filesystem } from '@agentskit/tools'
 import { sqliteChatMemory } from '@agentskit/memory'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 const runtime = createRuntime({
@@ -295,13 +295,14 @@ const result = streamText({
 import type { Observer } from '@agentskit/core'
 
 const telemetry: Observer = {
-  onModelStart: () => console.time('model'),
-  onRunEnd: (result) => {
-    console.timeEnd('model')
-    console.log(`${result.steps} steps, ${result.toolCalls.length} tool calls`)
-  },
-  onChunk: (chunk) => {
-    if (chunk.metadata?.usage) console.log('usage:', chunk.metadata.usage)
+  name: 'telemetry',
+  on(event) {
+    if (event.type === 'llm:start') console.time('model')
+    if (event.type === 'llm:end') {
+      console.timeEnd('model')
+      console.log(`${event.durationMs}ms`, event.usage)
+    }
+    if (event.type === 'agent:step') console.log(`step ${event.step}: ${event.action}`)
   },
 }
 

--- a/apps/docs-next/content/docs/packages/core.mdx
+++ b/apps/docs-next/content/docs/packages/core.mdx
@@ -58,17 +58,34 @@ The controller merges system prompts, runs retrieval, dispatches tool calls, per
 
 | Export | Role |
 |--------|------|
-| `createInMemoryMemory`, `createLocalStorageMemory`, `createFileMemory` | Simple bundled memories for tests or demos |
+| `createInMemoryMemory`, `createLocalStorageMemory` | Simple bundled memories for tests or demos |
 | `serializeMessages` / `deserializeMessages` | Persistence helpers |
 | `createStaticRetriever`, `formatRetrievedDocuments` | Retriever helpers for static context |
 
 Heavy backends live in [`@agentskit/memory`](../data-layer/memory); vector stores and chunking in [`@agentskit/rag`](../data-layer/rag).
 
-### Configuration file
+### Error handling
 
 | Export | Role |
 |--------|------|
-| `loadConfig` | Load `AgentsKitConfig` from project (CLI / tooling) |
+| `AgentsKitError` | Base error class with `code`, `hint`, and `docsUrl` fields |
+| `AdapterError` | Thrown on adapter/stream failures; links to adapter docs |
+| `ToolError` | Thrown on tool lookup or execution failures; links to tool docs |
+| `MemoryError` | Thrown on memory load/save/deserialize failures; links to memory docs |
+| `ConfigError` | Thrown on invalid configuration; links to configuration docs |
+| `ErrorCodes` | `as const` map of all `AK_*` error code strings |
+
+See [Error handling](#error-handling-1) below for usage examples.
+
+### Tool factory
+
+| Export | Role |
+|--------|------|
+| `defineTool` | Create a `ToolDefinition` with automatic type inference from a JSON Schema |
+| `DefineToolConfig` | Config type for `defineTool` — schema is narrowed to a const type |
+| `InferSchemaType` | Utility type: extract TypeScript args type from a JSON Schema |
+
+See [Type-safe tools with `defineTool`](#type-safe-tools-with-definetool) below.
 
 ### Types (high level)
 
@@ -112,6 +129,161 @@ await chat.send('Hello')
 ```
 
 Prefer `useChat` in React apps — it wraps this pattern with hooks.
+
+## Error handling
+
+AgentsKit uses a **didactic error system** inspired by the Rust compiler. Every error carries a machine-readable `code`, a human-readable `hint`, and a direct link to the relevant docs — so you can fix the problem without searching.
+
+### Error classes
+
+```ts
+import {
+  AgentsKitError,
+  AdapterError,
+  ToolError,
+  MemoryError,
+  ConfigError,
+  ErrorCodes,
+} from '@agentskit/core'
+```
+
+| Class | Thrown when |
+|-------|-------------|
+| `AgentsKitError` | Base class — all errors extend this |
+| `AdapterError` | Adapter is missing or a stream call fails |
+| `ToolError` | A tool is not found or its `execute` throws |
+| `MemoryError` | Memory load, save, or deserialization fails |
+| `ConfigError` | Required configuration is absent or invalid |
+
+### Error shape
+
+```ts
+class AgentsKitError extends Error {
+  readonly code: string       // e.g. 'AK_TOOL_EXEC_FAILED'
+  readonly hint: string | undefined   // actionable fix
+  readonly docsUrl: string | undefined // direct docs link
+  readonly cause: unknown     // original error, if any
+}
+```
+
+`toString()` formats the error Rust-compiler-style:
+
+```
+error[AK_ADAPTER_MISSING]: No adapter provided
+  --> Hint: Pass an adapter when creating the chat controller, e.g.
+            createChatController({ adapter: openaiAdapter() })
+  --> Docs: https://agentskit.dev/docs/adapters
+```
+
+### ErrorCodes reference
+
+```ts
+import { ErrorCodes } from '@agentskit/core'
+
+ErrorCodes.AK_ADAPTER_MISSING          // adapter not provided
+ErrorCodes.AK_ADAPTER_STREAM_FAILED    // streaming call failed
+ErrorCodes.AK_TOOL_NOT_FOUND          // tool name not registered
+ErrorCodes.AK_TOOL_EXEC_FAILED        // execute() threw
+ErrorCodes.AK_MEMORY_LOAD_FAILED      // memory.load() failed
+ErrorCodes.AK_MEMORY_SAVE_FAILED      // memory.save() failed
+ErrorCodes.AK_MEMORY_DESERIALIZE_FAILED // corrupt persisted state
+ErrorCodes.AK_CONFIG_INVALID          // missing or bad config
+```
+
+### Catching and narrowing errors
+
+```ts
+import { AgentsKitError, ToolError, ErrorCodes } from '@agentskit/core'
+
+try {
+  await runtime.run(task)
+} catch (err) {
+  if (err instanceof ToolError) {
+    if (err.code === ErrorCodes.AK_TOOL_EXEC_FAILED) {
+      console.error('Tool execution failed:', err.hint)
+      console.error('See:', err.docsUrl)
+    }
+  } else if (err instanceof AgentsKitError) {
+    // any other AgentsKit-originating error
+    console.error(err.toString())
+  } else {
+    throw err // re-throw unknown errors
+  }
+}
+```
+
+### Throwing in custom tools
+
+When your own tool implementation encounters a recoverable error, wrap it for consistent formatting:
+
+```ts
+import { ToolError, ErrorCodes } from '@agentskit/core'
+
+export const myTool = {
+  name: 'fetch_record',
+  async execute(args: { id: string }) {
+    const record = await db.find(args.id)
+    if (!record) {
+      throw new ToolError({
+        code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+        message: `Record ${args.id} not found`,
+        hint: 'Check that the id exists before calling fetch_record.',
+        cause: undefined,
+      })
+    }
+    return record
+  },
+}
+```
+
+## Type-safe tools with `defineTool`
+
+The `defineTool` factory infers the TypeScript type of `execute`'s `args` parameter directly from the JSON Schema you provide — no manual type annotation needed.
+
+```ts
+import { defineTool } from '@agentskit/core'
+
+const getWeather = defineTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a city.',
+  schema: {
+    type: 'object',
+    properties: {
+      city: { type: 'string', description: 'City name, e.g. "Madrid"' },
+      units: { type: 'string', enum: ['metric', 'imperial'] },
+    },
+    required: ['city'],
+  } as const,
+  async execute(args) {
+    // args.city  → string   (required)
+    // args.units → string | undefined  (optional)
+    const res = await fetch(`https://wttr.in/${args.city}?format=j1`)
+    return res.json()
+  },
+})
+```
+
+The `as const` assertion on `schema` is what enables the inference — without it TypeScript cannot narrow the property types.
+
+### `InferSchemaType` utility type
+
+When you want to reference the inferred args type outside of `defineTool`, use `InferSchemaType`:
+
+```ts
+import type { InferSchemaType } from '@agentskit/core'
+
+const schema = {
+  type: 'object',
+  properties: {
+    query: { type: 'string' },
+    limit: { type: 'integer' },
+  },
+  required: ['query'],
+} as const
+
+type SearchArgs = InferSchemaType<typeof schema>
+// { query: string; limit?: number }
+```
 
 ## Troubleshooting
 

--- a/apps/docs-next/content/docs/packages/core.mdx
+++ b/apps/docs-next/content/docs/packages/core.mdx
@@ -172,7 +172,7 @@ class AgentsKitError extends Error {
 error[AK_ADAPTER_MISSING]: No adapter provided
   --> Hint: Pass an adapter when creating the chat controller, e.g.
             createChatController({ adapter: openaiAdapter() })
-  --> Docs: https://agentskit.dev/docs/adapters
+  --> Docs: https://www.agentskit.io/docs/adapters
 ```
 
 ### ErrorCodes reference

--- a/apps/docs-next/content/docs/recipes/code-reviewer.mdx
+++ b/apps/docs-next/content/docs/recipes/code-reviewer.mdx
@@ -50,7 +50,7 @@ Always:
 
 const runtime = createRuntime({
   adapter: anthropic({ apiKey: KEY, model: 'claude-sonnet-4-6' }),
-  tools: [shell({ allowedCommands: ['git', 'pnpm', 'cat'] }), ...filesystem({ basePath: '.' })],
+  tools: [shell({ allowed: ['git', 'pnpm', 'cat'] }), ...filesystem({ basePath: '.' })],
   maxSteps: 20,
 })
 

--- a/apps/docs-next/content/docs/recipes/cost-guarded-chat.mdx
+++ b/apps/docs-next/content/docs/recipes/cost-guarded-chat.mdx
@@ -27,28 +27,31 @@ function createCostGuard(budgetUsd: number, abort: () => void): Observer {
   let outputTokens = 0
 
   return {
-    onChunk(chunk) {
-      // Adapters put usage in metadata when they have it
-      const usage = chunk.metadata?.usage as
-        | { input_tokens?: number; output_tokens?: number }
-        | undefined
-      if (usage?.input_tokens) inputTokens += usage.input_tokens
-      if (usage?.output_tokens) outputTokens += usage.output_tokens
+    name: 'cost-guard',
+    on(event) {
+      if (event.type === 'llm:end') {
+        // AgentEvent carries usage totals at the end of each LLM call
+        if (event.usage) {
+          inputTokens += event.usage.promptTokens
+          outputTokens += event.usage.completionTokens
+        }
 
-      const costUsd =
-        (inputTokens / 1000) * PRICE_PER_1K.input +
-        (outputTokens / 1000) * PRICE_PER_1K.output
+        const costUsd =
+          (inputTokens / 1000) * PRICE_PER_1K.input +
+          (outputTokens / 1000) * PRICE_PER_1K.output
 
-      if (costUsd > budgetUsd) {
-        console.warn(`Cost budget exceeded: $${costUsd.toFixed(4)} > $${budgetUsd}`)
-        abort()
+        if (costUsd > budgetUsd) {
+          console.warn(`Cost budget exceeded: $${costUsd.toFixed(4)} > $${budgetUsd}`)
+          abort()
+        }
       }
-    },
-    onRunEnd() {
-      const total =
-        (inputTokens / 1000) * PRICE_PER_1K.input +
-        (outputTokens / 1000) * PRICE_PER_1K.output
-      console.log(`Run cost: $${total.toFixed(4)} (${inputTokens}+${outputTokens} tokens)`)
+
+      if (event.type === 'agent:step') {
+        const total =
+          (inputTokens / 1000) * PRICE_PER_1K.input +
+          (outputTokens / 1000) * PRICE_PER_1K.output
+        console.log(`Step ${event.step} running cost: $${total.toFixed(4)} (${inputTokens}+${outputTokens} tokens)`)
+      }
     },
   }
 }
@@ -76,13 +79,13 @@ try {
 
 ## Why this works
 
-- The Adapter contract (ADR 0001) doesn't require usage data, but every well-behaved adapter exposes it via `chunk.metadata.usage`
+- The `llm:end` event carries a `usage` field (`promptTokens`, `completionTokens`) when the adapter reports it — well-behaved adapters always do
 - Observers are read-only (RT9) — they can't mutate state, but they can call external APIs (like `controller.abort()`)
 - Aborting from an observer triggers the Runtime's clean abort path: stream stops, memory **does not save** (RT7+RT13), promise rejects with `AbortError`
 
 ## Tighten the recipe
 
-- **Per-tool budget** — observe `onToolStart` / `onToolEnd` and assign costs (e.g. web search at $0.005/call)
+- **Per-tool budget** — handle `tool:start` / `tool:end` events in the observer and assign costs (e.g. web search at $0.005/call)
 - **Per-user quota** — store cumulative spend in Redis keyed by user id; reject before `run()` if over
 - **Pre-check budget** with `tiktoken` count of the system prompt before sending
 - **Cost-aware adapter** — wrap the adapter to upgrade/downgrade model based on remaining budget

--- a/apps/docs-next/content/docs/recipes/eval-suite.mdx
+++ b/apps/docs-next/content/docs/recipes/eval-suite.mdx
@@ -11,26 +11,28 @@ A vitest test that runs your agent against a dataset of inputs + expected output
 npm install -D @agentskit/eval @agentskit/runtime @agentskit/adapters vitest
 ```
 
-## The dataset
+## The suite
 
-```ts title="evals/dataset.ts"
-export const dataset = [
-  {
-    input: 'What is 2 + 2?',
-    expected: '4',
-    score: (output: string) => (output.includes('4') ? 1 : 0),
-  },
-  {
-    input: 'Translate "hello" to French',
-    expected: 'bonjour',
-    score: (output: string) => (output.toLowerCase().includes('bonjour') ? 1 : 0),
-  },
-  {
-    input: 'In one word, what color is the sky?',
-    expected: 'blue',
-    score: (output: string) => (output.toLowerCase().includes('blue') ? 1 : 0),
-  },
-]
+```ts title="evals/suite.ts"
+import type { EvalSuite } from '@agentskit/eval'
+
+export const suite: EvalSuite = {
+  name: 'basic-regression',
+  cases: [
+    {
+      input: 'What is 2 + 2?',
+      expected: '4',
+    },
+    {
+      input: 'Translate "hello" to French',
+      expected: (output) => output.toLowerCase().includes('bonjour'),
+    },
+    {
+      input: 'In one word, what color is the sky?',
+      expected: (output) => output.toLowerCase().includes('blue'),
+    },
+  ],
+}
 ```
 
 ## The eval test
@@ -38,28 +40,30 @@ export const dataset = [
 ```ts title="evals/agent.eval.test.ts"
 import { describe, it, expect } from 'vitest'
 import { runEval } from '@agentskit/eval'
+import type { AgentFn } from '@agentskit/eval'
 import { createRuntime } from '@agentskit/runtime'
 import { openai } from '@agentskit/adapters'
-import { dataset } from './dataset'
+import { suite } from './suite'
 
 const runtime = createRuntime({
   adapter: openai({ apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o-mini' }),
   systemPrompt: 'Be terse and direct.',
 })
 
+const agent: AgentFn = async (input) => {
+  const result = await runtime.run(input)
+  return result.content
+}
+
 describe('agent quality', () => {
-  it('passes the regression dataset above 80%', async () => {
-    const report = await runEval({
-      runtime,
-      dataset,
-      concurrency: 4,
-    })
+  it('passes the regression suite above 80%', async () => {
+    const report = await runEval({ agent, suite })
 
-    console.log(`Score: ${(report.averageScore * 100).toFixed(1)}%`)
-    console.log(`Total cost: ~$${report.estimatedCost?.toFixed(4) ?? '?'}`)
-    console.log(`p95 latency: ${report.p95LatencyMs}ms`)
+    console.log(`Score: ${(report.accuracy * 100).toFixed(1)}%`)
+    console.log(`Passed: ${report.passed} / ${report.totalCases}`)
+    console.log(`Failed: ${report.failed}`)
 
-    expect(report.averageScore).toBeGreaterThanOrEqual(0.8)
+    expect(report.accuracy).toBeGreaterThanOrEqual(0.8)
   }, 60_000)
 })
 ```

--- a/apps/docs-next/content/docs/recipes/pdf-qa.mdx
+++ b/apps/docs-next/content/docs/recipes/pdf-qa.mdx
@@ -15,7 +15,7 @@ npm install @agentskit/runtime @agentskit/adapters @agentskit/rag @agentskit/mem
 
 ```ts title="ask-pdf.ts"
 import { createRuntime } from '@agentskit/runtime'
-import { openai, openaiEmbed } from '@agentskit/adapters'
+import { openai, openaiEmbedder } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
 import { readFileSync } from 'node:fs'
@@ -53,7 +53,7 @@ function chunk(text: string, size = 500): string[] {
 // 3. Index in-memory (per-PDF, ephemeral)
 const rag = createRAG({
   store: fileVectorMemory({ path: `./.cache/${pdfPath}.embeddings.json` }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
   topK: 4,
 })
 

--- a/apps/docs-next/content/docs/recipes/rag-chat.mdx
+++ b/apps/docs-next/content/docs/recipes/rag-chat.mdx
@@ -16,13 +16,13 @@ npm install @agentskit/react @agentskit/adapters @agentskit/rag @agentskit/memor
 ```ts title="scripts/ingest.ts"
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 const docs = readdirSync('./content').map(name => ({
@@ -45,12 +45,12 @@ import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
 import { openai } from '@agentskit/adapters'
 import { createRAG } from '@agentskit/rag'
 import { fileVectorMemory } from '@agentskit/memory'
-import { openaiEmbed } from '@agentskit/adapters'
+import { openaiEmbedder } from '@agentskit/adapters'
 import '@agentskit/react/theme'
 
 const rag = createRAG({
   store: fileVectorMemory({ path: './embeddings.json' }),
-  embed: openaiEmbed({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
 })
 
 export default function Chat() {

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -71,6 +71,49 @@ const rag = createRAG({
 | [@agentskit/rag](https://www.npmjs.com/package/@agentskit/rag) | `createRAG` + embedders |
 | [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Vector + chat memory backends |
 
+## Testing Adapters
+
+Three built-in utilities let you test agents without hitting a real LLM.
+
+### `mockAdapter` — deterministic responses
+
+```ts
+import { mockAdapter } from '@agentskit/adapters'
+
+const adapter = mockAdapter({
+  response: [
+    { type: 'text', content: 'Hello!' },
+    { type: 'done' },
+  ],
+})
+```
+
+Pass a function to make responses request-aware, or pass an array of arrays to return different chunks on each call (sequenced mode). Use the optional `history` array to capture every request for assertions.
+
+### `recordingAdapter` + `inMemorySink` — capture real calls
+
+```ts
+import { recordingAdapter, inMemorySink, anthropic } from '@agentskit/adapters'
+
+const sink = inMemorySink()
+const adapter = recordingAdapter(
+  anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  sink,
+)
+// Runs the real LLM and captures every chunk to sink.fixture
+```
+
+### `replayAdapter` — replay captured fixtures
+
+```ts
+import { replayAdapter } from '@agentskit/adapters'
+import fixture from './fixture.json'
+
+const adapter = replayAdapter(fixture) // no network calls
+```
+
+Typical workflow: record once in dev → commit JSON fixture → replay in CI.
+
 ## Contributors
 
 <a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,6 +47,71 @@ console.log(controller.getState().messages)
 - Event emitter for `AgentEvent` streams — observability hooks attach here
 - Dual CJS/ESM output, strict TypeScript, no `any`
 
+## Error handling
+
+AgentsKit ships a **didactic error system** inspired by the Rust compiler. Every error includes a `code`, a `hint` for the fix, and a `docsUrl` — no more vague `"Something went wrong"` messages.
+
+```ts
+import {
+  AgentsKitError,
+  AdapterError,
+  ToolError,
+  MemoryError,
+  ConfigError,
+  ErrorCodes,
+} from '@agentskit/core'
+
+try {
+  await runtime.run(task)
+} catch (err) {
+  if (err instanceof ToolError) {
+    // err.code     → 'AK_TOOL_EXEC_FAILED'
+    // err.hint     → actionable suggestion
+    // err.docsUrl  → https://agentskit.dev/docs/tools
+    console.error(err.toString())
+    // error[AK_TOOL_EXEC_FAILED]: ...
+    //   --> Hint: ...
+    //   --> Docs: https://agentskit.dev/docs/tools
+  }
+}
+```
+
+Available error codes (via `ErrorCodes`):
+
+| Code | Thrown by |
+|------|-----------|
+| `AK_ADAPTER_MISSING` | adapter not provided to the controller |
+| `AK_ADAPTER_STREAM_FAILED` | streaming call to the provider fails |
+| `AK_TOOL_NOT_FOUND` | requested tool name is not registered |
+| `AK_TOOL_EXEC_FAILED` | `execute()` throws |
+| `AK_MEMORY_LOAD_FAILED` | memory.load() fails |
+| `AK_MEMORY_SAVE_FAILED` | memory.save() fails |
+| `AK_MEMORY_DESERIALIZE_FAILED` | persisted state is corrupt |
+| `AK_CONFIG_INVALID` | required config is missing or wrong type |
+
+## Type-safe tools with `defineTool`
+
+`defineTool` infers the TypeScript type of `execute`'s `args` parameter from the JSON Schema — no manual casting.
+
+```ts
+import { defineTool } from '@agentskit/core'
+
+const greet = defineTool({
+  name: 'greet',
+  schema: {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+  } as const,   // as const is required for inference
+  execute(args) {
+    // args.name → string  (inferred, not cast)
+    return `Hello, ${args.name}!`
+  },
+})
+```
+
+Use `InferSchemaType<typeof schema>` to reference the inferred type elsewhere in your codebase.
+
 ## Ecosystem
 
 | Package | Role |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,11 +67,11 @@ try {
   if (err instanceof ToolError) {
     // err.code     → 'AK_TOOL_EXEC_FAILED'
     // err.hint     → actionable suggestion
-    // err.docsUrl  → https://agentskit.dev/docs/tools
+    // err.docsUrl  → https://www.agentskit.io/docs/tools
     console.error(err.toString())
     // error[AK_TOOL_EXEC_FAILED]: ...
     //   --> Hint: ...
-    //   --> Docs: https://agentskit.dev/docs/tools
+    //   --> Docs: https://www.agentskit.io/docs/tools
   }
 }
 ```

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,7 +2,7 @@
 // AgentsKit didactic error system — Rust-compiler-style helpful errors
 // ---------------------------------------------------------------------------
 
-const DOCS_BASE = 'https://agentskit.dev/docs'
+const DOCS_BASE = 'https://www.agentskit.io/docs'
 
 /**
  * Format an error for display, Rust-compiler style.
@@ -12,7 +12,7 @@ const DOCS_BASE = 'https://agentskit.dev/docs'
  * error[AK_ADAPTER_MISSING]: No adapter provided
  *   --> Hint: Pass an adapter when creating the chat controller, e.g.
  *             createChatController({ adapter: openaiAdapter() })
- *   --> Docs: https://agentskit.dev/docs/adapters
+ *   --> Docs: https://www.agentskit.io/docs/adapters
  * ```
  */
 function formatError(code: string, message: string, hint?: string, docsUrl?: string): string {

--- a/packages/core/tests/errors.test.ts
+++ b/packages/core/tests/errors.test.ts
@@ -162,6 +162,6 @@ describe('toString() multiline format', () => {
     expect(lines).toHaveLength(3)
     expect(lines[0]).toBe('error[AK_TOOL_NOT_FOUND]: Tool "webSearch" not found or has no execute function')
     expect(lines[1]).toBe('  --> Hint: Register the tool in your ChatConfig, e.g. { tools: [webSearchTool] }.')
-    expect(lines[2]).toMatch(/^ {2}--> Docs: https:\/\/agentskit\.dev\/docs\/tools$/)
+    expect(lines[2]).toMatch(/^ {2}--> Docs: https:\/\/www\.agentskit\.io\/docs\/tools$/)
   })
 })

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -43,11 +43,60 @@ const result = await runtime.run('Analyze sales data in ./data/sales.csv')
 // Every step is now logged and traced automatically
 ```
 
+## Token counting
+
+`@agentskit/observability` includes a zero-dependency token counting API — useful for context-window budget checks, cost estimation, and message trimming.
+
+### Fast approximate count
+
+```ts
+import { countTokens, approximateCounter } from '@agentskit/observability'
+
+// async convenience function
+const total = await countTokens(messages)
+if (total > 120_000) trimOldMessages(messages)
+
+// synchronous via counter directly
+const syncTotal = approximateCounter.count(messages)
+```
+
+Uses the `chars / 4 + 4 per message` heuristic. Slightly over-estimates — intentional for budget guards.
+
+### Per-message breakdown
+
+```ts
+import { countTokensDetailed } from '@agentskit/observability'
+
+const { total, perMessage } = await countTokensDetailed(messages)
+// total      → number
+// perMessage → number[]  (one entry per message, same order)
+```
+
+### Exact count with a real tokenizer
+
+```ts
+import { createProviderCounter, countTokens } from '@agentskit/observability'
+import { encoding_for_model } from 'tiktoken'
+
+const enc = encoding_for_model('gpt-4o')
+const tiktokenCounter = createProviderCounter({
+  name: 'tiktoken',
+  tokenize: (text) => [...enc.encode(text)],
+})
+
+const exact = await countTokens(messages, { counter: tiktokenCounter, model: 'gpt-4o' })
+```
+
+`createProviderCounter` wraps any `tokenize(text, model?)` function in a `TokenCounter` that conforms to the core contract and supports `countDetailed` automatically.
+
 ## Features
 
 - `consoleLogger({ format })` — pretty-print or JSON structured logs for local dev
 - `langsmith({ apiKey })` — send runs to LangSmith for tracing and evaluation
 - OpenTelemetry OTLP exporter — ship traces to any OTEL-compatible backend
+- `approximateCounter` — zero-dep synchronous token counter (`chars/4` heuristic)
+- `countTokens` / `countTokensDetailed` — async token counting with optional custom counter
+- `createProviderCounter` — factory to wrap tiktoken or any tokenizer in the `TokenCounter` contract
 - Observer interface: `{ name: string, on(event: AgentEvent): void }` — write custom observers in minutes
 - Attaches via `observers` array on `createRuntime` — zero changes to agent logic
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -48,11 +48,50 @@ console.log(result.content)
 
 Tools are plain `ToolDefinition` values — register them in [`useChat`](https://www.npmjs.com/package/@agentskit/react) the same way as in `createRuntime`.
 
+## Authoring tools with `defineZodTool`
+
+If you use [Zod](https://zod.dev), `@agentskit/tools` ships `defineZodTool` — a factory that:
+
+- Types `execute` args from a Zod schema (full TypeScript inference)
+- Validates args at runtime via `schema.parse` before calling your function
+- Converts the Zod schema to JSON Schema for the adapter via a user-supplied `toJsonSchema` callback
+
+Zod and `zod-to-json-schema` are **not bundled** — install them as peer dependencies.
+
+```bash
+npm install zod zod-to-json-schema
+```
+
+```ts
+import { z } from 'zod'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import { defineZodTool } from '@agentskit/tools'
+import type { JSONSchema7 } from 'json-schema'
+
+const lookupUser = defineZodTool({
+  name: 'lookup_user',
+  description: 'Look up a user by ID.',
+  schema: z.object({
+    userId: z.string().uuid(),
+    includeProfile: z.boolean().optional(),
+  }),
+  toJsonSchema: (s) => zodToJsonSchema(s) as JSONSchema7,
+  async execute(args) {
+    // args.userId         → string  (UUID-validated by Zod at runtime)
+    // args.includeProfile → boolean | undefined
+    return await db.users.findById(args.userId, { profile: args.includeProfile })
+  },
+})
+```
+
+For tools without Zod, use `defineTool` from `@agentskit/core` with a JSON Schema `as const`.
+
 ## Features
 
 - `webSearch()` — live web search for agents
 - `filesystem({ basePath })` — sandboxed read, write, list, delete
 - `shell({ allowed })` — shell execution with command allowlist
+- `defineZodTool` — Zod-based tool factory with runtime validation and type inference
 - All tools follow `ToolDefinition` contract (ADR 0002) — parallel tool calling supported
 - Works in `@agentskit/runtime`, `useChat`, or any custom loop
 


### PR DESCRIPTION
## Summary

Comprehensive docs audit fix — 27 files changed across all priority levels.

### P1 — Won't compile (fixed)
- **Observer API**: 5 files updated from old method-based `onChunk/onRunEnd` to correct `{ name, on(event) }` interface
- **Embedder names**: 7 files fixed `openaiEmbed` → `openaiEmbedder` (+ gemini, ollama)
- **Eval recipe**: rewrote to use actual `{ agent, suite }` API and correct `EvalResult` fields
- **RAG docs**: fixed `retrieve()` signature, removed nonexistent `useRAGChat`

### P2 — Wrong but less critical (fixed)
- `shell({ allowedCommands })` → `shell({ allowed })` in 2 files
- Removed `createFileMemory`/`loadConfig` from core exports table
- **New feature docs added**:
  - `AgentsKitError` — full concept page + core.mdx exports + README
  - `defineTool()` — concept guide + core.mdx section
  - `defineZodTool()` — concept guide + tools README
  - Token counter — observability docs + README

### P3 — Gaps (fixed)
- `ToolConfirmation` added to components overview
- `mockAdapter`/`recordingAdapter`/`replayAdapter` documented in adapters page + README
- `useChat` docs expanded with 9 missing config options and 5 missing return values
- Removed nonexistent `writer` skill from CLAUDE.md and core-v1 announcement

## Test plan
- [x] Docs site builds successfully
- [ ] All code examples match actual API signatures