### PR TITLE
feat(core): progressive tool calls + virtualized memory + multi-modal (S12)

### DIFF
--- a/.changeset/phase2-s12-progressive-virtual-multimodal.md
+++ b/.changeset/phase2-s12-progressive-virtual-multimodal.md
@@ -1,0 +1,20 @@
+---
+'@agentskit/core': minor
+---
+
+Phase 2 sprint S12 — issues #140, #141, #142.
+
+- `createProgressiveArgParser` + `executeToolProgressively`: stream-
+  parse a JSON args object and fire tool execution as soon as a
+  trigger field arrives — before the model finishes emitting the
+  rest of the arguments.
+- `createVirtualizedMemory(backing, { maxActive, retriever? })`: wraps
+  any `ChatMemory` with a fixed hot window, preserving the full
+  history in the backing store. Optional retriever surfaces
+  relevant cold messages on each `load()`. `save()` is cold-safe.
+- Multi-modal content parts: provider-neutral `ContentPart` union
+  (`text` / `image` / `audio` / `video` / `file`) plus `Message.parts`,
+  `textPart` / `imagePart` / `audioPart` / `videoPart` / `filePart`
+  builders, and `normalizeContent` / `partsToText` / `filterParts`
+  helpers. Text-only adapters keep reading `content`; vision-aware
+  adapters read `parts`.

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -21,6 +21,9 @@
     "prompt-diff",
     "time-travel-debug",
     "token-budget",
-    "speculative-execution"
+    "speculative-execution",
+    "progressive-tool-calls",
+    "virtualized-memory",
+    "multi-modal"
   ]
 }

--- a/apps/docs-next/content/docs/recipes/multi-modal.mdx
+++ b/apps/docs-next/content/docs/recipes/multi-modal.mdx
@@ -1,0 +1,82 @@
+---
+title: Unified multi-modal
+description: One API for text, image, audio, video, and file inputs — regardless of provider.
+---
+
+Every provider has its own multi-modal shape. OpenAI wants
+`{ type: 'image_url', image_url: {...} }`, Anthropic wants
+`{ type: 'image', source: {...} }`, Gemini wants parts-with-inline-
+data. `@agentskit/core` provides a provider-neutral `ContentPart`
+model — adapters that understand a modality read the parts, the rest
+fall back to a text projection.
+
+## Install
+
+Built into `@agentskit/core`.
+
+## Build a multi-modal message
+
+```ts
+import {
+  textPart,
+  imagePart,
+  audioPart,
+  filePart,
+  partsToText,
+} from '@agentskit/core'
+import type { Message } from '@agentskit/core'
+
+const parts = [
+  textPart('What is in this screenshot?'),
+  imagePart('https://cdn.example.com/screenshot.png', { detail: 'high', mimeType: 'image/png' }),
+]
+
+const message: Message = {
+  id: crypto.randomUUID(),
+  role: 'user',
+  content: partsToText(parts),  // text projection: "What is...\n[image: ...]"
+  parts,                        // adapters that support vision read this
+  status: 'complete',
+  createdAt: new Date(),
+}
+```
+
+## Part kinds
+
+| Builder | `type` | Notes |
+|---------|--------|-------|
+| `textPart(text)` | `'text'` | Plain text segment |
+| `imagePart(src, { mimeType?, detail? })` | `'image'` | Data URL, http(s), or provider-hosted id |
+| `audioPart(src, { durationSec? })` | `'audio'` | |
+| `videoPart(src, { durationSec? })` | `'video'` | |
+| `filePart(src, { filename? })` | `'file'` | PDF, CSV, arbitrary binary |
+
+## In an adapter
+
+A vision-aware adapter reads `msg.parts` and maps each entry to its
+provider's shape. A text-only adapter keeps reading `msg.content` and
+sees a safe projection like `"caption\n[image: pic.png]"`.
+
+```ts
+import { normalizeContent, filterParts } from '@agentskit/core'
+
+function toOpenAIMessage(m: Message) {
+  const { parts } = normalizeContent(m.content, m.parts)
+  return {
+    role: m.role,
+    content: parts.map(p => {
+      if (p.type === 'text') return { type: 'text', text: p.text }
+      if (p.type === 'image') return { type: 'image_url', image_url: { url: p.source, detail: p.detail } }
+      return { type: 'text', text: `[${p.type}]` }
+    }),
+  }
+}
+
+// Quickly grab every attached image:
+const images = filterParts(parts, 'image')
+```
+
+## See also
+
+- [Custom adapter](/docs/recipes/custom-adapter)
+- [PDF Q&A](/docs/recipes/pdf-qa)

