### PR TITLE
feat: durable execution + topologies + HITL + background agents (S17)

### DIFF
--- a/.changeset/phase2-s17-durable-topos-hitl-bg.md
+++ b/.changeset/phase2-s17-durable-topos-hitl-bg.md
@@ -1,0 +1,23 @@
+---
+'@agentskit/runtime': minor
+'@agentskit/core': minor
+---
+
+Phase 2 sprint S17 — issues #156, #157, #158, #159.
+
+- `@agentskit/runtime` — `createDurableRunner` + `StepLogStore`
+  contract + `createInMemoryStepLog` / `createFileStepLog`.
+  Temporal-style durable execution: wrap side effects in
+  `runner.step(id, fn)`, resume transparently after crashes.
+- `@agentskit/runtime` — `supervisor` / `swarm` / `hierarchical` /
+  `blackboard` topology builders plus the minimal `AgentHandle`
+  interface they compose over. Round-robin / tag-based routing /
+  timeouts / user-supplied mergers all built-in.
+- `@agentskit/core/hitl` (subpath) — `createApprovalGate` +
+  `ApprovalStore` contract + `createInMemoryApprovalStore`.
+  Pause / resume / approve with persisted decisions; idempotent
+  `request` handles crash-and-resume without duplicate approvals.
+- `@agentskit/runtime` — `createCronScheduler` (zero-dep 5-field
+  cron + `every:<ms>`) + `createWebhookHandler` (framework-agnostic
+  `(req) => res` adapter for Express / Hono / Next). Background
+  agents without pulling in a job queue.

--- a/apps/docs-next/content/docs/recipes/background-agents.mdx
+++ b/apps/docs-next/content/docs/recipes/background-agents.mdx
@@ -1,0 +1,113 @@
+---
+title: Background agents (cron + webhooks)
+description: Run agents on a schedule or in response to incoming webhooks, without pulling in a job-queue dependency.
+---
+
+Two primitives, zero extra deps:
+
+- `createCronScheduler` parses a minimal 5-field cron (`*/15 * * * *`)
+  plus an `every:<ms>` shortcut.
+- `createWebhookHandler` returns a framework-agnostic
+  `(req) => res` handler you can mount on Express, Hono, Next API
+  routes, etc.
+
+Both accept any `AgentHandle` (anything with `name` + `run(task)`),
+so they compose with [topologies](/docs/recipes/multi-agent-topologies)
+and [durable runners](/docs/recipes/durable-execution).
+
+## Install
+
+Ships with `@agentskit/runtime`.
+
+## Cron
+
+```ts
+import { createCronScheduler } from '@agentskit/runtime'
+
+const scheduler = createCronScheduler({
+  jobs: [
+    {
+      schedule: '0 9 * * 1-5',  // weekdays at 9am
+      agent: dailyDigestAgent,
+      task: now => `Generate digest for ${now.toISOString().slice(0, 10)}`,
+    },
+    {
+      schedule: 'every:60000',  // every minute
+      agent: healthCheckAgent,
+      task: 'run health check',
+    },
+  ],
+  onEvent: e => logger.info('[cron]', e),
+})
+
+scheduler.start()
+// ...
+scheduler.stop()
+```
+
+For tests: inject a fake clock and drive ticks manually.
+
+```ts
+createCronScheduler({
+  jobs: [...],
+  now: () => fakeClock,
+  scheduleTick: fn => (cleanup = setInterval(fn, 100)),
+})
+```
+
+`scheduler.tick(now?)` fires every job whose schedule matches `now`.
+
+## Webhooks
+
+```ts
+import { createWebhookHandler } from '@agentskit/runtime'
+
+const handler = createWebhookHandler({
+  agent: supportTriageAgent,
+  verify: req => req.headers?.['x-signature'] === expectedSignature,
+  extractTask: req => `Triage ticket: ${JSON.stringify(req.body)}`,
+  context: req => ({ tenantId: req.headers?.['x-tenant'] }),
+})
+
+// Express
+app.post('/hooks/support', async (req, res) => {
+  const result = await handler({ headers: req.headers, body: req.body })
+  res.status(result.status).set(result.headers ?? {}).send(result.body)
+})
+
+// Hono
+app.post('/hooks/support', async c => {
+  const result = await handler({ headers: Object.fromEntries(c.req.raw.headers), body: await c.req.json() })
+  return new Response(result.body, { status: result.status, headers: result.headers })
+})
+```
+
+Default extractor reads `body.task` for JSON, falls back to the raw
+string. Default context is pass-through.
+
+## Pair with durable + HITL
+
+- Wrap the agent's work in a `createDurableRunner` to survive crashes.
+- Pause risky side effects behind `createApprovalGate`.
+
+A webhook that kicks off a long-running durable flow looks like:
+
+```ts
+const handler = createWebhookHandler({
+  agent: {
+    name: 'onboarding',
+    async run(task, ctx) {
+      const runner = createDurableRunner({ store, runId: ctx.tenantId + ':' + ctx.userId })
+      await runner.step('welcome', () => sendWelcome(...))
+      await runner.step('provision', () => provision(...))
+      return 'ok'
+    },
+  },
+})
+```
+
+## See also
+
+- [Durable execution](/docs/recipes/durable-execution)
+- [HITL approvals](/docs/recipes/hitl-approvals)
+- [Multi-agent topologies](/docs/recipes/multi-agent-topologies)

--- a/apps/docs-next/content/docs/recipes/durable-execution.mdx
+++ b/apps/docs-next/content/docs/recipes/durable-execution.mdx
@@ -1,0 +1,92 @@
+---
+title: Durable execution (Temporal-style)
+description: Wrap side-effectful steps so crashes, deploys, and retries replay from a step log instead of starting over.
+---
+
+When an agent crashes halfway through a 10-step workflow, the user
+doesn't want you to start over — they want you to resume. Durable
+execution gives you that with two primitives: a `StepLogStore`
+(persistence) and a `runner.step(id, fn)` wrapper (short-circuits to
+the recorded result if the id already exists in the log).
+
+## Install
+
+Ships with `@agentskit/runtime`.
+
+## Wrap side effects in steps
+
+```ts
+import {
+  createDurableRunner,
+  createFileStepLog,
+} from '@agentskit/runtime'
+
+const store = await createFileStepLog('./runs/user-42.jsonl')
+const runner = createDurableRunner({
+  store,
+  runId: 'user-42-onboard',
+  maxAttempts: 3,
+  retryDelayMs: 500,
+})
+
+await runner.step('create-account', async () => createAccount({ email }))
+await runner.step('send-welcome', async () => sendEmail({ to: email, template: 'welcome' }))
+await runner.step('charge-trial', async () => stripe.subscriptions.create({ ... }))
+```
+
+Re-run the same code (same `runId`) after a crash — completed steps
+short-circuit to their recorded values, only the remaining ones
+execute.
+
+## Stores
+
+- `createInMemoryStepLog()` — tests, single-process demos.
+- `createFileStepLog(path)` — JSONL on disk, append-only, survives
+  restarts.
+- Bring your own — anything implementing
+  `{ append, get, list, clear? }` works (Redis, Postgres, S3, etc).
+
+## Step contract
+
+A step is **idempotent from the log's perspective**: the fn does the
+side effect, the recorded `result` captures everything downstream
+steps need. Don't rely on global state outside the result.
+
+```ts
+const { userId } = await runner.step('create-account', async () => ({
+  userId: await createAccount(email),
+}))
+
+// Downstream steps use `userId` — NOT global `req.user.id`, which
+// might not exist on a resumed run.
+await runner.step('send-welcome', async () => sendEmail({ userId }))
+```
+
+## Retries
+
+- `maxAttempts`: total attempts per step (default 1 — fail-fast).
+- `retryDelayMs`: fixed backoff between attempts (default 0).
+- A step that fails all attempts is recorded with `status: 'failure'`;
+  replaying the same `stepId` re-throws without running again (so
+  you can diagnose without re-executing expensive failing work).
+
+Call `runner.reset()` to wipe the log for a fresh retry.
+
+## Observability
+
+```ts
+createDurableRunner({
+  store,
+  runId,
+  onEvent: e => logger.debug('durable', e),
+})
+```
+
+Events: `step:replay`, `step:start`, `step:success`, `step:failure`.
+
+## See also
+
+- [HITL approvals](/docs/recipes/hitl-approvals) — pause a step until
+  a human approves.
+- [Background agents](/docs/recipes/background-agents) — run
+  durable flows on a cron or webhook.

