### PR TITLE
docs(cli): document extensibility surface (plugins/hooks/permissions/MCP/RAG/sessions/telemetry)

### DIFF
--- a/apps/docs/docs/infrastructure/cli.md
+++ b/apps/docs/docs/infrastructure/cli.md
@@ -4,13 +4,16 @@ sidebar_position: 4
 
 # CLI
 
-`@agentskit/cli` provides terminal commands for **interactive chat** (Ink), **one-shot agent runs** (headless runtime), and **starter projects**. It reads optional project config from **`.agentskit.config.json`** via [`loadConfig`](../packages/core).
+`@agentskit/cli` provides terminal commands for **interactive chat** (Ink), **one-shot agent runs** (headless runtime), **starter projects**, and an **extensibility surface** — plugins, hooks, permission policies, MCP servers, RAG indexing, and cost/usage tracking.
+
+It reads optional project config from `.agentskit.config.json` (or `.agentskit.config.ts`, or a `package.json#agentskit` field, or `~/.agentskit/config.json`) via [`loadConfig`](../packages/core).
 
 ## When to use
 
 - You want a **quick terminal chat** without building a custom Ink app.
 - You run **automation or CI** tasks with `agentskit run <task>` and flags (no separate script file required).
 - You bootstrap **React or Ink** starters with `agentskit init`.
+- You need to **extend** chat with your own tools, slash commands, provider adapters, hooks, or MCP servers.
 
 ## Installation
 
@@ -20,11 +23,71 @@ npm install -g @agentskit/cli
 npx @agentskit/cli --help
 ```
 
-## Config file (optional)
+## Config file
 
-If present, `.agentskit.config.json` is merged into defaults (unless `--no-config`). [`loadConfig`](../packages/core) resolves it from the current working directory.
+If present, a config file is merged into defaults (unless `--no-config`).
 
-Typical fields include default `provider` and `model` for chat and run commands.
+Precedence (later wins):
+
+1. `~/.agentskit/config.(ts|json)` — user-wide defaults
+2. `.agentskit.config.ts` in cwd
+3. `.agentskit.config.json` in cwd
+4. `"agentskit"` field in `package.json`
+
+### Full config schema
+
+```jsonc
+{
+  "defaults": {
+    "provider": "openai",
+    "model": "openai/gpt-oss-120b:free",
+    "baseUrl": "https://openrouter.ai/api",
+    "apiKeyEnv": "OPENROUTER_API_KEY",
+    "tools": "web_search,fetch_url",
+    "skill": "researcher",
+    "system": "You are a helpful assistant.",
+    "memoryBackend": "file"
+  },
+
+  "plugins": [
+    "@my-org/agentskit-plugin",
+    "./plugins/local-plugin.mjs"
+  ],
+
+  "hooks": {
+    "SessionStart":     [{ "run": "echo 'Session began' >> ./audit.log" }],
+    "UserPromptSubmit": [{ "run": "./inject-context.sh" }],
+    "PreToolUse":       [{ "matcher": "shell|fs_write", "run": "./audit-write.sh" }]
+  },
+
+  "permissions": {
+    "mode": "default",
+    "rules": [
+      { "tool": "web_search", "action": "allow" },
+      { "tool": "fetch_url",  "action": "allow" },
+      { "tool": "shell",      "action": "ask"   },
+      { "tool": "fs_write",   "action": "ask", "scope": "session" },
+      { "tool": "fs_delete",  "action": "deny" }
+    ]
+  },
+
+  "mcp": {
+    "servers": {
+      "github":     { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] },
+      "filesystem": { "command": "mcp-fs", "args": ["--root", "./"] }
+    }
+  },
+
+  "rag": {
+    "backend": "file",
+    "dir": "./.agentskit-rag",
+    "sources": ["./docs/**/*.md"],
+    "embedder": { "provider": "openai", "model": "text-embedding-3-small" },
+    "chunkSize": 1000,
+    "topK": 5
+  }
+}
+```
 
 ## `agentskit chat`
 
@@ -41,17 +104,43 @@ agentskit chat [options]
 | `--api-key <key>` | Override env-based API key |
 | `--base-url <url>` | Custom API base URL |
 | `--system <prompt>` | System prompt |
-| `--memory <path>` | File path for file-backed history (default: `.agentskit-history.json`) |
+| `--memory <path>` | Explicit memory file path (overrides session management) |
 | `--memory-backend <backend>` | `file` (default) or `sqlite` |
-| `--tools <list>` | Comma-separated: `web_search`, `filesystem`, `shell` |
-| `--skill <list>` | Comma-separated built-in skill names (see [@agentskit/skills](../agents/skills)) |
-| `--no-config` | Skip `.agentskit.config.json` |
+| `--tools <list>` | Comma-separated: `web_search`, `fetch_url`, `filesystem`, `shell` |
+| `--skill <list>` | Comma-separated built-in skill names |
+| `--new` | Start a fresh session (ignore previous conversations in this directory) |
+| `--resume [id]` | Resume a prior session by id; omit id to resume the latest |
+| `--list-sessions` | List saved sessions for this directory and exit |
+| `--plugin-dir <dir>` | Extra directory to auto-discover plugin modules from (repeatable) |
+| `--mode <mode>` | Permission mode: `default` \| `plan` \| `acceptEdits` \| `bypassPermissions` |
+| `--no-config` | Skip config file loading |
 
 API keys: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc., depending on provider.
 
 ```bash
 agentskit chat --provider anthropic --model claude-sonnet-4-6 --tools web_search
 ```
+
+### Slash commands
+
+Inside a chat session, type `/help` for the full list. Built-ins:
+
+| Command | Description |
+|---------|-------------|
+| `/help` (alias `/?`) | List available commands |
+| `/model <name>` | Switch the active model live |
+| `/provider <name>` | Switch the adapter provider live |
+| `/base-url <url\|clear>` | Override or clear the provider base URL |
+| `/tools <list\|clear>` | Set or clear active tools |
+| `/skill <list\|clear>` | Set or clear active skills |
+| `/clear` (alias `/reset`) | Clear the conversation history |
+| `/rename <label>` | Attach a human-readable label to the current session |
+| `/fork` | Branch a copy of the current session (does not switch to it) |
+| `/usage` | Show cumulative token usage for this session |
+| `/cost` | Estimate USD cost so far for the current model |
+| `/exit` (alias `/quit`, `/q`) | Exit the chat |
+
+Plugins can register additional slash commands (see [Plugins](#plugins)).
 
 ## `agentskit run`
 
@@ -81,8 +170,6 @@ agentskit run --task "Summarize this" [options]
 agentskit run "What is 2+2?" --provider openai --model gpt-4o --verbose
 ```
 
