### PR TITLE
fix(cli): improve doctor UX — smarter checks + branded output

### DIFF
--- a/.changeset/doctor-ux-fix.md
+++ b/.changeset/doctor-ux-fix.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": patch
+---
+
+Improve `agentskit doctor` UX: skip network checks for unconfigured providers, fix reachability endpoints (Anthropic, Gemini), group output into sections with branded header and verdict

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -129,10 +129,10 @@ export async function checkProviderEnv(provider: string): Promise<CheckResult> {
   const value = process.env[envKey]
   if (!value) {
     return {
-      status: 'fail',
+      status: 'skip',
       name: `${provider} API key`,
-      detail: `${envKey} is not set`,
-      fix: `export ${envKey}=...`,
+      detail: `${envKey} not set`,
+      fix: `export ${envKey}=... (only needed if you use ${provider})`,
     }
   }
   if (value.length < 16) {
@@ -153,7 +153,13 @@ export async function checkProviderReachable(
 ): Promise<CheckResult> {
   const url = PROVIDER_REACH_URLS[provider]
   if (!url) {
-    return { status: 'skip', name: `${provider} reachable`, detail: 'No reachability check for this provider' }
+    return { status: 'skip', name: `${provider} reachable`, detail: 'No reachability check configured' }
+  }
+
+  // Skip reachability if no API key is set for keyed providers
+  const envKey = PROVIDER_ENV_KEYS[provider]
+  if (envKey && !process.env[envKey]) {
+    return { status: 'skip', name: `${provider} reachable`, detail: 'Skipped — no API key configured' }
   }
 
   const controller = new AbortController()
@@ -162,13 +168,20 @@ export async function checkProviderReachable(
     const res = await fetchImpl(url, {
       method: 'GET',
       signal: controller.signal,
-      // No auth — we just want to confirm DNS + network reach.
     })
-    // 401/403 means the host is reachable; anything else status-wise also confirms reach.
+    // 200-299 = healthy; 401/403 = reachable but auth issue (still pass);
+    // 404+ = reachable but endpoint may have changed (warn)
+    if (res.status >= 200 && res.status < 400) {
+      return { status: 'pass', name: `${provider} reachable`, detail: `${url} → ${res.status} OK` }
+    }
+    if (res.status === 401 || res.status === 403) {
+      return { status: 'pass', name: `${provider} reachable`, detail: `${url} → ${res.status} (auth needed, host reachable)` }
+    }
     return {
-      status: 'pass',
+      status: 'warn',
       name: `${provider} reachable`,
       detail: `${url} → HTTP ${res.status}`,
+      fix: 'Host reachable but returned unexpected status — check provider docs',
     }
   } catch (err) {
     const reason = (err as Error).name === 'AbortError' ? `timeout after ${timeoutMs}ms` : (err as Error).message
@@ -253,43 +266,76 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorRepo
 // ============================================================================
 
 const ICON: Record<CheckStatus, string> = {
-  pass: '✓',
-  warn: '!',
-  fail: '✗',
-  skip: '·',
+  pass: '✔',
+  warn: '⚠',
+  fail: '✘',
+  skip: '○',
 }
 
 export function renderReport(report: DoctorReport, opts: { color?: boolean } = {}): string {
   const color = opts.color ?? true
   const c = (code: string, text: string) => (color ? `\x1b[${code}m${text}\x1b[0m` : text)
   const colorFor: Record<CheckStatus, (t: string) => string> = {
-    pass: t => c('32', t),
-    warn: t => c('33', t),
-    fail: t => c('31', t),
-    skip: t => c('90', t),
+    pass: t => c('32', t),   // green
+    warn: t => c('33', t),   // yellow
+    fail: t => c('31', t),   // red
+    skip: t => c('90', t),   // dim
   }
 
   const lines: string[] = []
+
+  // Header
   lines.push('')
-  lines.push(c('1', 'agentskit doctor'))
+  lines.push(`  ${c('1;36', '⚡ AgentsKit Doctor')}`)
+  lines.push(`  ${c('90', '─'.repeat(50))}`)
   lines.push('')
+
+  // Group results by category
+  const groups: Record<string, CheckResult[]> = {
+    'Environment': [],
+    'Providers': [],
+    'Network': [],
+  }
   for (const r of report.results) {
-    const icon = colorFor[r.status](ICON[r.status])
-    const name = r.name.padEnd(28)
-    const detail = r.detail ? c('90', r.detail) : ''
-    lines.push(`  ${icon}  ${name} ${detail}`)
-    if (r.fix && (r.status === 'fail' || r.status === 'warn')) {
-      lines.push(`     ${c('90', '↳ ' + r.fix)}`)
+    if (r.name.includes('reachable')) {
+      groups['Network'].push(r)
+    } else if (r.name.includes('API key')) {
+      groups['Providers'].push(r)
+    } else {
+      groups['Environment'].push(r)
     }
   }
-  lines.push('')
-  const summary = [
-    `${report.pass} pass`,
-    report.warn > 0 ? colorFor.warn(`${report.warn} warn`) : `${report.warn} warn`,
-    report.fail > 0 ? colorFor.fail(`${report.fail} fail`) : `${report.fail} fail`,
-    `${report.skip} skip`,
-  ].join('  ·  ')
-  lines.push(`  ${c('1', 'Summary:')} ${summary}`)
+
+  for (const [group, results] of Object.entries(groups)) {
+    if (results.length === 0) continue
+    lines.push(`  ${c('1', group)}`)
+    for (const r of results) {
+      const icon = colorFor[r.status](ICON[r.status])
+      const name = r.name.padEnd(28)
+      const detail = r.detail ? c('90', r.detail) : ''
+      lines.push(`    ${icon}  ${name} ${detail}`)
+      if (r.fix && r.status !== 'pass') {
+        lines.push(`       ${c('90', '↳ ' + r.fix)}`)
+      }
+    }
+    lines.push('')
+  }
+
+  // Summary bar
+  lines.push(`  ${c('90', '─'.repeat(50))}`)
+  const parts: string[] = []
+  if (report.pass > 0) parts.push(colorFor.pass(`${report.pass} passed`))
+  if (report.warn > 0) parts.push(colorFor.warn(`${report.warn} warnings`))
+  if (report.fail > 0) parts.push(colorFor.fail(`${report.fail} failed`))
+  if (report.skip > 0) parts.push(colorFor.skip(`${report.skip} skipped`))
+  lines.push(`  ${parts.join('  ·  ')}`)
+
+  // Verdict
+  if (report.fail === 0) {
+    lines.push(`  ${c('32', '✔ Ready to build agents.')}`)
+  } else {
+    lines.push(`  ${c('31', '✘ Fix the issues above before continuing.')}`)
+  }
   lines.push('')
   return lines.join('\n')
 }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -31,8 +31,8 @@ const PROVIDER_ENV_KEYS: Record<string, string> = {
 
 const PROVIDER_REACH_URLS: Record<string, string> = {
   openai: 'https://api.openai.com/v1/models',
-  anthropic: 'https://api.anthropic.com',
-  gemini: 'https://generativelanguage.googleapis.com',
+  anthropic: 'https://api.anthropic.com/v1/messages',
+  gemini: 'https://generativelanguage.googleapis.com/v1beta/models',
   ollama: 'http://localhost:11434/api/tags',
 }
 
@@ -174,8 +174,8 @@ export async function checkProviderReachable(
     if (res.status >= 200 && res.status < 400) {
       return { status: 'pass', name: `${provider} reachable`, detail: `${url} → ${res.status} OK` }
     }
-    if (res.status === 401 || res.status === 403) {
-      return { status: 'pass', name: `${provider} reachable`, detail: `${url} → ${res.status} (auth needed, host reachable)` }
+    if (res.status === 401 || res.status === 403 || res.status === 405) {
+      return { status: 'pass', name: `${provider} reachable`, detail: `${url} → ${res.status} (host reachable)` }
     }
     return {
       status: 'warn',

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -23,10 +23,10 @@ describe('checkNodeVersion', () => {
 })
 
 describe('checkProviderEnv', () => {
-  it('fails when the env key is unset', async () => {
+  it('skips when the env key is unset', async () => {
     delete process.env.OPENAI_API_KEY
     const result = await checkProviderEnv('openai')
-    expect(result.status).toBe('fail')
+    expect(result.status).toBe('skip')
     expect(result.fix).toContain('OPENAI_API_KEY')
   })
 
@@ -49,7 +49,12 @@ describe('checkProviderEnv', () => {
 })
 
 describe('checkProviderReachable', () => {
-  it('reports pass when fetch resolves', async () => {
+  beforeEach(() => {
+    // Reachability checks require the API key to be set
+    process.env.OPENAI_API_KEY = 'sk-test-key-for-reach'
+  })
+
+  it('reports pass when fetch resolves with 401', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({ status: 401 } as Response)
     const result = await checkProviderReachable('openai', fakeFetch as unknown as typeof fetch)
     expect(result.status).toBe('pass')
@@ -66,6 +71,14 @@ describe('checkProviderReachable', () => {
   it('skips providers with no URL configured', async () => {
     const result = await checkProviderReachable('demo')
     expect(result.status).toBe('skip')
+  })
+
+  it('skips when no API key is set', async () => {
+    delete process.env.OPENAI_API_KEY
+    const fakeFetch = vi.fn()
+    const result = await checkProviderReachable('openai', fakeFetch as unknown as typeof fetch)
+    expect(result.status).toBe('skip')
+    expect(fakeFetch).not.toHaveBeenCalled()
   })
 
   it('treats an abort as a fail with timeout context', async () => {
@@ -119,11 +132,11 @@ describe('renderReport', () => {
       },
       { color: false },
     )
-    expect(out).toContain('agentskit doctor')
+    expect(out).toContain('AgentsKit Doctor')
     expect(out).toContain('Node version')
     expect(out).toContain('OPENAI_API_KEY')
     expect(out).toContain('export OPENAI_API_KEY=...')
-    expect(out).toContain('1 pass')
-    expect(out).toContain('1 fail')
+    expect(out).toContain('1 passed')
+    expect(out).toContain('1 failed')
   })
 })


### PR DESCRIPTION
## Summary
- Skip network reachability when no API key is configured (no more false 401/404 greens)
- Unconfigured provider keys → "skipped" not "failed"
- HTTP 401/403 = reachable (pass), HTTP 404+ = warn
- Grouped output: Environment → Providers → Network
- Branded header `⚡ AgentsKit Doctor` with summary bar and verdict

## Before
All providers checked regardless of config. 401 shows as green pass. Flat ungrouped list.

## After
Only configured providers get network checks. Clean grouped output with verdict.

## Test plan
- [x] `doctor --no-network` shows clean skip for unset keys
- [x] Build passes
- [x] Type check passes