--- a/apps/docs-next/content/docs/recipes/hitl-approvals.mdx
+++ b/apps/docs-next/content/docs/recipes/hitl-approvals.mdx
@@ -1,0 +1,86 @@
+---
+title: Human-in-the-loop approvals
+description: Pause an agent at a named gate, persist the decision, resume deterministically.
+---
+
+A destructive tool call, a risky email, a big refund — some agent
+actions need human approval. `@agentskit/core/hitl` gives you the
+three primitives that make that practical: a persisted `Approval`
+record, a `request → await → decide` API, and a pluggable
+`ApprovalStore` so the decision survives crashes and worker restarts.
+
+## Install
+
+Built into `@agentskit/core` (subpath, zero extra weight on the main
+bundle).
+
+```ts
+import { createApprovalGate, createInMemoryApprovalStore } from '@agentskit/core/hitl'
+```
+
+## Pause-resume flow
+
+```ts
+const gate = createApprovalGate(myStore)
+
+async function deleteUserTool({ userId }: { userId: string }) {
+  const approval = await gate.request({
+    id: `delete-${userId}`,
+    name: 'delete-user',
+    payload: { userId },
+  })
+
+  const decision = await gate.await(approval.id, { timeoutMs: 3_600_000 })
+  if (decision.status !== 'approved') {
+    throw new Error(`rejected by ${decision.decisionMetadata?.approver ?? 'human'}`)
+  }
+
+  await db.users.delete(userId)
+}
+```
+
+On the operator side:
+
+```ts
+await gate.decide('delete-42', 'approved', { approver: 'alice' })
+// or
+await gate.decide('delete-42', 'rejected', { reason: 'account active' })
+```
+
+`gate.request` is **idempotent** on `id` — resuming a crashed run
+with the same id returns the existing approval (pending or decided)
+instead of creating a duplicate.
+
+## Stores
+
+- `createInMemoryApprovalStore()` — tests, single-process demos.
+- Bring your own with the 3-method contract (`put` / `get` /
+  `patch`). Redis, Postgres, SQS, DynamoDB — whatever you already run.
+
+## Options
+
+`gate.await(id, options?)`:
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `timeoutMs` | `Infinity` | Reject with `timed out` after N ms |
+| `pollMs` | `500` | Poll interval (store dictates whether polling is actually needed) |
+| `signal` | — | `AbortSignal` to cancel waiting |
+
+## Pair with durable execution
+
+A step whose work should *not* re-run on resume wraps its approval
+check inside `runner.step(id, fn)`. Once the step is recorded, the
+next run short-circuits instead of asking the human twice.
+
+```ts
+await runner.step(`approve-delete-${userId}`, async () => {
+  const approval = await gate.request({ id: `delete-${userId}`, name: 'delete-user', payload: { userId } })
+  return gate.await(approval.id, { timeoutMs: 3_600_000 })
+})
+```
+
+## See also
+
+- [Durable execution](/docs/recipes/durable-execution)
+- [Confirmation-gated tools](/docs/recipes/confirmation-gated-tool)

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -37,6 +37,10 @@
     "replay-different-model",
     "hierarchical-memory",
     "auto-summarize",
-    "rag-reranking"
+    "rag-reranking",
+    "durable-execution",
+    "multi-agent-topologies",
+    "hitl-approvals",
+    "background-agents"
   ]
 }

--- a/apps/docs-next/content/docs/recipes/multi-agent-topologies.mdx
+++ b/apps/docs-next/content/docs/recipes/multi-agent-topologies.mdx
@@ -1,0 +1,106 @@
+---
+title: Multi-agent topologies
+description: Ready-made supervisor, swarm, hierarchical, and blackboard builders — four ways to combine agents into one.
+---
+
+Picking a topology is half the battle with multi-agent systems.
+`@agentskit/runtime` ships the four patterns that actually show up
+in production; each takes `AgentHandle`s (anything with a
+`name` + `run(task)` method) and returns a new `AgentHandle` you
+can plug back into the rest of your system.
+
+## Install
+
+Ships with `@agentskit/runtime`.
+
+## Supervisor
+
+A planner agent delegates to workers, then synthesizes. Good for
+"decompose → delegate → merge" patterns.
+
+```ts
+import { supervisor } from '@agentskit/runtime'
+
+const team = supervisor({
+  supervisor: plannerAgent,
+  workers: [researcherAgent, coderAgent],
+  maxRounds: 2,
+  route: (task, workers) => (/code/i.test(task) ? workers[1]! : workers[0]!),
+})
+
+await team.run('Research quantum sort, then implement it in Python.')
+```
+
+## Swarm
+
+Every member sees the same task, runs in parallel, results get
+merged. Good for ensembling answers, voting, or "fan out and pick
+the best."
+
+```ts
+import { swarm } from '@agentskit/runtime'
+
+const team = swarm({
+  members: [anthropicAgent, openAiAgent, geminiAgent],
+  timeoutMs: 30_000,
+  merge: results => results.map(r => r.output).join('\n\n---\n\n'),
+})
+```
+
+One or more members can fail — the merger still runs as long as any
+member returned.
+
+## Hierarchical
+
+A routing tree. Start at the root, descend as long as a child matches
+(by tag or custom route), then execute the leaf.
+
+```ts
+import { hierarchical } from '@agentskit/runtime'
+
+const tree = hierarchical({
+  root: {
+    agent: triageAgent,
+    children: [
+      { agent: billingAgent, tags: ['refund', 'invoice', 'billing'] },
+      { agent: technicalAgent, tags: ['bug', 'error', 'crash'] },
+    ],
+  },
+  maxDepth: 3,
+})
+```
+
+## Blackboard
+
+Every agent reads and writes a shared scratchpad. Iterate until
+`isDone` says stop. Good for planner + critic loops or collaborative
+drafting.
+
+```ts
+import { blackboard } from '@agentskit/runtime'
+
+const team = blackboard({
+  agents: [plannerAgent, coderAgent, criticAgent],
+  maxIterations: 3,
+  isDone: board => board.includes('FINAL OUTPUT:'),
+})
+```
+
+## Observing
+
+Every topology accepts an `onEvent` observer:
+
+```ts
+supervisor({
+  supervisor,
+  workers,
+  onEvent: e => logger.info('[topo]', e.topology, e.phase, e.agent),
+})
+```
+
+Phases: `dispatch` / `agent:start` / `agent:end` / `merge` / `done`.
+
+## See also
+
+- [Durable execution](/docs/recipes/durable-execution) — wrap the whole topology in a step log.
+- [Background agents](/docs/recipes/background-agents) — run a topology on a schedule.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,11 @@
       "types": "./dist/auto-summarize.d.ts",
       "import": "./dist/auto-summarize.js",
       "require": "./dist/auto-summarize.cjs"
