### PR TITLE
feat: agent tool-feedback loop + richer chat UX

### DIFF
--- a/.changeset/agent-loop-and-ux.md
+++ b/.changeset/agent-loop-and-ux.md
@@ -1,0 +1,39 @@
+---
+"@agentskit/core": minor
+"@agentskit/adapters": minor
+"@agentskit/ink": minor
+"@agentskit/cli": patch
+---
+
+feat(core): bounded agent loop that feeds tool results back to the model
+
+- `createChatController` now iterates after tool calls complete so the LLM
+  produces a final answer using the results. Configurable via
+  `ChatConfig.maxToolIterations` (default 5). Retrieval only runs on the
+  first turn of each user message.
+- `Message.toolCallId` added for `role: 'tool'` messages.
+- `buildMessage` forwards `toolCallId`.
+
+feat(adapters): serialize tool calls for OpenAI-compatible providers
+
+`toProviderMessages` now emits OpenAI-spec `tool_calls` on assistant
+messages and `tool_call_id` on tool-role messages, so follow-up turns
+carry full context to the model.
+
+feat(ink): richer terminal chat UX
+
+- Animated braille spinner in `ThinkingIndicator`
+- Role icons + color-coded badges in `Message`; tool-role rendered compact
+- `ToolCallView` — status-colored border, live spinner, previews, labels
+- `InputBar` — cyan prompt glyph, blinking cursor, context-aware hint
+- New `StatusHeader` with provider/model/tools/mode summary
+- New `MarkdownText` component (uses `marked` + `marked-terminal`),
+  renders tables, code fences, lists, emphasis, links
+- `Message` auto-renders markdown for assistant content (opt-out via
+  `markdown={false}`)
+
+feat(cli): agent-loop step badges + polished chat layout
+
+Groups messages into turns, renders `↻ step N/M` badge when the agent
+loop ran multiple tool-feedback iterations. Uses the new `StatusHeader`
+and passes `expanded` to `ToolCallView` so tool results are visible.

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -1,10 +1,30 @@
 import type { AdapterRequest, Message, StreamChunk, StreamSource } from '@agentskit/core'
 
 export function toProviderMessages(messages: Message[]) {
-  return messages.map(message => ({
-    role: message.role,
-    content: message.content,
-  }))
+  return messages.map(message => {
+    if (message.role === 'tool') {
+      return {
+        role: 'tool' as const,
+        content: message.content,
+        tool_call_id: message.toolCallId,
+      }
+    }
+    if (message.role === 'assistant' && message.toolCalls && message.toolCalls.length > 0) {
+      return {
+        role: 'assistant' as const,
+        content: message.content || null,
+        tool_calls: message.toolCalls.map(tc => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: {
+            name: tc.name,
+            arguments: typeof tc.args === 'string' ? tc.args : JSON.stringify(tc.args ?? {}),
+          },
+        })),
+      }
+    }
+    return { role: message.role, content: message.content }
+  })
 }
 
 export async function* readSSELines(stream: ReadableStream): AsyncIterableIterator<string> {

--- a/packages/cli/src/chat.tsx
+++ b/packages/cli/src/chat.tsx
@@ -1,6 +1,15 @@
 import React, { useMemo } from 'react'
 import { Box, Text } from 'ink'
-import { ChatContainer, InputBar, Message, ThinkingIndicator, ToolCallView, useChat } from '@agentskit/ink'
+import {
+  ChatContainer,
+  InputBar,
+  Message,
+  StatusHeader,
+  ThinkingIndicator,
+  ToolCallView,
+  useChat,
+} from '@agentskit/ink'
+import type { Message as ChatMessage, ToolCall } from '@agentskit/core'
 import { resolveChatProvider } from './providers'
 import { resolveTools, resolveMemory, skillRegistry } from './resolve'
 
@@ -19,11 +28,40 @@ export interface ChatCommandOptions {
   agentsKitConfig?: AgentsKitConfig
 }
 
+/**
+ * Group messages into user turns. A "turn" starts at a user message and
+ * contains every assistant/tool message that followed until the next user
+ * input. Each assistant message inside a turn is one agent-loop iteration,
+ * so we can render a `step i/n` badge.
+ */
+function groupIntoTurns(messages: ChatMessage[]): ChatMessage[][] {
+  const turns: ChatMessage[][] = []
+  let current: ChatMessage[] = []
+  for (const message of messages) {
+    if (message.role === 'user') {
+      if (current.length > 0) turns.push(current)
+      current = [message]
+    } else if (message.role === 'system') {
+      // System messages live outside turns for display purposes.
+      if (current.length > 0) turns.push(current)
+      turns.push([message])
+      current = []
+    } else {
+      current.push(message)
+    }
+  }
+  if (current.length > 0) turns.push(current)
+  return turns
+}
+
 export function ChatApp(options: ChatCommandOptions) {
-  const adapter = useMemo(
-    () => resolveChatProvider(options).adapter,
-    [options.apiKey, options.baseUrl, options.model, options.provider]
-  )
+  const runtime = useMemo(() => resolveChatProvider(options), [
+    options.apiKey,
+    options.baseUrl,
+    options.model,
+    options.provider,
+  ])
+
   const memory = useMemo(
     () => resolveMemory(options.memoryBackend, options.memoryPath ?? '.agentskit-history.json'),
     [options.memoryPath, options.memoryBackend]
@@ -38,33 +76,58 @@ export function ChatApp(options: ChatCommandOptions) {
   }, [options.skill])
 
   const chat = useChat({
-    adapter,
+    adapter: runtime.adapter,
     memory,
     systemPrompt: options.system,
     tools: tools.length > 0 ? tools : undefined,
     skills,
   })
 
+  const turns = useMemo(() => groupIntoTurns(chat.messages), [chat.messages])
+  const toolNames = options.tools ? options.tools.split(',').map(s => s.trim()).filter(Boolean) : []
+
   return (
     <Box flexDirection="column" gap={1}>
-      <Text bold color="cyan">
-        AgentsKit CLI
-      </Text>
-      <Text dimColor>
-        Press Enter to send. Live providers use env vars or --api-key, and demo mode stays available for zero-config usage.
-      </Text>
+      <StatusHeader
+        provider={runtime.provider}
+        model={runtime.model}
+        mode={runtime.mode}
+        tools={toolNames}
+        messageCount={chat.messages.length}
+      />
+
       <ChatContainer>
-        {chat.messages.map(message => (
-          <Box key={message.id} flexDirection="column" marginBottom={1}>
-            <Message message={message} />
-            {message.toolCalls?.map(toolCall => (
-              <ToolCallView key={toolCall.id} toolCall={toolCall} />
-            ))}
-          </Box>
-        ))}
+        {turns.map((turn, turnIdx) => {
+          const assistantSteps = turn.filter(m => m.role === 'assistant').length
+          let stepIndex = 0
+          return (
+            <Box key={`turn-${turnIdx}`} flexDirection="column" gap={1}>
+              {turn.map(message => {
+                const showStep = message.role === 'assistant' && assistantSteps > 1
+                if (showStep) stepIndex++
+                return (
+                  <Box key={message.id} flexDirection="column">
+                    {showStep ? (
+                      <Text dimColor>↻ step {stepIndex}/{assistantSteps}</Text>
+                    ) : null}
+                    <Message message={message} />
+                    {message.toolCalls?.map((toolCall: ToolCall) => (
+                      <ToolCallView key={toolCall.id} toolCall={toolCall} expanded />
+                    ))}
+                  </Box>
+                )
+              })}
+            </Box>
+          )
+        })}
       </ChatContainer>
-      <ThinkingIndicator visible={chat.status === 'streaming'} />
-      <InputBar chat={chat} placeholder="Type a message and press Enter..." />
+
+      <ThinkingIndicator
+        visible={chat.status === 'streaming'}
+        label={toolNames.length > 0 ? 'agent working' : 'thinking'}
+      />
+
+      <InputBar chat={chat} placeholder="Type a message and press Enter…" />
     </Box>
   )
 }

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -209,7 +209,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
   const buildAdapterRequest = async (messages: Message[], text: string): Promise<AdapterRequest> => {
     await ensureSkillsActivated()
     const withSystem = mergeSystemMessages(messages, effectiveSystemPrompt)
-    const retrievedDocuments = config.retriever
+    const retrievedDocuments = config.retriever && text
       ? await config.retriever.retrieve({ query: text, messages })
       : []
     const retrievalMessage = buildRetrievalMessage(formatRetrievedDocuments(retrievedDocuments))
@@ -226,12 +226,21 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
     }
   }
 
