### PR TITLE
feat: adapter ensemble + fallback chain + devtools server (S14)

### DIFF
--- a/.changeset/phase2-s14-ensemble-fallback-devtools.md
+++ b/.changeset/phase2-s14-ensemble-fallback-devtools.md
@@ -1,0 +1,23 @@
+---
+'@agentskit/adapters': minor
+'@agentskit/observability': minor
+---
+
+Phase 2 sprint S14 — issues #146, #147, #148.
+
+- `@agentskit/adapters` — `createEnsembleAdapter` fans a request out
+  to N candidates in parallel and aggregates into one text output.
+  Aggregators: `majority-vote` (weighted), `concat`, `longest`, or
+  custom fn. Per-branch timeouts and `onBranches` observability.
+- `@agentskit/adapters` — `createFallbackAdapter` takes an ordered
+  list of adapters and falls through on open/first-chunk errors
+  (or zero-chunk responses). Once committed, mid-stream errors
+  propagate — no duplicate tool calls. `shouldRetry` and
+  `onFallback` hooks.
+- `@agentskit/observability` — `createDevtoolsServer` +
+  `toSseFrame` form a transport-agnostic pub/sub hub for
+  `AgentEvent`s. Plug the returned observer into a runtime and
+  attach any client (SSE response / WebSocket / in-process sink).
+  New clients receive a `hello` envelope, replay of the ring
+  buffer, then the live feed — the contract a browser devtools
+  extension speaks against.

--- a/apps/docs-next/content/docs/recipes/adapter-ensemble.mdx
+++ b/apps/docs-next/content/docs/recipes/adapter-ensemble.mdx
@@ -1,0 +1,82 @@
+---
+title: Adapter ensemble
+description: Send one request to N models in parallel, aggregate the answers into a single output.
+---
+
+Ensembles are the "wisdom of crowds" move for LLMs: send the same
+request to several models, then combine their answers. Great for
+reducing variance on high-stakes outputs (classification labels,
+structured extraction, critical summaries).
+
+## Install
+
+Comes with `@agentskit/adapters`.
+
+## Quick start — majority vote
+
+```ts
+import { createEnsembleAdapter, anthropic, openai } from '@agentskit/adapters'
+
+const ensemble = createEnsembleAdapter({
+  candidates: [
+    { id: 'haiku', adapter: anthropic({ model: 'claude-haiku-4-5' }) },
+    { id: 'sonnet', adapter: anthropic({ model: 'claude-sonnet-4-6' }) },
+    { id: 'gpt-mini', adapter: openai({ model: 'gpt-4o-mini' }) },
+  ],
+  // aggregate: 'majority-vote' is the default
+})
+```
+
+The resulting `AdapterFactory` emits a single `text` chunk carrying
+the aggregated answer followed by `done`, so it plugs into any
+runtime that expects a streaming adapter.
+
+## Aggregators
+
+| `aggregate` | Behavior |
+|-------------|----------|
+| `'majority-vote'` *(default)* | Weighted vote — picks the text with the highest total `weight` (default 1 per candidate) |
+| `'concat'` | Joins all branches with `\n---\n` — useful for review workflows |
+| `'longest'` | Picks the branch with the most bytes of text |
+| `function` | Custom: `(branches) => string`, sync or async |
+
+```ts
+createEnsembleAdapter({
+  aggregate: branches => {
+    // Prefer a branch whose output parses as JSON.
+    const parsed = branches.find(b => {
+      try { JSON.parse(b.text); return true } catch { return false }
+    })
+    return parsed?.text ?? branches[0].text
+  },
+  candidates: [...],
+})
+```
+
+## Weighted vote
+
+Give higher-quality models a stronger say.
+
+```ts
+createEnsembleAdapter({
+  candidates: [
+    { id: 'cheap', adapter: haikuFactory, weight: 1 },
+    { id: 'premium', adapter: sonnetFactory, weight: 3 },
+  ],
+})
+```
+
+## Timeouts and resilience
+
+- `timeoutMs` bounds every branch. A branch that times out is
+  marked with an error and skipped.
+- If **every** branch fails, the adapter throws `all ensemble
+  branches failed` — callers can retry or fall back.
+- `onBranches` fires once per request with every branch's raw
+  output, so you can log, cost-meter, or audit.
+
+## See also
+
+- [Speculative execution](/docs/recipes/speculative-execution) — pick a winner instead of aggregating
+- [Adapter router](/docs/recipes/adapter-router) — pick one candidate based on policy
+- [Fallback chain](/docs/recipes/fallback-chain)

