### PR TITLE
feat(cli): plugin loader + registries (phase 2)

### DIFF
--- a/.changeset/cli-phase-2-plugins.md
+++ b/.changeset/cli-phase-2-plugins.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+Plugin loader (Phase 2 of ARCHITECTURE.md). Adds `config.plugins` (package specifiers or file paths), `--plugin-dir` CLI flag, and `~/.agentskit/plugins/` auto-discovery. Each plugin contributes `slashCommands`, `tools`, `skills`, `providers`, `hooks`, and `mcpServers` — the chat command merges them into its runtime registries. Failures in one plugin do not abort the CLI.

--- a/packages/cli/src/app/ChatApp.tsx
+++ b/packages/cli/src/app/ChatApp.tsx
@@ -10,7 +10,7 @@ import {
   ToolConfirmation,
   useChat,
 } from '@agentskit/ink'
-import type { Message as ChatMessage, ToolCall } from '@agentskit/core'
+import type { Message as ChatMessage, SkillDefinition, ToolCall, ToolDefinition } from '@agentskit/core'
 import { resolveChatProvider } from '../providers'
 import {
   builtinSlashCommands,
@@ -43,6 +43,10 @@ export interface ChatCommandOptions {
    * built-in by re-registering its name.
    */
   slashCommands?: SlashCommand[]
+  /** Extra tools contributed by plugins — merged into the resolved tool set. */
+  extraTools?: ToolDefinition[]
+  /** Extra skills contributed by plugins — merged into the resolved skill set. */
+  extraSkills?: SkillDefinition[]
 }
 
 function groupIntoTurns(messages: ChatMessage[]): ChatMessage[][] {
@@ -79,12 +83,23 @@ export function ChatApp(options: ChatCommandOptions) {
     setSkillFlag,
   } = useRuntime(options)
 
+  const mergedTools = useMemo(() => {
+    const extra = options.extraTools ?? []
+    return [...tools, ...extra]
+  }, [tools, options.extraTools])
+
+  const mergedSkills = useMemo(() => {
+    const extra = options.extraSkills ?? []
+    if (!skills && extra.length === 0) return undefined
+    return [...(skills ?? []), ...extra]
+  }, [skills, options.extraSkills])
+
   const chat = useChat({
     adapter: runtime.adapter,
     memory,
     systemPrompt: options.system,
-    tools: tools.length > 0 ? tools : undefined,
-    skills,
+    tools: mergedTools.length > 0 ? mergedTools : undefined,
+    skills: mergedSkills,
   })
 
   const { sessionAllowed, handleApproveAlways, awaitingConfirmation } = useToolPermissions(chat)

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -5,6 +5,7 @@ import { loadConfig } from '../config'
 import { ChatApp, renderChatHeader } from '../app/ChatApp'
 import { listSessions, resolveSession } from '../sessions'
 import { mergeWithConfig } from './shared'
+import { loadPlugins } from '../extensibility/plugins'
 
 export function registerChatCommand(program: Command): void {
   program
@@ -23,6 +24,12 @@ export function registerChatCommand(program: Command): void {
     .option('--resume [id]', 'Resume a prior session by id; omit id to resume the latest')
     .option('--list-sessions', 'List saved sessions for this directory and exit')
     .option('--no-config', 'Skip loading .agentskit.config.json')
+    .option(
+      '--plugin-dir <dir>',
+      'Extra directory to auto-discover plugin modules from (repeatable)',
+      (value: string, prev: string[] = []) => [...prev, value],
+      [],
+    )
     .action(async (options) => {
       if (options.listSessions) {
         const sessions = listSessions()
@@ -54,6 +61,11 @@ export function registerChatCommand(program: Command): void {
         )
       }
 
+      const pluginBundle = await loadPlugins({
+        specs: config?.plugins ?? [],
+        pluginDirs: (options.pluginDir as string[]) ?? [],
+      })
+
       const chatOptions = {
         apiKey: (merged.apiKey ?? options.apiKey) as string | undefined,
         baseUrl: (merged.baseUrl ?? options.baseUrl) as string | undefined,
@@ -66,6 +78,9 @@ export function registerChatCommand(program: Command): void {
         skill: (merged.skill ?? options.skill) as string | undefined,
         memoryBackend: (merged.memoryBackend ?? options.memoryBackend) as string | undefined,
         agentsKitConfig: config,
+        slashCommands: pluginBundle.slashCommands,
+        extraTools: pluginBundle.tools,
+        extraSkills: pluginBundle.skills,
       }
       process.stdout.write(`${renderChatHeader(chatOptions)}\n`)
       const instance = render(React.createElement(ChatApp, chatOptions))

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -29,6 +29,11 @@ export interface AgentsKitConfig {
     console?: boolean | { format?: 'human' | 'json' }
     langsmith?: { projectName?: string }
   }
+  /**
+   * Plugin specifiers. Each entry is a package name (`@org/plugin`) or
+   * a relative/absolute path to a module exporting a `Plugin`.
+   */
+  plugins?: string[]
 }
 
 async function loadJsonConfig(path: string): Promise<AgentsKitConfig | undefined> {

--- a/packages/cli/src/extensibility/plugins/index.ts
+++ b/packages/cli/src/extensibility/plugins/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export { loadPlugins, mergePluginsIntoBundle } from './loader'
+export type { LoadPluginsOptions } from './loader'

--- a/packages/cli/src/extensibility/plugins/loader.ts
+++ b/packages/cli/src/extensibility/plugins/loader.ts
@@ -1,0 +1,154 @@
+import { readdir, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { Plugin, PluginBundle, PluginContext, PluginFactory } from './types'
+
+export interface LoadPluginsOptions {
+  /** Plugin specifiers: absolute paths, relative paths, or package names. */
+  specs?: string[]
+  /** Extra directories to auto-discover plugin modules from. */
+  pluginDirs?: string[]
+  /** Working directory; defaults to process.cwd(). */
+  cwd?: string
+  /**
+   * Auto-discover from `~/.agentskit/plugins`. Defaults to true. Tests pass
+   * false so the user's real home dir can't contaminate runs.
+   */
+  autoDiscoverUserDir?: boolean
+  /** Error logger. Defaults to stderr. */
+  onError?: (spec: string, err: unknown) => void
+  /** Info logger. */
+  log?: (msg: string) => void
+}
+
+/**
+ * Load every plugin listed in `specs` + any auto-discovered module in
+ * `pluginDirs` (and `~/.agentskit/plugins` by default). Failures on a single
+ * plugin are reported but do not abort the rest — a broken third-party
+ * plugin should never prevent the CLI from starting.
+ */
+export async function loadPlugins(options: LoadPluginsOptions = {}): Promise<PluginBundle> {
+  const {
+    specs = [],
+    pluginDirs = [],
+    cwd = process.cwd(),
+    autoDiscoverUserDir = true,
+    onError = (spec, err) =>
+      process.stderr.write(
+        `[agentskit] plugin "${spec}" failed to load: ${err instanceof Error ? err.message : String(err)}\n`,
+      ),
+    log = () => {},
+  } = options
+
+  const resolvedSpecs = [...specs]
+
+  const discoveryDirs = [...pluginDirs]
+  if (autoDiscoverUserDir) discoveryDirs.push(join(homedir(), '.agentskit', 'plugins'))
+  for (const dir of discoveryDirs) {
+    const discovered = await discoverPluginsInDir(dir)
+    resolvedSpecs.push(...discovered)
+  }
+
+  const plugins: Plugin[] = []
+  for (const spec of resolvedSpecs) {
+    try {
+      const plugin = await loadPluginFromSpec(spec, cwd, log)
+      if (plugin) plugins.push(plugin)
+    } catch (err) {
+      onError(spec, err)
+    }
+  }
+
+  return mergePluginsIntoBundle(plugins)
+}
+
+async function discoverPluginsInDir(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir)
+    const absolutes = entries
+      .filter(name => /\.(m?js|ts)$/i.test(name))
+      .map(name => join(dir, name))
+    // Validate each is a file; skip subdirs / broken symlinks silently.
+    const validated: string[] = []
+    for (const p of absolutes) {
+      try {
+        const s = await stat(p)
+        if (s.isFile()) validated.push(p)
+      } catch {
+        /* ignore */
+      }
+    }
+    return validated
+  } catch {
+    return []
+  }
+}
+
+async function loadPluginFromSpec(
+  spec: string,
+  cwd: string,
+  log: (msg: string) => void,
+): Promise<Plugin | undefined> {
+  const isPath = spec.startsWith('./') || spec.startsWith('../') || isAbsolute(spec)
+  const importTarget = isPath
+    ? pathToFileURL(resolve(cwd, spec)).href
+    : spec
+
+  const mod = await import(importTarget)
+  const exported: unknown = mod.default ?? mod.plugin ?? mod
+  const sourcePath = isPath ? resolve(cwd, spec) : undefined
+
+  const ctx: PluginContext = {
+    cwd,
+    sourcePath,
+    log: (msg: string) => log(`[${spec}] ${msg}`),
+  }
+
+  if (typeof exported === 'function') {
+    const factory = exported as PluginFactory
+    return await factory(ctx)
+  }
+
+  if (exported && typeof exported === 'object' && 'name' in (exported as object)) {
+    const plugin = exported as Plugin
+    if (plugin.init) await plugin.init(ctx)
+    return plugin
+  }
+
+  throw new Error(
+    'Module did not export a Plugin — expected default export to be a Plugin object or a PluginFactory function.',
+  )
+}
+
+/**
+ * Merge every plugin's records into a single bundle. Later plugins override
+ * earlier ones by name (last-write-wins) — users override built-ins without
+ * forking.
+ */
+export function mergePluginsIntoBundle(plugins: Plugin[]): PluginBundle {
+  const bundle: PluginBundle = {
+    plugins,
+    slashCommands: [],
+    tools: [],
+    skills: [],
+    providers: {},
+    hooks: [],
+    mcpServers: [],
+  }
+
+  for (const plugin of plugins) {
+    if (plugin.slashCommands) bundle.slashCommands.push(...plugin.slashCommands)
+    if (plugin.tools) bundle.tools.push(...plugin.tools)
+    if (plugin.skills) bundle.skills.push(...plugin.skills)
+    if (plugin.hooks) bundle.hooks.push(...plugin.hooks)
+    if (plugin.mcpServers) bundle.mcpServers.push(...plugin.mcpServers)
+    if (plugin.providers) {
+      for (const [name, factory] of Object.entries(plugin.providers)) {
+        bundle.providers[name] = factory
+      }
+    }
+  }
+
+  return bundle
+}

--- a/packages/cli/src/extensibility/plugins/types.ts
+++ b/packages/cli/src/extensibility/plugins/types.ts
@@ -1,0 +1,86 @@
+import type { SkillDefinition, ToolDefinition } from '@agentskit/core'
+import type { SlashCommand } from '../../slash-commands'
+
+/**
+ * Public plugin contract. Every capability shipped by the CLI is a record
+ * that a plugin can contribute or override — built-ins use the same shape.
+ */
+export interface Plugin {
+  name: string
+  version?: string
+
+  slashCommands?: SlashCommand[]
+  tools?: ToolDefinition[]
+  skills?: SkillDefinition[]
+  providers?: Record<string, ProviderFactory>
+  hooks?: HookHandler[]
+  mcpServers?: McpServerSpec[]
+
+  init?: (ctx: PluginContext) => void | Promise<void>
+  dispose?: () => void | Promise<void>
+}
+
+export interface PluginContext {
+  /** Working directory the CLI was launched from. */
+  cwd: string
+  /** Absolute path to the plugin file (for relative resolution). */
+  sourcePath?: string
+  /** Logger. */
+  log: (msg: string) => void
+}
+
+export type ProviderFactory = (config: {
+  apiKey?: string
+  model: string
+  baseUrl?: string
+  extra?: Record<string, unknown>
+}) => unknown
+
+export type HookEvent =
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'UserPromptSubmit'
+  | 'PreLLM'
+  | 'PostLLM'
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'Stop'
+  | 'Error'
+
+export interface HookPayload {
+  event: HookEvent
+  [key: string]: unknown
+}
+
+export type HookResult =
+  | { decision: 'continue' }
+  | { decision: 'block'; reason: string }
+  | { decision: 'modify'; payload: HookPayload }
+
+export interface HookHandler {
+  event: HookEvent
+  matcher?: RegExp | ((payload: HookPayload) => boolean)
+  run: (payload: HookPayload) => HookResult | Promise<HookResult>
+}
+
+export interface McpServerSpec {
+  name: string
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+  timeout?: number
+}
+
+/** Plugin factory — a plugin module may export this instead of a Plugin value. */
+export type PluginFactory = (ctx: PluginContext) => Plugin | Promise<Plugin>
+
+/** Shape of aggregated plugin records after loading. */
+export interface PluginBundle {
+  plugins: Plugin[]
+  slashCommands: SlashCommand[]
+  tools: ToolDefinition[]
+  skills: SkillDefinition[]
+  providers: Record<string, ProviderFactory>
+  hooks: HookHandler[]
+  mcpServers: McpServerSpec[]
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,3 +15,17 @@ export { startDev } from './dev'
 export type { DevOptions, DevController, DevWatcher } from './dev'
 export { startTunnel } from './tunnel'
 export type { TunnelOptions, TunnelController, TunnelLike } from './tunnel'
+export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
+export type {
+  Plugin,
+  PluginBundle,
+  PluginContext,
+  PluginFactory,
+  ProviderFactory,
+  HookEvent,
+  HookPayload,
+  HookResult,
+  HookHandler,
+  McpServerSpec,
+  LoadPluginsOptions,
+} from './extensibility/plugins'

--- a/packages/cli/tests/plugins.test.ts
+++ b/packages/cli/tests/plugins.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadPlugins, mergePluginsIntoBundle } from '../src/extensibility/plugins'
+import type { Plugin } from '../src/extensibility/plugins'
+
+describe('mergePluginsIntoBundle', () => {
+  it('flattens plugin records into registries', () => {
+    const plugins: Plugin[] = [
+      {
+        name: 'a',
+        slashCommands: [{ name: 'cmd-a', description: '', run: () => {} }],
+        providers: { custom: () => ({}) },
+      },
+      {
+        name: 'b',
+        slashCommands: [{ name: 'cmd-b', description: '', run: () => {} }],
+      },
+    ]
+    const bundle = mergePluginsIntoBundle(plugins)
+    expect(bundle.plugins).toHaveLength(2)
+    expect(bundle.slashCommands.map(c => c.name)).toEqual(['cmd-a', 'cmd-b'])
+    expect(bundle.providers.custom).toBeTypeOf('function')
+  })
+
+  it('last plugin wins for provider name collisions', () => {
+    const firstProvider = () => 'first'
+    const secondProvider = () => 'second'
+    const bundle = mergePluginsIntoBundle([
+      { name: 'a', providers: { x: firstProvider } },
+      { name: 'b', providers: { x: secondProvider } },
+    ])
+    expect(bundle.providers.x).toBe(secondProvider)
+  })
+})
+
+describe('loadPlugins', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentskit-plugins-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('loads a plugin from an absolute file path', async () => {
+    const file = join(dir, 'plugin.mjs')
+    writeFileSync(
+      file,
+      `export default {
+        name: 'hello',
+        slashCommands: [{ name: 'hi', description: 'say hi', run: () => {} }],
+      }\n`,
+    )
+    const bundle = await loadPlugins({ specs: [file], autoDiscoverUserDir: false })
+    expect(bundle.plugins).toHaveLength(1)
+    expect(bundle.plugins[0]!.name).toBe('hello')
+    expect(bundle.slashCommands).toHaveLength(1)
+  })
+
+  it('supports factory-style plugins', async () => {
+    const file = join(dir, 'factory.mjs')
+    writeFileSync(
+      file,
+      `export default (ctx) => ({
+        name: 'factory',
+        slashCommands: [{ name: 'here', description: ctx.cwd, run: () => {} }],
+      })\n`,
+    )
+    const bundle = await loadPlugins({ specs: [file], cwd: dir, autoDiscoverUserDir: false })
+    expect(bundle.plugins).toHaveLength(1)
+    expect(bundle.slashCommands[0]!.description).toBe(dir)
+  })
+
+  it('auto-discovers plugins from a directory', async () => {
+    writeFileSync(
+      join(dir, 'one.mjs'),
+      `export default { name: 'one' }\n`,
+    )
+    writeFileSync(
+      join(dir, 'two.mjs'),
+      `export default { name: 'two' }\n`,
+    )
+    const bundle = await loadPlugins({
+      pluginDirs: [dir],
+      autoDiscoverUserDir: false,
+    })
+    const names = bundle.plugins.map(p => p.name).sort()
+    expect(names).toEqual(['one', 'two'])
+  })
+
+  it('reports but does not throw on a broken plugin', async () => {
+    const good = join(dir, 'good.mjs')
+    const bad = join(dir, 'bad.mjs')
+    writeFileSync(good, `export default { name: 'good' }\n`)
+    writeFileSync(bad, `throw new Error('boom')\n`)
+
+    const errors: string[] = []
+    const bundle = await loadPlugins({
+      specs: [bad, good],
+      autoDiscoverUserDir: false,
+      onError: (spec) => errors.push(spec),
+    })
+    expect(errors).toEqual([bad])
+    expect(bundle.plugins.map(p => p.name)).toEqual(['good'])
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #362.

- `Plugin` contract (+ `HookHandler`, `McpServerSpec`, `ProviderFactory` types) in `extensibility/plugins/types.ts`.
- `loadPlugins()` loader: accepts specs (package names or file paths), extra `--plugin-dir` dirs, and auto-discovers from `~/.agentskit/plugins`. Broken plugins report via \`onError\` but don't abort the rest.
- Chat command forwards the loaded bundle's slash commands, tools, and skills into \`ChatApp\`. Last-write-wins.
- \`config.plugins\` field on \`AgentsKitConfig\`.

Hooks, MCP, and provider registration are shaped but inert — wired in Phase 3 and Phase 5.

## Test plan

- [x] New \`plugins.test.ts\` — load-from-path, factory, auto-discover, error-safe
- [x] \`pnpm --filter @agentskit/cli lint\` — clean
- [x] \`pnpm --filter @agentskit/cli test\` — 65/65 pass
- [x] \`pnpm --filter @agentskit/cli build\` — success