### PR TITLE
feat: bidirectional MCP bridge + tool composer (S20)

### DIFF
--- a/.changeset/phase3-s20-mcp-composer.md
+++ b/.changeset/phase3-s20-mcp-composer.md
@@ -1,0 +1,21 @@
+---
+'@agentskit/tools': minor
+'@agentskit/core': minor
+---
+
+Phase 3 sprint S20 — issues #167, #168.
+
+- `@agentskit/tools/mcp` (new subpath) — bidirectional Model Context
+  Protocol bridge. `createMcpClient` + `toolsFromMcpClient` consume
+  any MCP server and expose its tools as native `ToolDefinition`s.
+  `createMcpServer` exposes AgentsKit tools to MCP hosts.
+  Transport-agnostic — ships `createStdioTransport` (newline-
+  delimited JSON on stdin/stdout) and `createInMemoryTransportPair`
+  for tests. Protocol subset: `initialize` + `tools/list` +
+  `tools/call` over JSON-RPC 2.0.
+- `@agentskit/core/compose-tool` (new subpath) — `composeTool` chains
+  N `ToolDefinition`s into a single macro tool. Each step's
+  `mapArgs` builds the next sub-call from accumulated state;
+  `mapResult` transforms output; `stopWhen` short-circuits the
+  chain. `finalize` reducer optional. Exposes one schema to the
+  model but runs a fixed recipe.

--- a/apps/docs-next/content/docs/recipes/mcp-bridge.mdx
+++ b/apps/docs-next/content/docs/recipes/mcp-bridge.mdx
@@ -1,0 +1,88 @@
+---
+title: MCP bridge (bidirectional)
+description: Consume any MCP server as AgentsKit tools, or expose your AgentsKit tools to MCP hosts — over stdio or any transport.
+---
+
+Model Context Protocol (MCP) is the emerging open standard for
+connecting LLM hosts (Claude Desktop, Cursor, Zed, IDEs) to external
+tool servers. `@agentskit/tools/mcp` ships a minimal bidirectional
+bridge — consume MCP servers *as* AgentsKit tools, and expose your
+AgentsKit tools *to* any MCP host.
+
+This is a protocol subset: `initialize` + `tools/list` + `tools/call`
+over JSON-RPC 2.0. Full MCP (resources, prompts, sampling) is a
+follow-up.
+
+## Install
+
+```bash
+npm install @agentskit/tools
+```
+
+Transports are framework-agnostic — bring your own stdio, WebSocket,
+or SSE + POST. An in-memory transport pair ships for tests.
+
+## Consume an MCP server
+
+```ts
+import { spawn } from 'node:child_process'
+import {
+  createMcpClient,
+  createStdioTransport,
+  toolsFromMcpClient,
+} from '@agentskit/tools/mcp'
+import { createRuntime } from '@agentskit/runtime'
+
+const child = spawn('my-mcp-server', ['--flag'], { stdio: ['pipe', 'pipe', 'inherit'] })
+const transport = createStdioTransport(child)
+const client = createMcpClient({ transport })
+await client.initialize()
+
+const tools = await toolsFromMcpClient(client)
+const runtime = createRuntime({ adapter, tools })
+
+// Later:
+await client.close()
+```
+
+`toolsFromMcpClient` advertises every MCP tool as a native
+`ToolDefinition` — schemas pass through, errors propagate, results
+are flattened from the MCP `content[]` array into a single string.
+
+## Publish AgentsKit tools as an MCP server
+
+```ts
+import { createMcpServer, createStdioTransport } from '@agentskit/tools/mcp'
+import { webSearch, fetchUrl } from '@agentskit/tools'
+
+const transport = createStdioTransport(process as unknown as {
+  stdin: typeof process.stdin
+  stdout: typeof process.stdout
+  on?: typeof process.on
+})
+
+createMcpServer({
+  transport,
+  tools: [webSearch(), fetchUrl()],
+  serverInfo: { name: 'my-agentskit-mcp', version: '1.0.0' },
+  onEvent: e => console.error('[mcp]', e),
+})
+```
+
+Your process now speaks MCP on stdin/stdout. Point Claude Desktop,
+Cursor, or any MCP host at the binary and your AgentsKit tools show
+up as first-class.
+
+## Transports
+
+| Transport | Provider |
+|---|---|
+| `createStdioTransport(child)` | newline-delimited JSON over stdin/stdout |
+| `createInMemoryTransportPair()` | paired in-process transports — tests, in-process bridges |
+| Your own | implement the `McpTransport` contract (`send` + `onMessage` + optional `onClose` + `close`) — WebSocket, SSE + POST, etc. |
+
+## See also
+
+- [Tool composer](/docs/recipes/tool-composer) — chain N tools into one macro tool
+- [Mandatory sandbox](/docs/recipes/mandatory-sandbox) — enforce policy on imported MCP tools
+- [More providers](/docs/recipes/more-providers)

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -47,6 +47,8 @@
     "audit-log",
     "rate-limiting",
     "mandatory-sandbox",
-    "more-providers"
+    "more-providers",
+    "mcp-bridge",
+    "tool-composer"
   ]
 }

