### PR TITLE
feat(cli): RAG index subcommand (phase 6)

### DIFF
--- a/.changeset/cli-phase-6-rag.md
+++ b/.changeset/cli-phase-6-rag.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+RAG scaffolding (Phase 6 of ARCHITECTURE.md). New `agentskit rag index` subcommand chunks + embeds every file matched by `config.rag.sources` into a file-backed vector store. Includes a minimal OpenAI-compatible embedder (`createOpenAiEmbedder`) that works against OpenAI, OpenRouter, Azure, and local servers speaking the same shape. `buildRagFromConfig` is exported for direct embedding in host apps. Auto-retrieval in chat is a follow-up.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "@agentskit/core": "workspace:*",
     "@agentskit/ink": "workspace:*",
     "@agentskit/memory": "workspace:*",
+    "@agentskit/rag": "workspace:*",
     "@agentskit/runtime": "workspace:*",
     "@agentskit/skills": "workspace:*",
     "@agentskit/tools": "workspace:*",

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -6,6 +6,7 @@ import { registerDoctorCommand } from './doctor'
 import { registerDevCommand } from './dev'
 import { registerConfigCommand } from './config'
 import { registerTunnelCommand } from './tunnel'
+import { registerRagCommand } from './rag'
 
 export function createCli(): Command {
   const program = new Command()
@@ -20,6 +21,7 @@ export function createCli(): Command {
   registerDevCommand(program)
   registerConfigCommand(program)
   registerTunnelCommand(program)
+  registerRagCommand(program)
 
   return program
 }

--- a/packages/cli/src/commands/rag.ts
+++ b/packages/cli/src/commands/rag.ts
@@ -1,0 +1,40 @@
+import type { Command } from 'commander'
+import { loadConfig } from '../config'
+import { buildRagFromConfig, indexSources, type RagConfig } from '../extensibility/rag'
+
+export function registerRagCommand(program: Command): void {
+  const rag = program.command('rag').description('Retrieval-augmented generation utilities.')
+
+  rag
+    .command('index')
+    .description('Index files referenced by config.rag.sources into the vector store.')
+    .option('--source <glob>', 'Glob to index (overrides config.rag.sources; repeatable)',
+      (value: string, prev: string[] = []) => [...prev, value],
+      [])
+    .action(async (options) => {
+      const config = await loadConfig()
+      const rawConfig = (config as unknown as { rag?: RagConfig })?.rag
+      const overrideSources = options.source as string[]
+      const ragConfig: RagConfig = {
+        ...(rawConfig ?? {}),
+        sources: overrideSources.length > 0 ? overrideSources : rawConfig?.sources ?? [],
+      }
+      if (!ragConfig.sources || ragConfig.sources.length === 0) {
+        process.stderr.write('No RAG sources configured. Set config.rag.sources or pass --source <glob>.\n')
+        process.exit(1)
+      }
+      try {
+        const instance = buildRagFromConfig({ config: ragConfig })
+        const result = await indexSources(instance, ragConfig)
+        process.stdout.write(
+          `Indexed ${result.documentCount} document${result.documentCount === 1 ? '' : 's'}.\n`,
+        )
+        for (const source of result.sources) {
+          process.stdout.write(`  • ${source}\n`)
+        }
+      } catch (err) {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+        process.exit(1)
+      }
+    })
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -39,6 +39,19 @@ export interface AgentsKitConfig {
    */
   hooks?: Record<string, Array<{ run: string; matcher?: string; timeout?: number }>>
   /**
+   * Retrieval-augmented generation config. Indexes files via
+   * `agentskit rag index`. Chat-side auto-retrieval lands in a later phase.
+   */
+  rag?: {
+    enabled?: boolean
+    backend?: 'memory' | 'file'
+    dir?: string
+    sources?: string[]
+    embedder?: { provider?: string; model?: string; apiKey?: string; baseUrl?: string }
+    chunkSize?: number
+    topK?: number
+  }
+  /**
    * MCP servers to spawn on chat start. Tools list + call bridge
    * them into the runtime tool set as `<serverName>__<toolName>`.
    */

--- a/packages/cli/src/extensibility/rag/embedders.ts
+++ b/packages/cli/src/extensibility/rag/embedders.ts
@@ -1,0 +1,37 @@
+import type { EmbedFn } from '@agentskit/core'
+
+export interface OpenAiEmbedderConfig {
+  apiKey: string
+  model?: string
+  baseUrl?: string
+}
+
+/**
+ * Minimal OpenAI-compatible embedder. Works with the official OpenAI API
+ * or any gateway that speaks the `/v1/embeddings` shape (OpenRouter,
+ * Azure OpenAI, local servers, etc.). One embedding per call — batching
+ * is a follow-up when demand arrives.
+ */
+export function createOpenAiEmbedder(config: OpenAiEmbedderConfig): EmbedFn {
+  const model = config.model ?? 'text-embedding-3-small'
+  const baseUrl = (config.baseUrl ?? 'https://api.openai.com').replace(/\/$/, '')
+
+  return async (text: string): Promise<number[]> => {
+    const res = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({ model, input: text }),
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`embedder ${model} HTTP ${res.status}: ${body}`)
+    }
+    const json = (await res.json()) as { data?: Array<{ embedding: number[] }> }
+    const first = json.data?.[0]?.embedding
+    if (!first) throw new Error(`embedder ${model}: response missing data[0].embedding`)
+    return first
+  }
+}

--- a/packages/cli/src/extensibility/rag/index.ts
+++ b/packages/cli/src/extensibility/rag/index.ts
@@ -1,0 +1,4 @@
+export { createOpenAiEmbedder } from './embedders'
+export type { OpenAiEmbedderConfig } from './embedders'
+export { buildRagFromConfig, indexSources } from './runner'
+export type { RagConfig, BuildRagOptions, IndexResult } from './runner'

--- a/packages/cli/src/extensibility/rag/runner.ts
+++ b/packages/cli/src/extensibility/rag/runner.ts
@@ -1,0 +1,100 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { glob } from 'node:fs/promises'
+import { fileVectorMemory } from '@agentskit/memory'
+import { createRAG } from '@agentskit/rag'
+import type { RAG } from '@agentskit/rag'
+import type { EmbedFn } from '@agentskit/core'
+import { createOpenAiEmbedder } from './embedders'
+
+export interface RagConfig {
+  enabled?: boolean
+  backend?: 'memory' | 'file'
+  dir?: string
+  sources?: string[]
+  embedder?: {
+    provider?: string
+    model?: string
+    apiKey?: string
+    baseUrl?: string
+  }
+  chunkSize?: number
+  topK?: number
+}
+
+export interface BuildRagOptions {
+  config: RagConfig
+  cwd?: string
+  /** Override the embedder resolution (useful for tests). */
+  embedder?: EmbedFn
+}
+
+export interface IndexResult {
+  /** Number of input documents ingested. */
+  documentCount: number
+  /** Sources globbed + ingested (absolute paths). */
+  sources: string[]
+}
+
+/** Resolve an `EmbedFn` from config. Currently only OpenAI-compatible. */
+export function resolveEmbedder(config: RagConfig): EmbedFn {
+  const embedder = config.embedder
+  const provider = embedder?.provider ?? 'openai'
+  if (provider !== 'openai') {
+    throw new Error(`Unsupported RAG embedder provider: ${provider}. Only "openai" is built-in.`)
+  }
+  const apiKey = embedder?.apiKey ?? process.env.OPENAI_API_KEY ?? process.env.OPENROUTER_API_KEY
+  if (!apiKey) {
+    throw new Error('RAG embedder needs an API key (config.rag.embedder.apiKey or OPENAI_API_KEY env).')
+  }
+  return createOpenAiEmbedder({
+    apiKey,
+    model: embedder?.model,
+    baseUrl: embedder?.baseUrl,
+  })
+}
+
+/**
+ * Build a live `RAG` instance from a config. Wires the embedder + vector
+ * store but does not ingest anything — call `indexSources` for that.
+ */
+export function buildRagFromConfig(options: BuildRagOptions): RAG {
+  const cwd = options.cwd ?? process.cwd()
+  const dir = resolve(cwd, options.config.dir ?? './.agentskit-rag')
+  const store = fileVectorMemory({ path: `${dir}/store.json` })
+  const embed = options.embedder ?? resolveEmbedder(options.config)
+  return createRAG({
+    embed,
+    store,
+    chunkSize: options.config.chunkSize,
+    topK: options.config.topK,
+  })
+}
+
+/**
+ * Glob `config.sources` from `cwd`, read each file, and ingest through the
+ * provided RAG. Returns a summary of what was indexed.
+ */
+export async function indexSources(rag: RAG, config: RagConfig, cwd?: string): Promise<IndexResult> {
+  const root = cwd ?? process.cwd()
+  const sources = config.sources ?? []
+  const absolutePaths: string[] = []
+
+  for (const pattern of sources) {
+    for await (const match of glob(pattern, { cwd: root })) {
+      absolutePaths.push(resolve(root, match))
+    }
+  }
+
+  const documents = await Promise.all(
+    absolutePaths.map(async (path) => ({
+      id: path,
+      content: await readFile(path, 'utf8'),
+      source: path,
+    })),
+  )
+
+  if (documents.length > 0) await rag.ingest(documents)
+
+  return { documentCount: documents.length, sources: absolutePaths }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,17 @@ export type { TunnelOptions, TunnelController, TunnelLike } from './tunnel'
 export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
 export { McpClient, bridgeMcpServers, disposeMcpClients } from './extensibility/mcp'
 export type { McpTool, McpBridgeResult } from './extensibility/mcp'
+export {
+  createOpenAiEmbedder,
+  buildRagFromConfig,
+  indexSources,
+} from './extensibility/rag'
+export type {
+  OpenAiEmbedderConfig,
+  RagConfig,
+  BuildRagOptions,
+  IndexResult,
+} from './extensibility/rag'
 export { HookDispatcher, configHooksToHandlers } from './extensibility/hooks'
 export type { HookDispatchResult, ConfigHookEntry, ConfigHooksMap } from './extensibility/hooks'
 export {

--- a/packages/cli/tests/rag.test.ts
+++ b/packages/cli/tests/rag.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildRagFromConfig, indexSources } from '../src/extensibility/rag'
+
+describe('rag', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentskit-rag-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('indexes globbed sources through an injected embedder', async () => {
+    writeFileSync(join(dir, 'a.md'), 'alpha content')
+    writeFileSync(join(dir, 'b.md'), 'beta content')
+
+    const rag = buildRagFromConfig({
+      config: {
+        dir: join(dir, 'store'),
+        sources: ['*.md'],
+        chunkSize: 1000,
+      },
+      cwd: dir,
+      embedder: async (text) => Array.from({ length: 3 }, (_, i) => (text.charCodeAt(i) ?? 0) / 255),
+    })
+
+    const result = await indexSources(rag, { sources: ['*.md'] }, dir)
+    expect(result.documentCount).toBe(2)
+    expect(result.sources.map(s => s.replace(dir, '').replace(/^\//, ''))).toEqual(
+      expect.arrayContaining(['a.md', 'b.md']),
+    )
+
+    const hits = await rag.search('alpha', { topK: 2 })
+    expect(hits.length).toBeGreaterThan(0)
+  })
+
+  it('returns zero sources when glob matches nothing', async () => {
+    const rag = buildRagFromConfig({
+      config: { dir: join(dir, 'store') },
+      cwd: dir,
+      embedder: async () => [0, 0, 0],
+    })
+    const result = await indexSources(rag, { sources: ['*.does-not-exist'] }, dir)
+    expect(result.documentCount).toBe(0)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,97 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 10.33.0
-        version: 10.33.0
-      pnpm:
-        specifier: 10.33.0
-        version: 10.33.0
-
-packages:
-
-  '@pnpm/exe@10.33.0':
-    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@10.33.0':
-    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/linux-x64@10.33.0':
-    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/macos-x64@10.33.0':
-    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/win-arm64@10.33.0':
-    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
-
-  '@pnpm/win-x64@10.33.0':
-    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
-    cpu: [x64]
-    os: [win32]
-    hasBin: true
-
-  pnpm@10.33.0:
-    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@10.33.0':
-    optionalDependencies:
-      '@pnpm/linux-arm64': 10.33.0
-      '@pnpm/linux-x64': 10.33.0
-      '@pnpm/macos-arm64': 10.33.0
-      '@pnpm/macos-x64': 10.33.0
-      '@pnpm/win-arm64': 10.33.0
-      '@pnpm/win-x64': 10.33.0
-
-  '@pnpm/linux-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/linux-x64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-x64@10.33.0':
-    optional: true
-
-  '@pnpm/win-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/win-x64@10.33.0':
-    optional: true
-
-  pnpm@10.33.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -418,6 +324,9 @@ importers:
       '@agentskit/memory':
         specifier: workspace:*
         version: link:../memory
+      '@agentskit/rag':
+        specifier: workspace:*
+        version: link:../rag
       '@agentskit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -466,7 +375,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     devDependencies:
@@ -543,7 +452,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/memory:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 6 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #366. Scoped per the doc's own \"optional, driven by demand\" note.

- \`agentskit rag index\` reads \`config.rag.sources\`, globs them from cwd, chunks + embeds + writes to a file-backed vector store (\`@agentskit/memory\` + \`@agentskit/rag\`).
- \`createOpenAiEmbedder\` — OpenAI-compatible embedder via plain \`fetch\`. Works with OpenAI, OpenRouter, Azure, local gateways.
- \`buildRagFromConfig\` + \`indexSources\` exported for hosts that want programmatic control.
- Chat-side auto-retrieval is intentionally deferred.

## Test plan

- [x] \`rag.test.ts\` indexes globbed Markdown via an injected embedder + verifies retrieval
- [x] Lint + 83/83 + build all green