--- a/apps/docs-next/content/docs/recipes/progressive-tool-calls.mdx
+++ b/apps/docs-next/content/docs/recipes/progressive-tool-calls.mdx
@@ -1,0 +1,71 @@
+---
+title: Progressive tool calls
+description: Start executing a tool before the model finishes streaming its arguments.
+---
+
+A common latency win: the model is still typing JSON args for a
+`search(query, limit, filters)` call, but you already have `query` —
+and `query` is the only field the tool actually needs to start
+working. `@agentskit/core` ships two primitives for this pattern.
+
+## Install
+
+Built into `@agentskit/core`.
+
+## Parse args progressively
+
+`createProgressiveArgParser` consumes JSON text in arbitrary chunks
+and fires an event per top-level field whose value is syntactically
+complete.
+
+```ts
+import { createProgressiveArgParser } from '@agentskit/core'
+
+const p = createProgressiveArgParser()
+p.push('{"query"')       // -> []
+p.push(':"pirates"')     // -> [{ field: 'query', value: 'pirates' }]
+p.push(', "limit": 10}') // -> [{ field: 'limit', value: 10 }]
+p.end()
+```
+
+It handles escaped strings and nested objects/arrays, which are
+parsed atomically when their enclosing top-level field closes.
+
+## Fire a tool early
+
+`executeToolProgressively` wires the parser into a tool. By default
+it starts executing as soon as the **first** field arrives; pass
+`triggerFields` to require specific fields before kicking off.
+
+```ts
+import { executeToolProgressively, defineTool } from '@agentskit/core'
+
+const search = defineTool({
+  name: 'search',
+  schema: { type: 'object', properties: { query: { type: 'string' }, limit: { type: 'number' } } } as const,
+  execute: async ({ query, limit }) => {
+    return fetch(`/api/search?q=${query}&limit=${limit ?? 20}`).then(r => r.json())
+  },
+})
+
+async function* argStream() {
+  yield '{"query":"open source"'
+  // ...LLM still generating...
+  yield ', "limit": 5}'
+}
+
+const { execution, finalArgs } = executeToolProgressively(search, argStream(), {
+  messages: [],
+  callId: 'call_1',
+}, { triggerFields: ['query'] })
+
+const result = await execution
+```
+
+- `execution` resolves once the tool returns.
+- `finalArgs` reflects the complete object after the stream closes.
+
+## See also
+
+- [Custom adapter](/docs/recipes/custom-adapter) — emit `tool_call` chunks with partial args
+- [Deterministic replay](/docs/recipes/deterministic-replay) — record progressive runs for debugging

--- a/apps/docs-next/content/docs/recipes/virtualized-memory.mdx
+++ b/apps/docs-next/content/docs/recipes/virtualized-memory.mdx
@@ -1,0 +1,69 @@
+---
+title: Virtualized memory
+description: Transparently handle giant conversations by keeping a hot window active and paging the rest.
+---
+
+A chat session with 10k messages shouldn't blow up `load()`.
+`createVirtualizedMemory` wraps any `ChatMemory` with a fixed
+"hot" window — recent messages always loaded — and lets you plug in a
+retriever to surface relevant older messages on demand.
+
+## Install
+
+Built into `@agentskit/core`.
+
+## Quick start
+
+```ts
+import { createInMemoryMemory, createVirtualizedMemory } from '@agentskit/core'
+
+const backing = createInMemoryMemory(history) // 10k messages
+const memory = createVirtualizedMemory(backing, { maxActive: 50 })
+
+const visible = await memory.load()      // latest 50
+await memory.save([...visible, newMsg])  // cold 9,950 preserved
+```
+
+- `maxActive` caps the number of recent messages returned.
+- Backing store always holds everything — `size()` / `loadAll()`
+  expose the full history.
+- `save` merges visible messages with the cold tail, so
+  load → mutate → save doesn't silently truncate history.
+
+## Surface older messages on demand
+
+Plug in a retriever. Typical impl: embed the latest user message and
+hit a vector store for the top-K cold matches.
+
+```ts
+const memory = createVirtualizedMemory(backing, {
+  maxActive: 30,
+  maxRetrieved: 5,
+  retriever: async ({ hot, cold, maxRetrieved }) => {
+    const latest = hot[hot.length - 1]
+    const embedding = await embed(latest.content)
+    const hits = await vectorStore.search(embedding, { topK: maxRetrieved })
+    return cold.filter(m => hits.some(h => h.id === m.id))
+  },
+})
+
+const merged = await memory.load()
+// returns retrieved cold msgs spliced chronologically before hot window
+```
+
+Retrieved messages are spliced in chronological order with the hot
+window, and duplicates are filtered out.
+
+## When to use this
+
+- Long-running assistants where users scroll back weeks later.
+- Agents whose task history grows unbounded (background crons).
+- Any session that would otherwise OOM on `load()`.
+
+Pair with [token budget](/docs/recipes/token-budget) — virtualized
+memory caps *count*, `compileBudget` caps *tokens*.
+
+## See also
+
+- [Persistent memory](/docs/recipes/persistent-memory)
+- [Token budget compiler](/docs/recipes/token-budget)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,34 @@ export type {
   CompileBudgetInput,
   CompileBudgetResult,
 } from './budget'
+export { createProgressiveArgParser, executeToolProgressively } from './progressive'
+export { createVirtualizedMemory } from './virtualized-memory'
+export type { VirtualizedMemoryOptions } from './virtualized-memory'
+export {
+  textPart,
+  imagePart,
+  audioPart,
+  videoPart,
+  filePart,
+  partsToText,
+  normalizeContent,
+  filterParts,
+} from './types/content'
+export type {
+  ContentPart,
+  TextPart,
+  ImagePart,
+  AudioPart,
+  VideoPart,
+  FilePart,
+  PartKind,
+} from './types/content'
+export type {
+  ProgressiveArgParser,
+  ProgressiveFieldEvent,
+  ProgressiveExecOptions,
+  ProgressiveExecResult,
+} from './progressive'
 export type { ConsumeStreamHandlers } from './primitives'
 export { buildToolMap, activateSkills, executeSafeTool } from './agent-loop'
 export type { ActivateSkillsResult, ToolExecResult, ExecuteSafeToolOptions } from './agent-loop'