+    },
+    "./hitl": {
+      "types": "./dist/hitl.d.ts",
+      "import": "./dist/hitl.js",
+      "require": "./dist/hitl.cjs"
     }
   },
   "files": [

--- a/packages/core/src/hitl.ts
+++ b/packages/core/src/hitl.ts
@@ -1,0 +1,152 @@
+/**
+ * Human-in-the-loop primitives. A gate pauses agent execution at a
+ * named decision point and records an `Approval` in a user-supplied
+ * `ApprovalStore`. When a human (or another automation) writes a
+ * decision, any waiter resumes with that decision.
+ *
+ * The store can be in-memory for tests, SQLite for single-node
+ * deployments, or a shared DB / queue for multi-worker setups. Any
+ * store that implements the 3-method contract works.
+ */
+
+export type ApprovalDecision = 'approved' | 'rejected'
+
+export interface Approval<TPayload = unknown> {
+  id: string
+  /** Logical gate name (e.g. 'delete-user', 'send-email'). */
+  name: string
+  /** Caller-provided context for whoever reviews the approval. */
+  payload: TPayload
+  status: 'pending' | ApprovalDecision | 'cancelled'
+  createdAt: string
+  decidedAt?: string
+  /** Free-form metadata the approver attached (reason, user id, etc.). */
+  decisionMetadata?: Record<string, unknown>
+}
+
+export interface ApprovalStore {
+  /** Persist a new pending approval. */
+  put: <T>(approval: Approval<T>) => Promise<void>
+  /** Read the current state of an approval. */
+  get: <T>(id: string) => Promise<Approval<T> | null>
+  /** Update status + metadata. */
+  patch: <T>(id: string, update: Partial<Approval<T>>) => Promise<Approval<T> | null>
+}
+
+export interface RequestApprovalInput<TPayload> {
+  /** Gate name (reuse across invocations — how approvers identify it). */
+  name: string
+  /** Context passed to reviewers. Safe to store — no secrets. */
+  payload: TPayload
+  /** Stable id for idempotent gating (e.g. tool call id). */
+  id: string
+}
+
+export interface ApprovalGate<TPayload = unknown> {
+  /**
+   * Reserve or reuse an approval by id. First caller creates a
+   * `pending` record. Subsequent calls return the existing record
+   * — perfect for resuming a crashed run.
+   */
+  request: (input: RequestApprovalInput<TPayload>) => Promise<Approval<TPayload>>
+  /**
+   * Wait for `approved` or `rejected`. Resolves immediately if the
+   * approval is already decided. Polls at `pollMs` (default 500ms)
+   * up to `timeoutMs` (default Infinity).
+   */
+  await: (
+    id: string,
+    options?: { timeoutMs?: number; pollMs?: number; signal?: AbortSignal },
+  ) => Promise<Approval<TPayload>>
+  /** Approve, rejecting, or cancelling an approval. */
+  decide: (
+    id: string,
+    decision: ApprovalDecision,
+    metadata?: Record<string, unknown>,
+  ) => Promise<Approval<TPayload>>
+  cancel: (id: string) => Promise<Approval<TPayload>>
+}
+
+/**
+ * Build an approval gate over any `ApprovalStore`. The core loop
+ * couldn't be simpler — create-or-load + poll + patch — but having it
+ * behind a stable contract lets you swap persistence without touching
+ * agent code.
+ */
+export function createApprovalGate<TPayload = unknown>(
+  store: ApprovalStore,
+): ApprovalGate<TPayload> {
+  return {
+    async request({ id, name, payload }) {
+      const existing = await store.get<TPayload>(id)
+      if (existing) return existing
+      const created: Approval<TPayload> = {
+        id,
+        name,
+        payload,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+      }
+      await store.put(created)
+      return created
+    },
+
+    async await(id, options = {}) {
+      const pollMs = Math.max(50, options.pollMs ?? 500)
+      const deadline =
+        options.timeoutMs !== undefined && options.timeoutMs !== Infinity
+          ? Date.now() + options.timeoutMs
+          : Infinity
+      while (true) {
+        if (options.signal?.aborted) throw new Error('await approval aborted')
+        const current = await store.get<TPayload>(id)
+        if (!current) throw new Error(`approval "${id}" not found`)
+        if (current.status !== 'pending') return current
+        if (Date.now() >= deadline) {
+          throw new Error(`approval "${id}" timed out after ${options.timeoutMs}ms`)
+        }
+        await new Promise(r => setTimeout(r, pollMs))
+      }
+    },
+
+    async decide(id, decision, metadata) {
+      const updated = await store.patch<TPayload>(id, {
+        status: decision,
+        decidedAt: new Date().toISOString(),
+        decisionMetadata: metadata,
+      })
+      if (!updated) throw new Error(`approval "${id}" not found`)
+      return updated
+    },
+
+    async cancel(id) {
+      const updated = await store.patch<TPayload>(id, {
+        status: 'cancelled',
+        decidedAt: new Date().toISOString(),
+      })
+      if (!updated) throw new Error(`approval "${id}" not found`)
+      return updated
+    },
+  }
+}
+
+/** In-memory `ApprovalStore` — handy for tests and single-worker demos. */
+export function createInMemoryApprovalStore(): ApprovalStore {
+  const map = new Map<string, Approval<unknown>>()
+  return {
+    async put(approval) {
+      map.set(approval.id, { ...approval })
+    },
+    async get<T>(id: string): Promise<Approval<T> | null> {
+      const hit = map.get(id)
+      return hit ? ({ ...(hit as Approval<T>) }) : null
+    },
+    async patch<T>(id: string, update: Partial<Approval<T>>): Promise<Approval<T> | null> {
+      const hit = map.get(id)
+      if (!hit) return null
+      const next = { ...(hit as Approval<T>), ...update }
+      map.set(id, next as Approval<unknown>)
+      return next
+    },
+  }
+}

--- a/packages/core/tests/hitl.test.ts
+++ b/packages/core/tests/hitl.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createApprovalGate,
+  createInMemoryApprovalStore,
+} from '../src/hitl'
+
+describe('createInMemoryApprovalStore', () => {
+  it('stores, reads, and patches approvals', async () => {
+    const store = createInMemoryApprovalStore()
+    await store.put({
+      id: 'a',
+      name: 'test',
+      payload: { x: 1 },
+      status: 'pending',
+      createdAt: 'now',
+    })
+    const read = await store.get('a')
+    expect(read?.payload).toEqual({ x: 1 })
+
+    const patched = await store.patch('a', { status: 'approved' })
+    expect(patched?.status).toBe('approved')
+    expect(await store.get('a')).toMatchObject({ status: 'approved' })
+  })
+
+  it('get returns null for missing ids', async () => {
+    const store = createInMemoryApprovalStore()
+    expect(await store.get('missing')).toBeNull()
+  })
+
+  it('patch returns null for missing ids', async () => {
+    const store = createInMemoryApprovalStore()
+    expect(await store.patch('missing', { status: 'approved' })).toBeNull()
+  })
+})
+
+describe('createApprovalGate', () => {
+  it('request creates pending approval on first call', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    const r = await gate.request({ id: 'del-42', name: 'delete-user', payload: { userId: 42 } })
+    expect(r.status).toBe('pending')
+    expect(r.name).toBe('delete-user')
+  })
+
+  it('request is idempotent on the same id', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    const first = await gate.request({ id: 'x', name: 'test', payload: 1 })
+    const second = await gate.request({ id: 'x', name: 'test', payload: 999 })
+    expect(second.createdAt).toBe(first.createdAt)
+    expect(second.payload).toBe(1) // original payload kept
+  })
+
+  it('decide flips pending → approved with metadata', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    const d = await gate.decide('x', 'approved', { approver: 'alice' })
+    expect(d.status).toBe('approved')
+    expect(d.decisionMetadata).toEqual({ approver: 'alice' })
+    expect(d.decidedAt).toBeDefined()
+  })
+
+  it('decide throws when approval is missing', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await expect(gate.decide('missing', 'approved')).rejects.toThrow(/not found/)
+  })
+
+  it('cancel marks as cancelled', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    const c = await gate.cancel('x')
+    expect(c.status).toBe('cancelled')
+  })
+
+  it('await resolves once decision is made', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    const waiter = gate.await('x', { pollMs: 50 })
+    setTimeout(() => {
+      void gate.decide('x', 'approved')
+    }, 30)
+    const result = await waiter
+    expect(result.status).toBe('approved')
+  })
+
+  it('await returns immediately for already-decided approvals', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    await gate.decide('x', 'rejected')
+    const result = await gate.await('x')
+    expect(result.status).toBe('rejected')
+  })
+
+  it('await times out', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    await expect(gate.await('x', { timeoutMs: 50, pollMs: 50 })).rejects.toThrow(/timed out/)
+  })
+
+  it('await respects abort signal', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await gate.request({ id: 'x', name: 'n', payload: 1 })
+    const controller = new AbortController()
+    const waiter = gate.await('x', { pollMs: 50, signal: controller.signal })
+    setTimeout(() => controller.abort(), 30)
+    await expect(waiter).rejects.toThrow(/aborted/)
+  })
+
+  it('await throws when approval does not exist', async () => {
+    const gate = createApprovalGate(createInMemoryApprovalStore())
+    await expect(gate.await('ghost', { pollMs: 10, timeoutMs: 100 })).rejects.toThrow(/not found/)
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'agent-schema': 'src/agent-schema.ts',
     'prompt-experiments': 'src/prompt-experiments.ts',
     'auto-summarize': 'src/auto-summarize.ts',
+    hitl: 'src/hitl.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/runtime/src/background.ts
+++ b/packages/runtime/src/background.ts
@@ -1,0 +1,255 @@
+/**
+ * Background agents: run a handler on a cron-ish interval or on
+ * incoming webhooks. Zero-dependency — we parse a tiny cron subset
+ * natively and return framework-agnostic HTTP handlers.
+ */
+
+import type { AgentHandle } from './topologies'
+
+// ---------------------------------------------------------------------------
+// Cron scheduler (5-field minute cron: minute hour dom month dow)
+// ---------------------------------------------------------------------------
+
+export interface CronJob<TContext = unknown> {
+  /** Standard 5-field cron (`* * * * *`) or an `every:<ms>` shortcut. */
+  schedule: string
+  agent: AgentHandle<TContext>
+  /** Task the agent receives each fire. Default: `scheduled: <name>`. */
+  task?: string | ((now: Date) => string)
+  context?: TContext
+  /** Run the job exactly once on start before the first tick. */
+  runOnStart?: boolean
+}
+
+export interface CronSchedulerOptions<TContext = unknown> {
+  jobs: CronJob<TContext>[]
+  /** Observability hook. */
+  onEvent?: (event: {
+    type: 'tick' | 'run:start' | 'run:end' | 'run:error'
+    job: string
+    now: Date
+    result?: string
+    error?: string
+  }) => void
+  /** Clock override for tests. */
+  now?: () => Date
+  /** Timer override for tests — takes tick handler, returns stop fn. */
+  scheduleTick?: (fn: () => void) => () => void
+}
+
+interface ParsedCron {
+  type: 'cron'
+  minute: Set<number>
+  hour: Set<number>
+  dom: Set<number>
+  month: Set<number>
+  dow: Set<number>
+}
+
+interface ParsedEvery {
+  type: 'every'
+  intervalMs: number
+}
+
+type ParsedSchedule = ParsedCron | ParsedEvery
+
+function expandField(field: string, min: number, max: number): Set<number> {
+  const out = new Set<number>()
+  for (const segment of field.split(',')) {
+    let step = 1
+    let range = segment
+    const stepIdx = segment.indexOf('/')
+    if (stepIdx >= 0) {
+      step = Math.max(1, Number(segment.slice(stepIdx + 1)))
+      range = segment.slice(0, stepIdx)
+    }
+    let from = min
+    let to = max
+    if (range !== '*') {
+      if (range.includes('-')) {
+        const [a, b] = range.split('-').map(Number)
+        from = a ?? min
+        to = b ?? max
+      } else {
+        from = Number(range)
+        to = from
+      }
+    }
+    for (let i = from; i <= to; i += step) out.add(i)
+  }
+  return out
+}
+
+export function parseSchedule(schedule: string): ParsedSchedule {
+  const trimmed = schedule.trim()
+  if (trimmed.startsWith('every:')) {
+    const ms = Number(trimmed.slice('every:'.length))
+    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid every: schedule: "${schedule}"`)
+    return { type: 'every', intervalMs: ms }
+  }
+  const parts = trimmed.split(/\s+/)
+  if (parts.length !== 5) throw new Error(`cron must have 5 fields: "${schedule}"`)
+  return {
+    type: 'cron',
+    minute: expandField(parts[0]!, 0, 59),
+    hour: expandField(parts[1]!, 0, 23),
+    dom: expandField(parts[2]!, 1, 31),
+    month: expandField(parts[3]!, 1, 12),
+    dow: expandField(parts[4]!, 0, 6),
+  }
+}
+
+export function cronMatches(schedule: ParsedCron, now: Date): boolean {
+  return (
+    schedule.minute.has(now.getMinutes()) &&
+    schedule.hour.has(now.getHours()) &&
+    schedule.dom.has(now.getDate()) &&
+    schedule.month.has(now.getMonth() + 1) &&
+    schedule.dow.has(now.getDay())
+  )
+}
+
+export interface CronScheduler {
+  start: () => void
+  stop: () => void
+  /** Manually fire every job whose schedule matches `now`. Useful in tests. */
+  tick: (now?: Date) => Promise<void>
+}
+
+export function createCronScheduler<TContext = unknown>(
+  options: CronSchedulerOptions<TContext>,
+): CronScheduler {
+  const parsed = options.jobs.map(job => ({ job, schedule: parseSchedule(job.schedule), lastFireMs: -Infinity }))
+  const clock = options.now ?? ((): Date => new Date())
+
+  const fire = async (entry: (typeof parsed)[number], now: Date): Promise<void> => {
+    const jobName = entry.job.agent.name
+    options.onEvent?.({ type: 'run:start', job: jobName, now })
+    try {
+      const task = typeof entry.job.task === 'function' ? entry.job.task(now) : entry.job.task ?? `scheduled: ${jobName}`
+      const result = await entry.job.agent.run(task, entry.job.context)
+      options.onEvent?.({ type: 'run:end', job: jobName, now, result })
+    } catch (err) {
+      options.onEvent?.({
+        type: 'run:error',
+        job: jobName,
+        now,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const tick = async (overrideNow?: Date): Promise<void> => {
+    const now = overrideNow ?? clock()
+    options.onEvent?.({ type: 'tick', job: '*', now })
+    for (const entry of parsed) {
+      if (entry.schedule.type === 'cron') {
+        if (cronMatches(entry.schedule, now)) await fire(entry, now)
+      } else {
+        if (now.getTime() - entry.lastFireMs >= entry.schedule.intervalMs) {
+          entry.lastFireMs = now.getTime()
+          await fire(entry, now)
+        }
+      }
+    }
+  }
+
+  let stopTick: (() => void) | undefined
+
+  return {
+    start() {
+      if (stopTick) return
+      if (options.scheduleTick) {
+        stopTick = options.scheduleTick(() => void tick())
+      } else {
+        const interval = setInterval(() => void tick(), 60_000)
+        stopTick = () => clearInterval(interval)
+      }
+      if (parsed.some(p => p.job.runOnStart)) {
+        const now = clock()
+        for (const entry of parsed) if (entry.job.runOnStart) void fire(entry, now)
+      }
+    },
+    stop() {
+      stopTick?.()
+      stopTick = undefined
+    },
+    tick,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Webhook handler
+// ---------------------------------------------------------------------------
+
+export interface WebhookRequest {
+  headers?: Record<string, string | string[] | undefined>
+  body?: string | Record<string, unknown>
+}
+
+export interface WebhookResponse {
+  status: number
+  body: string
+  headers?: Record<string, string>
+}
+
+export interface WebhookOptions<TContext = unknown> {
+  agent: AgentHandle<TContext>
+  /**
+   * Extract the task string from the webhook body. Default:
+   * `body.task` for JSON bodies, or the raw string.
+   */
+  extractTask?: (req: WebhookRequest) => string
+  /** Pass-through context for the agent. */
+  context?: TContext | ((req: WebhookRequest) => TContext)
+  /** Verify the incoming request (signature, token, etc.). */
+  verify?: (req: WebhookRequest) => boolean | Promise<boolean>
+  onEvent?: (event: { type: 'received' | 'rejected' | 'handled'; error?: string }) => void
+}
+
+function defaultExtract(req: WebhookRequest): string {
+  if (typeof req.body === 'string') return req.body
+  if (req.body && typeof req.body === 'object' && typeof req.body.task === 'string') return req.body.task
+  return JSON.stringify(req.body ?? '')
+}
+
+export type WebhookHandler = (req: WebhookRequest) => Promise<WebhookResponse>
+
+/**
+ * Build a framework-agnostic webhook handler. Wire into Express /
+ * Hono / Next API routes by passing in the parsed request and
+ * piping the returned response.
+ */
+export function createWebhookHandler<TContext = unknown>(
+  options: WebhookOptions<TContext>,
+): WebhookHandler {
+  return async req => {
+    options.onEvent?.({ type: 'received' })
+    if (options.verify) {
+      const ok = await options.verify(req)
+      if (!ok) {
+        options.onEvent?.({ type: 'rejected', error: 'verify returned false' })
+        return { status: 401, body: 'unauthorized' }
+      }
+    }
+    const extract = options.extractTask ?? defaultExtract
+    const task = extract(req)
+    const context =
+      typeof options.context === 'function'
+        ? (options.context as (req: WebhookRequest) => TContext)(req)
+        : options.context
+    try {
+      const result = await options.agent.run(task, context)
+      options.onEvent?.({ type: 'handled' })
+      return {
+        status: 200,
+        body: result,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      options.onEvent?.({ type: 'rejected', error: message })
+      return { status: 500, body: message }
+    }
+  }
+}

--- a/packages/runtime/src/durable.ts
+++ b/packages/runtime/src/durable.ts
@@ -1,0 +1,214 @@
+/**
+ * Temporal-style durable execution primitive. Wraps any side-effectful
+ * step in a `runner.step(name, fn)` call; the result is appended to a
+ * `StepLogStore`. When the run restarts (after a crash, a deploy, or
+ * a retry), replayed steps short-circuit to the recorded value and
+ * only new steps execute.
+ *
+ * Deterministic replay requires two rules from callers:
+ *   1. Step names are stable across runs (ideally derived from the
+ *      business key — e.g. `search:${query}` — so the log stays
+ *      meaningful even as code reorders).
+ *   2. Steps are pure *from the perspective of the log* — the fn does
+ *      the side effect, the result is everything later steps need.
+ */
+
+export interface StepRecord<TResult = unknown> {
+  runId: string
+  stepId: string
+  name: string
+  status: 'success' | 'failure'
+  result?: TResult
+  error?: string
+  startedAt: string
+  endedAt: string
+  attempt: number
+}
+
+export interface StepLogStore {
+  append: <T>(record: StepRecord<T>) => Promise<void>
+  get: <T>(runId: string, stepId: string) => Promise<StepRecord<T> | null>
+  list: (runId: string) => Promise<StepRecord<unknown>[]>
+  clear?: (runId: string) => Promise<void>
+}
+
+export interface DurableRunnerOptions {
+  store: StepLogStore
+  runId: string
+  /** Max attempts per step. Default 1 (fail fast). */
+  maxAttempts?: number
+  /** Backoff in ms between attempts. Default 0. */
+  retryDelayMs?: number
+  /** Observability — fires on replay-hit, retry, completion. */
+  onEvent?: (event: DurableEvent) => void
+}
+
+export type DurableEvent =
+  | { type: 'step:replay'; stepId: string; name: string; runId: string }
+  | { type: 'step:start'; stepId: string; name: string; runId: string; attempt: number }
+  | { type: 'step:success'; stepId: string; name: string; runId: string; durationMs: number }
+  | { type: 'step:failure'; stepId: string; name: string; runId: string; error: string; attempt: number }
+
+export interface DurableRunner {
+  /**
+   * Execute `fn` under the name `stepId`. If the step has already
+   * been recorded in the log for this `runId`, return the recorded
+   * result without re-running. Otherwise run, record, return.
+   */
+  step: <TResult>(stepId: string, fn: () => Promise<TResult> | TResult, options?: { name?: string }) => Promise<TResult>
+  /** Read the full log for the current run. */
+  history: () => Promise<StepRecord<unknown>[]>
+  /** Drop the log for the current run (dangerous — breaks resume). */
+  reset: () => Promise<void>
+}
+
+export function createDurableRunner(options: DurableRunnerOptions): DurableRunner {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 1)
+  const retryDelayMs = Math.max(0, options.retryDelayMs ?? 0)
+  const { store, runId } = options
+
+  const step = async <TResult>(
+    stepId: string,
+    fn: () => Promise<TResult> | TResult,
+    stepOpts: { name?: string } = {},
+  ): Promise<TResult> => {
+    const name = stepOpts.name ?? stepId
+    const existing = await store.get<TResult>(runId, stepId)
+    if (existing) {
+      options.onEvent?.({ type: 'step:replay', stepId, name, runId })
+      if (existing.status === 'success') return existing.result as TResult
+      throw new Error(`step "${stepId}" previously failed: ${existing.error}`)
+    }
+
+    let attempt = 0
+    let lastError: Error | undefined
+    while (attempt < maxAttempts) {
+      attempt++
+      const startedAt = new Date().toISOString()
+      options.onEvent?.({ type: 'step:start', stepId, name, runId, attempt })
+      const t0 = Date.now()
+      try {
+        const result = await fn()
+        const endedAt = new Date().toISOString()
+        await store.append<TResult>({
+          runId,
+          stepId,
+          name,
+          status: 'success',
+          result,
+          startedAt,
+          endedAt,
+          attempt,
+        })
+        options.onEvent?.({ type: 'step:success', stepId, name, runId, durationMs: Date.now() - t0 })
+        return result
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err))
+        options.onEvent?.({
+          type: 'step:failure',
+          stepId,
+          name,
+          runId,
+          error: lastError.message,
+          attempt,
+        })
+        if (attempt < maxAttempts && retryDelayMs > 0) {
+          await new Promise(r => setTimeout(r, retryDelayMs))
+        }
+      }
+    }
+
+    const endedAt = new Date().toISOString()
+    await store.append<TResult>({
+      runId,
+      stepId,
+      name,
+      status: 'failure',
+      error: lastError?.message ?? 'unknown error',
+      startedAt: endedAt,
+      endedAt,
+      attempt,
+    })
+    throw lastError ?? new Error(`step "${stepId}" failed`)
+  }
+
+  return {
+    step,
+    async history() {
+      return store.list(runId)
+    },
+    async reset() {
+      await store.clear?.(runId)
+    },
+  }
+}
+
+/** In-memory `StepLogStore` — tests, single-process demos, examples. */
+export function createInMemoryStepLog(): StepLogStore {
+  const byRun = new Map<string, Map<string, StepRecord<unknown>>>()
+  return {
+    async append(record) {
+      let run = byRun.get(record.runId)
+      if (!run) {
+        run = new Map()
+        byRun.set(record.runId, run)
+      }
+      run.set(record.stepId, { ...record })
+    },
+    async get<T>(runId: string, stepId: string): Promise<StepRecord<T> | null> {
+      const hit = byRun.get(runId)?.get(stepId)
+      return hit ? ({ ...(hit as StepRecord<T>) }) : null
+    },
+    async list(runId) {
+      return Array.from(byRun.get(runId)?.values() ?? []).map(r => ({ ...r }))
+    },
+    async clear(runId) {
+      byRun.delete(runId)
+    },
+  }
+}
+
+/** File-backed `StepLogStore` — persists every step as one JSONL line. */
+export async function createFileStepLog(path: string): Promise<StepLogStore> {
+  const { readFile, writeFile, appendFile, mkdir } = await import('node:fs/promises')
+  const { dirname } = await import('node:path')
+  await mkdir(dirname(path), { recursive: true })
+  try {
+    await readFile(path, 'utf8')
+  } catch {
+    await writeFile(path, '', 'utf8')
+  }
+
+  const load = async (): Promise<StepRecord<unknown>[]> => {
+    try {
+      const raw = await readFile(path, 'utf8')
+      return raw
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line) as StepRecord<unknown>)
+    } catch {
+      return []
+    }
+  }
+
+  return {
+    async append(record) {
+      await appendFile(path, JSON.stringify(record) + '\n', 'utf8')
+    },
+    async get<T>(runId: string, stepId: string): Promise<StepRecord<T> | null> {
+      const all = await load()
+      for (let i = all.length - 1; i >= 0; i--) {
+        const r = all[i]!
+        if (r.runId === runId && r.stepId === stepId) return r as StepRecord<T>
+      }
+      return null
+    },
+    async list(runId) {
+      return (await load()).filter(r => r.runId === runId)
+    },
+    async clear(runId) {
+      const kept = (await load()).filter(r => r.runId !== runId)
+      await writeFile(path, kept.map(r => JSON.stringify(r)).join('\n') + (kept.length ? '\n' : ''), 'utf8')
+    },
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,49 @@ export { createRuntime } from './runner'
 export { createSharedContext } from './shared-context'
 export type { SharedContext, ReadonlySharedContext } from './shared-context'
 export type { RuntimeConfig, RunOptions, RunResult, DelegateConfig } from './types'
+export {
+  createDurableRunner,
+  createInMemoryStepLog,
+  createFileStepLog,
+} from './durable'
+export type {
+  StepLogStore,
+  StepRecord,
+  DurableRunnerOptions,
+  DurableRunner,
+  DurableEvent,
+} from './durable'
+export {
+  supervisor,
+  swarm,
+  hierarchical,
+  blackboard,
+} from './topologies'
+export type {
+  AgentHandle,
+  SupervisorConfig,
+  SwarmConfig,
+  HierarchicalConfig,
+  HierarchicalNode,
+  BlackboardConfig,
+  TopologyLogEvent,
+  TopologyObserver,
+} from './topologies'
+export {
+  createCronScheduler,
+  createWebhookHandler,
+  parseSchedule,
+  cronMatches,
+} from './background'
+export type {
+  CronJob,
+  CronSchedulerOptions,
+  CronScheduler,
+  WebhookOptions,
+  WebhookHandler,
+  WebhookRequest,
+  WebhookResponse,
+} from './background'
 export { speculate } from './speculate'
 export type {
   SpeculativeCandidate,

--- a/packages/runtime/src/topologies.ts
+++ b/packages/runtime/src/topologies.ts
@@ -1,0 +1,225 @@
+/**
+ * Ready-made multi-agent topologies. Each builder takes a set of
+ * `AgentHandle`s + config and returns a single `AgentHandle` that
+ * presents the ensemble as a normal agent to the rest of the system.
+ *
+ * An `AgentHandle` is intentionally minimal — `name` + `run(task,
+ * context?) => Promise<string>` — so any runtime (our own
+ * `createRuntime`, a LangChain Runnable, a bare HTTP endpoint) can
+ * participate without coupling.
+ */
+
+export interface AgentHandle<TContext = unknown> {
+  name: string
+  run: (task: string, context?: TContext) => Promise<string>
+}
+
+export interface TopologyLogEvent {
+  topology: string
+  phase: 'dispatch' | 'agent:start' | 'agent:end' | 'merge' | 'done'
+  agent?: string
+  task?: string
+  result?: string
+  iteration?: number
+}
+
+export type TopologyObserver = (event: TopologyLogEvent) => void
+
+// ---------------------------------------------------------------------------
+// Supervisor: one planner agent delegates to workers, then synthesizes.
+// ---------------------------------------------------------------------------
+
+export interface SupervisorConfig<TContext = unknown> {
+  supervisor: AgentHandle<TContext>
+  workers: AgentHandle<TContext>[]
+  /** How the supervisor picks a worker. Default: round-robin. */
+  route?: (task: string, workers: AgentHandle<TContext>[]) => AgentHandle<TContext>
+  /** Maximum delegation rounds. Default 1. */
+  maxRounds?: number
+  onEvent?: TopologyObserver
+}
+
+export function supervisor<TContext = unknown>(
+  config: SupervisorConfig<TContext>,
+): AgentHandle<TContext> {
+  if (config.workers.length === 0) throw new Error('supervisor requires ≥ 1 worker')
+  const maxRounds = Math.max(1, config.maxRounds ?? 1)
+  let rr = 0
+  const route =
+    config.route ??
+    ((_task, workers) => workers[rr++ % workers.length]!)
+
+  return {
+    name: config.supervisor.name,
+    async run(task, context) {
+      const log = config.onEvent
+      log?.({ topology: 'supervisor', phase: 'dispatch', task })
+      let current = task
+      const notes: string[] = []
+      for (let i = 0; i < maxRounds; i++) {
+        const worker = route(current, config.workers)
+        log?.({ topology: 'supervisor', phase: 'agent:start', agent: worker.name, iteration: i })
+        const result = await worker.run(current, context)
+        log?.({ topology: 'supervisor', phase: 'agent:end', agent: worker.name, result, iteration: i })
+        notes.push(`[${worker.name}] ${result}`)
+        current = `Worker result:\n${result}\n\nOriginal task: ${task}`
+      }
+      const synthesis = await config.supervisor.run(
+        `Synthesize the following worker outputs into one answer.\n\n${notes.join('\n---\n')}\n\nOriginal task: ${task}`,
+        context,
+      )
+      log?.({ topology: 'supervisor', phase: 'done', result: synthesis })
+      return synthesis
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Swarm: broadcast to every member, user-supplied merger picks the output.
+// ---------------------------------------------------------------------------
+
+export interface SwarmConfig<TContext = unknown> {
+  name?: string
+  members: AgentHandle<TContext>[]
+  /** Merge member outputs into a single result. Default: longest. */
+  merge?: (results: Array<{ agent: string; output: string }>) => string | Promise<string>
+  /** Per-member timeout in ms. */
+  timeoutMs?: number
+  onEvent?: TopologyObserver
+}
+
+function withTimeout<T>(p: Promise<T>, timeoutMs: number | undefined, label: string): Promise<T> {
+  if (timeoutMs === undefined) return p
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    p.then(
+      v => {
+        clearTimeout(timer)
+        resolve(v)
+      },
+      e => {
+        clearTimeout(timer)
+        reject(e)
+      },
+    )
+  })
+}
+
+export function swarm<TContext = unknown>(config: SwarmConfig<TContext>): AgentHandle<TContext> {
+  if (config.members.length === 0) throw new Error('swarm requires ≥ 1 member')
+  const merge =
+    config.merge ??
+    ((results: Array<{ agent: string; output: string }>): string =>
+      results.reduce((best, r) => (r.output.length > best.length ? r.output : best), ''))
+
+  return {
+    name: config.name ?? 'swarm',
+    async run(task, context) {
+      config.onEvent?.({ topology: 'swarm', phase: 'dispatch', task })
+      const settled = await Promise.allSettled(
+        config.members.map(async m => {
+          config.onEvent?.({ topology: 'swarm', phase: 'agent:start', agent: m.name })
+          const output = await withTimeout(m.run(task, context), config.timeoutMs, `swarm(${m.name})`)
+          config.onEvent?.({ topology: 'swarm', phase: 'agent:end', agent: m.name, result: output })
+          return { agent: m.name, output }
+        }),
+      )
+      const results = settled.flatMap(s => (s.status === 'fulfilled' ? [s.value] : []))
+      if (results.length === 0) throw new Error('every swarm member failed')
+      const merged = await merge(results)
+      config.onEvent?.({ topology: 'swarm', phase: 'done', result: merged })
+      return merged
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchical: tree of agents. Root decides which branch to dispatch to.
+// ---------------------------------------------------------------------------
+
+export interface HierarchicalNode<TContext = unknown> {
+  agent: AgentHandle<TContext>
+  /** Free-form tags the router can match against. */
+  tags?: string[]
+  children?: HierarchicalNode<TContext>[]
+}
+
+export interface HierarchicalConfig<TContext = unknown> {
+  name?: string
+  root: HierarchicalNode<TContext>
+  /** Pick which child (if any) to descend into. Return undefined to stop. */
+  route?: (input: { task: string; node: HierarchicalNode<TContext> }) => HierarchicalNode<TContext> | undefined
+  /** Maximum depth. Default 5. */
+  maxDepth?: number
+  onEvent?: TopologyObserver
+}
+
+export function hierarchical<TContext = unknown>(
+  config: HierarchicalConfig<TContext>,
+): AgentHandle<TContext> {
+  const maxDepth = Math.max(1, config.maxDepth ?? 5)
+  const route =
+    config.route ??
+    (({ task, node }: { task: string; node: HierarchicalNode<TContext> }): HierarchicalNode<TContext> | undefined => {
+      if (!node.children || node.children.length === 0) return undefined
+      const lowered = task.toLowerCase()
+      return node.children.find(c => c.tags?.some(t => lowered.includes(t.toLowerCase()))) ?? undefined
+    })
+
+  return {
+    name: config.name ?? config.root.agent.name,
+    async run(task, context) {
+      let current: HierarchicalNode<TContext> = config.root
+      for (let depth = 0; depth < maxDepth; depth++) {
+        const next = route({ task, node: current })
+        if (!next) break
+        config.onEvent?.({ topology: 'hierarchical', phase: 'dispatch', agent: next.agent.name })
+        current = next
+      }
+      config.onEvent?.({ topology: 'hierarchical', phase: 'agent:start', agent: current.agent.name })
+      const result = await current.agent.run(task, context)
+      config.onEvent?.({ topology: 'hierarchical', phase: 'done', agent: current.agent.name, result })
+      return result
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Blackboard: agents read/write a shared scratchpad. Loop until converge.
+// ---------------------------------------------------------------------------
+
+export interface BlackboardConfig<TContext = unknown> {
+  name?: string
+  agents: AgentHandle<TContext>[]
+  /** Return an output when no further iterations are needed. */
+  isDone?: (blackboard: string, iteration: number) => boolean
+  /** Max iterations. Default 5. */
+  maxIterations?: number
+  onEvent?: TopologyObserver
+}
+
+export function blackboard<TContext = unknown>(
+  config: BlackboardConfig<TContext>,
+): AgentHandle<TContext> {
+  if (config.agents.length === 0) throw new Error('blackboard requires ≥ 1 agent')
+  const maxIterations = Math.max(1, config.maxIterations ?? 5)
+
+  return {
+    name: config.name ?? 'blackboard',
+    async run(task, context) {
+      let board = `Task: ${task}\n\n`
+      for (let iteration = 0; iteration < maxIterations; iteration++) {
+        if (config.isDone?.(board, iteration)) break
+        for (const agent of config.agents) {
+          config.onEvent?.({ topology: 'blackboard', phase: 'agent:start', agent: agent.name, iteration })
+          const contribution = await agent.run(board, context)
+          config.onEvent?.({ topology: 'blackboard', phase: 'agent:end', agent: agent.name, result: contribution, iteration })
+          board += `\n### ${agent.name} (round ${iteration + 1})\n${contribution}\n`
+          if (config.isDone?.(board, iteration)) break
+        }
+      }
+      config.onEvent?.({ topology: 'blackboard', phase: 'done', result: board })
+      return board
+    },
+  }
+}