-  const startStream = async (messages: Message[], assistantId: string, text: string) => {
-    const request = await buildAdapterRequest(messages, text)
+  const DEFAULT_MAX_TOOL_ITERATIONS = 5
+
+  const isCallSettled = (status: ToolCall['status']): boolean =>
+    status === 'complete' || status === 'error'
+
+  const isCallPending = (status: ToolCall['status']): boolean =>
+    status === 'pending' || status === 'running' || status === 'requires_confirmation'
+
+  const runAdapterTurn = async (assistantId: string, queryText: string): Promise<boolean> => {
+    const request = await buildAdapterRequest(state.messages, queryText)
     source = config.adapter.createSource(request)
 
     const streamStart = Date.now()
     let firstTokenEmitted = false
+    let errored = false
 
     emitter.emit({ type: 'llm:start', messageCount: request.messages.length })
 
@@ -241,10 +250,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
           emitter.emit({ type: 'llm:first-token', latencyMs: Date.now() - streamStart })
           firstTokenEmitted = true
         }
-        setAssistantMessage(assistantId, message => ({
-          ...message,
-          content: accumulated,
-        }))
+        setAssistantMessage(assistantId, message => ({ ...message, content: accumulated }))
       },
       onReasoning(accumulated) {
         setAssistantMessage(assistantId, message => ({
@@ -262,25 +268,94 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
         }))
       },
       onError(error) {
+        errored = true
         setAssistantMessage(assistantId, message => ({ ...message, status: 'error' }))
         setState(current => ({ ...current, status: 'error', error }))
         emitter.emit({ type: 'error', error })
         config.onError?.(error)
       },
       onDone(accumulatedText) {
-        let completedMessage: Message | undefined
-        setState(current => {
-          const updatedMessages = current.messages.map(message => {
-            if (message.id !== assistantId) return message
-            completedMessage = { ...message, status: 'complete' }
-            return completedMessage
-          })
-          return { ...current, messages: updatedMessages, status: 'idle', error: null }
-        })
         emitter.emit({ type: 'llm:end', content: accumulatedText, durationMs: Date.now() - streamStart })
-        if (completedMessage) config.onMessage?.(completedMessage)
       },
     })
