### PR TITLE
feat(cli): token usage + cost tracking (phase 8)

### DIFF
--- a/.changeset/cli-phase-8-telemetry.md
+++ b/.changeset/cli-phase-8-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/cli": minor
+---
+
+Telemetry + cost tracking (Phase 8 of ARCHITECTURE.md). New `/usage` and `/cost` slash commands show cumulative tokens and estimated USD for the active model. `registerPricing` lets hosts override the built-in table at runtime. Hard limit enforcement and PostHog auto-instrumentation remain follow-ups.

--- a/packages/cli/src/extensibility/telemetry/index.ts
+++ b/packages/cli/src/extensibility/telemetry/index.ts
@@ -1,0 +1,2 @@
+export { computeCost, getPricing, registerPricing } from './pricing'
+export type { ModelPricing, ComputedCost, TokenUsageLike } from './pricing'

--- a/packages/cli/src/extensibility/telemetry/pricing.ts
+++ b/packages/cli/src/extensibility/telemetry/pricing.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-million-token prices in USD. Keeps only a few canonical models —
+ * hosts can override at runtime via `registerPricing`. Values are
+ * publicly listed prices as of 2026-Q1 and may drift; authoritative
+ * cost tracking should come from the provider's invoice.
+ */
+export interface ModelPricing {
+  inputPerM: number
+  outputPerM: number
+}
+
+const builtinPricing: Record<string, ModelPricing> = {
+  'gpt-4o': { inputPerM: 2.5, outputPerM: 10 },
+  'gpt-4o-mini': { inputPerM: 0.15, outputPerM: 0.6 },
+  'gpt-4.1': { inputPerM: 2, outputPerM: 8 },
+  'gpt-4.1-mini': { inputPerM: 0.4, outputPerM: 1.6 },
+  'claude-opus-4': { inputPerM: 15, outputPerM: 75 },
+  'claude-sonnet-4': { inputPerM: 3, outputPerM: 15 },
+  'claude-haiku-4': { inputPerM: 0.8, outputPerM: 4 },
+  'gemini-2.5-pro': { inputPerM: 1.25, outputPerM: 10 },
+  'gemini-2.5-flash': { inputPerM: 0.3, outputPerM: 2.5 },
+}
+
+const customPricing: Record<string, ModelPricing> = {}
+
+export function registerPricing(model: string, pricing: ModelPricing): void {
+  customPricing[model] = pricing
+}
+
+export function getPricing(model: string | undefined): ModelPricing | undefined {
+  if (!model) return undefined
+  if (customPricing[model]) return customPricing[model]
+  if (builtinPricing[model]) return builtinPricing[model]
+  // Prefix match: `openai/gpt-4o` → `gpt-4o`.
+  const short = model.includes('/') ? model.split('/').pop()! : model
+  return customPricing[short] ?? builtinPricing[short]
+}
+
+export interface TokenUsageLike {
+  promptTokens: number
+  completionTokens: number
+}
+
+export interface ComputedCost {
+  model: string
+  inputUsd: number
+  outputUsd: number
+  totalUsd: number
+}
+
+/** Returns computed cost, or `undefined` if no pricing is registered for the model. */
+export function computeCost(
+  model: string | undefined,
+  usage: TokenUsageLike,
+): ComputedCost | undefined {
+  if (!model) return undefined
+  const pricing = getPricing(model)
+  if (!pricing) return undefined
+  const inputUsd = (usage.promptTokens / 1_000_000) * pricing.inputPerM
+  const outputUsd = (usage.completionTokens / 1_000_000) * pricing.outputPerM
+  return {
+    model,
+    inputUsd,
+    outputUsd,
+    totalUsd: inputUsd + outputUsd,
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,8 @@ export type {
 export { loadPlugins, mergePluginsIntoBundle } from './extensibility/plugins'
 export { McpClient, bridgeMcpServers, disposeMcpClients } from './extensibility/mcp'
 export type { McpTool, McpBridgeResult } from './extensibility/mcp'
+export { computeCost, getPricing, registerPricing } from './extensibility/telemetry'
+export type { ModelPricing, ComputedCost, TokenUsageLike } from './extensibility/telemetry'
 export {
   createOpenAiEmbedder,
   buildRagFromConfig,

--- a/packages/cli/src/slash-commands.ts
+++ b/packages/cli/src/slash-commands.ts
@@ -1,5 +1,6 @@
 import type { ChatReturn } from '@agentskit/core'
 import { forkSession, renameSession } from './sessions'
+import { computeCost } from './extensibility/telemetry'
 
 export type FeedbackKind = 'info' | 'warn' | 'error' | 'success'
 
@@ -165,6 +166,45 @@ export const builtinSlashCommands: SlashCommand[] = [
     async run(ctx) {
       await ctx.chat.clear()
       ctx.feedback('History cleared.', 'success')
+    },
+  },
+  {
+    name: 'usage',
+    description: 'Show the cumulative token usage for this session.',
+    run(ctx) {
+      const usage = ctx.chat.usage
+      if (!usage || usage.totalTokens === 0) {
+        ctx.feedback('No usage reported yet for this session.', 'info')
+        return
+      }
+      ctx.feedback(
+        `Tokens — prompt=${usage.promptTokens}  completion=${usage.completionTokens}  total=${usage.totalTokens}`,
+        'info',
+      )
+    },
+  },
+  {
+    name: 'cost',
+    description: 'Estimate the cost so far for the current model.',
+    run(ctx) {
+      const usage = ctx.chat.usage
+      const model = ctx.runtime.model
+      if (!usage || usage.totalTokens === 0) {
+        ctx.feedback('No usage reported yet for this session.', 'info')
+        return
+      }
+      const cost = computeCost(model, usage)
+      if (!cost) {
+        ctx.feedback(
+          `No pricing registered for model "${model ?? 'unset'}". Register with registerPricing() or provide a known model name.`,
+          'warn',
+        )
+        return
+      }
+      ctx.feedback(
+        `$${cost.totalUsd.toFixed(4)} total (in=$${cost.inputUsd.toFixed(4)}  out=$${cost.outputUsd.toFixed(4)}  model=${cost.model})`,
+        'info',
+      )
     },
   },
   {

--- a/packages/cli/tests/telemetry.test.ts
+++ b/packages/cli/tests/telemetry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeCost,
+  getPricing,
+  registerPricing,
+} from '../src/extensibility/telemetry'
+
+describe('pricing + cost', () => {
+  it('returns undefined for unknown models', () => {
+    expect(getPricing('mystery-model-9')).toBeUndefined()
+    expect(computeCost('mystery-model-9', { promptTokens: 1, completionTokens: 1 })).toBeUndefined()
+  })
+
+  it('matches provider-prefixed model names via suffix', () => {
+    expect(getPricing('openai/gpt-4o')?.inputPerM).toBeGreaterThan(0)
+  })
+
+  it('computes separate input and output USD', () => {
+    const cost = computeCost('gpt-4o', { promptTokens: 1_000_000, completionTokens: 500_000 })
+    expect(cost?.inputUsd).toBeCloseTo(2.5, 4)
+    expect(cost?.outputUsd).toBeCloseTo(5, 4)
+    expect(cost?.totalUsd).toBeCloseTo(7.5, 4)
+  })
+
+  it('respects runtime-registered overrides', () => {
+    registerPricing('custom-tiny', { inputPerM: 100, outputPerM: 200 })
+    expect(
+      computeCost('custom-tiny', { promptTokens: 1_000_000, completionTokens: 500_000 })?.totalUsd,
+    ).toBeCloseTo(200, 4)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 8 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md). Stacks on #368 — last phase in the plan.

- \`ModelPricing\` table with the common OpenAI / Anthropic / Google SKUs; resolves provider-prefixed names by suffix.
- \`registerPricing\` lets a host override or add models at runtime.
- \`/usage\` prints cumulative \`ChatReturn.usage\`.
- \`/cost\` multiplies through the pricing table and prints input / output / total USD.

Follow-ups: hard \`maxCostPerSession\` enforcement (needs PostLLM hook wiring in core) and PostHog LLM Analytics auto-instrumentation.

## Test plan

- [x] \`telemetry.test.ts\` — unknown model, prefixed model match, USD math, runtime override
- [x] Lint + 90/90 + build all green