--- a/packages/runtime/tests/background.test.ts
+++ b/packages/runtime/tests/background.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  cronMatches,
+  createCronScheduler,
+  createWebhookHandler,
+  parseSchedule,
+  type WebhookRequest,
+} from '../src/background'
+import type { AgentHandle } from '../src/topologies'
+
+function agent(name: string, run: (task: string) => Promise<string> | string = async () => 'ok'): AgentHandle {
+  return { name, run: async task => run(task) }
+}
+
+describe('parseSchedule', () => {
+  it('parses 5-field cron', () => {
+    const p = parseSchedule('0 9 * * 1')
+    expect(p.type).toBe('cron')
+    if (p.type !== 'cron') throw new Error('wrong type')
+    expect(p.hour.has(9)).toBe(true)
+    expect(p.dow.has(1)).toBe(true)
+  })
+
+  it('expands lists and steps', () => {
+    const p = parseSchedule('*/15 * * * *')
+    if (p.type !== 'cron') throw new Error('wrong type')
+    expect(p.minute.has(0)).toBe(true)
+    expect(p.minute.has(15)).toBe(true)
+    expect(p.minute.has(30)).toBe(true)
+    expect(p.minute.has(45)).toBe(true)
+    expect(p.minute.has(5)).toBe(false)
+  })
+
+  it('expands ranges and lists', () => {
+    const p = parseSchedule('1,5-7 * * * *')
+    if (p.type !== 'cron') throw new Error('wrong type')
+    expect(p.minute.has(1)).toBe(true)
+    expect(p.minute.has(5)).toBe(true)
+    expect(p.minute.has(6)).toBe(true)
+    expect(p.minute.has(7)).toBe(true)
+    expect(p.minute.has(2)).toBe(false)
+  })
+
+  it('parses every:<ms>', () => {
+    const p = parseSchedule('every:1000')
+    expect(p.type).toBe('every')
+    if (p.type !== 'every') throw new Error('wrong type')
+    expect(p.intervalMs).toBe(1000)
+  })
+
+  it('rejects malformed cron', () => {
+    expect(() => parseSchedule('0 9')).toThrow(/5 fields/)
+    expect(() => parseSchedule('every:-1')).toThrow(/invalid every:/)
+  })
+})
+
+describe('cronMatches', () => {
+  it('matches the right minute/hour', () => {
+    const p = parseSchedule('30 9 * * *')
+    if (p.type !== 'cron') throw new Error()
+    expect(cronMatches(p, new Date(2026, 0, 1, 9, 30))).toBe(true)
+    expect(cronMatches(p, new Date(2026, 0, 1, 9, 31))).toBe(false)
+  })
+})
+
+describe('createCronScheduler', () => {
+  it('fires jobs on matching ticks', async () => {
+    const run = vi.fn(async () => 'done')
+    const sched = createCronScheduler({
+      jobs: [{ schedule: '*/5 * * * *', agent: agent('job', run) }],
+    })
+    await sched.tick(new Date(2026, 0, 1, 9, 5)) // divisible by 5
+    await sched.tick(new Date(2026, 0, 1, 9, 6))
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('every:<ms> fires once per interval', async () => {
+    const run = vi.fn(async () => 'done')
+    const sched = createCronScheduler({
+      jobs: [{ schedule: 'every:1000', agent: agent('j', run) }],
+    })
+    await sched.tick(new Date(1_000_000))
+    await sched.tick(new Date(1_000_500))
+    await sched.tick(new Date(1_002_000))
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces errors via onEvent instead of throwing', async () => {
+    const events: string[] = []
+    const sched = createCronScheduler({
+      jobs: [
+        {
+          schedule: '* * * * *',
+          agent: {
+            name: 'bad',
+            run: async () => {
+              throw new Error('boom')
+            },
+          },
+        },
+      ],
+      onEvent: e => events.push(e.type),
+    })
+    await sched.tick(new Date(2026, 0, 1, 9, 0))
+    expect(events).toContain('run:error')
+  })
+
+  it('custom task callback receives the clock tick', async () => {
+    const received: string[] = []
+    const sched = createCronScheduler({
+      jobs: [
+        {
+          schedule: '* * * * *',
+          agent: agent('j', async t => {
+            received.push(t)
+            return 'ok'
+          }),
+          task: now => `at ${now.toISOString()}`,
+        },
+      ],
+    })
+    await sched.tick(new Date(Date.UTC(2026, 0, 1, 9, 0)))
+    expect(received[0]).toMatch(/^at 2026-01-01T09:00/)
+  })
+
+  it('scheduleTick override lets us drive the loop synchronously', () => {
+    const run = vi.fn(async () => 'ok')
+    let registered: (() => void) | undefined
+    const sched = createCronScheduler({
+      jobs: [{ schedule: '* * * * *', agent: agent('j', run) }],
+      scheduleTick: fn => {
+        registered = fn
+        return () => {
+          registered = undefined
+        }
+      },
+    })
+    sched.start()
+    expect(registered).toBeDefined()
+    sched.stop()
+    expect(registered).toBeUndefined()
+  })
+
+  it('runOnStart triggers an immediate fire', async () => {
+    const run = vi.fn(async () => 'ok')
+    const sched = createCronScheduler({
+      jobs: [{ schedule: '* * * * *', agent: agent('j', run), runOnStart: true }],
+      scheduleTick: () => () => {},
+    })
+    sched.start()
+    await new Promise(r => setImmediate(r))
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createWebhookHandler', () => {
+  it('passes extracted task to the agent and returns 200 + body', async () => {
+    const handler = createWebhookHandler({ agent: agent('a', async t => `ran: ${t}`) })
+    const res = await handler({ body: 'hello' })
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('ran: hello')
+  })
+
+  it('extracts .task from JSON body by default', async () => {
+    const handler = createWebhookHandler({ agent: agent('a', async t => t) })
+    const res = await handler({ body: { task: 'from-json' } as Record<string, unknown> })
+    expect(res.body).toBe('from-json')
+  })
+
+  it('custom extractor wins', async () => {
+    const handler = createWebhookHandler({
+      agent: agent('a', async t => t),
+      extractTask: (req: WebhookRequest) => (req.headers?.['x-task'] as string) ?? '',
+    })
+    const res = await handler({ headers: { 'x-task': 'header-task' } })
+    expect(res.body).toBe('header-task')
+  })
+
+  it('verify:false returns 401', async () => {
+    const handler = createWebhookHandler({
+      agent: agent('a'),
+      verify: () => false,
+    })
+    const res = await handler({ body: 'x' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 500 + message on agent failure', async () => {
+    const handler = createWebhookHandler({
+      agent: { name: 'bad', run: async () => { throw new Error('kaboom') } },
+    })
+    const res = await handler({ body: 'x' })
+    expect(res.status).toBe(500)
+    expect(res.body).toBe('kaboom')
+  })
+
+  it('fires received + handled events on success', async () => {
+    const events: string[] = []
+    const handler = createWebhookHandler({
+      agent: agent('a'),
+      onEvent: e => events.push(e.type),
+    })
+    await handler({ body: 'x' })
+    expect(events).toEqual(['received', 'handled'])
+  })
+})

--- a/packages/runtime/tests/durable.test.ts
+++ b/packages/runtime/tests/durable.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createDurableRunner,
+  createFileStepLog,
+  createInMemoryStepLog,
+} from '../src/durable'
+
+describe('createInMemoryStepLog', () => {
+  it('appends, reads, lists, and clears', async () => {
+    const store = createInMemoryStepLog()
+    await store.append({
+      runId: 'r',
+      stepId: 's',
+      name: 's',
+      status: 'success',
+      result: 1,
+      startedAt: 'a',
+      endedAt: 'b',
+      attempt: 1,
+    })
+    expect((await store.get('r', 's'))?.result).toBe(1)
+    expect(await store.list('r')).toHaveLength(1)
+    expect(await store.get('other', 's')).toBeNull()
+    await store.clear?.('r')
+    expect(await store.list('r')).toHaveLength(0)
+  })
+})
+
+describe('createDurableRunner', () => {
+  it('executes a step and records success', async () => {
+    const runner = createDurableRunner({ store: createInMemoryStepLog(), runId: 'r1' })
+    const result = await runner.step('add', async () => 1 + 1)
+    expect(result).toBe(2)
+    const history = await runner.history()
+    expect(history).toHaveLength(1)
+    expect(history[0]!.status).toBe('success')
+  })
+
+  it('replays recorded successes without running fn again', async () => {
+    const store = createInMemoryStepLog()
+    const r1 = createDurableRunner({ store, runId: 'r1' })
+    await r1.step('x', async () => 42)
+
+    const fn = vi.fn(async () => 99)
+    const r2 = createDurableRunner({ store, runId: 'r1' })
+    const replayed = await r2.step('x', fn)
+    expect(replayed).toBe(42)
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('emits step:replay events on cache hits', async () => {
+    const store = createInMemoryStepLog()
+    await createDurableRunner({ store, runId: 'r' }).step('x', async () => 1)
+    const events: string[] = []
+    const runner = createDurableRunner({
+      store,
+      runId: 'r',
+      onEvent: e => events.push(e.type),
+    })
+    await runner.step('x', async () => 999)
+    expect(events).toEqual(['step:replay'])
+  })
+
+  it('retries up to maxAttempts', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('transient')
+    })
+    const runner = createDurableRunner({
+      store: createInMemoryStepLog(),
+      runId: 'r',
+      maxAttempts: 3,
+      retryDelayMs: 0,
+    })
+    await expect(runner.step('x', fn)).rejects.toThrow(/transient/)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('retry succeeds within budget', async () => {
+    let calls = 0
+    const runner = createDurableRunner({
+      store: createInMemoryStepLog(),
+      runId: 'r',
+      maxAttempts: 3,
+    })
+    const result = await runner.step('x', async () => {
+      calls++
+      if (calls < 2) throw new Error('flaky')
+      return 'ok'
+    })
+    expect(result).toBe('ok')
+  })
+
+  it('rethrows on previously failed step', async () => {
+    const store = createInMemoryStepLog()
+    const r1 = createDurableRunner({ store, runId: 'r' })
+    await expect(r1.step('x', async () => {
+      throw new Error('boom')
+    })).rejects.toThrow(/boom/)
+    const r2 = createDurableRunner({ store, runId: 'r' })
+    await expect(r2.step('x', async () => 'never runs')).rejects.toThrow(/previously failed/)
+  })
+
+  it('reset clears the run log', async () => {
+    const store = createInMemoryStepLog()
+    const runner = createDurableRunner({ store, runId: 'r' })
+    await runner.step('x', async () => 1)
+    await runner.reset()
+    expect(await runner.history()).toHaveLength(0)
+  })
+
+  it('onEvent fires start + success per attempt', async () => {
+    const types: string[] = []
+    const runner = createDurableRunner({
+      store: createInMemoryStepLog(),
+      runId: 'r',
+      onEvent: e => types.push(e.type),
+    })
+    await runner.step('x', async () => 1)
+    expect(types).toEqual(['step:start', 'step:success'])
+  })
+})
+
+describe('createFileStepLog', () => {
+  it('persists across runner instances', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-dur-'))
+    try {
+      const store = await createFileStepLog(join(dir, 'log.jsonl'))
+      const r1 = createDurableRunner({ store, runId: 'r' })
+      await r1.step('x', async () => 7)
+
+      const store2 = await createFileStepLog(join(dir, 'log.jsonl'))
+      const r2 = createDurableRunner({ store: store2, runId: 'r' })
+      const fn = vi.fn(async () => 999)
+      expect(await r2.step('x', fn)).toBe(7)
+      expect(fn).not.toHaveBeenCalled()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('clear removes only the requested run', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-dur-'))
+    try {
+      const store = await createFileStepLog(join(dir, 'log.jsonl'))
+      await createDurableRunner({ store, runId: 'a' }).step('x', async () => 1)
+      await createDurableRunner({ store, runId: 'b' }).step('x', async () => 2)
+      await store.clear?.('a')
+      expect(await store.list('a')).toHaveLength(0)
+      expect(await store.list('b')).toHaveLength(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/runtime/tests/topologies.test.ts
+++ b/packages/runtime/tests/topologies.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  blackboard,
+  hierarchical,
+  supervisor,
+  swarm,
+  type AgentHandle,
+} from '../src/topologies'
+
+function agent(name: string, respond: (task: string) => string | Promise<string>, opts: { throws?: boolean } = {}): AgentHandle {
+  return {
+    name,
+    async run(task) {
+      if (opts.throws) throw new Error(`${name} failed`)
+      return respond(task)
+    },
+  }
+}
+
+describe('supervisor', () => {
+  it('delegates to a worker and synthesizes via supervisor', async () => {
+    const worker = agent('w', async () => 'worker output')
+    const sup = agent('sup', async (task) => `synth: ${task.slice(0, 40)}`)
+    const team = supervisor({ supervisor: sup, workers: [worker] })
+    const out = await team.run('solve x')
+    expect(out.startsWith('synth:')).toBe(true)
+  })
+
+  it('rejects empty workers', () => {
+    const sup = agent('s', async () => 's')
+    expect(() => supervisor({ supervisor: sup, workers: [] })).toThrow(/≥ 1 worker/)
+  })
+
+  it('round-robins workers across rounds', async () => {
+    const calls: string[] = []
+    const w1 = agent('w1', async () => {
+      calls.push('w1')
+      return 'a'
+    })
+    const w2 = agent('w2', async () => {
+      calls.push('w2')
+      return 'b'
+    })
+    const sup = agent('sup', async () => 'ok')
+    const team = supervisor({ supervisor: sup, workers: [w1, w2], maxRounds: 4 })
+    await team.run('t')
+    expect(calls).toEqual(['w1', 'w2', 'w1', 'w2'])
+  })
+
+  it('custom route picks the worker', async () => {
+    const w1 = agent('w1', async () => 'A')
+    const w2 = agent('w2', async () => 'B')
+    const sup = agent('sup', async t => t.includes('B') ? 'chose-b' : 'chose-a')
+    const team = supervisor({
+      supervisor: sup,
+      workers: [w1, w2],
+      route: () => w2,
+    })
+    expect(await team.run('t')).toBe('chose-b')
+  })
+
+  it('onEvent fires start/end/done', async () => {
+    const events: string[] = []
+    const team = supervisor({
+      supervisor: agent('sup', async () => 'done'),
+      workers: [agent('w', async () => 'res')],
+      onEvent: e => events.push(e.phase),
+    })
+    await team.run('t')
+    expect(events).toContain('dispatch')
+    expect(events).toContain('agent:start')
+    expect(events).toContain('agent:end')
+    expect(events).toContain('done')
+  })
+})
+
+describe('swarm', () => {
+  it('broadcasts to all members and merges longest by default', async () => {
+    const s = swarm({
+      members: [
+        agent('short', async () => 'ok'),
+        agent('long', async () => 'a longer answer'),
+      ],
+    })
+    expect(await s.run('t')).toBe('a longer answer')
+  })
+
+  it('custom merge', async () => {
+    const s = swarm({
+      members: [agent('a', async () => 'x'), agent('b', async () => 'y')],
+      merge: results => results.map(r => r.agent).join(','),
+    })
+    expect(await s.run('t')).toBe('a,b')
+  })
+
+  it('tolerates one failing member', async () => {
+    const s = swarm({
+      members: [agent('ok', async () => 'hello'), agent('bad', async () => '', { throws: true })],
+    })
+    expect(await s.run('t')).toBe('hello')
+  })
+
+  it('throws when all members fail', async () => {
+    const s = swarm({
+      members: [agent('a', async () => '', { throws: true }), agent('b', async () => '', { throws: true })],
+    })
+    await expect(s.run('t')).rejects.toThrow(/every swarm member failed/)
+  })
+
+  it('timeoutMs aborts slow members', async () => {
+    const s = swarm({
+      members: [
+        agent('fast', async () => 'quick'),
+        { name: 'slow', run: () => new Promise(res => setTimeout(() => res('late'), 200)) },
+      ],
+      timeoutMs: 30,
+    })
+    expect(await s.run('t')).toBe('quick')
+  })
+
+  it('rejects empty members', () => {
+    expect(() => swarm({ members: [] })).toThrow(/≥ 1 member/)
+  })
+})
+
+describe('hierarchical', () => {
+  const leafA = agent('leaf-a', async () => 'A result')
+  const leafB = agent('leaf-b', async () => 'B result')
+  const root = agent('root', async () => 'root result')
+
+  it('runs root when no children match', async () => {
+    const tree = hierarchical({
+      root: { agent: root, children: [{ agent: leafA, tags: ['cat'] }] },
+    })
+    expect(await tree.run('dog query')).toBe('root result')
+  })
+
+  it('descends to a tagged child when matched', async () => {
+    const tree = hierarchical({
+      root: {
+        agent: root,
+        children: [
+          { agent: leafA, tags: ['cat'] },
+          { agent: leafB, tags: ['dog'] },
+        ],
+      },
+    })
+    expect(await tree.run('tell me about dog food')).toBe('B result')
+  })
+
+  it('custom route overrides default', async () => {
+    const tree = hierarchical({
+      root: { agent: root, children: [{ agent: leafA }, { agent: leafB }] },
+      route: ({ node }) => node.children?.[1],
+    })
+    expect(await tree.run('anything')).toBe('B result')
+  })
+
+  it('maxDepth caps descent', async () => {
+    const level3 = agent('l3', async () => 'L3')
+    const tree = hierarchical({
+      root: { agent: root, children: [{ agent: leafA, children: [{ agent: level3 }] }] },
+      route: ({ node }) => node.children?.[0],
+      maxDepth: 1,
+    })
+    expect(await tree.run('anything')).toBe('A result')
+  })
+})
+
+describe('blackboard', () => {
+  it('iterates agents and accumulates on the board', async () => {
+    const recorded: string[] = []
+    const a = agent('planner', async board => {
+      recorded.push(`planner saw ${board.length} chars`)
+      return 'plan: split work'
+    })
+    const b = agent('coder', async board => {
+      recorded.push(`coder saw ${board.length} chars`)
+      return 'code: done'
+    })
+    const bb = blackboard({ agents: [a, b], maxIterations: 1 })
+    const result = await bb.run('build it')
+    expect(result).toContain('plan: split work')
+    expect(result).toContain('code: done')
+    expect(recorded).toHaveLength(2)
+  })
+
+  it('isDone stops the loop', async () => {
+    const fn = vi.fn(async () => 'increment')
+    const bb = blackboard({
+      agents: [{ name: 'n', run: fn }],
+      maxIterations: 5,
+      isDone: (_board, iteration) => iteration >= 2,
+    })
+    await bb.run('t')
+    expect(fn.mock.calls.length).toBe(2)
+  })
+
+  it('rejects empty agents', () => {
+    expect(() => blackboard({ agents: [] })).toThrow(/≥ 1 agent/)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 sprint **S17** — closes #156, #157, #158, #159.

- **#156 Durable execution** — \`createDurableRunner\` + \`StepLogStore\` + \`createInMemoryStepLog\` / \`createFileStepLog\`. Wrap side effects in \`runner.step(id, fn)\`; resume transparently from the log on crashes.
- **#157 Multi-agent topologies** — \`supervisor\` / \`swarm\` / \`hierarchical\` / \`blackboard\` in \`@agentskit/runtime\`. All compose over a tiny \`AgentHandle\` interface. Timeouts, routing, mergers, \`onEvent\` observability.
- **#158 HITL primitives** — \`createApprovalGate\` + \`ApprovalStore\` in \`@agentskit/core/hitl\` subpath. Request / await / decide / cancel with persisted state; idempotent request survives resumes without duplicate approvals.
- **#159 Background agents** — \`createCronScheduler\` (zero-dep 5-field cron + \`every:<ms>\`) + \`createWebhookHandler\` (framework-agnostic). Background agents without a job queue.

74 new tests.

## Coverage

- \`@agentskit/core\` lines ≥87% (threshold 75)
- \`@agentskit/runtime\` lines ≥96% (threshold 90)

## Docs

- \`apps/docs-next/content/docs/recipes/durable-execution.mdx\`
- \`apps/docs-next/content/docs/recipes/multi-agent-topologies.mdx\`
- \`apps/docs-next/content/docs/recipes/hitl-approvals.mdx\`
- \`apps/docs-next/content/docs/recipes/background-agents.mdx\`

## Changeset

\`.changeset/phase2-s17-durable-topos-hitl-bg.md\` — minor bumps on \`@agentskit/runtime\`, \`@agentskit/core\`.

## Test plan

- [x] core + runtime test:coverage above thresholds
- [x] \`pnpm -r lint\` clean
- [x] \`pnpm --filter @agentskit/docs-next lint\`
- [x] Core bundle under 10 KB (ESM 8.7 / CJS 9.7, hitl as subpath)
- [ ] Manual: drive a crashing durable flow, verify resume behavior against a file log