### PR TITLE
fix(ci): fix YAML syntax in workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6        with:
+      - uses: actions/setup-node@v6
+        with:
           node-version: 22
           cache: pnpm
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6        with:
+      - uses: actions/setup-node@v6
+        with:
           node-version: 22
           cache: pnpm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6        with:
+      - uses: actions/setup-node@v6
+        with:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary
The pnpm/action-setup merge joined `actions/setup-node@v6` and `with:` on the same line in 3 workflow files, breaking CI.

Fixes: ci.yml, docs.yml, release.yml

## Test plan
- [ ] CI passes (this PR itself validates ci.yml)