### PR TITLE
feat(cli): session rename + fork (phase 7)

### DIFF
--- a/.changeset/cli-phase-7-sessions.md
+++ b/.changeset/cli-phase-7-sessions.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+Session polish (Phase 7 of ARCHITECTURE.md). New `/rename` and `/fork` slash commands, plus `renameSession` / `forkSession` exports. Session metadata now carries optional `label` and `forkedFrom`. `--list-sessions` prints the label alongside the id and notes forks. The interactive `SessionsApp` picker is a follow-up.

--- a/packages/cli/src/app/ChatApp.tsx
+++ b/packages/cli/src/app/ChatApp.tsx
@@ -184,6 +184,7 @@ export function ChatApp(options: ChatCommandOptions) {
         baseUrl,
         tools: toolsFlag,
         skill: skillFlag,
+        sessionId: options.sessionId,
       },
       setProvider,
       setModel,

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -46,9 +46,11 @@ export function registerChatCommand(program: Command): void {
           return
         }
         for (const s of sessions) {
-          const { id, updatedAt, messageCount, preview, model } = s.metadata
+          const { id, updatedAt, messageCount, preview, model, label, forkedFrom } = s.metadata
+          const display = label ? `${label} (${id})` : id
+          const forkNote = forkedFrom ? `  ← fork ${forkedFrom}` : ''
           process.stdout.write(
-            `${id}  ${updatedAt}  msgs=${messageCount}${model ? `  model=${model}` : ''}\n    ${preview}\n`,
+            `${display}  ${updatedAt}  msgs=${messageCount}${model ? `  model=${model}` : ''}${forkNote}\n    ${preview}\n`,
           )
         }
         return

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,24 @@ export { startDev } from './dev'
 export type { DevOptions, DevController, DevWatcher } from './dev'
 export { startTunnel } from './tunnel'
 export type { TunnelOptions, TunnelController, TunnelLike } from './tunnel'