+
+    return !errored
+  }
+
+  const finalizeAssistant = (assistantId: string) => {
+    let completedMessage: Message | undefined
+    setState(current => ({
+      ...current,
+      messages: current.messages.map(message => {
+        if (message.id !== assistantId) return message
+        completedMessage = { ...message, status: 'complete' as const }
+        return completedMessage
+      }),
+      status: 'idle',
+      error: null,
+    }))
+    if (completedMessage) config.onMessage?.(completedMessage)
+  }
+
+  const appendToolResultsAndContinue = (assistantId: string, settledCalls: ToolCall[]): string => {
+    const toolResultMessages = settledCalls.map(call =>
+      buildMessage({
+        role: 'tool',
+        content: call.result ?? call.error ?? '',
+        toolCallId: call.id,
+      })
+    )
+    const nextAssistant = buildMessage({ role: 'assistant', content: '', status: 'streaming' })
+
+    setState(current => ({
+      ...current,
+      messages: [
+        ...current.messages.map(message =>
+          message.id === assistantId ? { ...message, status: 'complete' as const } : message
+        ),
+        ...toolResultMessages,
+        nextAssistant,
+      ],
+      status: 'streaming',
+      error: null,
+    }))
+
+    return nextAssistant.id
+  }
+
+  /**
+   * Runs one `send` — an LLM turn, plus any follow-up turns needed to feed
+   * completed tool results back to the model. Loop stops when the model
+   * produces a final answer (no new tool calls), any tool is still pending
+   * confirmation, an error fires, or the iteration cap is hit.
+   */
+  const startStream = async (assistantId: string, text: string) => {
+    const maxIterations = config.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS
+    let currentAssistantId = assistantId
+    let queryText = text
+
+    for (let iteration = 0; iteration < maxIterations; iteration++) {
+      const ok = await runAdapterTurn(currentAssistantId, queryText)
+      if (!ok) return // error handler already set state to 'error'
+
+      const assistant = state.messages.find(message => message.id === currentAssistantId)
+      const calls = assistant?.toolCalls ?? []
+      const hasPending = calls.some(call => isCallPending(call.status))
+      const settled = calls.filter(call => isCallSettled(call.status))
+
+      // No calls, or something still awaiting confirmation — stop here and
+      // let the caller (e.g. approve/deny) drive the next step if needed.
+      if (settled.length === 0 || hasPending) {
+        finalizeAssistant(currentAssistantId)
+        return
+      }
+
+      currentAssistantId = appendToolResultsAndContinue(currentAssistantId, settled)
+      queryText = '' // skip retrieval on follow-up turns; user query already consumed
+    }
+
+    // Iteration cap reached — finalize whatever the last assistant turn produced.
+    finalizeAssistant(currentAssistantId)
   }
 
   return {
@@ -303,7 +378,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
         error: null,
       }))
 
-      await startStream([...state.messages], assistantMessage.id, text)
+      await startStream(assistantMessage.id, text)
     },
     stop() {
       source?.abort()
@@ -327,7 +402,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
         error: null,
       }))
 
