### PR TITLE
feat(cli): permission policy (phase 4)

### DIFF
--- a/.changeset/cli-phase-4-permissions.md
+++ b/.changeset/cli-phase-4-permissions.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+Permission policy (Phase 4 of ARCHITECTURE.md). New `PermissionPolicy` with modes (`default` / `plan` / `acceptEdits` / `bypassPermissions`) and rules (`allow` / `ask` / `deny`, exact or regex). Applied when resolving the tool set for chat — denied tools are dropped, asked tools get `requiresConfirmation: true`, allowed tools run without confirmation. `--mode` CLI flag + `config.permissions` field.

--- a/packages/cli/src/app/ChatApp.tsx
+++ b/packages/cli/src/app/ChatApp.tsx
@@ -52,6 +52,8 @@ export interface ChatCommandOptions {
   extraSkills?: SkillDefinition[]
   /** Hook handlers — from plugins + config. Fire on lifecycle events. */
   hookHandlers?: HookHandler[]
+  /** Permission policy for tool calls. */
+  permissionPolicy?: import('../extensibility/permissions').PermissionPolicy
 }
 
 function groupIntoTurns(messages: ChatMessage[]): ChatMessage[][] {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -8,6 +8,7 @@ import { mergeWithConfig } from './shared'
 import { loadPlugins } from '../extensibility/plugins'
 import { configHooksToHandlers } from '../extensibility/hooks'
 import type { ConfigHooksMap } from '../extensibility/hooks'
+import type { PermissionMode, PermissionPolicy } from '../extensibility/permissions'
 
 export function registerChatCommand(program: Command): void {
   program
@@ -31,6 +32,10 @@ export function registerChatCommand(program: Command): void {
       'Extra directory to auto-discover plugin modules from (repeatable)',
       (value: string, prev: string[] = []) => [...prev, value],
       [],
+    )
+    .option(
+      '--mode <mode>',
+      'Permission mode: default | plan | acceptEdits | bypassPermissions',
     )
     .action(async (options) => {
       if (options.listSessions) {
@@ -71,6 +76,16 @@ export function registerChatCommand(program: Command): void {
       const configHooks = configHooksToHandlers(config?.hooks as ConfigHooksMap | undefined)
       const hookHandlers = [...configHooks, ...pluginBundle.hooks]
 
+      const policyMode = (options.mode ?? config?.permissions?.mode ?? 'default') as PermissionMode
+      const permissionPolicy: PermissionPolicy = {
+        mode: policyMode,
+        rules: (config?.permissions?.rules ?? []).map(r => ({
+          tool: r.tool,
+          action: r.action,
+          scope: r.scope,
+        })),
+      }
+
       const chatOptions = {
         apiKey: (merged.apiKey ?? options.apiKey) as string | undefined,
         baseUrl: (merged.baseUrl ?? options.baseUrl) as string | undefined,
@@ -87,6 +102,7 @@ export function registerChatCommand(program: Command): void {
         extraTools: pluginBundle.tools,
         extraSkills: pluginBundle.skills,
         hookHandlers,
+        permissionPolicy,
       }
       process.stdout.write(`${renderChatHeader(chatOptions)}\n`)
       const instance = render(React.createElement(ChatApp, chatOptions))

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -38,6 +38,17 @@ export interface AgentsKitConfig {
    * Shell-based hooks keyed by event name. See `extensibility/hooks`.
    */
   hooks?: Record<string, Array<{ run: string; matcher?: string; timeout?: number }>>
+  /**
+   * Tool permission policy. See `extensibility/permissions`.
+   */
+  permissions?: {
+    mode?: 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions'
+    rules?: Array<{
+      tool: string
+      action: 'allow' | 'ask' | 'deny'
+      scope?: 'session' | 'project' | 'global'
+    }>
+  }
 }
 
 async function loadJsonConfig(path: string): Promise<AgentsKitConfig | undefined> {

--- a/packages/cli/src/extensibility/permissions/index.ts
+++ b/packages/cli/src/extensibility/permissions/index.ts
@@ -1,0 +1,7 @@
+export {
+  defaultPolicy,
+  evaluatePolicy,
+  applyPolicyToTool,
+  applyPolicyToTools,
+} from './policy'
+export type { PermissionAction, PermissionMode, PermissionPolicy, PermissionRule } from './policy'

--- a/packages/cli/src/extensibility/permissions/policy.ts
+++ b/packages/cli/src/extensibility/permissions/policy.ts
@@ -1,0 +1,80 @@
+import type { ToolDefinition } from '@agentskit/core'
+
+export type PermissionMode = 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions'
+
+export type PermissionAction = 'allow' | 'ask' | 'deny'
+
+export interface PermissionRule {
+  /** Exact name, or a `RegExp` / `"re:pattern"` string matching the tool name. */
+  tool: string | RegExp
+  action: PermissionAction
+  scope?: 'session' | 'project' | 'global'
+}
+
+export interface PermissionPolicy {
+  mode: PermissionMode
+  rules: PermissionRule[]
+}
+
+export const defaultPolicy: PermissionPolicy = {
+  mode: 'default',
+  rules: [],
+}
+
+/**
+ * Resolve an action for a tool name. Modes override specific rules:
+ *
+ *   - `bypassPermissions`: everything → allow
+ *   - `plan`:              everything → ask (pretend the agent is planning)
+ *   - `acceptEdits`:       fs_write / edit tools → allow, others unchanged
+ *   - `default`:           rules drive it; no matching rule → ask
+ */
+export function evaluatePolicy(policy: PermissionPolicy, toolName: string): PermissionAction {
+  if (policy.mode === 'bypassPermissions') return 'allow'
+  if (policy.mode === 'plan') return 'ask'
+
+  for (const rule of policy.rules) {
+    if (matchesRule(rule, toolName)) return rule.action
+  }
+
+  if (policy.mode === 'acceptEdits' && /^(fs_write|edit|write_file)/.test(toolName)) {
+    return 'allow'
+  }
+
+  return 'ask'
+}
+
+function matchesRule(rule: PermissionRule, toolName: string): boolean {
+  if (rule.tool instanceof RegExp) return rule.tool.test(toolName)
+  const str = rule.tool
+  if (str.startsWith('re:')) return new RegExp(str.slice(3)).test(toolName)
+  return str === toolName
+}
+
+/**
+ * Apply the policy to a tool definition. Returns the tool with
+ * `requiresConfirmation` set per the evaluated action, or `null` when the
+ * tool is denied (the caller should skip it entirely).
+ */
+export function applyPolicyToTool(
+  policy: PermissionPolicy,
+  tool: ToolDefinition,
+): ToolDefinition | null {
+  const action = evaluatePolicy(policy, tool.name)
+  if (action === 'deny') return null
+  if (action === 'allow') return { ...tool, requiresConfirmation: false }
+  return { ...tool, requiresConfirmation: true }
+}
+
+/** Filter+annotate a tool list under a policy. Denied tools dropped. */
+export function applyPolicyToTools(
+  policy: PermissionPolicy,
+  tools: ToolDefinition[],
+): ToolDefinition[] {
+  const out: ToolDefinition[] = []
+  for (const tool of tools) {
+    const gated = applyPolicyToTool(policy, tool)
+    if (gated) out.push(gated)
+  }
+  return out
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,18 @@ export type { TunnelOptions, TunnelController, TunnelLike } from './tunnel'
 export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
 export { HookDispatcher, configHooksToHandlers } from './extensibility/hooks'
 export type { HookDispatchResult, ConfigHookEntry, ConfigHooksMap } from './extensibility/hooks'
+export {
+  defaultPolicy,
+  evaluatePolicy,
+  applyPolicyToTool,
+  applyPolicyToTools,
+} from './extensibility/permissions'
+export type {
+  PermissionAction,
+  PermissionMode,
+  PermissionPolicy,
+  PermissionRule,
+} from './extensibility/permissions'
 export type {
   Plugin,
   PluginBundle,

--- a/packages/cli/src/runtime/use-runtime.ts
+++ b/packages/cli/src/runtime/use-runtime.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { resolveChatProvider } from '../providers'
 import { resolveMemory, resolveTools, skillRegistry } from '../resolve'
+import { applyPolicyToTools, type PermissionPolicy } from '../extensibility/permissions'
 
 export interface UseRuntimeOptions {
   provider: string
@@ -11,6 +12,8 @@ export interface UseRuntimeOptions {
   skill?: string
   memoryBackend?: string
   memoryPath?: string
+  /** Optional permission policy applied to the resolved tool set. */
+  permissionPolicy?: PermissionPolicy
 }
 
 export function useRuntime(options: UseRuntimeOptions) {
@@ -31,7 +34,11 @@ export function useRuntime(options: UseRuntimeOptions) {
     [options.memoryPath, options.memoryBackend],
   )
 
-  const tools = useMemo(() => resolveTools(toolsFlag), [toolsFlag])
+  const tools = useMemo(() => {
+    const resolved = resolveTools(toolsFlag)
+    if (!options.permissionPolicy) return resolved
+    return applyPolicyToTools(options.permissionPolicy, resolved)
+  }, [toolsFlag, options.permissionPolicy])
 
   const skills = useMemo(() => {
     if (!skillFlag) return undefined

--- a/packages/cli/tests/permissions.test.ts
+++ b/packages/cli/tests/permissions.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyPolicyToTool,
+  applyPolicyToTools,
+  evaluatePolicy,
+  type PermissionPolicy,
+} from '../src/extensibility/permissions'
+import type { ToolDefinition } from '@agentskit/core'
+
+const mkTool = (name: string): ToolDefinition => ({
+  name,
+  description: name,
+  parameters: { type: 'object', properties: {} } as never,
+  execute: async () => ({}),
+})
+
+describe('evaluatePolicy', () => {
+  it('default mode + no rules → ask', () => {
+    const policy: PermissionPolicy = { mode: 'default', rules: [] }
+    expect(evaluatePolicy(policy, 'shell')).toBe('ask')
+  })
+
+  it('bypassPermissions short-circuits to allow', () => {
+    const policy: PermissionPolicy = {
+      mode: 'bypassPermissions',
+      rules: [{ tool: 'shell', action: 'deny' }],
+    }
+    expect(evaluatePolicy(policy, 'shell')).toBe('allow')
+  })
+
+  it('plan mode returns ask everywhere', () => {
+    const policy: PermissionPolicy = {
+      mode: 'plan',
+      rules: [{ tool: 'shell', action: 'allow' }],
+    }
+    expect(evaluatePolicy(policy, 'shell')).toBe('ask')
+  })
+
+  it('rules matched by exact name', () => {
+    const policy: PermissionPolicy = {
+      mode: 'default',
+      rules: [
+        { tool: 'web_search', action: 'allow' },
+        { tool: 'shell', action: 'deny' },
+      ],
+    }
+    expect(evaluatePolicy(policy, 'web_search')).toBe('allow')
+    expect(evaluatePolicy(policy, 'shell')).toBe('deny')
+    expect(evaluatePolicy(policy, 'unknown')).toBe('ask')
+  })
+
+  it('supports regex and re: prefix', () => {
+    const policy: PermissionPolicy = {
+      mode: 'default',
+      rules: [
+        { tool: /^fs_/, action: 'ask' },
+        { tool: 're:^danger', action: 'deny' },
+      ],
+    }
+    expect(evaluatePolicy(policy, 'fs_read')).toBe('ask')
+    expect(evaluatePolicy(policy, 'danger_zone')).toBe('deny')
+  })
+
+  it('acceptEdits auto-allows fs_write', () => {
+    const policy: PermissionPolicy = { mode: 'acceptEdits', rules: [] }
+    expect(evaluatePolicy(policy, 'fs_write')).toBe('allow')
+    expect(evaluatePolicy(policy, 'shell')).toBe('ask')
+  })
+})
+
+describe('applyPolicyToTool(s)', () => {
+  it('drops denied tools', () => {
+    const policy: PermissionPolicy = {
+      mode: 'default',
+      rules: [{ tool: 'shell', action: 'deny' }],
+    }
+    const tools = [mkTool('shell'), mkTool('web_search')]
+    const result = applyPolicyToTools(policy, tools)
+    expect(result.map(t => t.name)).toEqual(['web_search'])
+  })
+
+  it('sets requiresConfirmation based on action', () => {
+    const policy: PermissionPolicy = {
+      mode: 'default',
+      rules: [
+        { tool: 'web_search', action: 'allow' },
+        { tool: 'shell', action: 'ask' },
+      ],
+    }
+    const allow = applyPolicyToTool(policy, mkTool('web_search'))
+    const ask = applyPolicyToTool(policy, mkTool('shell'))
+    expect(allow?.requiresConfirmation).toBe(false)
+    expect(ask?.requiresConfirmation).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 4 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #364.

- \`PermissionPolicy\` with 4 modes + rule list (exact / RegExp / \`re:\` string).
- \`evaluatePolicy\` returns \`allow\` / \`ask\` / \`deny\`; modes override rules (bypass/plan) or augment (acceptEdits).
- \`applyPolicyToTools\` drops denied tools and sets \`requiresConfirmation\` on survivors.
- \`config.permissions\` + \`--mode\` wire it through the chat command.

## Test plan

- [x] \`permissions.test.ts\` covers every mode + exact / regex / \`re:\` rules
- [x] Lint + 78/78 tests + build all green