+export {
+  listSessions,
+  findSession,
+  findLatestSession,
+  renameSession,
+  forkSession,
+  resolveSession,
+  writeSessionMeta,
+  derivePreview,
+  generateSessionId,
+  sessionFilePath,
+} from './sessions'
+export type {
+  SessionMetadata,
+  SessionRecord,
+  ResolveSessionInput,
+  ResolvedSession,
+} from './sessions'
 export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
 export { McpClient, bridgeMcpServers, disposeMcpClients } from './extensibility/mcp'
 export type { McpTool, McpBridgeResult } from './extensibility/mcp'

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -19,6 +19,10 @@ export interface SessionMetadata {
   preview: string
   provider?: string
   model?: string
+  /** Optional human-readable label. Set via `/rename` or `renameSession`. */
+  label?: string
+  /** Session id this one was forked from, if any. */
+  forkedFrom?: string
 }
 
 export interface SessionRecord {
@@ -122,11 +126,59 @@ export function findLatestSession(cwd: string = process.cwd()): SessionRecord | 
 }
 
 export function findSession(id: string, cwd: string = process.cwd()): SessionRecord | null {
-  const exact = listSessions(cwd).find(s => s.metadata.id === id)
+  const all = listSessions(cwd)
+  const exact = all.find(s => s.metadata.id === id || s.metadata.label === id)
   if (exact) return exact
   // Allow prefix match so users can type the first few chars.
-  const prefix = listSessions(cwd).find(s => s.metadata.id.startsWith(id))
+  const prefix = all.find(s => s.metadata.id.startsWith(id))
   return prefix ?? null
+}
+
+/** Attach or update a human-readable label on an existing session. */
+export function renameSession(
+  id: string,
+  label: string,
+  cwd: string = process.cwd(),
+): SessionMetadata {
+  const record = findSession(id, cwd)
+  if (!record) throw new Error(`No session matching "${id}".`)
+  const next: SessionMetadata = { ...record.metadata, label, updatedAt: new Date().toISOString() }
+  writeSessionMeta(next, cwd)
+  return next
+}
+
+/**
+ * Copy an existing session's message file into a new session so the user
+ * can branch a conversation without disturbing the original.
+ */
+export function forkSession(
+  id: string,
+  cwd: string = process.cwd(),
+): ResolvedSession {
+  const record = findSession(id, cwd)
+  if (!record) throw new Error(`No session matching "${id}".`)
+
+  const newId = generateSessionId()
+  const newFile = sessionFilePath(newId, cwd)
+
+  if (existsSync(record.file)) {
+    writeFileSync(newFile, readFileSync(record.file, 'utf8'))
+  }
+
+  const now = new Date().toISOString()
+  writeSessionMeta(
+    {
+      ...record.metadata,
+      id: newId,
+      createdAt: now,
+      updatedAt: now,
+      forkedFrom: record.metadata.id,
+      label: undefined,
+    },
+    cwd,
+  )
+
+  return { id: newId, file: newFile, isNew: true }
 }
 
 export interface ResolveSessionInput {

--- a/packages/cli/src/slash-commands.ts
+++ b/packages/cli/src/slash-commands.ts
@@ -1,4 +1,5 @@
 import type { ChatReturn } from '@agentskit/core'
+import { forkSession, renameSession } from './sessions'
 
 export type FeedbackKind = 'info' | 'warn' | 'error' | 'success'
 
@@ -12,6 +13,7 @@ export interface SlashCommandContext {
     baseUrl?: string
     tools?: string
     skill?: string
+    sessionId?: string
   }
   /** Mutators — each rebuilds the underlying adapter/tool chain. */
   setProvider: (value: string) => void
@@ -163,6 +165,49 @@ export const builtinSlashCommands: SlashCommand[] = [
     async run(ctx) {
       await ctx.chat.clear()
       ctx.feedback('History cleared.', 'success')
+    },
+  },
+  {
+    name: 'rename',
+    description: 'Attach a human-readable label to the current session.',
+    usage: '/rename <label>',
+    run(ctx, args) {
+      const label = args.trim()
+      const sessionId = ctx.runtime.sessionId
+      if (!sessionId || sessionId === 'custom') {
+        ctx.feedback('Rename is only available for managed sessions.', 'warn')
+        return
+      }
+      if (!label) {
+        ctx.feedback('Usage: /rename <label>', 'warn')
+        return
+      }
+      try {
+        renameSession(sessionId, label)
+        ctx.feedback(`Session labeled "${label}".`, 'success')
+      } catch (err) {
+        ctx.feedback(`/rename failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+      }
+    },
+  },
+  {
+    name: 'fork',
+    description: 'Branch a copy of the current session. Does not switch to it.',
+    run(ctx) {
+      const sessionId = ctx.runtime.sessionId
+      if (!sessionId || sessionId === 'custom') {
+        ctx.feedback('Fork is only available for managed sessions.', 'warn')
+        return
+      }
+      try {
+        const result = forkSession(sessionId)
+        ctx.feedback(
+          `Forked into ${result.id}. Resume with:\n  agentskit chat --resume ${result.id}`,
+          'success',
+        )
+      } catch (err) {
+        ctx.feedback(`/fork failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+      }
     },
   },
   {

--- a/packages/cli/tests/sessions.test.ts
+++ b/packages/cli/tests/sessions.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const fakeHome = mkdtempSync(join(tmpdir(), 'agentskit-home-'))
+const prevHome = process.env.HOME
+const prevUserProfile = process.env.USERPROFILE
+process.env.HOME = fakeHome
+process.env.USERPROFILE = fakeHome
+
+// Imported after env override so sessions.ts computes ROOT from fakeHome.
+// eslint-disable-next-line import/first
+import {
+  forkSession,
+  generateSessionId,
+  listSessions,
+  renameSession,
+  sessionFilePath,
+  writeSessionMeta,
+} from '../src/sessions'
+
+afterAll(() => {
+  process.env.HOME = prevHome
+  process.env.USERPROFILE = prevUserProfile
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('sessions lifecycle', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'agentskit-cwd-'))
+  })
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('renameSession stores a label on existing session', () => {
+    const id = generateSessionId()
+    const file = sessionFilePath(id, cwd)
+    writeFileSync(file, '[]')
+    writeSessionMeta(
+      {
+        id,
+        cwd,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messageCount: 0,
+        preview: 'hello',
+      },
+      cwd,
+    )
+    renameSession(id, 'my-label', cwd)
+    const [listed] = listSessions(cwd)
+    expect(listed?.metadata.label).toBe('my-label')
+  })
+
+  it('forkSession duplicates the session file and records provenance', () => {
+    const id = generateSessionId()
+    const file = sessionFilePath(id, cwd)
+    writeFileSync(file, '[{"role":"user","content":"hi"}]')
+    writeSessionMeta(
+      {
+        id,
+        cwd,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messageCount: 1,
+        preview: 'hi',
+      },
+      cwd,
+    )
+
+    const forked = forkSession(id, cwd)
+    expect(forked.id).not.toBe(id)
+    expect(forked.isNew).toBe(true)
+
+    const listed = listSessions(cwd)
+    const newRecord = listed.find(s => s.metadata.id === forked.id)
+    expect(newRecord?.metadata.forkedFrom).toBe(id)
+    expect(newRecord?.metadata.label).toBeUndefined()
+  })
+
+  it('rename + fork throw for unknown id', () => {
+    expect(() => renameSession('missing', 'nope', cwd)).toThrow(/No session/)
+    expect(() => forkSession('missing', cwd)).toThrow(/No session/)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 7 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #367.

- \`renameSession(id, label)\` + \`/rename\` slash command.
- \`forkSession(id)\` copies the message file + writes a new meta with \`forkedFrom\`; \`/fork\` slash command wires it.
- SessionMetadata gains optional \`label\` and \`forkedFrom\`.
- \`--list-sessions\` output prints the label when set and notes forks.
- Session helpers exported from the package root.

Interactive \`SessionsApp\` picker intentionally left as a follow-up.

## Test plan

- [x] \`sessions.test.ts\` — rename label, fork duplicates + provenance, errors
- [x] Lint + 86/86 + build all green