--- a/apps/docs-next/content/docs/recipes/devtools-server.mdx
+++ b/apps/docs-next/content/docs/recipes/devtools-server.mdx
@@ -1,0 +1,89 @@
+---
+title: Devtools server
+description: Expose a live feed of agent events so any browser extension or custom dashboard can inspect a running agent.
+---
+
+The AgentsKit devtools server is a **transport-agnostic pub/sub hub**
+for agent events. Plug it into your runtime as an observer; attach
+any transport (SSE response, WebSocket, in-process sink) as a client.
+New clients get a replay of the recent ring buffer so they can jump
+in mid-session. The envelope shape is the contract a browser
+extension (or your own dashboard) speaks against.
+
+## Install
+
+Comes with `@agentskit/observability`.
+
+## Wire it up
+
+```ts
+import { createDevtoolsServer } from '@agentskit/observability'
+import { createRuntime } from '@agentskit/runtime'
+import { anthropic } from '@agentskit/adapters'
+
+export const devtools = createDevtoolsServer({ bufferSize: 500 })
+
+export const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  observers: [devtools.observer],
+})
+```
+
+`devtools.observer` receives every `AgentEvent` the runtime emits and
+fans it out to every attached client.
+
+## Expose over SSE (Node `http` example)
+
+```ts
+import { createServer } from 'node:http'
+import { toSseFrame } from '@agentskit/observability'
+import { devtools } from './runtime'
+
+createServer((req, res) => {
+  if (req.url !== '/agentskit/devtools') {
+    res.statusCode = 404
+    res.end()
+    return
+  }
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+  const detach = devtools.attach({
+    id: `c-${Date.now()}`,
+    send: envelope => res.write(toSseFrame(envelope)),
+    close: () => res.end(),
+  })
+  req.on('close', detach)
+}).listen(4999)
+```
+
+Point your browser extension at `http://localhost:4999/agentskit/devtools`
+and it receives:
+
+1. `{ type: 'hello', protocol: 1, serverId, since }`
+2. One `{ type: 'agent-event' }` per retained event
+3. `{ type: 'replay-end', seq }`
+4. Live feed of new `agent-event` envelopes
+
+## Protocol
+
+```ts
+type DevtoolsEnvelope =
+  | { type: 'hello'; protocol: 1; serverId: string; since: string }
+  | { type: 'agent-event'; seq: number; at: number; event: AgentEvent }
+  | { type: 'replay-end'; seq: number }
+```
+
+`seq` is monotonic per server, `at` is `Date.now()` at publish time.
+
+## Programmatic access
+
+No browser needed — `devtools.buffer()` returns a snapshot of retained
+events for in-process assertions, tests, or CLI tools.
+
+## See also
+
+- [Console logger](/docs/recipes/cost-guarded-chat) — simpler observability for local runs
+- [Cost guard](/docs/recipes/cost-guard) — hard $ ceiling

--- a/apps/docs-next/content/docs/recipes/fallback-chain.mdx
+++ b/apps/docs-next/content/docs/recipes/fallback-chain.mdx
@@ -1,0 +1,69 @@
+---
+title: Fallback chain
+description: Try adapters in order — on error, fall through to the next without duplicating tool calls.
+---
+
+Providers go down. APIs rate-limit. Keys rotate. `createFallbackAdapter`
+takes an ordered list of adapters and tries them in sequence: first
+one that produces a real chunk wins. Once any adapter has committed
+(emitted its first non-`done` chunk), mid-stream errors are
+propagated — no silent cross-candidate retries that would duplicate
+tool calls or double-charge tokens.
+
+## Install
+
+Comes with `@agentskit/adapters`.
+
+## Quick start
+
+```ts
+import { createFallbackAdapter, anthropic, openai } from '@agentskit/adapters'
+
+const adapter = createFallbackAdapter([
+  { id: 'primary', adapter: anthropic({ model: 'claude-sonnet-4-6' }) },
+  { id: 'backup', adapter: openai({ model: 'gpt-4o' }) },
+  { id: 'local', adapter: ollama({ model: 'llama3.1' }) },
+])
+```
+
+## When does it fall through?
+
+- `createSource` throws synchronously
+- `stream()` throws **before** the first chunk
+- The adapter returns an async iterable that yields **zero** chunks
+
+Once the first chunk is out, the adapter is committed.
+
+## Opt out of retrying specific errors
+
+```ts
+createFallbackAdapter(candidates, {
+  shouldRetry: (error, index) => {
+    // Don't fall through on auth errors — they'll likely hit every provider.
+    if (/401|403|unauthorized/i.test(error.message)) return false
+    return true
+  },
+})
+```
+
+## Observe hops
+
+```ts
+createFallbackAdapter(candidates, {
+  onFallback: ({ id, index, error }) => {
+    logger.warn(`[fallback] ${id} (idx=${index}) failed: ${error.message}`)
+  },
+})
+```
+
+## What happens when everything fails
+
+The adapter throws `all fallback candidates failed (id1: msg; id2:
+msg; ...)` with each candidate's last error, so you can diagnose
+without rerunning.
+
+## See also
+
+- [Adapter router](/docs/recipes/adapter-router) — pick by cost/latency, not by order
+- [Ensemble](/docs/recipes/adapter-ensemble) — combine, not select
+- [Speculative execution](/docs/recipes/speculative-execution)

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -27,6 +27,9 @@
     "multi-modal",
     "schema-first-agent",
     "agentskit-ai",
-    "adapter-router"
+    "adapter-router",
+    "adapter-ensemble",
+    "fallback-chain",
+    "devtools-server"
   ]
 }

