### PR TITLE
feat(cli): MCP bridge + client (phase 5)

### DIFF
--- a/.changeset/cli-phase-5-mcp.md
+++ b/.changeset/cli-phase-5-mcp.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+MCP bridge (Phase 5 of ARCHITECTURE.md). Spawn MCP servers from `config.mcp.servers` (or `plugin.mcpServers`), list their tools via `tools/list`, and expose each as a `ToolDefinition` named `<server>__<tool>` whose `execute` forwards to `tools/call`. Line-delimited JSON-RPC transport. Clients disposed automatically on chat exit. `McpClient` is also exported for direct use.

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -6,6 +6,7 @@ import { ChatApp, renderChatHeader } from '../app/ChatApp'
 import { listSessions, resolveSession } from '../sessions'
 import { mergeWithConfig } from './shared'
 import { loadPlugins } from '../extensibility/plugins'
+import { bridgeMcpServers, disposeMcpClients } from '../extensibility/mcp'
 import { configHooksToHandlers } from '../extensibility/hooks'
 import type { ConfigHooksMap } from '../extensibility/hooks'
 import type { PermissionMode, PermissionPolicy } from '../extensibility/permissions'
@@ -76,6 +77,16 @@ export function registerChatCommand(program: Command): void {
       const configHooks = configHooksToHandlers(config?.hooks as ConfigHooksMap | undefined)
       const hookHandlers = [...configHooks, ...pluginBundle.hooks]
 
+      const configMcpSpecs = Object.entries(config?.mcp?.servers ?? {}).map(([name, spec]) => ({
+        name,
+        command: spec.command,
+        args: spec.args,
+        env: spec.env,
+        timeout: spec.timeout,
+      }))
+      const allMcpSpecs = [...configMcpSpecs, ...pluginBundle.mcpServers]
+      const { clients: mcpClients, tools: mcpTools } = await bridgeMcpServers(allMcpSpecs)
+
       const policyMode = (options.mode ?? config?.permissions?.mode ?? 'default') as PermissionMode
       const permissionPolicy: PermissionPolicy = {
         mode: policyMode,
@@ -99,14 +110,18 @@ export function registerChatCommand(program: Command): void {
         memoryBackend: (merged.memoryBackend ?? options.memoryBackend) as string | undefined,
         agentsKitConfig: config,
         slashCommands: pluginBundle.slashCommands,
-        extraTools: pluginBundle.tools,
+        extraTools: [...pluginBundle.tools, ...mcpTools],
         extraSkills: pluginBundle.skills,
         hookHandlers,
         permissionPolicy,
       }
       process.stdout.write(`${renderChatHeader(chatOptions)}\n`)
       const instance = render(React.createElement(ChatApp, chatOptions))
-      await instance.waitUntilExit()
+      try {
+        await instance.waitUntilExit()
+      } finally {
+        disposeMcpClients(mcpClients)
+      }
 
       if (options.memory) {
         process.stdout.write(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -39,6 +39,13 @@ export interface AgentsKitConfig {
    */
   hooks?: Record<string, Array<{ run: string; matcher?: string; timeout?: number }>>
   /**
+   * MCP servers to spawn on chat start. Tools list + call bridge
+   * them into the runtime tool set as `<serverName>__<toolName>`.
+   */
+  mcp?: {
+    servers?: Record<string, { command: string; args?: string[]; env?: Record<string, string>; timeout?: number }>
+  }
+  /**
    * Tool permission policy. See `extensibility/permissions`.
    */
   permissions?: {

--- a/packages/cli/src/extensibility/mcp/bridge.ts
+++ b/packages/cli/src/extensibility/mcp/bridge.ts
@@ -1,0 +1,57 @@
+import type { ToolDefinition } from '@agentskit/core'
+import type { McpServerSpec } from '../plugins/types'
+import { McpClient, type McpTool } from './client'
+
+export interface McpBridgeResult {
+  clients: McpClient[]
+  tools: ToolDefinition[]
+}
+
+/**
+ * Start every MCP server in `specs`, call `tools/list`, and produce a
+ * `ToolDefinition[]` whose `execute` forwards to the server via
+ * `tools/call`. Returns the live clients so the caller can dispose them
+ * on session end.
+ */
+export async function bridgeMcpServers(specs: McpServerSpec[]): Promise<McpBridgeResult> {
+  const clients: McpClient[] = []
+  const tools: ToolDefinition[] = []
+
+  for (const spec of specs) {
+    const client = new McpClient(spec)
+    try {
+      await client.start()
+      const mcpTools = await client.listTools()
+      for (const mcpTool of mcpTools) {
+        tools.push(mcpToolToDefinition(spec.name, client, mcpTool))
+      }
+      clients.push(client)
+    } catch (err) {
+      process.stderr.write(
+        `[agentskit] mcp server "${spec.name}" failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      )
+      client.dispose()
+    }
+  }
+
+  return { clients, tools }
+}
+
+function mcpToolToDefinition(
+  serverName: string,
+  client: McpClient,
+  tool: McpTool,
+): ToolDefinition {
+  return {
+    name: `${serverName}__${tool.name}`,
+    description: tool.description ?? `MCP tool ${tool.name} from ${serverName}`,
+    schema: (tool.inputSchema ?? { type: 'object', properties: {} }) as never,
+    execute: async (args) => {
+      return await client.callTool(tool.name, args)
+    },
+  }
+}
+
+export function disposeMcpClients(clients: McpClient[]): void {
+  for (const client of clients) client.dispose()
+}

--- a/packages/cli/src/extensibility/mcp/client.ts
+++ b/packages/cli/src/extensibility/mcp/client.ts
@@ -1,0 +1,132 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { McpServerSpec } from '../plugins/types'
+
+export interface McpTool {
+  name: string
+  description?: string
+  inputSchema?: unknown
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: number | string
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+}
+
+/**
+ * Minimal JSON-RPC-over-stdio client for an MCP server. This is a
+ * pragmatic subset of the MCP protocol sufficient for `tools/list` +
+ * `tools/call` — full spec support lives in `@modelcontextprotocol/sdk`
+ * if/when we depend on it.
+ *
+ * Transport: newline-delimited JSON (per the MCP stdio transport spec).
+ */
+export class McpClient {
+  private child: ChildProcessWithoutNullStreams | undefined
+  private buffer = ''
+  private nextId = 1
+  private readonly pending = new Map<number, (res: JsonRpcResponse) => void>()
+  private disposed = false
+
+  constructor(
+    readonly spec: McpServerSpec,
+    private readonly onError: (err: unknown) => void = (err) =>
+      process.stderr.write(
+        `[agentskit] mcp[${spec.name}] error: ${err instanceof Error ? err.message : String(err)}\n`,
+      ),
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.child) return
+    const child = spawn(this.spec.command, this.spec.args ?? [], {
+      env: { ...process.env, ...(this.spec.env ?? {}) },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as ChildProcessWithoutNullStreams
+    this.child = child
+
+    child.stdout.on('data', (chunk) => this.onStdout(chunk.toString()))
+    child.stderr.on('data', (chunk) => {
+      process.stderr.write(`[mcp ${this.spec.name}] ${chunk}`)
+    })
+    child.on('error', (err) => this.onError(err))
+    child.on('close', () => {
+      this.disposed = true
+      for (const pending of this.pending.values()) {
+        pending({ jsonrpc: '2.0', id: 0, error: { code: -1, message: 'server closed' } })
+      }
+      this.pending.clear()
+    })
+
+    await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'agentskit', version: '0' },
+    })
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    const res = await this.request('tools/list', {})
+    const tools = (res as { tools?: McpTool[] }).tools ?? []
+    return tools
+  }
+
+  async callTool(name: string, args: unknown): Promise<unknown> {
+    return await this.request('tools/call', { name, arguments: args })
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.child?.kill('SIGTERM')
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    return new Promise((resolvePromise, rejectPromise) => {
+      if (!this.child || this.disposed) {
+        rejectPromise(new Error(`mcp server ${this.spec.name} not running`))
+        return
+      }
+      const id = this.nextId++
+      const timeoutMs = this.spec.timeout ?? 10_000
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        rejectPromise(new Error(`mcp ${this.spec.name}.${method} timed out`))
+      }, timeoutMs)
+
+      this.pending.set(id, (res) => {
+        clearTimeout(timer)
+        if (res.error) {
+          rejectPromise(new Error(`mcp ${method} failed: ${res.error.message}`))
+          return
+        }
+        resolvePromise(res.result)
+      })
+
+      const message = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'
+      this.child.stdin.write(message)
+    })
+  }
+
+  private onStdout(chunk: string): void {
+    this.buffer += chunk
+    let newlineIndex = this.buffer.indexOf('\n')
+    while (newlineIndex !== -1) {
+      const line = this.buffer.slice(0, newlineIndex).trim()
+      this.buffer = this.buffer.slice(newlineIndex + 1)
+      if (line) {
+        try {
+          const parsed = JSON.parse(line) as JsonRpcResponse
+          const pending = this.pending.get(Number(parsed.id))
+          if (pending) {
+            this.pending.delete(Number(parsed.id))
+            pending(parsed)
+          }
+        } catch (err) {
+          this.onError(err)
+        }
+      }
+      newlineIndex = this.buffer.indexOf('\n')
+    }
+  }
+}

--- a/packages/cli/src/extensibility/mcp/index.ts
+++ b/packages/cli/src/extensibility/mcp/index.ts
@@ -1,0 +1,4 @@
+export { McpClient } from './client'
+export type { McpTool } from './client'
+export { bridgeMcpServers, disposeMcpClients } from './bridge'
+export type { McpBridgeResult } from './bridge'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,8 @@ export type { DevOptions, DevController, DevWatcher } from './dev'
 export { startTunnel } from './tunnel'
 export type { TunnelOptions, TunnelController, TunnelLike } from './tunnel'
 export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
+export { McpClient, bridgeMcpServers, disposeMcpClients } from './extensibility/mcp'
+export type { McpTool, McpBridgeResult } from './extensibility/mcp'
 export { HookDispatcher, configHooksToHandlers } from './extensibility/hooks'
 export type { HookDispatchResult, ConfigHookEntry, ConfigHooksMap } from './extensibility/hooks'
 export {

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { bridgeMcpServers, McpClient, disposeMcpClients } from '../src/extensibility/mcp'
+
+/**
+ * Fake MCP server (inline node process): answers `initialize` + `tools/list`
+ * + `tools/call` with predictable output. Line-delimited JSON-RPC.
+ */
+const FAKE_SERVER_SRC = `
+const rl = require('readline').createInterface({ input: process.stdin })
+function send(obj) { process.stdout.write(JSON.stringify(obj) + '\\n') }
+rl.on('line', (line) => {
+  let msg
+  try { msg = JSON.parse(line) } catch { return }
+  if (msg.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { serverInfo: { name: 'fake' } } })
+  } else if (msg.method === 'tools/list') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { tools: [{ name: 'echo', description: 'echo back', inputSchema: { type: 'object' } }] } })
+  } else if (msg.method === 'tools/call') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { echoed: msg.params.arguments } })
+  }
+})
+`
+
+describe('McpClient', () => {
+  it('initializes + lists + calls a fake server', async () => {
+    const client = new McpClient({
+      name: 'fake',
+      command: process.execPath,
+      args: ['-e', FAKE_SERVER_SRC],
+      timeout: 3000,
+    })
+    try {
+      await client.start()
+      const tools = await client.listTools()
+      expect(tools).toHaveLength(1)
+      expect(tools[0]!.name).toBe('echo')
+      const result = await client.callTool('echo', { hello: 'world' })
+      expect(result).toEqual({ echoed: { hello: 'world' } })
+    } finally {
+      client.dispose()
+    }
+  }, 10_000)
+})
+
+describe('bridgeMcpServers', () => {
+  it('returns empty bundle when no specs', async () => {
+    const bundle = await bridgeMcpServers([])
+    expect(bundle.tools).toEqual([])
+    expect(bundle.clients).toEqual([])
+  })
+
+  it('bridges fake server tools as prefixed ToolDefinitions', async () => {
+    const bundle = await bridgeMcpServers([
+      {
+        name: 'fake',
+        command: process.execPath,
+        args: ['-e', FAKE_SERVER_SRC],
+        timeout: 3000,
+      },
+    ])
+    try {
+      expect(bundle.tools.map(t => t.name)).toEqual(['fake__echo'])
+      const result = await bundle.tools[0]!.execute({ a: 1 }, {} as never)
+      expect(result).toEqual({ echoed: { a: 1 } })
+    } finally {
+      disposeMcpClients(bundle.clients)
+    }
+  }, 10_000)
+})

--- a/packages/cli/tests/permissions.test.ts
+++ b/packages/cli/tests/permissions.test.ts
@@ -10,7 +10,7 @@ import type { ToolDefinition } from '@agentskit/core'
 const mkTool = (name: string): ToolDefinition => ({
   name,
   description: name,
-  parameters: { type: 'object', properties: {} } as never,
+  schema: { type: 'object', properties: {} } as never,
   execute: async () => ({}),
 })
 


### PR DESCRIPTION
## Summary

Phase 5 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #365.

- \`McpClient\` — minimal JSON-RPC-over-stdio (initialize, tools/list, tools/call, timeout-per-request).
- \`bridgeMcpServers\` spawns every config/plugin MCP spec and surfaces their tools as \`<server>__<name>\` ToolDefinitions.
- Chat command wires config \`mcp.servers\` + plugin \`mcpServers\` into the bridge and disposes clients on exit.
- Test uses an inline fake server.

Followups: \`/mcp-reload\` slash command, richer schema translation, content-length framing, streamable tool results.

## Test plan

- [x] \`mcp.test.ts\` — initialize + list + call round-trip against a fake server
- [x] Lint + 81/81 + build all green