-There is **no** `agentskit run ./script.ts` mode in the current CLI — invoke your own TypeScript entrypoints with `node`/`tsx` and [`createRuntime`](../agents/runtime) instead.
-
 ## `agentskit init`
 
 Scaffold a starter project.
@@ -93,31 +180,292 @@ agentskit init [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--template <react\|ink>` | `react` | Stack for the starter |
-| `--dir <path>` | `agentskit-starter` | Output directory (resolved from cwd) |
+| `--template <template>` | `react` | `react` \| `ink` \| `runtime` \| `multi-agent` |
+| `--dir <path>` | `agentskit-app` | Output directory (resolved from cwd) |
+| `--provider <provider>` | `demo` | LLM provider baked into the starter |
+| `--tools <list>` | — | Comma-separated tools preset |
+| `--memory <backend>` | `none` | `none` \| `file` \| `sqlite` |
+| `--pm <manager>` | `pnpm` | `pnpm` \| `npm` \| `yarn` \| `bun` |
+| `-y, --yes` | — | Skip interactive prompts |
 
 ```bash
 agentskit init --template react --dir my-chat
 cd my-chat && npm install && npm run dev
 ```
 
+## `agentskit doctor`
+
+Diagnose the environment.
+
+| Option | Description |
+|--------|-------------|
+| `--no-network` | Skip provider reachability checks |
+| `--providers <list>` | Comma-separated providers to check |
+| `--json` | Emit JSON instead of formatted output |
+
+## `agentskit dev [entry]`
+
+Run an entry file with hot-reload on file changes.
+
+| Option | Description |
+|--------|-------------|
+| `--watch <globs>` | Comma-separated globs to watch |
+| `--ignore <globs>` | Comma-separated globs to ignore |
+| `--debounce <ms>` | Debounce window before restart (default: `200`) |
+
+## `agentskit config [action]`
+
+Show or scaffold the config file.
+
+| Action | Description |
+|--------|-------------|
+| `show` (default) | Print the merged config as JSON |
+| `init` | Write a template config (use `--global` or `--local`, `--force` to overwrite) |
+
+## `agentskit tunnel <port>`
+
+Expose a local port through a public URL (webhook testing).
+
+| Option | Description |
+|--------|-------------|
+| `--subdomain <name>` | Hint for a stable subdomain |
+| `--host <host>` | Local hostname (default: `localhost`) |
+
+## `agentskit rag index`
+
+Chunk + embed every file matched by `config.rag.sources` into a file-backed vector store.
+
+```bash
+agentskit rag index
+agentskit rag index --source 'docs/**/*.md' --source 'README.md'
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source <glob>` | Glob to index; repeatable. Overrides `config.rag.sources`. |
+
+Embedder: currently OpenAI-compatible only. Provide `config.rag.embedder` (with optional `model`, `baseUrl`, `apiKey`) or set `OPENAI_API_KEY` / `OPENROUTER_API_KEY` in the environment.
+
+Programmatic API (`buildRagFromConfig`, `indexSources`, `createOpenAiEmbedder`) is exported from the package root for hosts that want to integrate RAG into their own flows.
+
+## Plugins
+
+Drop-in bundles of slash commands, tools, skills, provider factories, hooks, or MCP servers.
+
+### Declaring plugins
+
+```jsonc
+{
+  "plugins": [
+    "@my-org/agentskit-plugin",
+    "./plugins/local-plugin.mjs"
+  ]
+}
+```
+
+Additional auto-discovery dirs: pass `--plugin-dir <dir>` (repeatable) or drop modules in `~/.agentskit/plugins/`.
+
+### Writing a plugin
+
+```ts
+import type { Plugin } from '@agentskit/cli'
+
+export default {
+  name: 'my-plugin',
+  version: '0.1.0',
+
+  slashCommands: [
+    {
+      name: 'ping',
+      description: 'Say pong.',
+      run: (ctx) => ctx.feedback('pong', 'success'),
+    },
+  ],
+
+  tools: [
+    /* ToolDefinition[] from @agentskit/core */
+  ],
+
+  skills: [
+    /* SkillDefinition[] from @agentskit/core */
+  ],
+
+  providers: {
+    // registers `--provider openrouter`
+    openrouter: (cfg) => /* return an AdapterFactory */,
+  },
+
+  hooks: [
+    {
+      event: 'UserPromptSubmit',
+      run: async (payload) => ({ decision: 'continue' }),
+    },
+  ],
+
+  mcpServers: [
+    { name: 'gh', command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'] },
+  ],
+} satisfies Plugin
+```
+
+Plugins may also export a **factory function** `(ctx) => Plugin` when they need the cwd or a log callback.
+
+Registration is **last-write-wins** — user plugins override built-ins by name.
+
+## Hooks
+
+Runtime events fire through a dispatcher; handlers can `continue`, `block`, or `modify` the payload.
+
+### Events
+
+| Event | Fired when |
+|-------|-----------|
+| `SessionStart` | Chat mounts |
+| `SessionEnd` | Chat unmounts |
+| `UserPromptSubmit` | User submits a non-slash-command message |
+| `PreLLM` / `PostLLM` | Before/after each LLM call *(registrable; wires in once core exposes the lifecycle)* |
+| `PreToolUse` / `PostToolUse` | Before/after each tool call *(same caveat)* |
+| `Stop` | Session stops via `/exit` or Ctrl+C |
+| `Error` | Any unhandled error |
+
+### Shell-based hooks (from config)
+
+```jsonc
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "run": "./inject-context.sh", "timeout": 3000 }
+    ],
+    "PreToolUse": [
+      { "matcher": "shell|fs_write", "run": "./audit-write.sh" }
+    ]
+  }
+}
+```
+
+The command receives the JSON payload on stdin. It can:
+
+- exit `0` silently → `continue`
+- print JSON `{"decision":"block","reason":"…"}` → cancel the action
+- print JSON `{"decision":"modify","payload":{…}}` → replace the payload for subsequent handlers
+- exit non-zero → implicit `block`
+
+### JS-based hooks (from plugins)
+
+```ts
+hooks: [
+  {
+    event: 'PreToolUse',
+    matcher: /shell|fs_/,
+    run: async (payload) => {
+      if (looksDangerous(payload)) {
+        return { decision: 'block', reason: 'blocked by policy' }
+      }
+      return { decision: 'continue' }
+    },
+  },
+]
+```
+
+## Permission policy
+
+Decide which tools run, which require confirmation, and which are refused outright.
+
+### Modes
+
+| Mode | Effect |
+|------|--------|
+| `default` | Rules drive decisions; no matching rule → `ask` |
+| `plan` | Every tool → `ask` (useful for review-first workflows) |
+| `acceptEdits` | `fs_write` / `edit` / `write_file` → `allow`; others unchanged |
+| `bypassPermissions` | Everything → `allow` (skip prompts — dangerous) |
+
+Set with `--mode <mode>` or `config.permissions.mode`.
+
+### Rules
+
+```jsonc
+{
+  "permissions": {
+    "rules": [
+      { "tool": "web_search",     "action": "allow" },
+      { "tool": "shell",          "action": "ask"   },
+      { "tool": "fs_delete",      "action": "deny"  },
+      { "tool": "re:^fs_.*",      "action": "ask"   }
+    ]
+  }
+}
+```
+
+Rule `tool` matches exact names or, when prefixed with `re:`, a regex. Programmatic API (`applyPolicyToTools`, `evaluatePolicy`) is exported from the package root.
+
+## MCP servers
+
+Spawn any [Model Context Protocol](https://modelcontextprotocol.io) server over stdio and bridge its tools into chat as `<server>__<tool>` `ToolDefinition`s.
+
+```jsonc
+{
+  "mcp": {
+    "servers": {
+      "github":     { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] },
+      "filesystem": { "command": "mcp-fs", "args": ["--root", "./"] }
+    }
+  }
+}
+```
+
+Plugins may also contribute MCP servers via `plugin.mcpServers`. Clients auto-dispose on chat exit.
+
+Programmatic API (`McpClient`, `bridgeMcpServers`, `disposeMcpClients`) is exported from the package root.
+
+## Sessions
+
+Each directory gets its own session directory under `~/.agentskit/sessions/<hash>/`. Metadata (id, preview, model, label, forkedFrom) is written next to each session file.
+
+- `--new` starts fresh
+- `--resume [id]` resumes by id, label, or prefix (defaults to latest)
+- `--list-sessions` prints every session in the current directory
+- `/rename <label>` attaches a label — resume by that label too
+- `/fork` branches a copy of the current session without switching
+
+Programmatic helpers exported from the package root: `listSessions`, `findSession`, `findLatestSession`, `renameSession`, `forkSession`, `resolveSession`.
+
+## Telemetry
+
+`/usage` prints cumulative `TokenUsage` for the live chat. `/cost` multiplies by the model's per-million-token prices and prints input, output, and total USD.
+
+Override or extend the built-in pricing table at runtime:
+
+```ts
+import { registerPricing } from '@agentskit/cli'
+
+registerPricing('my-fine-tune-v1', { inputPerM: 1.2, outputPerM: 3.6 })
+```
+
+Hard limit enforcement (`config.limits.maxCostPerSession`) and PostHog LLM Analytics auto-instrumentation are planned follow-ups.
+
 ## Environment variables
 
 | Variable | Used for |
-|----------|-----------|
+|----------|----------|
 | `ANTHROPIC_API_KEY` | Anthropic |
-| `OPENAI_API_KEY` | OpenAI |
-| `REDIS_URL` | If you wire Redis memory in custom code (not default CLI file memory) |
+| `OPENAI_API_KEY` | OpenAI / embedder fallback |
+| `OPENROUTER_API_KEY` | OpenRouter / embedder fallback |
+| Any env named by `defaults.apiKeyEnv` | Generic provider key |
+| `REDIS_URL` | If you wire Redis memory in custom code |
 
 ## Troubleshooting
 
 | Issue | Mitigation |
 |-------|------------|
 | `task is required` | Pass a string after `run` or use `--task`. |
-| `--skill` and `--skills` both set | CLI exits with error — use only one. |
+| `--skill` and `--skills` both set | Use only one. |
 | Provider auth errors | Export the correct `*_API_KEY` or pass `--api-key`. |
-| Wrong defaults | Check `.agentskit.config.json` or pass `--no-config`. |
+| Wrong defaults | Check config precedence or pass `--no-config`. |
+| Plugin fails to load | Error surfaces on stderr; the rest of the CLI keeps running. |
+| MCP server refuses to start | Check the `command` resolves on `$PATH`; see stderr for its output. |
+| `/cost` says "no pricing" | Register the model with `registerPricing` or use a known model name. |
 
 ## See also
 
-[Start here](../getting-started/read-this-first) · [Packages](../packages/overview) · [TypeDoc](pathname:///agentskit/api-reference/) (`@agentskit/cli`) · [Quick Start](../getting-started/quick-start) · [Ink](../chat-uis/ink) · [Runtime](../agents/runtime) · [Eval](./eval)
+[Start here](../getting-started/read-this-first) · [Packages](../packages/overview) · [TypeDoc](pathname:///agentskit/api-reference/) (`@agentskit/cli`) · [Quick Start](../getting-started/quick-start) · [Ink](../chat-uis/ink) · [Runtime](../agents/runtime) · [Eval](./eval) · [ARCHITECTURE.md](https://github.com/AgentsKit-io/agentskit/blob/main/packages/cli/ARCHITECTURE.md)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,8 +55,13 @@ agentskit run --help
 - `agentskit doctor` — diagnose your environment, packages, and provider config
 - `agentskit dev` — hot-reload agent development
 - `agentskit tunnel` — expose local agent via public URL
-- Provider flags: `--provider`, `--model`, `--system`, `--skill`, `--memory`
+- `agentskit rag index` — chunk + embed files into a file-backed vector store
+- `agentskit config` — print merged config or scaffold a template
+- **Extensibility** — plugins (slash commands, tools, skills, providers, hooks, MCP servers), permission policy with modes, lifecycle hooks (shell or JS), MCP stdio bridge, session rename + fork, `/usage` + `/cost`
+- Provider flags: `--provider`, `--model`, `--system`, `--skill`, `--memory`, `--mode`, `--plugin-dir`
 - Env-var based key injection — works seamlessly in CI and scripts
+
+Full reference: [docs/infrastructure/cli](https://www.agentskit.io/docs/infrastructure/cli) · [ARCHITECTURE.md](./ARCHITECTURE.md)
 
 ### agentskit doctor
 


### PR DESCRIPTION
Brings `apps/docs/docs/infrastructure/cli.md` + the CLI README back in sync with the CLI after phases 1–8 of [packages/cli/ARCHITECTURE.md](packages/cli/ARCHITECTURE.md) shipped (#362, #363, #365, #366, #367, #368, #369, #371).

New or expanded sections:

- Full config schema (plugins, hooks, permissions, mcp, rag)
- Slash commands table includes `/rename`, `/fork`, `/usage`, `/cost`
- `agentskit rag index` + `createOpenAiEmbedder` / `buildRagFromConfig`
- Plugins — declaring via config or `--plugin-dir`, writing object-style and factory-style
- Hooks — event list, shell protocol (stdin/stdout JSON), JS handler examples
- Permissions — modes, rules, `re:` regex form, programmatic API
- MCP — config shape + programmatic bridge API
- Sessions — new/resume/list + rename/fork lifecycle
- Telemetry — `registerPricing` runtime override, deferred hard-limit + PostHog work

## Test plan

- [x] Local `pnpm --filter @agentskit/docs build` fails with the same progress-plugin schema error present on `main` (unrelated to this PR)
- [ ] Reviewer spot-checks the new sections render correctly once the build issue is unblocked