--- a/packages/core/src/progressive.ts
+++ b/packages/core/src/progressive.ts
@@ -1,0 +1,294 @@
+import type { ToolCall, ToolDefinition, ToolExecutionContext } from './types/tool'
+import type { Message } from './types/message'
+
+export interface ProgressiveFieldEvent {
+  /** Top-level field name whose value just finished being streamed. */
+  field: string
+  /** Parsed value (string / number / boolean / array / object / null). */
+  value: unknown
+  /** Raw JSON text for that field. */
+  raw: string
+  /** Byte offset in the accumulated buffer where this field ended. */
+  offset: number
+}
+
+export interface ProgressiveArgParser {
+  /** Append a new chunk of JSON text. Emits `onField` for each top-level field that completes. */
+  push: (chunk: string) => ProgressiveFieldEvent[]
+  /** Mark the stream finished — validates the object closed cleanly. Returns any final events. */
+  end: () => ProgressiveFieldEvent[]
+  /** All events seen so far, in order. */
+  readonly events: ReadonlyArray<ProgressiveFieldEvent>
+  /** Current parsed partial object (fields completed so far). */
+  readonly value: Record<string, unknown>
+  /** Accumulated raw buffer. */
+  readonly buffer: string
+}
+
+/**
+ * Stream-parse a JSON object where top-level field values arrive
+ * incrementally. Fires an event as soon as each top-level field has a
+ * syntactically complete value, enabling "progressive" tool execution
+ * — the tool can begin work on the first field before the LLM has
+ * finished emitting the rest.
+ *
+ * Only works at the top level of a JSON object — nested structures
+ * are parsed atomically when their enclosing top-level field closes.
+ * That matches the common tool-args shape: a flat `{ query, limit, ...}`
+ * object where the expensive operation depends on one key.
+ */
+export function createProgressiveArgParser(): ProgressiveArgParser {
+  let buffer = ''
+  const events: ProgressiveFieldEvent[] = []
+  const value: Record<string, unknown> = {}
+
+  // Parser state — we track whether we have entered the top-level `{`,
+  // are between fields, reading a key, between `:` and value, reading
+  // a value, etc.
+  let started = false
+  let finished = false
+  let pos = 0
+
+  const skipWs = (): void => {
+    while (pos < buffer.length && /\s/.test(buffer[pos]!)) pos++
+  }
+
+  /** Try to parse a JSON string starting at `pos`. Returns end index or -1 if incomplete. */
+  const scanString = (): number => {
+    if (buffer[pos] !== '"') return -1
+    let i = pos + 1
+    while (i < buffer.length) {
+      const ch = buffer[i]
+      if (ch === '\\') {
+        i += 2
+        continue
+      }
+      if (ch === '"') return i + 1
+      i++
+    }
+    return -1
+  }
+
+  /** Scan a balanced nested value ({...} / [...]). Returns end index or -1. */
+  const scanBalanced = (open: string, close: string): number => {
+    let depth = 0
+    let i = pos
+    let inStr = false
+    let esc = false
+    while (i < buffer.length) {
+      const ch = buffer[i]!
+      if (inStr) {
+        if (esc) esc = false
+        else if (ch === '\\') esc = true
+        else if (ch === '"') inStr = false
+      } else {
+        if (ch === '"') inStr = true
+        else if (ch === open) depth++
+        else if (ch === close) {
+          depth--
+          if (depth === 0) return i + 1
+        }
+      }
+      i++
+    }
+    return -1
+  }
+
+  /** Scan a primitive (number / bool / null). Returns end or -1 if not terminated. */
+  const scanPrimitive = (): number => {
+    let i = pos
+    while (i < buffer.length) {
+      const ch = buffer[i]!
+      if (ch === ',' || ch === '}' || /\s/.test(ch)) return i
+      i++
+    }
+    return -1
+  }
+
+  const readValue = (): { end: number; raw: string; value: unknown } | null => {
+    skipWs()
+    if (pos >= buffer.length) return null
+    const ch = buffer[pos]!
+    let end = -1
+    if (ch === '"') end = scanString()
+    else if (ch === '{') end = scanBalanced('{', '}')
+    else if (ch === '[') end = scanBalanced('[', ']')
+    else end = scanPrimitive()
+    if (end < 0) return null
+    const raw = buffer.slice(pos, end)
+    try {
+      return { end, raw, value: JSON.parse(raw) }
+    } catch {
+      return null
+    }
+  }
+
+  const tryConsume = (): ProgressiveFieldEvent[] => {
+    const out: ProgressiveFieldEvent[] = []
+    if (finished) return out
+
+    if (!started) {
+      skipWs()
+      if (pos >= buffer.length) return out
+      if (buffer[pos] !== '{') throw new Error(`Expected '{' at position ${pos}`)
+      pos++
+      started = true
+    }
+
+    while (true) {
+      skipWs()
+      if (pos >= buffer.length) return out
+      if (buffer[pos] === '}') {
+        pos++
+        finished = true
+        return out
+      }
+      if (buffer[pos] === ',') {
+        pos++
+        continue
+      }
+      const keyEnd = scanString()
+      if (keyEnd < 0) return out
+      const keyRaw = buffer.slice(pos, keyEnd)
+      const key = JSON.parse(keyRaw) as string
+      const savedPos = pos
+      pos = keyEnd
+      skipWs()
+      if (buffer[pos] !== ':') {
+        pos = savedPos
+        return out
+      }
+      pos++
+      const scanned = readValue()
+      if (!scanned) {
+        pos = savedPos
+        return out
+      }
+      const ev: ProgressiveFieldEvent = {
+        field: key,
+        value: scanned.value,
+        raw: scanned.raw,
+        offset: scanned.end,
+      }
+      value[key] = scanned.value
+      events.push(ev)
+      out.push(ev)
+      pos = scanned.end
+    }
+  }
+
+  return {
+    push(chunk) {
+      buffer += chunk
+      return tryConsume()
+    },
+    end() {
+      const tail = tryConsume()
+      if (!finished) {
+        throw new Error('Progressive JSON ended without closing `}`')
+      }
+      return tail
+    },
+    get events() {
+      return events
+    },
+    get value() {
+      return value
+    },
+    get buffer() {
+      return buffer
+    },
+  }
+}
+
+export interface ProgressiveExecOptions {
+  /** Start executing after these fields have been received. Default: first field. */
+  triggerFields?: string[]
+  /** Called for each field event, including those after execution starts. */
+  onField?: (event: ProgressiveFieldEvent) => void
+}
+
+export interface ProgressiveExecResult {
+  fields: ProgressiveFieldEvent[]
+  finalArgs: Record<string, unknown>
+  /** Resolves with the tool's return value. */
+  execution: Promise<unknown>
+}
+
+/**
+ * Run a tool "progressively": feed argument-text chunks as they
+ * stream, and kick off `tool.execute` as soon as the trigger fields
+ * have arrived. Additional field events keep landing in the same
+ * `onField` callback so the tool can adapt.
+ *
+ * The tool's `args` parameter reflects whichever fields had arrived
+ * by the trigger point — callers that need the complete object should
+ * wait for `finalArgs`.
+ */
+export function executeToolProgressively<TArgs extends Record<string, unknown>>(
+  tool: ToolDefinition<TArgs>,
+  chunks: AsyncIterable<string>,
+  context: Omit<ToolExecutionContext, 'call'> & { messages: Message[]; callId: string },
+  options: ProgressiveExecOptions = {},
+): ProgressiveExecResult {
+  const parser = createProgressiveArgParser()
+  const trigger = new Set(options.triggerFields ?? [])
+  const useFirst = trigger.size === 0
+  let started = false
+  let startResolve: (args: Record<string, unknown>) => void = () => {}
+  const startArgs = new Promise<Record<string, unknown>>(res => {
+    startResolve = res
+  })
+  const finalArgs: Record<string, unknown> = {}
+
+  const handle = (ev: ProgressiveFieldEvent): void => {
+    finalArgs[ev.field] = ev.value
+    options.onField?.(ev)
+    if (!started) {
+      if (useFirst || trigger.has(ev.field)) {
+        if (!useFirst) trigger.delete(ev.field)
+        if (useFirst || trigger.size === 0) {
+          started = true
+          startResolve({ ...finalArgs })
+        }
+      }
+    }
+  }
+
+  const consume = async (): Promise<void> => {
+    for await (const chunk of chunks) {
+      for (const ev of parser.push(chunk)) handle(ev)
+    }
+    for (const ev of parser.end()) handle(ev)
+    if (!started) {
+      started = true
+      startResolve({ ...finalArgs })
+    }
+  }
+
+  const execution = (async (): Promise<unknown> => {
+    const consumer = consume()
+    const argsAtStart = await startArgs
+    const toolCall: ToolCall = {
+      id: context.callId,
+      name: tool.name,
+      args: argsAtStart,
+      status: 'running',
+    }
+    const execPromise = tool.execute
+      ? Promise.resolve(tool.execute(argsAtStart as TArgs, { messages: context.messages, call: toolCall }))
+      : Promise.resolve(undefined)
+    const [result] = await Promise.all([execPromise, consumer])
+    return result
+  })()
+
+  return {
+    get fields() {
+      return parser.events.slice()
+    },
+    get finalArgs() {
+      return finalArgs
+    },
+    execution,
+  }
+}

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -1,0 +1,123 @@
+/**
+ * Provider-neutral multi-modal content parts. A single `Message.content`
+ * is a string (classic path); multi-modal messages populate `parts`
+ * alongside — adapters that understand parts read them, the rest fall
+ * back to `content` (which we keep as a text projection via
+ * `partsToText`).
+ */
+
+export interface TextPart {
+  type: 'text'
+  text: string
+}
+
+export interface ImagePart {
+  type: 'image'
+  /** Data URL, http(s) URL, or provider-hosted reference id. */
+  source: string
+  mimeType?: string
+  /** Provider-neutral hint, e.g. 'low' / 'high'. */
+  detail?: 'low' | 'high' | 'auto'
+}
+
+export interface AudioPart {
+  type: 'audio'
+  source: string
+  mimeType?: string
+  /** Duration in seconds, if known. */
+  durationSec?: number
+}
+
+export interface VideoPart {
+  type: 'video'
+  source: string
+  mimeType?: string
+  durationSec?: number
+}
+
+export interface FilePart {
+  type: 'file'
+  source: string
+  mimeType?: string
+  /** Original filename, when available. */
+  filename?: string
+}
+
+export type ContentPart = TextPart | ImagePart | AudioPart | VideoPart | FilePart
+
+export type PartKind = ContentPart['type']
+
+/** Build a text part. */
+export function textPart(text: string): TextPart {
+  return { type: 'text', text }
+}
+
+/** Build an image part from a URL / data URI / hosted id. */
+export function imagePart(source: string, opts: Omit<ImagePart, 'type' | 'source'> = {}): ImagePart {
+  return { type: 'image', source, ...opts }
+}
+
+export function audioPart(source: string, opts: Omit<AudioPart, 'type' | 'source'> = {}): AudioPart {
+  return { type: 'audio', source, ...opts }
+}
+
+export function videoPart(source: string, opts: Omit<VideoPart, 'type' | 'source'> = {}): VideoPart {
+  return { type: 'video', source, ...opts }
+}
+
+export function filePart(source: string, opts: Omit<FilePart, 'type' | 'source'> = {}): FilePart {
+  return { type: 'file', source, ...opts }
+}
+
+/**
+ * Collapse a parts array into a text-only projection. Non-text parts
+ * are rendered as `[image: url]` / `[audio: url]` etc. so plain-text
+ * adapters see *something* meaningful.
+ */
+export function partsToText(parts: ContentPart[]): string {
+  const out: string[] = []
+  for (const p of parts) {
+    switch (p.type) {
+      case 'text':
+        out.push(p.text)
+        break
+      case 'image':
+        out.push(`[image: ${p.source}]`)
+        break
+      case 'audio':
+        out.push(`[audio: ${p.source}]`)
+        break
+      case 'video':
+        out.push(`[video: ${p.source}]`)
+        break
+      case 'file':
+        out.push(`[file: ${p.filename ?? p.source}]`)
+        break
+    }
+  }
+  return out.join('\n')
+}
+
+/**
+ * Normalize any of (string | ContentPart[] | undefined) into
+ * `{ text, parts }`. Callers that have both the legacy `content`
+ * string and the new `parts` array use this to pick the right one.
+ */
+export function normalizeContent(
+  content: string | undefined,
+  parts: ContentPart[] | undefined,
+): { text: string; parts: ContentPart[] } {
+  if (parts && parts.length > 0) {
+    return { text: partsToText(parts), parts }
+  }
+  const text = content ?? ''
+  return { text, parts: text ? [textPart(text)] : [] }
+}
+
+/** Filter parts by kind. */
+export function filterParts<T extends PartKind>(
+  parts: ContentPart[],
+  kind: T,
+): Extract<ContentPart, { type: T }>[] {
+  return parts.filter(p => p.type === kind) as Extract<ContentPart, { type: T }>[]
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -11,3 +11,12 @@ export type { SkillDefinition } from './skill'
 export type { AgentEvent, Observer } from './agent'
 export type { EvalTestCase, EvalResult, EvalSuite } from './eval'
 export type { TokenCounter, TokenCounterOptions, TokenCountResult } from './token-counter'
+export type {
+  ContentPart,
+  TextPart,
+  ImagePart,
+  AudioPart,
+  VideoPart,
+  FilePart,
+  PartKind,
+} from './content'

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -1,3 +1,4 @@
+import type { ContentPart } from './content'
 import type { ToolCall } from './tool'
 
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
@@ -6,7 +7,14 @@ export type MessageStatus = 'pending' | 'streaming' | 'complete' | 'error'
 export interface Message {
   id: string
   role: MessageRole
+  /** Text projection of the message. Always populated, even for multi-modal. */
   content: string
+  /**
+   * Multi-modal parts. When provided, `content` is a text projection
+   * of these parts (see `partsToText`). Adapters that support the
+   * relevant modality should prefer `parts` over `content`.
+   */
+  parts?: ContentPart[]
   status: MessageStatus
   toolCalls?: ToolCall[]
   toolCallId?: string

--- a/packages/core/src/virtualized-memory.ts
+++ b/packages/core/src/virtualized-memory.ts
@@ -1,0 +1,90 @@
+import type { ChatMemory } from './types/memory'
+import type { Message } from './types/message'
+
+export interface VirtualizedMemoryOptions {
+  /** Maximum number of recent messages to keep "hot" (always loaded). Default 50. */
+  maxActive?: number
+  /**
+   * Optional retriever used to surface relevant "cold" messages on
+   * each `load()`. Given the hot window, returns up to `maxRetrieved`
+   * older messages to splice back in (in chronological order).
+   */
+  retriever?: (input: {
+    hot: Message[]
+    cold: Message[]
+    maxRetrieved: number
+  }) => Message[] | Promise<Message[]>
+  /** Maximum retrieved cold messages per load. Default 10. */
+  maxRetrieved?: number
+}
+
+/**
+ * Wrap any `ChatMemory` implementation with a fixed active window.
+ * Older messages (cold) are preserved on disk / in the backing store
+ * but omitted from `load()` unless a `retriever` surfaces them.
+ *
+ * Key guarantees:
+ *  - Backing store always holds the full conversation. No data loss.
+ *  - `load()` returns at most `maxActive + maxRetrieved` messages.
+ *  - `save()` merges the caller's messages with any cold tail the
+ *    caller did not see, so callers that load -> mutate -> save do not
+ *    accidentally truncate history.
+ */
+export function createVirtualizedMemory(
+  backing: ChatMemory,
+  options: VirtualizedMemoryOptions = {},
+): ChatMemory & {
+  /** Total messages in the backing store (hot + cold). */
+  size: () => Promise<number>
+  /** Read the full (cold + hot) message list, bypassing virtualization. */
+  loadAll: () => Promise<Message[]>
+} {
+  const maxActive = Math.max(1, options.maxActive ?? 50)
+  const maxRetrieved = Math.max(0, options.maxRetrieved ?? 10)
+
+  const splitHotCold = (msgs: Message[]): { hot: Message[]; cold: Message[] } => {
+    if (msgs.length <= maxActive) return { hot: msgs.slice(), cold: [] }
+    return { hot: msgs.slice(msgs.length - maxActive), cold: msgs.slice(0, msgs.length - maxActive) }
+  }
+
+  return {
+    async load() {
+      const all = [...(await backing.load())]
+      const { hot, cold } = splitHotCold(all)
+      if (cold.length === 0) return hot
+      let retrieved: Message[] = []
+      if (options.retriever && maxRetrieved > 0) {
+        retrieved = [...(await options.retriever({ hot, cold, maxRetrieved }))]
+      }
+      const seen = new Set(hot.map(m => m.id))
+      const interleaved = retrieved.filter(m => !seen.has(m.id))
+      return mergeByCreatedAt(interleaved, hot)
+    },
+
+    async save(visible) {
+      const all = [...(await backing.load())]
+      const { cold } = splitHotCold(all)
+      const visibleIds = new Set(visible.map(m => m.id))
+      const coldKept = cold.filter(m => !visibleIds.has(m.id))
+      await backing.save(mergeByCreatedAt(coldKept, visible))
+    },
+
+    async clear() {
+      await backing.clear?.()
+    },
+
+    async size() {
+      return (await backing.load()).length
+    },
+
+    async loadAll() {
+      return [...(await backing.load())]
+    },
+  }
+}
+
+function mergeByCreatedAt(a: Message[], b: Message[]): Message[] {
+  const out = [...a, ...b]
+  out.sort((x, y) => x.createdAt.getTime() - y.createdAt.getTime())
+  return out
+}

--- a/packages/core/tests/content.test.ts
+++ b/packages/core/tests/content.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  audioPart,
+  filePart,
+  filterParts,
+  imagePart,
+  normalizeContent,
+  partsToText,
+  textPart,
+  videoPart,
+} from '../src/types/content'
+
+describe('part builders', () => {
+  it('textPart', () => {
+    expect(textPart('hi')).toEqual({ type: 'text', text: 'hi' })
+  })
+
+  it('imagePart with options', () => {
+    expect(imagePart('https://x/a.png', { mimeType: 'image/png', detail: 'high' })).toEqual({
+      type: 'image',
+      source: 'https://x/a.png',
+      mimeType: 'image/png',
+      detail: 'high',
+    })
+  })
+
+  it('audioPart / videoPart / filePart', () => {
+    expect(audioPart('a.mp3').type).toBe('audio')
+    expect(videoPart('v.mp4', { durationSec: 10 }).durationSec).toBe(10)
+    expect(filePart('doc.pdf', { filename: 'doc.pdf' }).filename).toBe('doc.pdf')
+  })
+})
+
+describe('partsToText', () => {
+  it('flattens text parts', () => {
+    expect(partsToText([textPart('hello'), textPart('world')])).toBe('hello\nworld')
+  })
+
+  it('renders placeholders for non-text parts', () => {
+    const out = partsToText([
+      textPart('caption'),
+      imagePart('pic.png'),
+      audioPart('clip.mp3'),
+      videoPart('v.mp4'),
+      filePart('doc.pdf', { filename: 'doc.pdf' }),
+    ])
+    expect(out).toContain('caption')
+    expect(out).toContain('[image: pic.png]')
+    expect(out).toContain('[audio: clip.mp3]')
+    expect(out).toContain('[video: v.mp4]')
+    expect(out).toContain('[file: doc.pdf]')
+  })
+
+  it('falls back to source when filename missing', () => {
+    expect(partsToText([filePart('s3://bucket/x')])).toBe('[file: s3://bucket/x]')
+  })
+})
+
+describe('normalizeContent', () => {
+  it('prefers parts when non-empty', () => {
+    const r = normalizeContent('ignored', [textPart('hi')])
+    expect(r.parts).toHaveLength(1)
+    expect(r.text).toBe('hi')
+  })
+
+  it('wraps plain string in a text part', () => {
+    const r = normalizeContent('plain', undefined)
+    expect(r.parts).toEqual([{ type: 'text', text: 'plain' }])
+    expect(r.text).toBe('plain')
+  })
+
+  it('empty string yields empty parts', () => {
+    const r = normalizeContent('', undefined)
+    expect(r.parts).toEqual([])
+    expect(r.text).toBe('')
+  })
+
+  it('empty parts array falls back to string', () => {
+    const r = normalizeContent('x', [])
+    expect(r.parts).toEqual([{ type: 'text', text: 'x' }])
+  })
+})
+
+describe('filterParts', () => {
+  it('returns only parts of the requested kind', () => {
+    const parts = [textPart('a'), imagePart('x'), textPart('b'), audioPart('y')]
+    const texts = filterParts(parts, 'text')
+    expect(texts.map(p => p.text)).toEqual(['a', 'b'])
+    const images = filterParts(parts, 'image')
+    expect(images).toHaveLength(1)
+  })
+})

--- a/packages/core/tests/progressive.test.ts
+++ b/packages/core/tests/progressive.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createProgressiveArgParser,
+  executeToolProgressively,
+} from '../src/progressive'
+import type { ToolDefinition } from '../src/types/tool'
+
+async function* asChunks(parts: string[]): AsyncGenerator<string> {
+  for (const p of parts) yield p
+}
+
+describe('createProgressiveArgParser', () => {
+  it('emits one event per completed top-level field', () => {
+    const p = createProgressiveArgParser()
+    const events = [
+      ...p.push('{"query"'),
+      ...p.push(':"hello"'),
+      ...p.push(', "limit": 10'),
+      ...p.push('}'),
+    ]
+    expect(events.map(e => e.field)).toEqual(['query', 'limit'])
+    expect(p.value).toEqual({ query: 'hello', limit: 10 })
+  })
+
+  it('parses nested objects atomically', () => {
+    const p = createProgressiveArgParser()
+    p.push('{"filter": {"a": 1, "b": [2,3]}, "k": "v"}')
+    p.end()
+    expect(p.value).toEqual({ filter: { a: 1, b: [2, 3] }, k: 'v' })
+  })
+
+  it('handles escaped strings', () => {
+    const p = createProgressiveArgParser()
+    p.push('{"msg": "he said \\"hi\\""}')
+    p.end()
+    expect(p.value).toEqual({ msg: 'he said "hi"' })
+  })
+
+  it('throws on malformed opening char', () => {
+    const p = createProgressiveArgParser()
+    expect(() => p.push('x{')).toThrow(/Expected '{'/)
+  })
+
+  it('throws on unclosed stream', () => {
+    const p = createProgressiveArgParser()
+    p.push('{"a": 1')
+    expect(() => p.end()).toThrow(/without closing/)
+  })
+
+  it('buffers until a field value is fully scannable', () => {
+    const p = createProgressiveArgParser()
+    expect(p.push('{"q":')).toEqual([])
+    expect(p.push('"part')).toEqual([])
+    const [ev] = p.push('ial"}')
+    expect(ev?.field).toBe('q')
+    expect(p.value).toEqual({ q: 'partial' })
+  })
+
+  it('preserves raw text per field', () => {
+    const p = createProgressiveArgParser()
+    p.push('{"n": 42}')
+    p.end()
+    expect(p.events[0]!.raw).toBe('42')
+  })
+})
+
+describe('executeToolProgressively', () => {
+  it('fires tool execution after first field by default', async () => {
+    const seen: Record<string, unknown>[] = []
+    const tool: ToolDefinition = {
+      name: 'search',
+      execute: async args => {
+        seen.push({ ...args })
+        return 'ok'
+      },
+    }
+    const result = executeToolProgressively(
+      tool,
+      asChunks(['{"query":"hello"', ', "limit": 10}']),
+      { messages: [], callId: 'c1' },
+    )
+    const out = await result.execution
+    expect(out).toBe('ok')
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toEqual({ query: 'hello' })
+    expect(result.finalArgs).toEqual({ query: 'hello', limit: 10 })
+  })
+
+  it('respects triggerFields', async () => {
+    const seen: Record<string, unknown>[] = []
+    const tool: ToolDefinition = {
+      name: 't',
+      execute: async args => {
+        seen.push({ ...args })
+      },
+    }
+    const r = executeToolProgressively(
+      tool,
+      asChunks(['{"a":1,', ' "b": 2, "c": 3}']),
+      { messages: [], callId: 'c2' },
+      { triggerFields: ['b'] },
+    )
+    await r.execution
+    expect(seen[0]).toEqual({ a: 1, b: 2 })
+  })
+
+  it('invokes onField for every field', async () => {
+    const fields: string[] = []
+    const r = executeToolProgressively(
+      { name: 't', execute: async () => null },
+      asChunks(['{"a":1,"b":2}']),
+      { messages: [], callId: 'c3' },
+      { onField: ev => fields.push(ev.field) },
+    )
+    await r.execution
+    expect(fields).toEqual(['a', 'b'])
+  })
+
+  it('handles tools with no execute function', async () => {
+    const r = executeToolProgressively(
+      { name: 'noop' },
+      asChunks(['{"x":1}']),
+      { messages: [], callId: 'c4' },
+    )
+    expect(await r.execution).toBeUndefined()
+  })
+
+  it('starts execution even when args are empty', async () => {
+    let called = false
+    const r = executeToolProgressively(
+      {
+        name: 'noargs',
+        execute: async args => {
+          called = true
+          expect(args).toEqual({})
+        },
+      },
+      asChunks(['{}']),
+      { messages: [], callId: 'c5' },
+    )
+    await r.execution
+    expect(called).toBe(true)
+  })
+})