--- a/packages/adapters/src/ensemble.ts
+++ b/packages/adapters/src/ensemble.ts
@@ -1,0 +1,146 @@
+import type { AdapterFactory, AdapterRequest, StreamChunk, StreamSource } from '@agentskit/core'
+
+export interface EnsembleCandidate {
+  id: string
+  adapter: AdapterFactory
+  /** Weight used by 'weighted-vote' aggregator. Default 1. */
+  weight?: number
+}
+
+export interface EnsembleBranchResult {
+  id: string
+  text: string
+  chunks: StreamChunk[]
+  error?: Error
+}
+
+export type EnsembleAggregator =
+  | 'majority-vote'
+  | 'concat'
+  | 'longest'
+  | ((branches: EnsembleBranchResult[]) => string | Promise<string>)
+
+export interface EnsembleOptions {
+  candidates: EnsembleCandidate[]
+  /** How to combine branches into the single output text. Default 'majority-vote'. */
+  aggregate?: EnsembleAggregator
+  /** Per-candidate timeout in ms. Branches that time out are marked with an error. */
+  timeoutMs?: number
+  /** Observability hook — fires once with every branch's result. */
+  onBranches?: (branches: EnsembleBranchResult[]) => void
+}
+
+async function drain(source: StreamSource, timeoutMs?: number): Promise<{ chunks: StreamChunk[]; text: string; error?: Error }> {
+  const chunks: StreamChunk[] = []
+  let text = ''
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let timedOut = false
+  let error: Error | undefined
+  if (timeoutMs !== undefined) {
+    timer = setTimeout(() => {
+      timedOut = true
+      source.abort()
+    }, timeoutMs)
+  }
+  try {
+    for await (const chunk of source.stream()) {
+      chunks.push(chunk)
+      if (chunk.type === 'text' && typeof chunk.content === 'string') text += chunk.content
+    }
+  } catch (err) {
+    error = err instanceof Error ? err : new Error(String(err))
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+  if (timedOut) error = new Error(`timeout after ${timeoutMs}ms`)
+  return { chunks, text, error }
+}
+
+function majorityVote(branches: EnsembleBranchResult[], candidates: EnsembleCandidate[]): string {
+  const counts = new Map<string, number>()
+  const weightById = new Map(candidates.map(c => [c.id, c.weight ?? 1]))
+  for (const b of branches) {
+    if (b.error) continue
+    counts.set(b.text, (counts.get(b.text) ?? 0) + (weightById.get(b.id) ?? 1))
+  }
+  let best = ''
+  let bestScore = -1
+  for (const [text, score] of counts) {
+    if (score > bestScore) {
+      bestScore = score
+      best = text
+    }
+  }
+  return best
+}
+
+/**
+ * Build an AdapterFactory that runs the same request against N
+ * candidates in parallel, then aggregates the results into a single
+ * text output. Unlike `speculate` (which picks a winner), `ensemble`
+ * combines — majority vote, concatenation, longest, or a custom fn.
+ *
+ * The returned source emits a single `{ type: 'text' }` chunk with
+ * the aggregated output followed by `{ type: 'done' }`, so it plugs
+ * into any runtime that expects a regular streaming adapter.
+ */
+export function createEnsembleAdapter(options: EnsembleOptions): AdapterFactory {
+  if (options.candidates.length === 0) {
+    throw new Error('createEnsembleAdapter requires at least one candidate')
+  }
+  const aggregate = options.aggregate ?? 'majority-vote'
+
+  return {
+    createSource: (request: AdapterRequest): StreamSource => {
+      let aborted = false
+      const sources: StreamSource[] = []
+
+      const run = async (): Promise<EnsembleBranchResult[]> => {
+        const tasks = options.candidates.map(async (c, i): Promise<EnsembleBranchResult> => {
+          const source = c.adapter.createSource(request)
+          sources[i] = source
+          const { chunks, text, error } = await drain(source, options.timeoutMs)
+          return { id: c.id, chunks, text, error }
+        })
+        return Promise.all(tasks)
+      }
+
+      const finalText = async (branches: EnsembleBranchResult[]): Promise<string> => {
+        if (typeof aggregate === 'function') return aggregate(branches)
+        if (aggregate === 'concat') {
+          return branches
+            .filter(b => !b.error)
+            .map(b => b.text)
+            .join('\n---\n')
+        }
+        if (aggregate === 'longest') {
+          return branches
+            .filter(b => !b.error)
+            .reduce(
+              (best, b) => (b.text.length > best.length ? b.text : best),
+              '',
+            )
+        }
+        return majorityVote(branches, options.candidates)
+      }
+
+      return {
+        abort: () => {
+          aborted = true
+          for (const s of sources) s?.abort()
+        },
+        stream: async function* () {
+          const branches = await run()
+          options.onBranches?.(branches)
+          if (aborted) return
+          const text = await finalText(branches)
+          if (!text && branches.every(b => b.error)) {
+            throw new Error('all ensemble branches failed')
+          }
+          yield { type: 'text', content: text, metadata: { ensemble: branches.map(b => ({ id: b.id, bytes: b.text.length, error: b.error?.message })) } } as StreamChunk
+          yield { type: 'done' } as StreamChunk
+        },
+      }
+    },
+  }
+}

--- a/packages/adapters/src/fallback.ts
+++ b/packages/adapters/src/fallback.ts
@@ -1,0 +1,99 @@
+import type { AdapterFactory, AdapterRequest, StreamChunk, StreamSource } from '@agentskit/core'
+
+export interface FallbackOptions {
+  /**
+   * Predicate deciding whether an error from a given adapter should
+   * trigger fall-through to the next. Default: always retry the next.
+   */
+  shouldRetry?: (error: Error, index: number) => boolean
+  /** Observability hook — fires when one adapter fails and the chain advances. */
+  onFallback?: (from: { id: string; index: number; error: Error }) => void
+}
+
+export interface FallbackCandidate {
+  id: string
+  adapter: AdapterFactory
+}
+
+/**
+ * Try adapters in order. If the first fails (throws while opening, or
+ * errors mid-stream before emitting any non-done chunk), fall through
+ * to the next. As soon as a candidate produces its first real chunk,
+ * that's the committed one — we don't retroactively retry mid-stream.
+ *
+ * Errors that happen *after* committing are propagated; the caller
+ * sees a normal streaming failure, not a mysterious cross-candidate
+ * retry that could duplicate tool calls.
+ */
+export function createFallbackAdapter(
+  candidates: FallbackCandidate[],
+  options: FallbackOptions = {},
+): AdapterFactory {
+  if (candidates.length === 0) {
+    throw new Error('createFallbackAdapter requires at least one candidate')
+  }
+
+  return {
+    createSource: (request: AdapterRequest): StreamSource => {
+      let active: StreamSource | undefined
+      let aborted = false
+
+      return {
+        abort: () => {
+          aborted = true
+          active?.abort()
+        },
+        stream: async function* () {
+          const errors: Array<{ id: string; error: Error }> = []
+          for (let i = 0; i < candidates.length; i++) {
+            if (aborted) return
+            const candidate = candidates[i]!
+            let source: StreamSource
+            try {
+              source = candidate.adapter.createSource(request)
+            } catch (err) {
+              const error = err instanceof Error ? err : new Error(String(err))
+              errors.push({ id: candidate.id, error })
+              options.onFallback?.({ id: candidate.id, index: i, error })
+              if (options.shouldRetry && !options.shouldRetry(error, i)) throw error
+              continue
+            }
+            active = source
+
+            const iter = source.stream()[Symbol.asyncIterator]()
+            let first: IteratorResult<StreamChunk>
+            try {
+              first = await iter.next()
+            } catch (err) {
+              const error = err instanceof Error ? err : new Error(String(err))
+              errors.push({ id: candidate.id, error })
+              options.onFallback?.({ id: candidate.id, index: i, error })
+              if (options.shouldRetry && !options.shouldRetry(error, i)) throw error
+              active = undefined
+              continue
+            }
+
+            if (first.done) {
+              // Candidate produced zero chunks — treat as a failed branch.
+              const error = new Error(`candidate ${candidate.id} emitted no chunks`)
+              errors.push({ id: candidate.id, error })
+              options.onFallback?.({ id: candidate.id, index: i, error })
+              if (options.shouldRetry && !options.shouldRetry(error, i)) throw error
+              active = undefined
+              continue
+            }
+
+            yield first.value
+            while (true) {
+              const next = await iter.next()
+              if (next.done) return
+              yield next.value
+            }
+          }
+          const summary = errors.map(e => `${e.id}: ${e.error.message}`).join('; ')
+          throw new Error(`all fallback candidates failed (${summary})`)
+        },
+      }
+    },
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -27,6 +27,16 @@ export type { RetryOptions } from './utils'
 export { createRouter } from './router'
 export type { RouterCandidate, RouterOptions, RouterPolicy } from './router'
 
+export { createEnsembleAdapter } from './ensemble'
+export type {
+  EnsembleCandidate,
+  EnsembleBranchResult,
+  EnsembleAggregator,
+  EnsembleOptions,
+} from './ensemble'
+export { createFallbackAdapter } from './fallback'
+export type { FallbackCandidate, FallbackOptions } from './fallback'
+
 export { mockAdapter, recordingAdapter, replayAdapter, inMemorySink } from './mock'
 export type {
   MockAdapterOptions,

--- a/packages/adapters/tests/ensemble.test.ts
+++ b/packages/adapters/tests/ensemble.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core'
+import { createEnsembleAdapter } from '../src/ensemble'
+
+function adapter(chunks: StreamChunk[], opts: { delayMs?: number; throwImmediately?: boolean } = {}): AdapterFactory {
+  return {
+    createSource: () => ({
+      abort: () => {},
+      stream: async function* () {
+        if (opts.throwImmediately) throw new Error('boom')
+        for (const c of chunks) {
+          if (opts.delayMs !== undefined) await new Promise(r => setTimeout(r, opts.delayMs))
+          yield c
+        }
+      },
+    }),
+  }
+}
+
+function textOnly(text: string): AdapterFactory {
+  return adapter([{ type: 'text', content: text }, { type: 'done' }])
+}
+
+function req(): AdapterRequest {
+  return {
+    messages: [{ id: '1', role: 'user', content: 'hi', status: 'complete', createdAt: new Date(0) }],
+  }
+}
+
+async function collect(factory: AdapterFactory): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = []
+  for await (const c of factory.createSource(req()).stream()) out.push(c)
+  return out
+}
+
+describe('createEnsembleAdapter', () => {
+  it('rejects empty candidate list', () => {
+    expect(() => createEnsembleAdapter({ candidates: [] })).toThrow(/at least one candidate/)
+  })
+
+  it('majority-vote default picks the most popular text', async () => {
+    const ens = createEnsembleAdapter({
+      candidates: [
+        { id: 'a', adapter: textOnly('yes') },
+        { id: 'b', adapter: textOnly('yes') },
+        { id: 'c', adapter: textOnly('no') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('yes')
+    expect(chunks[chunks.length - 1]!.type).toBe('done')
+  })
+
+  it('weighted vote respects weights', async () => {
+    const ens = createEnsembleAdapter({
+      candidates: [
+        { id: 'a', adapter: textOnly('cheap'), weight: 1 },
+        { id: 'b', adapter: textOnly('premium'), weight: 10 },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('premium')
+  })
+
+  it('concat aggregator joins branches with separator', async () => {
+    const ens = createEnsembleAdapter({
+      aggregate: 'concat',
+      candidates: [
+        { id: 'a', adapter: textOnly('hello') },
+        { id: 'b', adapter: textOnly('world') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toContain('hello')
+    expect(chunks[0]!.content).toContain('---')
+    expect(chunks[0]!.content).toContain('world')
+  })
+
+  it('longest aggregator picks the longest branch', async () => {
+    const ens = createEnsembleAdapter({
+      aggregate: 'longest',
+      candidates: [
+        { id: 'a', adapter: textOnly('short') },
+        { id: 'b', adapter: textOnly('a much longer reply') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('a much longer reply')
+  })
+
+  it('custom aggregator receives branch results', async () => {
+    const ens = createEnsembleAdapter({
+      aggregate: branches => branches.map(b => `${b.id}:${b.text}`).join('|'),
+      candidates: [
+        { id: 'a', adapter: textOnly('x') },
+        { id: 'b', adapter: textOnly('y') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('a:x|b:y')
+  })
+
+  it('onBranches fires with per-branch results', async () => {
+    let seen: { id: string; text: string }[] = []
+    const ens = createEnsembleAdapter({
+      onBranches: b => {
+        seen = b.map(x => ({ id: x.id, text: x.text }))
+      },
+      candidates: [
+        { id: 'a', adapter: textOnly('x') },
+        { id: 'b', adapter: textOnly('y') },
+      ],
+    })
+    await collect(ens)
+    expect(seen.map(s => s.id)).toEqual(['a', 'b'])
+  })
+
+  it('tolerates one failing branch', async () => {
+    const ens = createEnsembleAdapter({
+      candidates: [
+        { id: 'bad', adapter: adapter([], { throwImmediately: true }) },
+        { id: 'ok', adapter: textOnly('hi') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('hi')
+  })
+
+  it('throws when every branch fails', async () => {
+    const ens = createEnsembleAdapter({
+      candidates: [
+        { id: 'a', adapter: adapter([], { throwImmediately: true }) },
+        { id: 'b', adapter: adapter([], { throwImmediately: true }) },
+      ],
+    })
+    await expect(collect(ens)).rejects.toThrow(/all ensemble branches failed/)
+  })
+
+  it('timeoutMs marks slow branches as errors', async () => {
+    const seen: { id: string; error?: string }[] = []
+    const ens = createEnsembleAdapter({
+      timeoutMs: 5,
+      onBranches: b => {
+        seen.push(...b.map(x => ({ id: x.id, error: x.error?.message })))
+      },
+      candidates: [
+        { id: 'slow', adapter: adapter([{ type: 'text', content: 'late' }, { type: 'done' }], { delayMs: 100 }) },
+        { id: 'fast', adapter: textOnly('quick') },
+      ],
+    })
+    const chunks = await collect(ens)
+    expect(chunks[0]!.content).toBe('quick')
+    expect(seen.find(s => s.id === 'slow')!.error).toMatch(/timeout|aborted/i)
+  })
+
+  it('abort cancels all running sources', async () => {
+    const ens = createEnsembleAdapter({
+      candidates: [
+        { id: 'a', adapter: adapter([{ type: 'text', content: 'x' }, { type: 'done' }], { delayMs: 50 }) },
+      ],
+    })
+    const source = ens.createSource(req())
+    source.abort()
+    const chunks: StreamChunk[] = []
+    for await (const c of source.stream()) chunks.push(c)
+    expect(chunks).toHaveLength(0)
+  })
+})

--- a/packages/adapters/tests/fallback.test.ts
+++ b/packages/adapters/tests/fallback.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core'
+import { createFallbackAdapter } from '../src/fallback'
+
+function req(): AdapterRequest {
+  return { messages: [{ id: '1', role: 'user', content: 'x', status: 'complete', createdAt: new Date(0) }] }
+}
+
+function ok(text: string): AdapterFactory {
+  return {
+    createSource: () => ({
+      abort: () => {},
+      stream: async function* () {
+        yield { type: 'text', content: text } as StreamChunk
+        yield { type: 'done' } as StreamChunk
+      },
+    }),
+  }
+}
+
+function throwsOnOpen(): AdapterFactory {
+  return {
+    createSource: () => {
+      throw new Error('cannot open')
+    },
+  }
+}
+
+function throwsOnFirst(): AdapterFactory {
+  return {
+    createSource: () => ({
+      abort: () => {},
+      stream: async function* () {
+        throw new Error('explodes before first chunk')
+      },
+    }),
+  }
+}
+
+function emitsNone(): AdapterFactory {
+  return {
+    createSource: () => ({
+      abort: () => {},
+      stream: async function* () {
+        // yields nothing
+      },
+    }),
+  }
+}
+
+async function collect(factory: AdapterFactory): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = []
+  for await (const c of factory.createSource(req()).stream()) out.push(c)
+  return out
+}
+
+describe('createFallbackAdapter', () => {
+  it('rejects empty candidate list', () => {
+    expect(() => createFallbackAdapter([])).toThrow(/at least one candidate/)
+  })
+
+  it('uses the first candidate when it succeeds', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: ok('A') },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('A')
+  })
+
+  it('falls through when createSource throws', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: throwsOnOpen() },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('B')
+  })
+
+  it('falls through when first chunk throws', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: throwsOnFirst() },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('B')
+  })
+
+  it('falls through when a candidate emits zero chunks', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: emitsNone() },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('B')
+  })
+
+  it('aggregates errors when every candidate fails', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: throwsOnOpen() },
+      { id: 'b', adapter: throwsOnFirst() },
+    ])
+    await expect(collect(f)).rejects.toThrow(/all fallback candidates failed.*a:.*b:/)
+  })
+
+  it('onFallback observes each hop', async () => {
+    const hops: string[] = []
+    const f = createFallbackAdapter(
+      [
+        { id: 'a', adapter: throwsOnOpen() },
+        { id: 'b', adapter: ok('B') },
+      ],
+      { onFallback: x => hops.push(`${x.id}@${x.index}:${x.error.message}`) },
+    )
+    await collect(f)
+    expect(hops[0]).toMatch(/^a@0:cannot open/)
+  })
+
+  it('shouldRetry=false stops the chain and rethrows', async () => {
+    const f = createFallbackAdapter(
+      [
+        { id: 'a', adapter: throwsOnOpen() },
+        { id: 'b', adapter: ok('B') },
+      ],
+      { shouldRetry: () => false },
+    )
+    await expect(collect(f)).rejects.toThrow(/cannot open/)
+  })
+
+  it('committed candidate propagates mid-stream errors without retrying', async () => {
+    const flaky: AdapterFactory = {
+      createSource: () => ({
+        abort: () => {},
+        stream: async function* () {
+          yield { type: 'text', content: 'partial' } as StreamChunk
+          throw new Error('mid-stream')
+        },
+      }),
+    }
+    const f = createFallbackAdapter([
+      { id: 'flaky', adapter: flaky },
+      { id: 'backup', adapter: ok('backup') },
+    ])
+    const iter = f.createSource(req()).stream()[Symbol.asyncIterator]()
+    const first = await iter.next()
+    expect(first.value.content).toBe('partial')
+    await expect(iter.next()).rejects.toThrow(/mid-stream/)
+  })
+
+  it('abort stops further fallthrough', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: throwsOnOpen() },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const source = f.createSource(req())
+    source.abort()
+    const out: StreamChunk[] = []
+    for await (const c of source.stream()) out.push(c)
+    expect(out).toHaveLength(0)
+  })
+})

--- a/packages/observability/src/devtools.ts
+++ b/packages/observability/src/devtools.ts
@@ -1,0 +1,123 @@
+import type { AgentEvent, Observer } from '@agentskit/core'
+
+export interface DevtoolsClient {
+  id: string
+  send: (event: DevtoolsEnvelope) => void
+  close?: () => void
+}
+
+export type DevtoolsEnvelope =
+  | { type: 'hello'; protocol: 1; serverId: string; since: string }
+  | { type: 'agent-event'; seq: number; at: number; event: AgentEvent }
+  | { type: 'replay-end'; seq: number }
+
+export interface DevtoolsServerOptions {
+  /** Max events to retain in the ring buffer. Default 500. */
+  bufferSize?: number
+  /** Server id emitted in the `hello` envelope. Default: random. */
+  serverId?: string
+}
+
+export interface DevtoolsServer {
+  /** Observer you can plug into `createRuntime({ observers: [...] })`. */
+  observer: Observer
+  /** Push arbitrary events (tests / custom sources). */
+  publish: (event: AgentEvent) => void
+  /** Attach a transport — SSE response, WS connection, in-process sink. */
+  attach: (client: DevtoolsClient) => () => void
+  /** Drop all clients and clear buffer. */
+  close: () => void
+  /** Snapshot of retained events, newest last. */
+  buffer: () => ReadonlyArray<{ seq: number; at: number; event: AgentEvent }>
+}
+
+/**
+ * In-process pub/sub hub for agent events. Transport-agnostic — hand
+ * the returned `attach` function any object that can `send` envelopes
+ * (an SSE response, a WebSocket, a test sink). Designed as the
+ * contract a browser devtools extension speaks against.
+ *
+ * New clients receive a `hello` envelope followed by a replay of the
+ * ring buffer (so the extension can jump in mid-session and see
+ * recent history), then `replay-end`, then the live feed.
+ */
+export function createDevtoolsServer(options: DevtoolsServerOptions = {}): DevtoolsServer {
+  const bufferSize = Math.max(10, options.bufferSize ?? 500)
+  const serverId = options.serverId ?? `ak-${Math.random().toString(36).slice(2, 10)}`
+  const buffer: Array<{ seq: number; at: number; event: AgentEvent }> = []
+  const clients = new Map<string, DevtoolsClient>()
+  let seq = 0
+  let closed = false
+
+  const publish = (event: AgentEvent): void => {
+    if (closed) return
+    seq++
+    const record = { seq, at: Date.now(), event }
+    buffer.push(record)
+    while (buffer.length > bufferSize) buffer.shift()
+    const envelope: DevtoolsEnvelope = { type: 'agent-event', seq, at: record.at, event }
+    for (const client of clients.values()) {
+      try {
+        client.send(envelope)
+      } catch {
+        // A misbehaving client shouldn't poison the pub-sub loop.
+      }
+    }
+  }
+
+  const attach = (client: DevtoolsClient): (() => void) => {
+    if (closed) {
+      client.close?.()
+      return () => {}
+    }
+    clients.set(client.id, client)
+    const safeSend = (envelope: DevtoolsEnvelope): void => {
+      try {
+        client.send(envelope)
+      } catch {
+        // Misbehaving client — leave it registered so the caller can detach.
+      }
+    }
+    safeSend({
+      type: 'hello',
+      protocol: 1,
+      serverId,
+      since: new Date().toISOString(),
+    })
+    for (const record of buffer) {
+      safeSend({ type: 'agent-event', seq: record.seq, at: record.at, event: record.event })
+    }
+    safeSend({ type: 'replay-end', seq })
+    return () => {
+      clients.delete(client.id)
+      client.close?.()
+    }
+  }
+
+  const close = (): void => {
+    closed = true
+    for (const client of clients.values()) client.close?.()
+    clients.clear()
+    buffer.length = 0
+  }
+
+  return {
+    observer: {
+      name: 'devtools',
+      on: (event: AgentEvent) => publish(event),
+    },
+    publish,
+    attach,
+    close,
+    buffer: () => buffer.slice(),
+  }
+}
+
+/**
+ * Serialize a devtools envelope as a single `data: ...\n\n` SSE frame.
+ * Framework-agnostic — hook into Express / Hono / plain http by
+ * writing the returned string to your response.
+ */
+export function toSseFrame(envelope: DevtoolsEnvelope): string {
+  return `data: ${JSON.stringify(envelope)}\n\n`
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -15,3 +15,11 @@ export type { CostGuardOptions, TokenPrice } from './cost-guard'
 
 export { approximateCounter, countTokens, countTokensDetailed, createProviderCounter } from './token-counter'
 export type { ProviderTokenCounterOptions } from './token-counter'
+
+export { createDevtoolsServer, toSseFrame } from './devtools'
+export type {
+  DevtoolsServer,
+  DevtoolsServerOptions,
+  DevtoolsClient,
+  DevtoolsEnvelope,
+} from './devtools'

--- a/packages/observability/tests/devtools.test.ts
+++ b/packages/observability/tests/devtools.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentEvent } from '@agentskit/core'
+import {
+  createDevtoolsServer,
+  toSseFrame,
+  type DevtoolsClient,
+  type DevtoolsEnvelope,
+} from '../src/devtools'
+
+function sink(id: string): DevtoolsClient & { envelopes: DevtoolsEnvelope[]; closed: boolean } {
+  const envelopes: DevtoolsEnvelope[] = []
+  let closed = false
+  return {
+    id,
+    envelopes,
+    get closed() {
+      return closed
+    },
+    send: e => envelopes.push(e),
+    close: () => {
+      closed = true
+    },
+  }
+}
+
+const sampleEvent: AgentEvent = { type: 'llm:start', model: 'x', messageCount: 1 }
+
+describe('createDevtoolsServer', () => {
+  it('publish appends to buffer and fans out to clients', () => {
+    const server = createDevtoolsServer()
+    const s = sink('a')
+    server.attach(s)
+    server.publish(sampleEvent)
+    const events = s.envelopes.filter(e => e.type === 'agent-event')
+    expect(events).toHaveLength(1)
+    expect(events[0]!).toMatchObject({ seq: 1, event: { type: 'llm:start' } })
+    expect(server.buffer()).toHaveLength(1)
+  })
+
+  it('observer forwards agent events to publish', () => {
+    const server = createDevtoolsServer()
+    const s = sink('a')
+    server.attach(s)
+    server.observer.on(sampleEvent)
+    expect(s.envelopes.some(e => e.type === 'agent-event')).toBe(true)
+  })
+
+  it('attach replays buffer to new clients between hello and replay-end', () => {
+    const server = createDevtoolsServer()
+    server.publish(sampleEvent)
+    server.publish({ type: 'llm:end', content: 'hi', durationMs: 10 })
+    const s = sink('late')
+    server.attach(s)
+    const types = s.envelopes.map(e => e.type)
+    expect(types[0]).toBe('hello')
+    expect(types[1]).toBe('agent-event')
+    expect(types[types.length - 1]).toBe('replay-end')
+    const replays = s.envelopes.filter(e => e.type === 'agent-event')
+    expect(replays).toHaveLength(2)
+  })
+
+  it('ring buffer caps at bufferSize', () => {
+    const server = createDevtoolsServer({ bufferSize: 10 })
+    for (let i = 0; i < 25; i++) server.publish(sampleEvent)
+    expect(server.buffer()).toHaveLength(10)
+  })
+
+  it('detach removes the client from fan-out', () => {
+    const server = createDevtoolsServer()
+    const s = sink('a')
+    const detach = server.attach(s)
+    detach()
+    const before = s.envelopes.length
+    server.publish(sampleEvent)
+    expect(s.envelopes.length).toBe(before)
+    expect(s.closed).toBe(true)
+  })
+
+  it('close drops all clients and empties the buffer', () => {
+    const server = createDevtoolsServer()
+    const s = sink('a')
+    server.attach(s)
+    server.publish(sampleEvent)
+    server.close()
+    expect(s.closed).toBe(true)
+    expect(server.buffer()).toHaveLength(0)
+    // publish after close is a no-op
+    server.publish(sampleEvent)
+    expect(server.buffer()).toHaveLength(0)
+  })
+
+  it('attach after close immediately closes the client', () => {
+    const server = createDevtoolsServer()
+    server.close()
+    const s = sink('a')
+    server.attach(s)
+    expect(s.closed).toBe(true)
+    expect(s.envelopes).toHaveLength(0)
+  })
+
+  it('a throwing client does not poison other clients', () => {
+    const server = createDevtoolsServer()
+    const bad: DevtoolsClient = {
+      id: 'bad',
+      send: () => {
+        throw new Error('nope')
+      },
+    }
+    const good = sink('good')
+    server.attach(bad)
+    server.attach(good)
+    server.publish(sampleEvent)
+    expect(good.envelopes.some(e => e.type === 'agent-event')).toBe(true)
+  })
+
+  it('hello envelope exposes configured serverId', () => {
+    const server = createDevtoolsServer({ serverId: 'test-server' })
+    const s = sink('a')
+    server.attach(s)
+    const hello = s.envelopes[0]!
+    if (hello.type !== 'hello') throw new Error('expected hello')
+    expect(hello.serverId).toBe('test-server')
+    expect(hello.protocol).toBe(1)
+  })
+})
+
+describe('toSseFrame', () => {
+  it('serializes to a valid SSE frame', () => {
+    const frame = toSseFrame({ type: 'hello', protocol: 1, serverId: 's', since: new Date(0).toISOString() })
+    expect(frame.startsWith('data: ')).toBe(true)
+    expect(frame.endsWith('\n\n')).toBe(true)
+    const json = frame.slice(6, -2)
+    expect(JSON.parse(json)).toMatchObject({ type: 'hello', protocol: 1 })
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 sprint **S14** — closes #146, #147, #148.

- **#146 Adapter ensemble** — \`createEnsembleAdapter\` in \`@agentskit/adapters\`. Fan-out to N candidates, aggregate with \`majority-vote\` (weighted) / \`concat\` / \`longest\` / custom fn. Per-branch \`timeoutMs\` + \`onBranches\` hook. Tolerates partial failures; throws only when every branch fails.
- **#147 Fallback chain** — \`createFallbackAdapter\` in \`@agentskit/adapters\`. Try candidates in order; fall through on open / first-chunk / zero-chunk failures. Once committed, errors propagate — no duplicate tool calls. \`shouldRetry\` + \`onFallback\` hooks.
- **#148 Devtools server** — \`createDevtoolsServer\` + \`toSseFrame\` in \`@agentskit/observability\`. Transport-agnostic pub/sub for \`AgentEvent\`s. Plug the observer into a runtime; attach any client (SSE response / WS / in-process sink). New clients get \`hello\` → ring-buffer replay → \`replay-end\` → live feed. Contract for any browser devtools UI.

33 new tests (ensemble 12 · fallback 11 · devtools 10).

## Coverage

- \`@agentskit/adapters\` lines 77% (threshold 60)
- \`@agentskit/observability\` lines 76% (threshold 55)

## Docs

- \`apps/docs-next/content/docs/recipes/adapter-ensemble.mdx\`
- \`apps/docs-next/content/docs/recipes/fallback-chain.mdx\`
- \`apps/docs-next/content/docs/recipes/devtools-server.mdx\`

## Changeset

\`.changeset/phase2-s14-ensemble-fallback-devtools.md\` — minor bumps on \`@agentskit/adapters\` and \`@agentskit/observability\`.

## Test plan

- [x] adapters / observability test:coverage above thresholds
- [x] \`pnpm -r lint\` clean
- [x] \`pnpm --filter @agentskit/docs-next lint\`
- [ ] Manual: wire SSE endpoint + open in Chrome, verify live feed
- [ ] Follow-up: publish the actual browser extension in a later sprint