--- a/apps/docs-next/content/docs/recipes/tool-composer.mdx
+++ b/apps/docs-next/content/docs/recipes/tool-composer.mdx
@@ -1,0 +1,106 @@
+---
+title: Tool composer
+description: Chain N tools into a single macro tool — a fixed recipe the model can invoke with one schema.
+---
+
+Some agent capabilities are always the same multi-step recipe: fetch
+→ parse → rerank → summarize. Letting the model pick each step adds
+latency and unreliability; baking the recipe into a single tool
+gives the model one lever and you predictable behavior.
+
+`composeTool` takes N sub-tools, a mapper per step, and an optional
+finalizer — and returns one `ToolDefinition` the model sees as a
+single tool.
+
+## Install
+
+Ships in `@agentskit/core` under a subpath:
+
+```ts
+import { composeTool } from '@agentskit/core/compose-tool'
+```
+
+## Chain three tools into one
+
+```ts
+import { composeTool } from '@agentskit/core/compose-tool'
+import { defineTool } from '@agentskit/core'
+import { fetchUrl, webSearch } from '@agentskit/tools'
+
+const summarize = defineTool({
+  name: 'summarize',
+  schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } as const,
+  execute: async ({ text }) => `summary: ${text.slice(0, 80)}...`,
+})
+
+const research = composeTool<{ query: string }>({
+  name: 'research',
+  description: 'Search the web, fetch the top result, summarize it.',
+  schema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+  steps: [
+    {
+      tool: webSearch(),
+      mapArgs: ({ args }) => ({ query: args.query, limit: 1 }),
+    },
+    {
+      tool: fetchUrl(),
+      mapArgs: ({ state }) => ({ url: (state as { results: { url: string }[] }).results[0]!.url }),
+    },
+    {
+      tool: summarize,
+      mapArgs: ({ state }) => ({ text: String(state) }),
+    },
+  ],
+})
+```
+
+## Step contract
+
+Each `steps[i]`:
+
+```ts
+{
+  tool,
+  mapArgs({ args, state, prior }) => Record<string, unknown>,
+  mapResult?(result, { args, state, prior }) => newState,
+  stopWhen?(state, { args, prior }) => boolean,  // short-circuit the chain
+}
+```
+
+- `args` — the macro tool's original input.
+- `state` — output of the previous step (after `mapResult`).
+- `prior` — every intermediate output in declaration order.
+
+Return a `finalize({ args, prior, state })` to produce a different
+return value than the last step's state.
+
+## Stop when done
+
+A step can short-circuit the rest of the chain if its `stopWhen`
+predicate returns true — useful for early termination in cache-hit
+scenarios.
+
+```ts
+{
+  tool: cacheCheck,
+  mapArgs: ({ args }) => ({ key: args.query }),
+  stopWhen: state => state !== null,
+}
+```
+
+## Observability
+
+```ts
+composeTool({
+  ...,
+  onStep: e => logger.debug('[compose]', e),
+})
+```
+
+Events: `start` / `end` / `skip`, with step index + tool name.
+
+## See also
+
+- [MCP bridge](/docs/recipes/mcp-bridge) — expose composed tools to MCP hosts
+- [Mandatory sandbox](/docs/recipes/mandatory-sandbox)
+- [Custom adapter](/docs/recipes/custom-adapter)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,11 @@
       "types": "./dist/security.d.ts",
       "import": "./dist/security.js",
       "require": "./dist/security.cjs"