-      await startStream([...withoutLast, replacementAssistant], replacementAssistant.id, lastUser.content)
+      await startStream(replacementAssistant.id, lastUser.content)
     },
     async edit(messageId, newContent, opts = {}) {
       const messages = state.messages
@@ -372,7 +447,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
         error: null,
       }))
 
-      await startStream(nextMessages, replacementAssistant.id, newContent)
+      await startStream(replacementAssistant.id, newContent)
     },
     async regenerate(messageId) {
       const messages = state.messages
@@ -409,7 +484,7 @@ export function createChatController(initialConfig: ChatConfig): ChatController 
         error: null,
       }))
 
-      await startStream(nextMessages, replacementAssistant.id, messages[userIndex].content)
+      await startStream(replacementAssistant.id, messages[userIndex].content)
     },
     setInput(value) {
       setState(current => ({ ...current, input: value }))

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -45,6 +45,7 @@ export function buildMessage(params: {
   content: string
   status?: MessageStatus
   metadata?: Record<string, unknown>
+  toolCallId?: string
 }): Message {
   return {
     id: generateId('msg'),
@@ -52,6 +53,7 @@ export function buildMessage(params: {
     content: params.content,
     status: params.status ?? 'complete',
     metadata: params.metadata,
+    toolCallId: params.toolCallId,
     createdAt: new Date(),
   }
 }

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -18,6 +18,13 @@ export interface ChatConfig {
   memory?: ChatMemory
   retriever?: Retriever
   initialMessages?: Message[]
+  /**
+   * Maximum number of LLM ↔ tool feedback turns per `send()`.
+   * After a tool call, the controller feeds the result back to the model
+   * so it can continue reasoning. This caps that loop to prevent runaway
+   * cost if a model keeps requesting tools. Default: 5. Set to 1 to disable.
+   */
+  maxToolIterations?: number
   onMessage?: (message: Message) => void
   onError?: (error: Error) => void
   onToolCall?: (toolCall: ToolCall, context: ToolCallHandlerContext) => MaybePromise<void>

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -9,6 +9,7 @@ export interface Message {
   content: string
   status: MessageStatus
   toolCalls?: ToolCall[]
+  toolCallId?: string
   metadata?: Record<string, unknown>
   createdAt: Date
 }

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -45,12 +45,15 @@
   },
   "dependencies": {
     "@agentskit/core": "workspace:*",
-    "ink": "^7.0.0"
+    "ink": "^7.0.0",
+    "marked": "^18.0.1",
+    "marked-terminal": "^7.3.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0"
   },
   "devDependencies": {
+    "@types/marked-terminal": "^6.1.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",

--- a/packages/ink/src/components/InputBar.tsx
+++ b/packages/ink/src/components/InputBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Text, useInput } from 'ink'
 import type { ChatReturn } from '@agentskit/core'
 
@@ -8,9 +8,19 @@ export interface InputBarProps {
   disabled?: boolean
 }
 
+const CURSOR_MS = 500
+
 export function InputBar({ chat, placeholder = 'Type a message...', disabled = false }: InputBarProps) {
+  const isBusy = disabled || chat.status === 'streaming'
+  const [cursorOn, setCursorOn] = useState(true)
+
+  useEffect(() => {
+    const id = setInterval(() => setCursorOn(v => !v), CURSOR_MS)
+    return () => clearInterval(id)
+  }, [])
+
   useInput((input, key) => {
-    if (disabled || chat.status === 'streaming') return
+    if (isBusy) return
 
     if (key.return) {
       if (chat.input.trim()) {
@@ -29,12 +39,24 @@ export function InputBar({ chat, placeholder = 'Type a message...', disabled = f
     }
   })
 
+  const hint = isBusy
+    ? chat.status === 'streaming'
+      ? 'streaming response… press Ctrl+C to abort'
+      : 'input disabled'
+    : placeholder
+
   return (
     <Box flexDirection="column">
-      <Text dimColor>{placeholder}</Text>
-      <Text color={disabled ? 'gray' : 'white'}>
-        &gt; {chat.input}
-      </Text>
+      <Text dimColor>{hint}</Text>
+      <Box>
+        <Text color={isBusy ? 'gray' : 'cyan'} bold>
+          ❯{' '}
+        </Text>
+        <Text color={isBusy ? 'gray' : 'white'}>
+          {chat.input}
+          {!isBusy && cursorOn ? <Text inverse> </Text> : null}
+        </Text>
+      </Box>
     </Box>
   )
 }

--- a/packages/ink/src/components/MarkdownText.tsx
+++ b/packages/ink/src/components/MarkdownText.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react'
+import { Text } from 'ink'
+import { Marked } from 'marked'
+import { markedTerminal } from 'marked-terminal'
+
+export interface MarkdownTextProps {
+  content: string
+}
+
+/**
+ * One shared Marked instance — creating it per render forces the terminal
+ * renderer to re-register its hooks every time.
+ */
+const marked = new Marked()
+marked.use(
+  markedTerminal({
+    width: 80,
+    reflowText: true,
+    tab: 2,
+  }) as unknown as Parameters<typeof marked.use>[0]
+)
+
+/**
+ * Renders markdown (incl. tables, code blocks, links) to ANSI-styled text.
+ * Delegates parsing to `marked` and terminal rendering to `marked-terminal`;
+ * Ink's `<Text>` passes ANSI escapes through untouched.
+ */
+export function MarkdownText({ content }: MarkdownTextProps) {
+  const rendered = useMemo(() => {
+    try {
+      const output = marked.parse(content, { async: false }) as string
+      return output.replace(/\n+$/, '')
+    } catch {
+      return content
+    }
+  }, [content])
+
+  return <Text>{rendered}</Text>
+}

--- a/packages/ink/src/components/Message.tsx
+++ b/packages/ink/src/components/Message.tsx
@@ -1,33 +1,64 @@
 import React from 'react'
 import { Box, Text } from 'ink'
-import type { Message as MessageType } from '@agentskit/core'
+import type { Message as MessageType, MessageRole } from '@agentskit/core'
+import { MarkdownText } from './MarkdownText'
 
 export interface MessageProps {
   message: MessageType
+  /**
+   * Render assistant message content as markdown (headings, lists, code,
+   * bold, italic, links). Default: `true`. Set to `false` to render as
+   * plain text — useful for tool output or raw logs.
+   */
+  markdown?: boolean
 }
 
-function roleColor(role: MessageType['role']) {
-  switch (role) {
-    case 'assistant':
-      return 'cyan'
-    case 'user':
-      return 'green'
-    case 'system':
-      return 'yellow'
-    case 'tool':
-      return 'magenta'
-    default:
-      return 'white'
+const ROLE_META: Record<MessageRole, { icon: string; label: string; color: string }> = {
+  user: { icon: '❯', label: 'you', color: 'green' },
+  assistant: { icon: '✦', label: 'assistant', color: 'cyan' },
+  system: { icon: '◆', label: 'system', color: 'yellow' },
+  tool: { icon: '⚙', label: 'tool', color: 'magenta' },
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return `${text.slice(0, max)}…`
+}
+
+export function Message({ message, markdown = true }: MessageProps) {
+  const meta = ROLE_META[message.role] ?? ROLE_META.assistant
+  const isStreaming = message.status === 'streaming'
+
+  // Tool-role messages are raw results passed back to the model; render compact.
+  if (message.role === 'tool') {
+    return (
+      <Box flexDirection="column" marginLeft={2}>
+        <Text dimColor>
+          <Text color={meta.color}>{meta.icon} </Text>
+          tool result
+        </Text>
+        <Text dimColor>{truncate(message.content, 400)}</Text>
+      </Box>
+    )
   }
-}
 
-export function Message({ message }: MessageProps) {
+  const shouldRenderMarkdown = markdown && message.role === 'assistant' && !!message.content
+
   return (
     <Box flexDirection="column">
-      <Text bold color={roleColor(message.role)}>
-        {message.role.toUpperCase()}
-      </Text>
-      <Text>{message.content || (message.status === 'streaming' ? '...' : '')}</Text>
+      <Box>
+        <Text color={meta.color} bold>
+          {meta.icon} {meta.label}
+        </Text>
+        {isStreaming ? <Text dimColor>  · streaming</Text> : null}
+      </Box>
+      {message.content ? (
+        shouldRenderMarkdown ? (
+          <MarkdownText content={message.content} />
+        ) : (
+          <Text>{message.content}</Text>
+        )
+      ) : null}
     </Box>
   )
 }

--- a/packages/ink/src/components/StatusHeader.tsx
+++ b/packages/ink/src/components/StatusHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+
+export interface StatusHeaderProps {
+  title?: string
+  provider?: string
+  model?: string
+  tools?: string[]
+  mode?: 'demo' | 'live'
+  messageCount?: number
+}
+
+export function StatusHeader({
+  title = 'AgentsKit CLI',
+  provider,
+  model,
+  tools,
+  mode,
+  messageCount,
+}: StatusHeaderProps) {
+  const segments: Array<{ label: string; value: string; color?: string }> = []
+
+  if (provider) segments.push({ label: 'provider', value: provider, color: 'cyan' })
+  if (model) segments.push({ label: 'model', value: model, color: 'magenta' })
+  if (mode) segments.push({ label: 'mode', value: mode, color: mode === 'live' ? 'green' : 'yellow' })
+  if (tools && tools.length > 0) {
+    segments.push({ label: 'tools', value: tools.join(','), color: 'blue' })
+  }
+  if (typeof messageCount === 'number') {
+    segments.push({ label: 'msgs', value: String(messageCount), color: 'gray' })
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text color="cyan" bold>
+        ✦ {title}
+      </Text>
+      {segments.length > 0 ? (
+        <Box>
+          {segments.map((seg, i) => (
+            <Box key={seg.label}>
+              {i > 0 ? <Text dimColor>  ·  </Text> : null}
+              <Text dimColor>{seg.label}=</Text>
+              <Text color={seg.color ?? 'white'}>{seg.value}</Text>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  )
+}

--- a/packages/ink/src/components/ThinkingIndicator.tsx
+++ b/packages/ink/src/components/ThinkingIndicator.tsx
@@ -1,12 +1,33 @@
-import React from 'react'
-import { Text } from 'ink'
+import React, { useEffect, useState } from 'react'
+import { Box, Text } from 'ink'
 
 export interface ThinkingIndicatorProps {
   visible: boolean
   label?: string
 }
 
-export function ThinkingIndicator({ visible, label = 'Thinking...' }: ThinkingIndicatorProps) {
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+const FRAME_MS = 80
+
+export function ThinkingIndicator({ visible, label = 'Thinking' }: ThinkingIndicatorProps) {
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    if (!visible) return
+    const id = setInterval(() => {
+      setFrame(f => (f + 1) % SPINNER_FRAMES.length)
+    }, FRAME_MS)
+    return () => clearInterval(id)
+  }, [visible])
+
   if (!visible) return null
-  return <Text color="yellow">{label}</Text>
+
+  return (
+    <Box>
+      <Text color="cyan">{SPINNER_FRAMES[frame]} </Text>
+      <Text dimColor italic>
+        {label}
+      </Text>
+    </Box>
+  )
 }

--- a/packages/ink/src/components/ToolCallView.tsx
+++ b/packages/ink/src/components/ToolCallView.tsx
@@ -1,24 +1,77 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Text } from 'ink'
-import type { ToolCall } from '@agentskit/core'
+import type { ToolCall, ToolCallStatus } from '@agentskit/core'
 
 export interface ToolCallViewProps {
   toolCall: ToolCall
   expanded?: boolean
+  /** Max characters rendered from result/error. Default 500. */
+  resultPreviewChars?: number
+  /** Max characters rendered from args. Default 120. */
+  argsPreviewChars?: number
 }
 
-export function ToolCallView({ toolCall, expanded = false }: ToolCallViewProps) {
+const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+const STATUS_META: Record<ToolCallStatus, { icon: string; color: string; label: string }> = {
+  pending: { icon: '○', color: 'gray', label: 'pending' },
+  running: { icon: SPINNER[0], color: 'cyan', label: 'running' },
+  complete: { icon: '✓', color: 'green', label: 'complete' },
+  error: { icon: '✗', color: 'red', label: 'error' },
+  requires_confirmation: { icon: '?', color: 'yellow', label: 'requires_confirmation' },
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return `${text.slice(0, max)}…`
+}
+
+function previewArgs(args: unknown, max: number): string {
+  try {
+    const serialized = typeof args === 'string' ? args : JSON.stringify(args)
+    return truncate(serialized ?? '', max)
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+export function ToolCallView({
+  toolCall,
+  expanded = false,
+  resultPreviewChars = 500,
+  argsPreviewChars = 120,
+}: ToolCallViewProps) {
+  const meta = STATUS_META[toolCall.status] ?? STATUS_META.pending
+  const [frame, setFrame] = useState(0)
+  const isRunning = toolCall.status === 'running'
+
+  useEffect(() => {
+    if (!isRunning) return
+    const id = setInterval(() => setFrame(f => (f + 1) % SPINNER.length), 80)
+    return () => clearInterval(id)
+  }, [isRunning])
+
+  const icon = isRunning ? SPINNER[frame] : meta.icon
+
   return (
-    <Box flexDirection="column" borderStyle="round" paddingX={1}>
-      <Text color="magenta">
-        Tool: {toolCall.name} [{toolCall.status}]
-      </Text>
+    <Box flexDirection="column" borderStyle="round" borderColor={meta.color} paddingX={1}>
+      <Box>
+        <Text color={meta.color} bold>
+          {icon} {toolCall.name}
+        </Text>
+        <Text dimColor>  · {meta.label}</Text>
+      </Box>
+
       {expanded ? (
-        <>
-          <Text dimColor>{JSON.stringify(toolCall.args)}</Text>
-          {toolCall.result ? <Text>{toolCall.result}</Text> : null}
-          {toolCall.error ? <Text color="red">{toolCall.error}</Text> : null}
-        </>
+        <Box flexDirection="column" marginTop={0}>
+          <Text dimColor>args: {previewArgs(toolCall.args, argsPreviewChars)}</Text>
+          {toolCall.result ? (
+            <Text>{truncate(toolCall.result, resultPreviewChars)}</Text>
+          ) : null}
+          {toolCall.error ? (
+            <Text color="red">{truncate(toolCall.error, resultPreviewChars)}</Text>
+          ) : null}
+        </Box>
       ) : null}
     </Box>
   )

--- a/packages/ink/src/components/index.ts
+++ b/packages/ink/src/components/index.ts
@@ -3,11 +3,15 @@ export { Message } from './Message'
 export { InputBar } from './InputBar'
 export { ToolCallView } from './ToolCallView'
 export { ThinkingIndicator } from './ThinkingIndicator'
+export { StatusHeader } from './StatusHeader'
+export { MarkdownText } from './MarkdownText'
+export { ToolConfirmation } from './ToolConfirmation'
 
 export type { ChatContainerProps } from './ChatContainer'
 export type { MessageProps } from './Message'
 export type { InputBarProps } from './InputBar'
 export type { ToolCallViewProps } from './ToolCallView'
 export type { ThinkingIndicatorProps } from './ThinkingIndicator'
-export { ToolConfirmation } from "./ToolConfirmation"
-export type { ToolConfirmationProps } from "./ToolConfirmation"
+export type { StatusHeaderProps } from './StatusHeader'
+export type { MarkdownTextProps } from './MarkdownText'
+export type { ToolConfirmationProps } from './ToolConfirmation'

--- a/packages/ink/src/index.ts
+++ b/packages/ink/src/index.ts
@@ -44,6 +44,8 @@ export {
   InputBar,
   ToolCallView,
   ThinkingIndicator,
+  StatusHeader,
+  MarkdownText,
   ToolConfirmation,
 } from './components'
 
@@ -53,5 +55,7 @@ export type {
   InputBarProps,
   ToolCallViewProps,
   ThinkingIndicatorProps,
+  StatusHeaderProps,
+  MarkdownTextProps,
   ToolConfirmationProps,
 } from './components'

--- a/packages/ink/tests/integration.test.tsx
+++ b/packages/ink/tests/integration.test.tsx
@@ -115,9 +115,9 @@ describe('Ink chat integration', () => {
     rerender(<ChatApp adapter={adapter} />)
 
     const output = lastFrame()
-    expect(output).toContain('USER')
+    expect(output).toContain('you')
     expect(output).toContain('Hello from AgentsKit!')
-    expect(output).toContain('ASSISTANT')
+    expect(output).toContain('assistant')
   })
 
   it('shows thinking indicator during streaming', async () => {
@@ -136,16 +136,17 @@ describe('Ink chat integration', () => {
     const { lastFrame, rerender } = render(<ChatApp adapter={adapter} />)
 
     await typeText('go')
+    rerender(<ChatApp adapter={adapter} />)
     pressEnter()
-    await delay(100)
+    await delay(200)
     rerender(<ChatApp adapter={adapter} />)
 
-    expect(lastFrame()).toContain('Thinking...')
+    expect(lastFrame()).toContain('Thinking')
 
     resolveStream?.()
-    await delay(100)
+    await delay(200)
     rerender(<ChatApp adapter={adapter} />)
 
-    expect(lastFrame()).not.toContain('Thinking...')
+    expect(lastFrame()).not.toContain('Thinking')
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,97 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 10.33.0
-        version: 10.33.0
-      pnpm:
-        specifier: 10.33.0
-        version: 10.33.0
-
-packages:
-
-  '@pnpm/exe@10.33.0':
-    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@10.33.0':
-    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/linux-x64@10.33.0':
-    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/macos-x64@10.33.0':
-    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/win-arm64@10.33.0':
-    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
-
-  '@pnpm/win-x64@10.33.0':
-    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
-    cpu: [x64]
-    os: [win32]
-    hasBin: true
-
-  pnpm@10.33.0:
-    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@10.33.0':
-    optionalDependencies:
-      '@pnpm/linux-arm64': 10.33.0
-      '@pnpm/linux-x64': 10.33.0
-      '@pnpm/macos-arm64': 10.33.0
-      '@pnpm/macos-x64': 10.33.0
-      '@pnpm/win-arm64': 10.33.0
-      '@pnpm/win-x64': 10.33.0
-
-  '@pnpm/linux-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/linux-x64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-x64@10.33.0':
-    optional: true
-
-  '@pnpm/win-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/win-x64@10.33.0':
-    optional: true
-
-  pnpm@10.33.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -402,7 +308,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -513,7 +419,16 @@ importers:
       ink:
         specifier: ^7.0.0
         version: 7.0.0(@types/react@19.2.14)(react@19.2.5)
+      marked:
+        specifier: ^18.0.1
+        version: 18.0.1
+      marked-terminal:
+        specifier: ^7.3.0
+        version: 7.3.0(marked@18.0.1)
     devDependencies:
+      '@types/marked-terminal':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -534,7 +449,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/memory:
     dependencies:
@@ -4151,6 +4066,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/cardinal@2.1.1':
+    resolution: {integrity: sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -4315,6 +4233,9 @@ packages:
 
   '@types/localtunnel@2.0.4':
     resolution: {integrity: sha512-7WM5nlEfEKp8MpwthPa2utdy+f/7ZBxMPzu8qw6EijFFTcpzh5CXgt2YoncxWAZNOPNieMofXCKFudtDEY4bag==}
+
+  '@types/marked-terminal@6.1.1':
+    resolution: {integrity: sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -5054,6 +4975,11 @@ packages:
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -6446,6 +6372,9 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
 
@@ -7180,8 +7109,24 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@11.2.0:
+    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@18.0.1:
+    resolution: {integrity: sha512-IILJE4Aap/KIGu4ZRCzQcYMxkhumblXnbqfQe+HAD4f982wrRAsJEGKGM653yAioS6g3Yq3yOhjrUebcrtOgRA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -7809,11 +7754,20 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
   parse5-parser-stream@7.1.2:
     resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -9116,6 +9070,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -9912,6 +9870,10 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.1.1:
     resolution: {integrity: sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==}
@@ -13920,6 +13882,8 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/cardinal@2.1.1': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -14122,6 +14086,13 @@ snapshots:
   '@types/localtunnel@2.0.4':
     dependencies:
       '@types/node': 25.6.0
+
+  '@types/marked-terminal@6.1.1':
+    dependencies:
+      '@types/cardinal': 2.1.1
+      '@types/node': 25.6.0
+      chalk: 5.6.2
+      marked: 11.2.0
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -14926,6 +14897,15 @@ snapshots:
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
 
   cli-table3@0.6.5:
     dependencies:
@@ -16483,6 +16463,8 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
+  highlight.js@10.7.3: {}
+
   history@4.10.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -17189,7 +17171,22 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked-terminal@7.3.0(marked@18.0.1):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 18.0.1
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@11.2.0: {}
+
   marked@16.4.2: {}
+
+  marked@18.0.1: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -18124,6 +18121,10 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -18132,6 +18133,10 @@ snapshots:
   parse5-parser-stream@7.1.2:
     dependencies:
       parse5: 7.3.0
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -19683,6 +19688,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
@@ -20538,6 +20548,16 @@ snapshots:
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

- **core**: bounded agent loop in `createChatController` — after tool calls complete, feeds results back to the LLM until it produces a final answer. Configurable `maxToolIterations` (default 5). Retrieval runs only on turn 0.
- **adapters**: `toProviderMessages` now emits OpenAI-spec `tool_calls` / `tool_call_id` so follow-up turns carry full context.
- **ink**: animated spinner, role icons, status-colored tool cards with previews, blinking input cursor, new `StatusHeader`, new `MarkdownText` component (tables, code, lists, bold, italic, links via `marked` + `marked-terminal`). Assistant messages render as markdown by default.
- **cli**: message grouping into turns with `step N/M` badges, passes `expanded` to `ToolCallView`.

## Fixes

- Tool calls previously showed `[complete]` but no result rendered — LLM never re-invoked with tool output. Root causes: missing agent loop + missing `tool_call_id` serialization + `ToolCallView` default `expanded=false`.

## Test plan

- [x] `pnpm -F @agentskit/core test` — 104/104 pass
- [x] `pnpm -F @agentskit/adapters test` — 90/90 pass
- [x] `pnpm -F @agentskit/ink test` — 23/23 pass
- [x] `pnpm -F @agentskit/core lint` + adapters/ink/cli/react — clean
- [x] `pnpm exec size-limit` — core 6.49 KB gzipped (budget 10 KB), ink 2.73 KB (budget 15 KB)
- [ ] Manual: `agentskit chat --tools web_search` with OpenAI/OpenRouter — verify final answer appears after tool call
- [ ] Manual: ask LLM for a table — verify markdown renders