--- a/packages/core/tests/virtualized-memory.test.ts
+++ b/packages/core/tests/virtualized-memory.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { createInMemoryMemory } from '../src/memory'
+import { createVirtualizedMemory } from '../src/virtualized-memory'
+import type { Message } from '../src/types/message'
+
+function msg(id: string, offsetMs: number, role: Message['role'] = 'user', content = id): Message {
+  return { id, role, content, status: 'complete', createdAt: new Date(offsetMs) }
+}
+
+function history(n: number): Message[] {
+  return Array.from({ length: n }, (_, i) => msg(`m${i}`, i * 1000))
+}
+
+describe('createVirtualizedMemory', () => {
+  it('returns the full history when it fits in the hot window', async () => {
+    const backing = createInMemoryMemory(history(5))
+    const vm = createVirtualizedMemory(backing, { maxActive: 10 })
+    const loaded = await vm.load()
+    expect(loaded.map(m => m.id)).toEqual(history(5).map(m => m.id))
+  })
+
+  it('trims to the hot window when over maxActive', async () => {
+    const backing = createInMemoryMemory(history(20))
+    const vm = createVirtualizedMemory(backing, { maxActive: 5 })
+    const loaded = await vm.load()
+    expect(loaded).toHaveLength(5)
+    expect(loaded[0]!.id).toBe('m15')
+    expect(loaded[4]!.id).toBe('m19')
+  })
+
+  it('size reports full backing length', async () => {
+    const backing = createInMemoryMemory(history(20))
+    const vm = createVirtualizedMemory(backing, { maxActive: 5 })
+    expect(await vm.size()).toBe(20)
+  })
+
+  it('loadAll bypasses virtualization', async () => {
+    const backing = createInMemoryMemory(history(10))
+    const vm = createVirtualizedMemory(backing, { maxActive: 3 })
+    const all = await vm.loadAll()
+    expect(all).toHaveLength(10)
+  })
+
+  it('retriever interleaves cold messages in chronological order', async () => {
+    const backing = createInMemoryMemory(history(20))
+    const vm = createVirtualizedMemory(backing, {
+      maxActive: 5,
+      retriever: ({ cold, maxRetrieved }) => cold.slice(0, maxRetrieved).slice(0, 2),
+      maxRetrieved: 2,
+    })
+    const loaded = await vm.load()
+    expect(loaded).toHaveLength(7)
+    expect(loaded.map(m => m.id)).toEqual(['m0', 'm1', 'm15', 'm16', 'm17', 'm18', 'm19'])
+  })
+
+  it('retriever skips ids already in the hot window', async () => {
+    const backing = createInMemoryMemory(history(20))
+    const vm = createVirtualizedMemory(backing, {
+      maxActive: 5,
+      retriever: ({ hot }) => hot.slice(0, 1),
+      maxRetrieved: 5,
+    })
+    const loaded = await vm.load()
+    expect(loaded).toHaveLength(5)
+  })
+
+  it('save merges caller messages with cold tail preserved', async () => {
+    const backing = createInMemoryMemory(history(20))
+    const vm = createVirtualizedMemory(backing, { maxActive: 5 })
+    const hot = await vm.load()
+    const mutated = [...hot, msg('m20', 20_000, 'assistant', 'new')]
+    await vm.save(mutated)
+
+    const all = await vm.loadAll()
+    expect(all).toHaveLength(21)
+    expect(all[all.length - 1]!.id).toBe('m20')
+    expect(all[0]!.id).toBe('m0')
+  })
+
+  it('save replaces edited hot messages without duplicating', async () => {
+    const backing = createInMemoryMemory(history(3))
+    const vm = createVirtualizedMemory(backing, { maxActive: 10 })
+    const hot = await vm.load()
+    hot[1]!.content = 'edited'
+    await vm.save(hot)
+    const all = await vm.loadAll()
+    expect(all).toHaveLength(3)
+    expect(all[1]!.content).toBe('edited')
+  })
+
+  it('clear delegates to backing', async () => {
+    const backing = createInMemoryMemory(history(3))
+    const vm = createVirtualizedMemory(backing, { maxActive: 5 })
+    await vm.clear?.()
+    expect(await backing.load()).toHaveLength(0)
+  })
+
+  it('clear no-ops when backing has no clear', async () => {
+    const backing: { load: () => Promise<Message[]>; save: (m: Message[]) => Promise<void> } = {
+      load: async () => history(2),
+      save: async () => {},
+    }
+    const vm = createVirtualizedMemory(backing, { maxActive: 5 })
+    await expect(vm.clear?.()).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 sprint **S12** — closes #140, #141, #142.

- **#140 Progressive streaming tool calls** — `createProgressiveArgParser` stream-parses top-level JSON fields; `executeToolProgressively` fires tool execution as soon as trigger fields arrive.
- **#141 Context window virtualization** — `createVirtualizedMemory(backing, { maxActive, retriever? })` caps \`load()\` at a hot window, preserves full history in the backing store, and splices retrieved cold messages chronologically. \`save()\` is cold-safe.
- **#142 Unified multi-modal** — Provider-neutral \`ContentPart\` union (text/image/audio/video/file). \`Message.parts\` added as optional sibling to \`content\`. Builders (\`textPart\`, \`imagePart\`, …) + \`normalizeContent\`, \`partsToText\`, \`filterParts\` helpers. Adapters that speak the modality read \`.parts\`; text-only adapters get a safe text projection via \`content\`.

32 new tests (progressive 12 · virtualized 10 · content 10). Core lines coverage 87.13%; per-file ≥93%.

## Docs

- \`apps/docs-next/content/docs/recipes/progressive-tool-calls.mdx\`
- \`apps/docs-next/content/docs/recipes/virtualized-memory.mdx\`
- \`apps/docs-next/content/docs/recipes/multi-modal.mdx\`

## Changeset

\`.changeset/phase2-s12-progressive-virtual-multimodal.md\` — minor bump \`@agentskit/core\`.

## Test plan

- [x] \`pnpm --filter @agentskit/core test:coverage\` (152/152, 87% lines)
- [x] \`pnpm --filter @agentskit/core build\` (ESM + CJS + DTS clean)
- [x] \`pnpm lint\` across workspace (28/28 green)
- [x] \`pnpm --filter @agentskit/docs-next lint\`
- [ ] Manual: wire a vision-capable adapter (anthropic) to consume \`parts\`