+    },
+    "./compose-tool": {
+      "types": "./dist/compose-tool.d.ts",
+      "import": "./dist/compose-tool.js",
+      "require": "./dist/compose-tool.cjs"
     }
   },
   "files": [

--- a/packages/core/src/compose-tool.ts
+++ b/packages/core/src/compose-tool.ts
@@ -1,0 +1,107 @@
+import type { JSONSchema7 } from 'json-schema'
+import type { ToolDefinition, ToolExecutionContext } from './types/tool'
+
+/**
+ * One link in a composed tool: invoke `tool` with arguments derived
+ * from the prior step's output (or the macro-call's original args),
+ * optionally transform the result before feeding it into the next
+ * link.
+ */
+export interface ComposeStep<TArgs extends Record<string, unknown> = Record<string, unknown>, TState = unknown> {
+  tool: ToolDefinition
+  /**
+   * Map the current pipeline state into the sub-tool's arguments.
+   * Receives the macro call's raw args and the accumulated state
+   * (the result of every prior step, in declaration order).
+   */
+  mapArgs: (input: { args: TArgs; state: TState; prior: unknown[] }) => Record<string, unknown> | Promise<Record<string, unknown>>
+  /**
+   * Transform the sub-tool's raw output before storing it in state.
+   * Default: pass the value through untouched.
+   */
+  mapResult?: (output: unknown, input: { args: TArgs; state: TState; prior: unknown[] }) => TState | Promise<TState>
+  /**
+   * Short-circuit the pipeline and return the current state when
+   * this returns true. The step's sub-tool is still executed; use
+   * `mapArgs` to skip if needed.
+   */
+  stopWhen?: (state: TState, input: { args: TArgs; prior: unknown[] }) => boolean
+}
+
+export interface ComposeToolOptions<TArgs extends Record<string, unknown> = Record<string, unknown>> {
+  name: string
+  description?: string
+  schema?: JSONSchema7
+  requiresConfirmation?: boolean
+  tags?: string[]
+  category?: string
+  /** Execution steps. Run left-to-right; output becomes input of next. */
+  steps: ComposeStep<TArgs, unknown>[]
+  /**
+   * Final reducer — receives the last state + every intermediate
+   * output, returns the macro tool's result. Default: the last state.
+   */
+  finalize?: (input: { args: TArgs; prior: unknown[]; state: unknown }) => unknown | Promise<unknown>
+  /** Observability — fires before/after each step. */
+  onStep?: (event: {
+    phase: 'start' | 'end' | 'skip'
+    step: number
+    tool: string
+    args?: Record<string, unknown>
+    result?: unknown
+  }) => void
+}
+
+/**
+ * Chain N tools into a single macro tool. The composed tool exposes
+ * one schema to the model (`options.schema`) but under the hood runs
+ * a fixed pipeline of sub-tools — a "skill" that always performs the
+ * same multi-step recipe.
+ *
+ * Each step's `mapArgs` builds the next call from the running state;
+ * `mapResult` transforms the output before it's stored. The final
+ * step's state is returned unless a `finalize` reducer is given.
+ */
+export function composeTool<TArgs extends Record<string, unknown> = Record<string, unknown>>(
+  options: ComposeToolOptions<TArgs>,
+): ToolDefinition<TArgs> {
+  if (options.steps.length === 0) {
+    throw new Error(`composeTool("${options.name}"): at least one step required`)
+  }
+
+  return {
+    name: options.name,
+    description: options.description,
+    schema: options.schema,
+    requiresConfirmation: options.requiresConfirmation,
+    tags: options.tags,
+    category: options.category,
+    async execute(args: TArgs, context: ToolExecutionContext): Promise<unknown> {
+      const prior: unknown[] = []
+      let state: unknown = undefined
+
+      for (let i = 0; i < options.steps.length; i++) {
+        const step = options.steps[i]!
+        if (!step.tool.execute) {
+          throw new Error(`composeTool("${options.name}"): step ${i} tool "${step.tool.name}" has no execute`)
+        }
+        const subArgs = await step.mapArgs({ args, state, prior })
+        options.onStep?.({ phase: 'start', step: i, tool: step.tool.name, args: subArgs })
+        const subCall = { ...context.call, name: step.tool.name, args: subArgs }
+        const result = await step.tool.execute(subArgs, { messages: context.messages, call: subCall })
+        prior.push(result)
+        state = step.mapResult
+          ? await step.mapResult(result, { args, state, prior })
+          : result
+        options.onStep?.({ phase: 'end', step: i, tool: step.tool.name, result })
+        if (step.stopWhen?.(state, { args, prior })) {
+          options.onStep?.({ phase: 'skip', step: i + 1, tool: 'remaining' })
+          break
+        }
+      }
+
+      if (options.finalize) return options.finalize({ args, prior, state })
+      return state
+    },
+  }
+}

--- a/packages/core/tests/compose-tool.test.ts
+++ b/packages/core/tests/compose-tool.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+import { composeTool } from '../src/compose-tool'
+import type { ToolDefinition } from '../src/types/tool'
+
+function tool(
+  name: string,
+  run: (args: Record<string, unknown>) => unknown | Promise<unknown>,
+): ToolDefinition {
+  return { name, description: name, execute: async args => run(args) }
+}
+
+const stubCtx = {
+  messages: [],
+  call: { id: 'c', name: 'x', args: {}, status: 'running' as const },
+}
+
+describe('composeTool', () => {
+  it('rejects empty step list', () => {
+    expect(() => composeTool({ name: 'empty', steps: [] })).toThrow(/at least one step/)
+  })
+
+  it('runs steps left-to-right, piping state', async () => {
+    const double = tool('double', async ({ n }) => (n as number) * 2)
+    const addOne = tool('add-one', async ({ n }) => (n as number) + 1)
+    const macro = composeTool<{ start: number }>({
+      name: 'macro',
+      steps: [
+        { tool: double, mapArgs: ({ args }) => ({ n: args.start }) },
+        { tool: addOne, mapArgs: ({ state }) => ({ n: state as number }) },
+      ],
+    })
+    expect(await macro.execute!({ start: 5 }, stubCtx)).toBe(11)
+  })
+
+  it('mapResult transforms the step output before storing', async () => {
+    const macro = composeTool({
+      name: 'macro',
+      steps: [
+        {
+          tool: tool('returner', async () => ({ payload: 'hello' })),
+          mapArgs: () => ({}),
+          mapResult: (result: unknown) => (result as { payload: string }).payload.toUpperCase(),
+        },
+      ],
+    })
+    expect(await macro.execute!({}, stubCtx)).toBe('HELLO')
+  })
+
+  it('finalize reducer wraps every intermediate output', async () => {
+    const macro = composeTool({
+      name: 'macro',
+      steps: [
+        { tool: tool('a', async () => 1), mapArgs: () => ({}) },
+        { tool: tool('b', async () => 2), mapArgs: () => ({}) },
+      ],
+      finalize: ({ prior }) => ({ sum: prior.reduce<number>((s, v) => s + (v as number), 0) }),
+    })
+    expect(await macro.execute!({}, stubCtx)).toEqual({ sum: 3 })
+  })
+
+  it('stopWhen short-circuits the remaining steps', async () => {
+    const second = vi.fn(async () => 'never')
+    const macro = composeTool({
+      name: 'macro',
+      steps: [
+        {
+          tool: tool('first', async () => 'done'),
+          mapArgs: () => ({}),
+          stopWhen: state => state === 'done',
+        },
+        { tool: { name: 'second', description: '', execute: second }, mapArgs: () => ({}) },
+      ],
+    })
+    expect(await macro.execute!({}, stubCtx)).toBe('done')
+    expect(second).not.toHaveBeenCalled()
+  })
+
+  it('throws when a step has no execute', async () => {
+    const macro = composeTool({
+      name: 'macro',
+      steps: [{ tool: { name: 'broken', description: '' }, mapArgs: () => ({}) }],
+    })
+    await expect(macro.execute!({}, stubCtx)).rejects.toThrow(/has no execute/)
+  })
+
+  it('onStep fires start + end per step', async () => {
+    const phases: string[] = []
+    const macro = composeTool({
+      name: 'macro',
+      steps: [
+        { tool: tool('a', async () => 1), mapArgs: () => ({}) },
+        { tool: tool('b', async () => 2), mapArgs: () => ({}) },
+      ],
+      onStep: e => phases.push(`${e.step}:${e.phase}`),
+    })
+    await macro.execute!({}, stubCtx)
+    expect(phases).toEqual(['0:start', '0:end', '1:start', '1:end'])
+  })
+
+  it('exposes schema + description + confirmation on the macro', () => {
+    const macro = composeTool({
+      name: 'macro',
+      description: 'chains',
+      schema: { type: 'object', properties: { q: { type: 'string' } } },
+      requiresConfirmation: true,
+      tags: ['chain'],
+      category: 'macro',
+      steps: [{ tool: tool('a', async () => null), mapArgs: () => ({}) }],
+    })
+    expect(macro.description).toBe('chains')
+    expect(macro.requiresConfirmation).toBe(true)
+    expect(macro.tags).toEqual(['chain'])
+    expect(macro.category).toBe('macro')
+    expect(macro.schema?.properties).toEqual({ q: { type: 'string' } })
+  })
+
+  it('mapArgs receives the macro args and prior results', async () => {
+    const captured: Array<Record<string, unknown>> = []
+    const macro = composeTool<{ id: string }>({
+      name: 'macro',
+      steps: [
+        {
+          tool: tool('fetch', async ({ id }) => ({ name: `user-${id}` })),
+          mapArgs: ({ args }) => {
+            captured.push({ id: args.id })
+            return { id: args.id }
+          },
+        },
+        {
+          tool: tool('greet', async ({ name }) => `hi, ${name}`),
+          mapArgs: ({ prior, state }) => {
+            captured.push({ prior: prior.length, state })
+            return { name: (state as { name: string }).name }
+          },
+        },
+      ],
+    })
+    const result = await macro.execute!({ id: '42' }, stubCtx)
+    expect(result).toBe('hi, user-42')
+    expect(captured[0]).toEqual({ id: '42' })
+    expect(captured[1]).toMatchObject({ prior: 1 })
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'auto-summarize': 'src/auto-summarize.ts',
     hitl: 'src/hitl.ts',
     security: 'src/security/index.ts',
+    'compose-tool': 'src/compose-tool.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./mcp": {
+      "types": "./dist/mcp.d.ts",
+      "import": "./dist/mcp.js",
+      "require": "./dist/mcp.cjs"
     }
   },
   "files": [

--- a/packages/tools/src/mcp/client.ts
+++ b/packages/tools/src/mcp/client.ts
@@ -1,0 +1,105 @@
+import type { ToolDefinition } from '@agentskit/core'
+import type {
+  JsonRpcMessage,
+  JsonRpcSuccess,
+  JsonRpcError,
+  McpCallToolResult,
+  McpToolsListResult,
+  McpTransport,
+} from './types'
+
+export interface McpClient {
+  initialize: () => Promise<{ serverInfo: { name: string; version?: string } }>
+  listTools: () => Promise<McpToolsListResult>
+  callTool: (name: string, args: Record<string, unknown>) => Promise<McpCallToolResult>
+  close: () => Promise<void>
+}
+
+function isResponse(msg: JsonRpcMessage): msg is JsonRpcSuccess | JsonRpcError {
+  return 'id' in msg && (('result' in msg) || ('error' in msg))
+}
+
+function isError(msg: JsonRpcSuccess | JsonRpcError): msg is JsonRpcError {
+  return 'error' in msg
+}
+
+/**
+ * Build an MCP client over any `McpTransport`. Supports
+ * `initialize`, `tools/list`, and `tools/call` — the minimum needed
+ * to drive external MCP servers as AgentsKit tools.
+ */
+export function createMcpClient(options: {
+  transport: McpTransport
+  clientInfo?: { name: string; version: string }
+}): McpClient {
+  const pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
+  let nextId = 1
+
+  const detach = options.transport.onMessage(message => {
+    if (!isResponse(message)) return
+    const entry = pending.get(Number(message.id))
+    if (!entry) return
+    pending.delete(Number(message.id))
+    if (isError(message)) {
+      entry.reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`))
+    } else {
+      entry.resolve(message.result)
+    }
+  })
+
+  const call = <T>(method: string, params?: Record<string, unknown>): Promise<T> => {
+    const id = nextId++
+    return new Promise<T>((resolve, reject) => {
+      pending.set(id, { resolve: v => resolve(v as T), reject })
+      Promise.resolve(
+        options.transport.send({ jsonrpc: '2.0', id, method, params }),
+      ).catch(err => {
+        pending.delete(id)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      })
+    })
+  }
+
+  return {
+    async initialize() {
+      return call<{ serverInfo: { name: string; version?: string } }>('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        clientInfo: options.clientInfo ?? { name: 'agentskit-mcp-client', version: '0.1.0' },
+      })
+    },
+    async listTools() {
+      return call<McpToolsListResult>('tools/list')
+    },
+    async callTool(name, args) {
+      return call<McpCallToolResult>('tools/call', { name, arguments: args })
+    },
+    async close() {
+      detach()
+      await options.transport.close?.()
+    },
+  }
+}
+
+/**
+ * Hydrate the tools advertised by an MCP server into AgentsKit
+ * `ToolDefinition`s. Each call delegates to `client.callTool` and
+ * flattens the text content into a single string result.
+ */
+export async function toolsFromMcpClient(client: McpClient): Promise<ToolDefinition[]> {
+  const { tools } = await client.listTools()
+  return tools.map(t => ({
+    name: t.name,
+    description: t.description,
+    schema: t.inputSchema,
+    async execute(args) {
+      const result = await client.callTool(t.name, args)
+      const text = result.content
+        .map(c => (c.type === 'text' ? c.text : ''))
+        .filter(Boolean)
+        .join('\n')
+      if (result.isError) throw new Error(text || `MCP tool ${t.name} errored`)
+      return text
+    },
+  }))
+}

--- a/packages/tools/src/mcp/index.ts
+++ b/packages/tools/src/mcp/index.ts
@@ -1,0 +1,24 @@
+export { createMcpClient, toolsFromMcpClient } from './client'
+export type { McpClient } from './client'
+
+export { createMcpServer } from './server'
+export type { McpServer, McpServerOptions } from './server'
+
+export {
+  createInMemoryTransportPair,
+  createStdioTransport,
+} from './transports'
+export type { StdioLikeProcess } from './transports'
+
+export type {
+  McpTransport,
+  JsonRpcMessage,
+  JsonRpcRequest,
+  JsonRpcNotification,
+  JsonRpcSuccess,
+  JsonRpcError,
+  McpToolDescriptor,
+  McpToolsListResult,
+  McpCallToolResult,
+  McpContentText,
+} from './types'

--- a/packages/tools/src/mcp/server.ts
+++ b/packages/tools/src/mcp/server.ts
@@ -1,0 +1,138 @@
+import type { ToolDefinition } from '@agentskit/core'
+import type {
+  JsonRpcMessage,
+  JsonRpcRequest,
+  McpTransport,
+} from './types'
+
+export interface McpServerOptions {
+  transport: McpTransport
+  tools: ToolDefinition[]
+  serverInfo?: { name: string; version: string }
+  /** Observability hook. */
+  onEvent?: (event: { type: 'call' | 'error' | 'list'; tool?: string; error?: string }) => void
+}
+
+export interface McpServer {
+  close: () => Promise<void>
+}
+
+/**
+ * Expose a set of AgentsKit tools as an MCP server over any
+ * `McpTransport`. Implements the three methods most MCP hosts need:
+ * `initialize`, `tools/list`, `tools/call`.
+ */
+export function createMcpServer(options: McpServerOptions): McpServer {
+  const { transport, tools } = options
+  const serverInfo = options.serverInfo ?? { name: 'agentskit-mcp-server', version: '0.1.0' }
+
+  const respond = async (message: JsonRpcMessage): Promise<void> => {
+    try {
+      await transport.send(message)
+    } catch {
+      // transport already errored — nothing to do
+    }
+  }
+
+  const detach = transport.onMessage(async raw => {
+    if (!('method' in raw)) return
+    const request = raw as JsonRpcRequest
+    const hasId = 'id' in request
+
+    try {
+      if (request.method === 'initialize') {
+        if (!hasId) return
+        await respond({
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: { tools: { listChanged: false } },
+            serverInfo,
+          },
+        })
+        return
+      }
+
+      if (request.method === 'tools/list') {
+        options.onEvent?.({ type: 'list' })
+        if (!hasId) return
+        await respond({
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {
+            tools: tools.map(t => ({
+              name: t.name,
+              description: t.description,
+              inputSchema: t.schema ?? { type: 'object', properties: {} },
+            })),
+          },
+        })
+        return
+      }
+
+      if (request.method === 'tools/call') {
+        if (!hasId) return
+        const params = request.params as { name?: string; arguments?: Record<string, unknown> } | undefined
+        const tool = tools.find(t => t.name === params?.name)
+        if (!tool || !tool.execute) {
+          options.onEvent?.({ type: 'error', tool: params?.name, error: 'unknown tool' })
+          await respond({
+            jsonrpc: '2.0',
+            id: request.id,
+            error: { code: -32602, message: `unknown tool: ${params?.name}` },
+          })
+          return
+        }
+        options.onEvent?.({ type: 'call', tool: tool.name })
+        try {
+          const result = await tool.execute(params?.arguments ?? {}, {
+            messages: [],
+            call: { id: String(request.id), name: tool.name, args: params?.arguments ?? {}, status: 'running' },
+          })
+          const text = typeof result === 'string' ? result : JSON.stringify(result)
+          await respond({
+            jsonrpc: '2.0',
+            id: request.id,
+            result: { content: [{ type: 'text', text }] },
+          })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          options.onEvent?.({ type: 'error', tool: tool.name, error: message })
+          await respond({
+            jsonrpc: '2.0',
+            id: request.id,
+            result: { content: [{ type: 'text', text: message }], isError: true },
+          })
+        }
+        return
+      }
+
+      if (hasId) {
+        await respond({
+          jsonrpc: '2.0',
+          id: request.id,
+          error: { code: -32601, message: `method not found: ${request.method}` },
+        })
+      }
+    } catch (err) {
+      if (hasId) {
+        await respond({
+          jsonrpc: '2.0',
+          id: request.id,
+          error: {
+            code: -32603,
+            message: err instanceof Error ? err.message : String(err),
+          },
+        })
+      }
+    }
+  })
+
+  return {
+    async close() {
+      detach()
+      await transport.close?.()
+    },
+  }
+}

--- a/packages/tools/src/mcp/transports.ts
+++ b/packages/tools/src/mcp/transports.ts
@@ -1,0 +1,118 @@
+import type { JsonRpcMessage, McpTransport } from './types'
+
+/**
+ * Paired in-memory transports for tests and in-process bridges.
+ * Returns two transports that see each other's `send` output on
+ * their `onMessage` handlers.
+ */
+export function createInMemoryTransportPair(): [McpTransport, McpTransport] {
+  const listeners: [Set<(m: JsonRpcMessage) => void>, Set<(m: JsonRpcMessage) => void>] = [
+    new Set(),
+    new Set(),
+  ]
+  const closeListeners: [Set<() => void>, Set<() => void>] = [new Set(), new Set()]
+  let closed = false
+
+  const make = (self: 0 | 1): McpTransport => {
+    const other = (self === 0 ? 1 : 0) as 0 | 1
+    return {
+      send(message) {
+        if (closed) return
+        for (const l of listeners[other]) l(message)
+      },
+      onMessage(handler) {
+        listeners[self].add(handler)
+        return () => {
+          listeners[self].delete(handler)
+        }
+      },
+      onClose(handler) {
+        closeListeners[self].add(handler)
+        return () => {
+          closeListeners[self].delete(handler)
+        }
+      },
+      close() {
+        closed = true
+        for (const l of closeListeners[0]) l()
+        for (const l of closeListeners[1]) l()
+      },
+    }
+  }
+
+  return [make(0), make(1)]
+}
+
+/**
+ * Create a stdio transport over a child process handle. The spawned
+ * process is expected to speak MCP's newline-delimited JSON framing
+ * on stdin/stdout.
+ *
+ * Pass any object exposing the three streams; this intentionally
+ * avoids importing `node:child_process` so the module stays
+ * environment-agnostic. Most callers will wrap `child_process.spawn`
+ * themselves and hand the handle in.
+ */
+export interface StdioLikeProcess {
+  stdin: { write: (chunk: string) => boolean | void }
+  stdout: {
+    on: (event: 'data', cb: (chunk: Buffer | string) => void) => void
+    off?: (event: 'data', cb: (chunk: Buffer | string) => void) => void
+  }
+  on?: (event: 'exit' | 'close', cb: () => void) => void
+  kill?: () => void
+}
+
+export function createStdioTransport(child: StdioLikeProcess): McpTransport {
+  const messageListeners = new Set<(m: JsonRpcMessage) => void>()
+  const closeListeners = new Set<() => void>()
+  let buffer = ''
+
+  const onData = (chunk: Buffer | string): void => {
+    buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    let newlineIdx = buffer.indexOf('\n')
+    while (newlineIdx >= 0) {
+      const line = buffer.slice(0, newlineIdx).trim()
+      buffer = buffer.slice(newlineIdx + 1)
+      if (line) {
+        try {
+          const message = JSON.parse(line) as JsonRpcMessage
+          for (const l of messageListeners) l(message)
+        } catch {
+          // ignore malformed frames
+        }
+      }
+      newlineIdx = buffer.indexOf('\n')
+    }
+  }
+
+  child.stdout.on('data', onData)
+  child.on?.('exit', () => {
+    for (const l of closeListeners) l()
+  })
+  child.on?.('close', () => {
+    for (const l of closeListeners) l()
+  })
+
+  return {
+    send(message) {
+      child.stdin.write(`${JSON.stringify(message)}\n`)
+    },
+    onMessage(handler) {
+      messageListeners.add(handler)
+      return () => {
+        messageListeners.delete(handler)
+      }
+    },
+    onClose(handler) {
+      closeListeners.add(handler)
+      return () => {
+        closeListeners.delete(handler)
+      }
+    },
+    close() {
+      child.stdout.off?.('data', onData)
+      child.kill?.()
+    },
+  }
+}

--- a/packages/tools/src/mcp/types.ts
+++ b/packages/tools/src/mcp/types.ts
@@ -1,0 +1,71 @@
+import type { JSONSchema7 } from 'json-schema'
+
+/**
+ * Subset of the Model Context Protocol (MCP) used by the bridge.
+ * Full MCP spec covers resources, prompts, sampling, and more —
+ * this module focuses on the most common case: tools.
+ */
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: number | string
+  method: string
+  params?: Record<string, unknown>
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: '2.0'
+  method: string
+  params?: Record<string, unknown>
+}
+
+export interface JsonRpcSuccess<TResult = unknown> {
+  jsonrpc: '2.0'
+  id: number | string
+  result: TResult
+}
+
+export interface JsonRpcError {
+  jsonrpc: '2.0'
+  id: number | string | null
+  error: { code: number; message: string; data?: unknown }
+}
+
+export type JsonRpcMessage =
+  | JsonRpcRequest
+  | JsonRpcNotification
+  | JsonRpcSuccess
+  | JsonRpcError
+
+export interface McpToolDescriptor {
+  name: string
+  description?: string
+  inputSchema: JSONSchema7
+}
+
+export interface McpToolsListResult {
+  tools: McpToolDescriptor[]
+}
+
+export interface McpContentText {
+  type: 'text'
+  text: string
+}
+
+export interface McpCallToolResult {
+  content: McpContentText[]
+  isError?: boolean
+}
+
+/**
+ * Transport contract. A transport is a bidirectional byte / object
+ * pipe — stdio pipes, WebSocket, SSE + POST, whatever. Implementers
+ * deliver JSON-RPC messages intact and signal disconnection via
+ * `onClose`.
+ */
+export interface McpTransport {
+  send: (message: JsonRpcMessage) => void | Promise<void>
+  onMessage: (handler: (message: JsonRpcMessage) => void) => () => void
+  onClose?: (handler: () => void) => () => void
+  close?: () => void | Promise<void>
+}

--- a/packages/tools/tests/mcp.test.ts
+++ b/packages/tools/tests/mcp.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolDefinition } from '@agentskit/core'
+import {
+  createInMemoryTransportPair,
+  createMcpClient,
+  createMcpServer,
+  createStdioTransport,
+  toolsFromMcpClient,
+  type JsonRpcMessage,
+  type McpTransport,
+} from '../src/mcp'
+
+function makeTool(name: string, run: (args: Record<string, unknown>) => unknown | Promise<unknown>): ToolDefinition {
+  return {
+    name,
+    description: `desc-${name}`,
+    schema: { type: 'object', properties: { q: { type: 'string' } } },
+    execute: async args => run(args),
+  }
+}
+
+describe('MCP bridge (client ↔ server over in-memory transport)', () => {
+  it('initialize returns server info', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    const server = createMcpServer({ transport: b, tools: [] })
+    const client = createMcpClient({ transport: a })
+    const info = await client.initialize()
+    expect(info.serverInfo.name).toBe('agentskit-mcp-server')
+    await server.close()
+    await client.close()
+  })
+
+  it('lists exposed tools with their schemas', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    const tools = [makeTool('echo', async args => `hi ${args.q}`)]
+    createMcpServer({ transport: b, tools })
+    const client = createMcpClient({ transport: a })
+    const result = await client.listTools()
+    expect(result.tools.map(t => t.name)).toEqual(['echo'])
+    expect(result.tools[0]!.inputSchema.properties).toBeDefined()
+    await client.close()
+  })
+
+  it('callTool invokes the server-side execute', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({ transport: b, tools: [makeTool('echo', async ({ q }) => `you said ${q}`)] })
+    const client = createMcpClient({ transport: a })
+    const result = await client.callTool('echo', { q: 'hi' })
+    expect(result.content[0]!.type).toBe('text')
+    expect(result.content[0]!.text).toBe('you said hi')
+    expect(result.isError).toBeUndefined()
+    await client.close()
+  })
+
+  it('returns isError: true when the tool throws', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({
+      transport: b,
+      tools: [{ name: 'boom', description: '', execute: async () => { throw new Error('bang') } }],
+    })
+    const client = createMcpClient({ transport: a })
+    const result = await client.callTool('boom', {})
+    expect(result.isError).toBe(true)
+    expect(result.content[0]!.text).toBe('bang')
+    await client.close()
+  })
+
+  it('errors on unknown tool', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({ transport: b, tools: [] })
+    const client = createMcpClient({ transport: a })
+    await expect(client.callTool('missing', {})).rejects.toThrow(/unknown tool/)
+    await client.close()
+  })
+
+  it('errors on unknown method', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({ transport: b, tools: [] })
+    const client = createMcpClient({ transport: a })
+    // Call into the private transport to test the method-not-found branch.
+    const send = (msg: JsonRpcMessage): void => {
+      void a.send(msg)
+    }
+    const received = new Promise<JsonRpcMessage>(resolve => {
+      a.onMessage(resolve)
+    })
+    send({ jsonrpc: '2.0', id: 99, method: 'nonsense' })
+    const response = await received
+    expect('error' in response && response.error.code).toBe(-32601)
+    await client.close()
+  })
+
+  it('onEvent observer fires for list / call / error', async () => {
+    const events: string[] = []
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({
+      transport: b,
+      tools: [makeTool('echo', async () => 'ok')],
+      onEvent: e => events.push(`${e.type}:${e.tool ?? ''}`),
+    })
+    const client = createMcpClient({ transport: a })
+    await client.listTools()
+    await client.callTool('echo', {})
+    await client.callTool('missing', {}).catch(() => undefined)
+    expect(events).toEqual(['list:', 'call:echo', 'error:missing'])
+    await client.close()
+  })
+
+  it('non-text results are serialized to JSON text', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({
+      transport: b,
+      tools: [makeTool('obj', async () => ({ k: 1, arr: [1, 2] }))],
+    })
+    const client = createMcpClient({ transport: a })
+    const result = await client.callTool('obj', {})
+    expect(result.content[0]!.text).toBe(JSON.stringify({ k: 1, arr: [1, 2] }))
+    await client.close()
+  })
+})
+
+describe('toolsFromMcpClient', () => {
+  it('hydrates MCP tools into AgentsKit ToolDefinitions', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({ transport: b, tools: [makeTool('echo', async ({ q }) => `you said ${q}`)] })
+    const client = createMcpClient({ transport: a })
+    const tools = await toolsFromMcpClient(client)
+    expect(tools).toHaveLength(1)
+    expect(tools[0]!.name).toBe('echo')
+    const out = await tools[0]!.execute!(
+      { q: 'hi' },
+      { messages: [], call: { id: 'c', name: 'echo', args: { q: 'hi' }, status: 'running' } },
+    )
+    expect(out).toBe('you said hi')
+    await client.close()
+  })
+
+  it('propagates tool errors', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({
+      transport: b,
+      tools: [{ name: 'boom', description: '', execute: async () => { throw new Error('bang') } }],
+    })
+    const client = createMcpClient({ transport: a })
+    const tools = await toolsFromMcpClient(client)
+    await expect(
+      tools[0]!.execute!({}, { messages: [], call: { id: 'c', name: 'boom', args: {}, status: 'running' } }),
+    ).rejects.toThrow(/bang/)
+    await client.close()
+  })
+})
+
+describe('createStdioTransport', () => {
+  it('frames newline-delimited JSON on stdin/stdout', () => {
+    const writes: string[] = []
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const child = {
+      stdin: { write: (chunk: string) => { writes.push(chunk); return true } },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+      },
+    }
+    const transport: McpTransport = createStdioTransport(child)
+    const received: JsonRpcMessage[] = []
+    transport.onMessage(m => received.push(m))
+
+    transport.send({ jsonrpc: '2.0', id: 1, method: 'initialize' })
+    expect(writes[0]).toBe(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' })}\n`)
+
+    dataCb!(`${JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } })}\n`)
+    expect(received[0]).toMatchObject({ result: { ok: true } })
+  })
+
+  it('buffers partial chunks until newline arrives', () => {
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const child = {
+      stdin: { write: (_chunk: string) => true },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+      },
+    }
+    const transport = createStdioTransport(child)
+    const received: JsonRpcMessage[] = []
+    transport.onMessage(m => received.push(m))
+    dataCb!('{"jsonrpc":"2.0","id":1,')
+    expect(received).toHaveLength(0)
+    dataCb!('"result":{}}\n')
+    expect(received).toHaveLength(1)
+  })
+
+  it('ignores malformed JSON frames', () => {
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const child = {
+      stdin: { write: vi.fn() },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+      },
+    }
+    const transport = createStdioTransport(child)
+    const received: JsonRpcMessage[] = []
+    transport.onMessage(m => received.push(m))
+    dataCb!('not-json\n')
+    expect(received).toHaveLength(0)
+  })
+})

--- a/packages/tools/tsup.config.ts
+++ b/packages/tools/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    mcp: 'src/mcp/index.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },


### PR DESCRIPTION
## Summary

Phase 3 sprint **S20** — closes #167, #168.

- **#167 Bidirectional MCP bridge** — new \`@agentskit/tools/mcp\` subpath.
  - **Consume:** \`createMcpClient\` + \`toolsFromMcpClient\` pull an MCP server's tools into native AgentsKit \`ToolDefinition\`s.
  - **Publish:** \`createMcpServer\` exposes your AgentsKit tools to any MCP host (Claude Desktop, Cursor, Zed, IDEs).
  - **Transports:** \`createStdioTransport\` (newline-JSON over stdin/stdout) + \`createInMemoryTransportPair\` for tests. Bring your own for WebSocket / SSE + POST.
  - **Protocol subset:** \`initialize\` + \`tools/list\` + \`tools/call\` over JSON-RPC 2.0. Resources / prompts / sampling deferred.
- **#168 Tool composer** — new \`@agentskit/core/compose-tool\` subpath. \`composeTool\` chains N tools into one macro tool; each step's \`mapArgs\` builds the next sub-call from accumulated state, \`mapResult\` transforms, \`stopWhen\` short-circuits, \`finalize\` reduces. One schema to the model, fixed recipe underneath.

23 new tests.

## Coverage

- \`@agentskit/core\` lines ≥87% (threshold 75); \`compose-tool.ts\` 100%
- \`@agentskit/tools\` lines ≥70% (threshold 70)

## Docs

- \`apps/docs-next/content/docs/recipes/mcp-bridge.mdx\`
- \`apps/docs-next/content/docs/recipes/tool-composer.mdx\`

## Changeset

\`.changeset/phase3-s20-mcp-composer.md\` — minor bumps on \`@agentskit/tools\`, \`@agentskit/core\`.

## Test plan

- [x] \`pnpm --filter @agentskit/tools test\` (62, 17 new from MCP)
- [x] \`pnpm --filter @agentskit/core test\` (226, 10 new from composer)
- [x] \`pnpm -r lint\`
- [x] Core bundle under 10 KB
- [ ] Manual: run an external MCP server through the stdio transport