### PR TITLE
feat: self-debug + vector memory adapters + encrypted memory (S23)

### DIFF
--- a/.changeset/phase3-s23-selfdebug-memory-encrypt.md
+++ b/.changeset/phase3-s23-selfdebug-memory-encrypt.md
@@ -1,0 +1,24 @@
+---
+'@agentskit/core': minor
+'@agentskit/memory': minor
+---
+
+Phase 3 sprint S23 — issues #176, #177, #178.
+
+- `@agentskit/core/self-debug` (subpath) —
+  `wrapToolWithSelfDebug(tool, debugger, options)` retries on
+  `execute` failure with user-supplied corrected args.
+  `createLlmSelfDebugger(complete)` wraps any completion fn into a
+  debugger that reads the error + schema + args and emits JSON
+  corrections. `maxAttempts`, `onEvent` (success/failure/retry/
+  give-up) included.
+- `@agentskit/memory` — five new `VectorMemory` implementations
+  over the shared contract: `pgvector` (BYO SQL runner),
+  `pinecone`, `qdrant`, `chroma`, `upstashVector`. All return
+  normalized `score` and support optional `threshold` filtering.
+- `@agentskit/memory` — `createEncryptedMemory` wraps any
+  `ChatMemory` with AES-GCM (Web Crypto, 256-bit). Backing store
+  only sees ciphertext; keys never leave the caller. Optional AAD
+  binds ciphertext to a tenant / room. Idempotent on re-save.
+
+~85 new tests.

--- a/apps/docs-next/content/docs/recipes/encrypted-memory.mdx
+++ b/apps/docs-next/content/docs/recipes/encrypted-memory.mdx
@@ -1,0 +1,71 @@
+---
+title: Encrypted memory
+description: Client-side AES-GCM encryption for any ChatMemory — keys never leave the caller, backing store only sees ciphertext.
+---
+
+`createEncryptedMemory` wraps any existing `ChatMemory` so the
+backing store only ever sees opaque ciphertext. Users hold the key;
+rogue middleware, backups, and even the backing service itself
+can't read the plaintext. Uses Web Crypto (AES-GCM, 256-bit) —
+available on Node 20+ and all modern browsers.
+
+## Install
+
+Ships with `@agentskit/memory`.
+
+## Wire it up
+
+```ts
+import { createEncryptedMemory, fileChatMemory } from '@agentskit/memory'
+
+// A 32-byte key. Generate once per user during onboarding and store
+// it on their device (iOS Keychain, Android Keystore, OS credential
+// manager, browser IndexedDB with key derivation from a passphrase).
+const key = crypto.getRandomValues(new Uint8Array(32))
+
+const memory = await createEncryptedMemory({
+  backing: fileChatMemory({ path: './sessions/user-42.json' }),
+  key,
+})
+
+const runtime = createRuntime({ adapter, memory })
+```
+
+On `save`, every message's `content` becomes `""` and the ciphertext
+is stashed in `metadata.{ciphertext, iv, length}`. On `load`, the
+process reverses transparently — the agent never knows the
+encryption is there.
+
+## Additional authenticated data (AAD)
+
+Bind ciphertext to context so the same key can't decrypt messages
+captured from a different tenant / room / session:
+
+```ts
+const memory = await createEncryptedMemory({
+  backing,
+  key,
+  aad: new TextEncoder().encode(`tenant:${tenantId}`),
+})
+```
+
+## Idempotent
+
+Already-encrypted messages (tagged with `metadata.agentskitEncrypted`)
+are passed through untouched on subsequent saves, so re-reading and
+re-saving won't double-encrypt.
+
+## Key management
+
+- Keys **never** pass through the backing store — they live on the
+  user's device.
+- Different key → decryption fails with `OperationError`. That's
+  the correct behavior; treat it as "data is lost, key rotation
+  required."
+- Pair with [Signed audit log](/docs/recipes/audit-log) for
+  regulator-friendly evidence of who accessed what.
+
+## See also
+
+- [Persistent memory](/docs/recipes/persistent-memory)
+- [Vector memory adapters](/docs/recipes/vector-adapters)

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -49,6 +49,9 @@
     "mandatory-sandbox",
     "more-providers",
     "mcp-bridge",
-    "tool-composer"
+    "tool-composer",
+    "self-debug",
+    "vector-adapters",
+    "encrypted-memory"
   ]
 }

--- a/apps/docs-next/content/docs/recipes/self-debug.mdx
+++ b/apps/docs-next/content/docs/recipes/self-debug.mdx
@@ -1,0 +1,75 @@
+---
+title: Self-debug tool
+description: On tool error, let the agent read the error + schema and draft corrected arguments for a retry.
+---
+
+Tool calls fail for boring reasons: the model hallucinated a field,
+missed a required arg, or passed a string where a number was
+expected. `wrapToolWithSelfDebug` gives your tool a feedback loop —
+on failure, a user-supplied "debugger" sees the error + schema +
+args and returns corrected arguments for a retry.
+
+## Install
+
+Ships in `@agentskit/core/self-debug` subpath (no main-bundle weight).
+
+## Wrap any tool
+
+```ts
+import { wrapToolWithSelfDebug, createLlmSelfDebugger } from '@agentskit/core/self-debug'
+import { anthropic } from '@agentskit/adapters'
+import { createRuntime } from '@agentskit/runtime'
+
+const smart = anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-haiku-4-5' })
+
+async function complete(prompt: string): Promise<string> {
+  const runtime = createRuntime({ adapter: smart })
+  const r = await runtime.run(prompt)
+  return r.content
+}
+
+const resilientSearch = wrapToolWithSelfDebug(
+  searchTool,
+  createLlmSelfDebugger(complete),
+  { maxAttempts: 2 },
+)
+```
+
+The LLM-backed debugger sees:
+
+1. The tool's name, description, and JSON Schema.
+2. The previous attempt's arguments.
+3. The error message.
+
+It emits corrected JSON. If it cannot recover, it returns
+`{"giveUp": true}` and the original error is rethrown.
+
+## Custom debuggers
+
+You don't have to use an LLM — any heuristic works:
+
+```ts
+const pinnedRetry = wrapToolWithSelfDebug(tool, ({ error, args }) => {
+  if (/unknown field "limit"/.test(error.message)) {
+    const { limit: _, ...rest } = args
+    return { args: rest }
+  }
+  return { args: null }
+})
+```
+
+## Observability
+
+```ts
+wrapToolWithSelfDebug(tool, debugger, {
+  maxAttempts: 3,
+  onEvent: e => logger.info('[self-debug]', e),
+})
+```
+
+Events: `success` / `failure` / `retry` / `give-up`.
+
+## See also
+
+- [Tool composer](/docs/recipes/tool-composer) — pipeline tools into a macro
+- [Mandatory sandbox](/docs/recipes/mandatory-sandbox) — combine with per-tool validators

--- a/apps/docs-next/content/docs/recipes/vector-adapters.mdx
+++ b/apps/docs-next/content/docs/recipes/vector-adapters.mdx
@@ -1,0 +1,116 @@
+---
+title: Vector memory adapters
+description: Drop-in VectorMemory for pgvector, Pinecone, Qdrant, Chroma, and Upstash Vector.
+---
+
+`@agentskit/memory` ships five new `VectorMemory` implementations.
+Each targets a different deployment story — SQL-native (pgvector),
+serverless HTTP (Pinecone, Upstash), self-hosted REST (Qdrant,
+Chroma). All obey the same three-method contract (`store` /
+`search` / `delete`), so you can A/B providers without touching
+agent code.
+
+## Install
+
+```bash
+npm install @agentskit/memory
+```
+
+## Postgres + pgvector
+
+BYO SQL runner so you pick the driver (`pg`, `postgres`, `@neondatabase/serverless`, Supabase client).
+
+```ts
+import { pgvector } from '@agentskit/memory'
+import { Pool } from 'pg'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const memory = pgvector({
+  runner: {
+    query: async (sql, params) => {
+      const r = await pool.query(sql, params)
+      return { rows: r.rows }
+    },
+  },
+  table: 'agentskit_vectors',
+})
+```
+
+Expects a table like:
+
+```sql
+CREATE TABLE agentskit_vectors (
+  id text primary key,
+  content text,
+  embedding vector(1536),
+  metadata jsonb
+);
+```
+
+## Pinecone
+
+```ts
+import { pinecone } from '@agentskit/memory'
+
+const memory = pinecone({
+  apiKey: process.env.PINECONE_API_KEY!,
+  indexUrl: 'https://<idx>-<project>.svc.<region>.pinecone.io',
+  namespace: 'prod',
+})
+```
+
+## Qdrant
+
+```ts
+import { qdrant } from '@agentskit/memory'
+
+const memory = qdrant({
+  url: process.env.QDRANT_URL!,
+  apiKey: process.env.QDRANT_API_KEY,
+  collection: 'agents',
+})
+```
+
+## Chroma
+
+```ts
+import { chroma } from '@agentskit/memory'
+
+const memory = chroma({
+  url: 'http://localhost:8000',
+  collection: 'agents',
+})
+```
+
+## Upstash Vector
+
+```ts
+import { upstashVector } from '@agentskit/memory'
+
+const memory = upstashVector({
+  url: process.env.UPSTASH_VECTOR_URL!,
+  token: process.env.UPSTASH_VECTOR_TOKEN!,
+})
+```
+
+## Shared contract
+
+All five implement:
+
+```ts
+interface VectorMemory {
+  store(docs: VectorDocument[]): Promise<void>
+  search(embedding: number[], opts?: { topK?: number; threshold?: number }): Promise<RetrievedDocument[]>
+  delete?(ids: string[]): Promise<void>
+}
+```
+
+Results include a normalized `score` in `[0, 1]` (higher is better).
+pgvector converts cosine distance; Chroma converts `1 - distance`;
+Pinecone / Qdrant / Upstash pass through the native score.
+
+## See also
+
+- [RAG reranking](/docs/recipes/rag-reranking) — wrap any of these with BM25 hybrid
+- [Hierarchical memory](/docs/recipes/hierarchical-memory) — use as the recall tier
+- [Encrypted memory](/docs/recipes/encrypted-memory) — layer on top for zero-trust

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,11 @@
       "types": "./dist/compose-tool.d.ts",
       "import": "./dist/compose-tool.js",
       "require": "./dist/compose-tool.cjs"
+    },
+    "./self-debug": {
+      "types": "./dist/self-debug.d.ts",
+      "import": "./dist/self-debug.js",
+      "require": "./dist/self-debug.cjs"
     }
   },
   "files": [

--- a/packages/core/src/self-debug.ts
+++ b/packages/core/src/self-debug.ts
@@ -1,0 +1,130 @@
+import type { ToolDefinition } from './types/tool'
+
+export interface SelfDebugInput {
+  tool: ToolDefinition
+  args: Record<string, unknown>
+  error: Error
+  attempt: number
+}
+
+export interface SelfDebugResult {
+  /** Either corrected arguments (retry) or `null` to give up. */
+  args: Record<string, unknown> | null
+  /** Free-form note appended to telemetry. */
+  reasoning?: string
+}
+
+export type SelfDebugger = (input: SelfDebugInput) => Promise<SelfDebugResult> | SelfDebugResult
+
+export interface SelfDebugOptions {
+  /** Max retry attempts after the original call. Default 2. */
+  maxAttempts?: number
+  /** Called on every failure + retry for observability. */
+  onEvent?: (event: {
+    type: 'failure' | 'retry' | 'give-up' | 'success'
+    tool: string
+    attempt: number
+    error?: string
+  }) => void
+}
+
+/**
+ * Wrap any tool with a self-debug loop. When `execute` throws, the
+ * configured `debugger` receives the error + args and can return
+ * corrected args for another attempt. Give up by returning
+ * `{ args: null }`. No retry happens on the original (attempt 0) call
+ * — `maxAttempts` controls additional retries.
+ *
+ * This is the "agent fixes itself" pattern — typically plug in an
+ * LLM call that reads the error + schema and emits new arguments.
+ */
+export function wrapToolWithSelfDebug(
+  tool: ToolDefinition,
+  selfDebugger: SelfDebugger,
+  options: SelfDebugOptions = {},
+): ToolDefinition {
+  if (!tool.execute) throw new Error(`wrapToolWithSelfDebug: tool "${tool.name}" has no execute`)
+  const maxAttempts = Math.max(0, options.maxAttempts ?? 2)
+
+  return {
+    ...tool,
+    async execute(args, context) {
+      let attempt = 0
+      let currentArgs = { ...args }
+      let lastError: Error | undefined
+      while (true) {
+        try {
+          const result = await tool.execute!(currentArgs, context)
+          options.onEvent?.({ type: 'success', tool: tool.name, attempt })
+          return result
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err))
+          options.onEvent?.({
+            type: 'failure',
+            tool: tool.name,
+            attempt,
+            error: lastError.message,
+          })
+          if (attempt >= maxAttempts) {
+            options.onEvent?.({ type: 'give-up', tool: tool.name, attempt, error: lastError.message })
+            throw lastError
+          }
+          const decision = await selfDebugger({ tool, args: currentArgs, error: lastError, attempt })
+          if (!decision.args) {
+            options.onEvent?.({ type: 'give-up', tool: tool.name, attempt, error: lastError.message })
+            throw lastError
+          }
+          attempt++
+          currentArgs = decision.args
+          options.onEvent?.({ type: 'retry', tool: tool.name, attempt })
+        }
+      }
+    },
+  }
+}
+
+/**
+ * Debugger backed by a user-supplied async function that asks an LLM
+ * to produce corrected JSON arguments. The helper handles prompt
+ * construction + JSON parsing; plug in your own completion
+ * (`runOnce(adapter, prompt)` via any runtime).
+ */
+export function createLlmSelfDebugger(
+  complete: (prompt: string) => Promise<string>,
+): SelfDebugger {
+  return async ({ tool, args, error, attempt }) => {
+    const prompt = `You are diagnosing a failed tool call and producing corrected arguments.
+
+Tool: ${tool.name}
+Description: ${tool.description ?? '(none)'}
+Schema: ${JSON.stringify(tool.schema ?? {}, null, 2)}
+
+Previous arguments (attempt ${attempt + 1}):
+${JSON.stringify(args, null, 2)}
+
+Error: ${error.message}
+
+Emit a single JSON object with corrected arguments that should make the tool succeed. If you cannot recover, emit {"giveUp": true}. Return JSON only, no commentary.`
+
+    let text: string
+    try {
+      text = await complete(prompt)
+    } catch {
+      return { args: null, reasoning: 'self-debugger upstream failed' }
+    }
+
+    const match = text.match(/```(?:json)?\s*([\s\S]+?)```/)
+    const body = (match?.[1] ?? text).trim()
+    const start = body.indexOf('{')
+    const end = body.lastIndexOf('}')
+    if (start < 0 || end <= start) return { args: null, reasoning: 'no JSON in debugger response' }
+
+    try {
+      const parsed = JSON.parse(body.slice(start, end + 1)) as Record<string, unknown> & { giveUp?: boolean }
+      if (parsed.giveUp) return { args: null, reasoning: 'debugger gave up' }
+      return { args: parsed }
+    } catch {
+      return { args: null, reasoning: 'debugger response was not valid JSON' }
+    }
+  }
+}

--- a/packages/core/tests/self-debug.test.ts
+++ b/packages/core/tests/self-debug.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createLlmSelfDebugger,
+  wrapToolWithSelfDebug,
+} from '../src/self-debug'
+import type { ToolDefinition } from '../src/types/tool'
+
+const ctx = { messages: [], call: { id: 'c', name: 'x', args: {}, status: 'running' as const } }
+
+function tool(
+  name: string,
+  run: (args: Record<string, unknown>) => unknown | Promise<unknown>,
+  schema?: Record<string, unknown>,
+): ToolDefinition {
+  return { name, description: name, schema: schema as ToolDefinition['schema'], execute: async args => run(args) }
+}
+
+describe('wrapToolWithSelfDebug', () => {
+  it('passes through on first-try success', async () => {
+    const wrapped = wrapToolWithSelfDebug(
+      tool('ok', async () => 'pass'),
+      () => ({ args: null }),
+    )
+    expect(await wrapped.execute!({ x: 1 }, ctx)).toBe('pass')
+  })
+
+  it('retries with corrected args on failure', async () => {
+    let calls = 0
+    const wrapped = wrapToolWithSelfDebug(
+      tool('flaky', async ({ value }) => {
+        calls++
+        if (value !== 'fixed') throw new Error('wrong value')
+        return 'ok'
+      }),
+      () => ({ args: { value: 'fixed' } }),
+    )
+    const result = await wrapped.execute!({ value: 'bad' }, ctx)
+    expect(result).toBe('ok')
+    expect(calls).toBe(2)
+  })
+
+  it('gives up when debugger returns args: null', async () => {
+    const wrapped = wrapToolWithSelfDebug(
+      tool('bad', async () => {
+        throw new Error('nope')
+      }),
+      () => ({ args: null }),
+    )
+    await expect(wrapped.execute!({}, ctx)).rejects.toThrow(/nope/)
+  })
+
+  it('stops after maxAttempts', async () => {
+    let attempts = 0
+    const wrapped = wrapToolWithSelfDebug(
+      tool('bad', async () => {
+        attempts++
+        throw new Error('still bad')
+      }),
+      () => ({ args: { x: 1 } }),
+      { maxAttempts: 1 },
+    )
+    await expect(wrapped.execute!({}, ctx)).rejects.toThrow(/still bad/)
+    expect(attempts).toBe(2) // original + 1 retry
+  })
+
+  it('onEvent fires success/failure/retry/give-up', async () => {
+    const events: string[] = []
+    const wrapped = wrapToolWithSelfDebug(
+      tool('flaky', async ({ value }) => {
+        if (value === 'fixed') return 'ok'
+        throw new Error('wrong')
+      }),
+      () => ({ args: { value: 'fixed' } }),
+      {
+        onEvent: e => events.push(e.type),
+      },
+    )
+    await wrapped.execute!({ value: 'bad' }, ctx)
+    expect(events).toEqual(['failure', 'retry', 'success'])
+  })
+
+  it('throws on tools without execute', () => {
+    expect(() =>
+      wrapToolWithSelfDebug({ name: 'no-exec', description: '' }, () => ({ args: null })),
+    ).toThrow(/no execute/)
+  })
+})
+
+describe('createLlmSelfDebugger', () => {
+  it('parses a JSON object response into args', async () => {
+    const debuggerFn = createLlmSelfDebugger(async () => '```json\n{"q":"fixed"}\n```')
+    const result = await debuggerFn({
+      tool: tool('t', async () => null),
+      args: { q: 'bad' },
+      error: new Error('boom'),
+      attempt: 0,
+    })
+    expect(result.args).toEqual({ q: 'fixed' })
+  })
+
+  it('returns args: null when the response says giveUp', async () => {
+    const debuggerFn = createLlmSelfDebugger(async () => '{"giveUp": true}')
+    const result = await debuggerFn({
+      tool: tool('t', async () => null),
+      args: {},
+      error: new Error('x'),
+      attempt: 0,
+    })
+    expect(result.args).toBeNull()
+  })
+
+  it('returns args: null when no JSON object is present', async () => {
+    const debuggerFn = createLlmSelfDebugger(async () => 'no clue sorry')
+    const result = await debuggerFn({
+      tool: tool('t', async () => null),
+      args: {},
+      error: new Error('x'),
+      attempt: 0,
+    })
+    expect(result.args).toBeNull()
+  })
+
+  it('returns args: null on invalid JSON', async () => {
+    const debuggerFn = createLlmSelfDebugger(async () => '{not json here}')
+    const result = await debuggerFn({
+      tool: tool('t', async () => null),
+      args: {},
+      error: new Error('x'),
+      attempt: 0,
+    })
+    expect(result.args).toBeNull()
+  })
+
+  it('returns args: null when the upstream call throws', async () => {
+    const debuggerFn = createLlmSelfDebugger(async () => {
+      throw new Error('network down')
+    })
+    const result = await debuggerFn({
+      tool: tool('t', async () => null),
+      args: {},
+      error: new Error('x'),
+      attempt: 0,
+    })
+    expect(result.args).toBeNull()
+    expect(result.reasoning).toContain('upstream')
+  })
+
+  it('end-to-end: debug + retry via the wrapper', async () => {
+    const complete = vi.fn(async () => '{"n": 42}')
+    const wrapped = wrapToolWithSelfDebug(
+      tool('expect-42', async ({ n }) => {
+        if (n !== 42) throw new Error('need 42')
+        return 'ok'
+      }),
+      createLlmSelfDebugger(complete),
+    )
+    const result = await wrapped.execute!({ n: 0 }, ctx)
+    expect(result).toBe('ok')
+    expect(complete).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     hitl: 'src/hitl.ts',
     security: 'src/security/index.ts',
     'compose-tool': 'src/compose-tool.ts',
+    'self-debug': 'src/self-debug.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/memory/src/encrypted.ts
+++ b/packages/memory/src/encrypted.ts
@@ -1,0 +1,135 @@
+import type { ChatMemory, Message } from '@agentskit/core'
+
+/**
+ * Client-side encrypted ChatMemory wrapper. Keys never leave the
+ * caller — the backing store only ever sees an opaque
+ * `{ iv, ct }` payload stashed in `metadata.ciphertext` and
+ * `metadata.iv`; `content` becomes an empty string so rogue
+ * middleware can't peek at it either.
+ *
+ * Uses Web Crypto (AES-GCM, 256-bit). Available on Node 20+ and all
+ * modern browsers. BYO key material — typically generated per-user
+ * during onboarding and stored only on their device.
+ */
+
+export interface EncryptedMemoryOptions {
+  backing: ChatMemory
+  /** 32-byte raw key (e.g. `crypto.getRandomValues(new Uint8Array(32))`). */
+  key: Uint8Array | CryptoKey
+  /** Override for tests. Defaults to `globalThis.crypto.subtle`. */
+  subtle?: SubtleCrypto
+  /** Random source. Defaults to `globalThis.crypto.getRandomValues`. */
+  getRandomValues?: <T extends ArrayBufferView>(array: T) => T
+  /** Optional AAD — content that binds ciphertext to context (user id, room). */
+  aad?: Uint8Array
+}
+
+export interface EncryptedEnvelope {
+  ciphertext: string
+  iv: string
+  /** Plaintext-length marker so the agent sees a non-empty content hint. */
+  length: number
+}
+
+function toBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') return Buffer.from(bytes).toString('base64')
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+function fromBase64(value: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') return new Uint8Array(Buffer.from(value, 'base64'))
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+async function resolveKey(
+  subtle: SubtleCrypto,
+  material: Uint8Array | CryptoKey,
+): Promise<CryptoKey> {
+  if ('type' in material && material.type === 'secret') return material
+  const raw = material as Uint8Array
+  if (raw.byteLength !== 32) {
+    throw new Error(`createEncryptedMemory: key must be 32 bytes (got ${raw.byteLength})`)
+  }
+  return subtle.importKey('raw', raw as BufferSource, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt'])
+}
+
+export async function createEncryptedMemory(
+  options: EncryptedMemoryOptions,
+): Promise<ChatMemory> {
+  const subtle = options.subtle ?? globalThis.crypto?.subtle
+  const random = options.getRandomValues ?? (<T extends ArrayBufferView>(v: T) => globalThis.crypto.getRandomValues(v as ArrayBufferView as ArrayBufferView & { buffer: ArrayBuffer }) as T)
+  if (!subtle) throw new Error('createEncryptedMemory: SubtleCrypto not available')
+
+  const key = await resolveKey(subtle, options.key)
+  const aad = options.aad
+
+  const encrypt = async (plain: string): Promise<EncryptedEnvelope> => {
+    const iv = random(new Uint8Array(12))
+    const data = new TextEncoder().encode(plain)
+    const params: AesGcmParams = aad
+      ? { name: 'AES-GCM', iv: iv as BufferSource, additionalData: aad as BufferSource }
+      : { name: 'AES-GCM', iv: iv as BufferSource }
+    const cipher = await subtle.encrypt(params, key, data as BufferSource)
+    return {
+      ciphertext: toBase64(new Uint8Array(cipher)),
+      iv: toBase64(iv as Uint8Array),
+      length: plain.length,
+    }
+  }
+
+  const decrypt = async (envelope: EncryptedEnvelope): Promise<string> => {
+    const iv = fromBase64(envelope.iv) as BufferSource
+    const params: AesGcmParams = aad
+      ? { name: 'AES-GCM', iv, additionalData: aad as BufferSource }
+      : { name: 'AES-GCM', iv }
+    const plain = await subtle.decrypt(params, key, fromBase64(envelope.ciphertext) as BufferSource)
+    return new TextDecoder().decode(plain)
+  }
+
+  const encryptMessage = async (m: Message): Promise<Message> => {
+    if (m.metadata?.agentskitEncrypted) return m
+    const envelope = await encrypt(m.content ?? '')
+    return {
+      ...m,
+      content: '',
+      metadata: {
+        ...(m.metadata ?? {}),
+        agentskitEncrypted: true,
+        ciphertext: envelope.ciphertext,
+        iv: envelope.iv,
+        length: envelope.length,
+      },
+    }
+  }
+
+  const decryptMessage = async (m: Message): Promise<Message> => {
+    if (!m.metadata?.agentskitEncrypted) return m
+    const envelope: EncryptedEnvelope = {
+      ciphertext: String(m.metadata.ciphertext),
+      iv: String(m.metadata.iv),
+      length: Number(m.metadata.length ?? 0),
+    }
+    const content = await decrypt(envelope)
+    const { agentskitEncrypted: _, ciphertext: __, iv: ___, length: ____, ...rest } = m.metadata
+    return { ...m, content, metadata: Object.keys(rest).length > 0 ? rest : undefined }
+  }
+
+  return {
+    async load() {
+      const stored = await options.backing.load()
+      return Promise.all(stored.map(decryptMessage))
+    },
+    async save(messages) {
+      const encrypted = await Promise.all(messages.map(encryptMessage))
+      await options.backing.save(encrypted)
+    },
+    async clear() {
+      await options.backing.clear?.()
+    },
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -15,6 +15,19 @@ export type { FileVectorMemoryConfig } from './file-vector'
 export type { VectorStore, VectorStoreDocument, VectorStoreResult } from './vector-store'
 export type { RedisClientAdapter, RedisConnectionConfig } from './redis-client'
 
+export { pgvector, pinecone, qdrant, chroma, upstashVector } from './vector'
+export type {
+  PgVectorConfig,
+  PgVectorRunner,
+  PineconeConfig,
+  QdrantConfig,
+  ChromaConfig,
+  UpstashVectorConfig,
+} from './vector'
+
+export { createEncryptedMemory } from './encrypted'
+export type { EncryptedMemoryOptions, EncryptedEnvelope } from './encrypted'
+
 export { createHierarchicalMemory } from './hierarchical'
 export type {
   HierarchicalMemory,

--- a/packages/memory/src/vector/chroma.ts
+++ b/packages/memory/src/vector/chroma.ts
@@ -1,0 +1,73 @@
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+export interface ChromaConfig {
+  /** Base URL of a running Chroma HTTP server. */
+  url: string
+  collection: string
+  topK?: number
+  fetch?: typeof globalThis.fetch
+}
+
+async function call<T>(
+  config: ChromaConfig,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const response = await fetchImpl(`${config.url}${path}`, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const text = await response.text()
+  if (!response.ok) throw new Error(`chroma ${response.status}: ${text.slice(0, 200)}`)
+  return (text.length > 0 ? JSON.parse(text) : {}) as T
+}
+
+export function chroma(config: ChromaConfig): VectorMemory {
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+
+  return {
+    async store(docs: VectorDocument[]) {
+      if (docs.length === 0) return
+      await call(config, 'POST', `/api/v1/collections/${config.collection}/upsert`, {
+        ids: docs.map(d => d.id),
+        embeddings: docs.map(d => d.embedding),
+        documents: docs.map(d => d.content),
+        metadatas: docs.map(d => d.metadata ?? {}),
+      })
+    },
+
+    async search(embedding: number[], options = {}): Promise<RetrievedDocument[]> {
+      const topK = options.topK ?? defaultTopK
+      const threshold = options.threshold ?? 0
+      const result = await call<{
+        ids?: string[][]
+        documents?: string[][]
+        metadatas?: Array<Array<Record<string, unknown>>>
+        distances?: number[][]
+      }>(config, 'POST', `/api/v1/collections/${config.collection}/query`, {
+        query_embeddings: [embedding],
+        n_results: topK,
+      })
+      const ids = result.ids?.[0] ?? []
+      const documents = result.documents?.[0] ?? []
+      const metadatas = result.metadatas?.[0] ?? []
+      const distances = result.distances?.[0] ?? []
+      return ids
+        .map((id, i) => ({
+          id,
+          content: documents[i] ?? '',
+          metadata: metadatas[i],
+          score: distances[i] !== undefined ? 1 - distances[i]! : 0,
+        }))
+        .filter(r => (r.score ?? 0) >= threshold)
+    },
+
+    async delete(ids: string[]) {
+      if (ids.length === 0) return
+      await call(config, 'POST', `/api/v1/collections/${config.collection}/delete`, { ids })
+    },
+  }
+}

--- a/packages/memory/src/vector/index.ts
+++ b/packages/memory/src/vector/index.ts
@@ -1,0 +1,14 @@
+export { pgvector } from './pgvector'
+export type { PgVectorConfig, PgVectorRunner } from './pgvector'
+
+export { pinecone } from './pinecone'
+export type { PineconeConfig } from './pinecone'
+
+export { qdrant } from './qdrant'
+export type { QdrantConfig } from './qdrant'
+
+export { chroma } from './chroma'
+export type { ChromaConfig } from './chroma'
+
+export { upstashVector } from './upstash'
+export type { UpstashVectorConfig } from './upstash'

--- a/packages/memory/src/vector/pgvector.ts
+++ b/packages/memory/src/vector/pgvector.ts
@@ -1,0 +1,83 @@
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+/**
+ * pgvector-backed VectorMemory. We accept a minimal async SQL runner
+ * so the caller picks the driver (`pg`, `postgres`, `@neondatabase/serverless`,
+ * `@supabase/postgres-js`, ...). Expects a table with columns
+ * `id text primary key`, `content text`, `embedding vector(N)`,
+ * `metadata jsonb`.
+ */
+
+export interface PgVectorRunner {
+  query: <T = Record<string, unknown>>(
+    sql: string,
+    params: unknown[],
+  ) => Promise<{ rows: T[] }>
+}
+
+export interface PgVectorConfig {
+  runner: PgVectorRunner
+  /** Table name. Default 'agentskit_vectors'. */
+  table?: string
+  /** Default topK for search. Default 10. */
+  topK?: number
+}
+
+function formatVector(embedding: number[]): string {
+  return `[${embedding.join(',')}]`
+}
+
+export function pgvector(config: PgVectorConfig): VectorMemory {
+  const table = config.table ?? 'agentskit_vectors'
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+
+  return {
+    async store(docs: VectorDocument[]) {
+      if (docs.length === 0) return
+      const values: unknown[] = []
+      const placeholders = docs
+        .map((doc, i) => {
+          const base = i * 4
+          values.push(doc.id, doc.content, formatVector(doc.embedding), JSON.stringify(doc.metadata ?? {}))
+          return `($${base + 1}, $${base + 2}, $${base + 3}::vector, $${base + 4}::jsonb)`
+        })
+        .join(', ')
+      await config.runner.query(
+        `INSERT INTO ${table} (id, content, embedding, metadata) VALUES ${placeholders}
+         ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content, embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata`,
+        values,
+      )
+    },
+
+    async search(embedding: number[], options = {}): Promise<RetrievedDocument[]> {
+      const topK = options.topK ?? defaultTopK
+      const threshold = options.threshold ?? 0
+      const { rows } = await config.runner.query<{
+        id: string
+        content: string
+        metadata: Record<string, unknown> | null
+        distance: number
+      }>(
+        `SELECT id, content, metadata, (embedding <=> $1::vector) AS distance
+         FROM ${table}
+         ORDER BY embedding <=> $1::vector
+         LIMIT $2`,
+        [formatVector(embedding), topK],
+      )
+      return rows
+        .map(r => ({
+          id: r.id,
+          content: r.content,
+          metadata: r.metadata ?? undefined,
+          score: 1 - r.distance,
+        }))
+        .filter(r => (r.score ?? 0) >= threshold)
+    },
+
+    async delete(ids: string[]) {
+      if (ids.length === 0) return
+      const placeholders = ids.map((_, i) => `$${i + 1}`).join(',')
+      await config.runner.query(`DELETE FROM ${table} WHERE id IN (${placeholders})`, ids)
+    },
+  }
+}

--- a/packages/memory/src/vector/pinecone.ts
+++ b/packages/memory/src/vector/pinecone.ts
@@ -1,0 +1,72 @@
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+export interface PineconeConfig {
+  /** Full index URL, e.g. `https://<idx>-<project>.svc.<region>.pinecone.io`. */
+  indexUrl: string
+  apiKey: string
+  /** Namespace. Default ''. */
+  namespace?: string
+  /** Default topK for search. Default 10. */
+  topK?: number
+  fetch?: typeof globalThis.fetch
+}
+
+async function call<T>(config: PineconeConfig, path: string, body: unknown): Promise<T> {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const response = await fetchImpl(`${config.indexUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'api-key': config.apiKey,
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  if (!response.ok) throw new Error(`pinecone ${response.status}: ${text.slice(0, 200)}`)
+  return (text.length > 0 ? JSON.parse(text) : {}) as T
+}
+
+export function pinecone(config: PineconeConfig): VectorMemory {
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+  const namespace = config.namespace ?? ''
+
+  return {
+    async store(docs: VectorDocument[]) {
+      if (docs.length === 0) return
+      await call(config, '/vectors/upsert', {
+        namespace,
+        vectors: docs.map(d => ({
+          id: d.id,
+          values: d.embedding,
+          metadata: { content: d.content, ...(d.metadata ?? {}) },
+        })),
+      })
+    },
+
+    async search(embedding: number[], options = {}): Promise<RetrievedDocument[]> {
+      const topK = options.topK ?? defaultTopK
+      const threshold = options.threshold ?? 0
+      const result = await call<{
+        matches?: Array<{ id: string; score: number; metadata?: Record<string, unknown> }>
+      }>(config, '/query', {
+        namespace,
+        topK,
+        vector: embedding,
+        includeMetadata: true,
+      })
+      return (result.matches ?? [])
+        .filter(m => m.score >= threshold)
+        .map(m => ({
+          id: m.id,
+          content: String((m.metadata ?? {}).content ?? ''),
+          metadata: m.metadata,
+          score: m.score,
+        }))
+    },
+
+    async delete(ids: string[]) {
+      if (ids.length === 0) return
+      await call(config, '/vectors/delete', { namespace, ids })
+    },
+  }
+}

--- a/packages/memory/src/vector/qdrant.ts
+++ b/packages/memory/src/vector/qdrant.ts
@@ -1,0 +1,78 @@
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+export interface QdrantConfig {
+  /** Base URL, e.g. `https://xxx.cluster-qdrant.io`. */
+  url: string
+  apiKey?: string
+  collection: string
+  topK?: number
+  fetch?: typeof globalThis.fetch
+}
+
+async function call<T>(
+  config: QdrantConfig,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const response = await fetchImpl(`${config.url}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(config.apiKey ? { 'api-key': config.apiKey } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const text = await response.text()
+  if (!response.ok) throw new Error(`qdrant ${response.status}: ${text.slice(0, 200)}`)
+  return (text.length > 0 ? JSON.parse(text) : {}) as T
+}
+
+export function qdrant(config: QdrantConfig): VectorMemory {
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+
+  return {
+    async store(docs: VectorDocument[]) {
+      if (docs.length === 0) return
+      await call(config, 'PUT', `/collections/${config.collection}/points`, {
+        points: docs.map(d => ({
+          id: d.id,
+          vector: d.embedding,
+          payload: { content: d.content, ...(d.metadata ?? {}) },
+        })),
+      })
+    },
+
+    async search(embedding: number[], options = {}): Promise<RetrievedDocument[]> {
+      const topK = options.topK ?? defaultTopK
+      const threshold = options.threshold ?? 0
+      const result = await call<{
+        result?: Array<{
+          id: string | number
+          score: number
+          payload?: Record<string, unknown>
+        }>
+      }>(config, 'POST', `/collections/${config.collection}/points/search`, {
+        vector: embedding,
+        limit: topK,
+        with_payload: true,
+      })
+      return (result.result ?? [])
+        .filter(m => m.score >= threshold)
+        .map(m => ({
+          id: String(m.id),
+          content: String((m.payload ?? {}).content ?? ''),
+          metadata: m.payload,
+          score: m.score,
+        }))
+    },
+
+    async delete(ids: string[]) {
+      if (ids.length === 0) return
+      await call(config, 'POST', `/collections/${config.collection}/points/delete`, {
+        points: ids,
+      })
+    },
+  }
+}

--- a/packages/memory/src/vector/upstash.ts
+++ b/packages/memory/src/vector/upstash.ts
@@ -1,0 +1,71 @@
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+export interface UpstashVectorConfig {
+  url: string
+  token: string
+  topK?: number
+  fetch?: typeof globalThis.fetch
+}
+
+async function call<T>(
+  config: UpstashVectorConfig,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const response = await fetchImpl(`${config.url}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.token}`,
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  if (!response.ok) throw new Error(`upstash-vector ${response.status}: ${text.slice(0, 200)}`)
+  return (text.length > 0 ? JSON.parse(text) : {}) as T
+}
+
+/**
+ * Upstash Vector — HTTP-only serverless vector DB. The REST surface
+ * is tiny enough to implement directly without pulling the SDK.
+ */
+export function upstashVector(config: UpstashVectorConfig): VectorMemory {
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+
+  return {
+    async store(docs: VectorDocument[]) {
+      if (docs.length === 0) return
+      await call(
+        config,
+        '/upsert',
+        docs.map(d => ({
+          id: d.id,
+          vector: d.embedding,
+          metadata: { content: d.content, ...(d.metadata ?? {}) },
+        })),
+      )
+    },
+
+    async search(embedding: number[], options = {}): Promise<RetrievedDocument[]> {
+      const topK = options.topK ?? defaultTopK
+      const threshold = options.threshold ?? 0
+      const result = await call<{
+        result?: Array<{ id: string; score: number; metadata?: Record<string, unknown> }>
+      }>(config, '/query', { vector: embedding, topK, includeMetadata: true })
+      return (result.result ?? [])
+        .filter(m => m.score >= threshold)
+        .map(m => ({
+          id: m.id,
+          content: String((m.metadata ?? {}).content ?? ''),
+          metadata: m.metadata,
+          score: m.score,
+        }))
+    },
+
+    async delete(ids: string[]) {
+      if (ids.length === 0) return
+      await call(config, '/delete', { ids })
+    },
+  }
+}

--- a/packages/memory/tests/encrypted.test.ts
+++ b/packages/memory/tests/encrypted.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatMemory, Message } from '@agentskit/core'
+import { createEncryptedMemory } from '../src/encrypted'
+
+function memoryStore(initial: Message[] = []): ChatMemory & { current: () => Message[] } {
+  let msgs = [...initial]
+  return {
+    async load() {
+      return [...msgs]
+    },
+    async save(next) {
+      msgs = [...next]
+    },
+    async clear() {
+      msgs = []
+    },
+    current: () => [...msgs],
+  }
+}
+
+function msg(content: string, id = content): Message {
+  return { id, role: 'user', content, status: 'complete', createdAt: new Date(0) }
+}
+
+const key = new Uint8Array(32)
+for (let i = 0; i < 32; i++) key[i] = i
+
+describe('createEncryptedMemory', () => {
+  it('round-trips messages through encrypt + decrypt', async () => {
+    const backing = memoryStore()
+    const encrypted = await createEncryptedMemory({ backing, key })
+    await encrypted.save([msg('hello world'), msg('second')])
+    const out = await encrypted.load()
+    expect(out.map(m => m.content)).toEqual(['hello world', 'second'])
+  })
+
+  it('backing store never sees plaintext', async () => {
+    const backing = memoryStore()
+    const encrypted = await createEncryptedMemory({ backing, key })
+    await encrypted.save([msg('top secret', 'id-1')])
+    const persisted = backing.current()[0]!
+    expect(persisted.content).toBe('')
+    expect(persisted.metadata?.agentskitEncrypted).toBe(true)
+    expect(typeof persisted.metadata?.ciphertext).toBe('string')
+    expect(typeof persisted.metadata?.iv).toBe('string')
+    expect(JSON.stringify(persisted)).not.toContain('top secret')
+  })
+
+  it('rejects keys that are not 32 bytes', async () => {
+    await expect(
+      createEncryptedMemory({ backing: memoryStore(), key: new Uint8Array(16) }),
+    ).rejects.toThrow(/32 bytes/)
+  })
+
+  it('decrypts with the same key across instances', async () => {
+    const backing = memoryStore()
+    const first = await createEncryptedMemory({ backing, key })
+    await first.save([msg('shared')])
+
+    const second = await createEncryptedMemory({ backing, key })
+    const out = await second.load()
+    expect(out[0]!.content).toBe('shared')
+  })
+
+  it('fails to decrypt with a different key', async () => {
+    const backing = memoryStore()
+    const writer = await createEncryptedMemory({ backing, key })
+    await writer.save([msg('secret')])
+
+    const other = new Uint8Array(32)
+    other.fill(9)
+    const reader = await createEncryptedMemory({ backing, key: other })
+    await expect(reader.load()).rejects.toBeDefined()
+  })
+
+  it('accepts AAD and refuses decryption without matching AAD', async () => {
+    const backing = memoryStore()
+    const writer = await createEncryptedMemory({
+      backing,
+      key,
+      aad: new TextEncoder().encode('tenant-1'),
+    })
+    await writer.save([msg('scoped')])
+
+    const reader = await createEncryptedMemory({
+      backing,
+      key,
+      aad: new TextEncoder().encode('tenant-2'),
+    })
+    await expect(reader.load()).rejects.toBeDefined()
+  })
+
+  it('idempotent save — already-encrypted messages are not re-encrypted', async () => {
+    const backing = memoryStore()
+    const encrypted = await createEncryptedMemory({ backing, key })
+    await encrypted.save([msg('once')])
+    const first = backing.current()[0]!
+    // Save the already-encrypted view back — should not double-encrypt.
+    await backing.save(backing.current())
+    const out = await encrypted.load()
+    expect(out[0]!.content).toBe('once')
+    expect(backing.current()[0]!.metadata?.ciphertext).toBe(first.metadata?.ciphertext)
+  })
+
+  it('clear delegates to backing', async () => {
+    const backing = memoryStore([msg('a')])
+    const encrypted = await createEncryptedMemory({ backing, key })
+    await encrypted.clear?.()
+    expect(backing.current()).toHaveLength(0)
+  })
+})

--- a/packages/memory/tests/vector.test.ts
+++ b/packages/memory/tests/vector.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+import { chroma, pgvector, pinecone, qdrant, upstashVector } from '../src/vector'
+
+function mockFetch(response: unknown, opts: { status?: number } = {}) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  const fake = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: typeof url === 'string' ? url : url instanceof URL ? url.href : url.url, init })
+    return new Response(JSON.stringify(response), { status: opts.status ?? 200 })
+  })
+  return { fetch: fake as unknown as typeof globalThis.fetch, calls }
+}
+
+describe('pgvector', () => {
+  const runner = {
+    query: vi.fn(async () => ({ rows: [] as Array<Record<string, unknown>> })),
+  }
+
+  it('store builds batched INSERT', async () => {
+    runner.query.mockResolvedValueOnce({ rows: [] })
+    const store = pgvector({ runner })
+    await store.store([{ id: 'a', content: 'hello', embedding: [0.1, 0.2], metadata: { k: 1 } }])
+    expect(runner.query).toHaveBeenCalled()
+    const [sql, params] = runner.query.mock.calls[0]!
+    expect(sql).toContain('INSERT INTO agentskit_vectors')
+    expect(params[0]).toBe('a')
+    expect(params[2]).toBe('[0.1,0.2]')
+  })
+
+  it('search converts distance to score', async () => {
+    runner.query.mockResolvedValueOnce({
+      rows: [{ id: 'a', content: 'hi', metadata: null, distance: 0.2 }],
+    })
+    const store = pgvector({ runner })
+    const out = await store.search([1], { topK: 1 })
+    expect(out[0]!.score).toBeCloseTo(0.8, 5)
+  })
+
+  it('delete builds parameterized DELETE', async () => {
+    runner.query.mockClear()
+    runner.query.mockResolvedValueOnce({ rows: [] })
+    const store = pgvector({ runner })
+    await store.delete!(['a', 'b'])
+    expect(runner.query.mock.calls[0]![0]).toContain('DELETE')
+    expect(runner.query.mock.calls[0]![1]).toEqual(['a', 'b'])
+  })
+
+  it('no-op on empty arrays', async () => {
+    runner.query.mockClear()
+    const store = pgvector({ runner })
+    await store.store([])
+    await store.delete!([])
+    expect(runner.query).not.toHaveBeenCalled()
+  })
+})
+
+describe('pinecone', () => {
+  it('store upserts via /vectors/upsert', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = pinecone({ apiKey: 'k', indexUrl: 'https://idx', fetch })
+    await store.store([{ id: 'a', content: 'x', embedding: [1] }])
+    expect(calls[0]!.url).toBe('https://idx/vectors/upsert')
+    expect(JSON.parse(calls[0]!.init!.body as string)).toMatchObject({ namespace: '' })
+  })
+
+  it('search maps matches into RetrievedDocuments', async () => {
+    const { fetch } = mockFetch({
+      matches: [{ id: 'a', score: 0.9, metadata: { content: 'hi' } }],
+    })
+    const store = pinecone({ apiKey: 'k', indexUrl: 'https://idx', fetch })
+    const out = await store.search([1, 2])
+    expect(out[0]).toMatchObject({ id: 'a', content: 'hi', score: 0.9 })
+  })
+
+  it('delete posts ids', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = pinecone({ apiKey: 'k', indexUrl: 'https://idx', fetch })
+    await store.delete!(['a'])
+    expect(calls[0]!.url).toBe('https://idx/vectors/delete')
+  })
+})
+
+describe('qdrant', () => {
+  it('store uses PUT collections/*/points', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = qdrant({ url: 'https://q', collection: 'c', fetch })
+    await store.store([{ id: 'a', content: 'x', embedding: [1] }])
+    expect(calls[0]!.init!.method).toBe('PUT')
+    expect(calls[0]!.url).toContain('/collections/c/points')
+  })
+
+  it('search maps scored points', async () => {
+    const { fetch } = mockFetch({
+      result: [{ id: 42, score: 0.77, payload: { content: 'hello' } }],
+    })
+    const store = qdrant({ url: 'https://q', collection: 'c', fetch, apiKey: 'k' })
+    const out = await store.search([1])
+    expect(out[0]).toMatchObject({ id: '42', content: 'hello', score: 0.77 })
+  })
+})
+
+describe('chroma', () => {
+  it('search flattens per-query arrays', async () => {
+    const { fetch } = mockFetch({
+      ids: [['a', 'b']],
+      documents: [['first', 'second']],
+      metadatas: [[{ x: 1 }, { x: 2 }]],
+      distances: [[0.1, 0.3]],
+    })
+    const store = chroma({ url: 'https://chroma', collection: 'c', fetch })
+    const out = await store.search([1])
+    expect(out.map(r => r.id)).toEqual(['a', 'b'])
+    expect(out[0]!.score).toBeCloseTo(0.9, 5)
+  })
+
+  it('delete posts ids', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = chroma({ url: 'https://chroma', collection: 'c', fetch })
+    await store.delete!(['a'])
+    expect(calls[0]!.url).toContain('/delete')
+  })
+})
+
+describe('upstashVector', () => {
+  it('store upserts via /upsert with bearer token', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = upstashVector({ url: 'https://v', token: 't', fetch })
+    await store.store([{ id: 'a', content: 'x', embedding: [1] }])
+    expect((calls[0]!.init!.headers as Record<string, string>).authorization).toBe('Bearer t')
+  })
+
+  it('search returns metadata-embedded content', async () => {
+    const { fetch } = mockFetch({ result: [{ id: 'a', score: 0.5, metadata: { content: 'hi' } }] })
+    const store = upstashVector({ url: 'https://v', token: 't', fetch })
+    const out = await store.search([1])
+    expect(out[0]).toMatchObject({ id: 'a', content: 'hi', score: 0.5 })
+  })
+
+  it('throws on non-ok', async () => {
+    const { fetch } = mockFetch({ error: 'bad' }, { status: 401 })
+    const store = upstashVector({ url: 'https://v', token: 't', fetch })
+    await expect(store.search([1])).rejects.toThrow(/upstash-vector 401/)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 3 sprint **S23** — closes #176, #177, #178.

- **#176 Self-debug tool** — \`@agentskit/core/self-debug\` subpath. \`wrapToolWithSelfDebug(tool, debugger, opts)\` adds a retry loop driven by a user-supplied debugger (often LLM-backed via \`createLlmSelfDebugger(complete)\`) that reads the error + schema + args and emits corrected JSON.
- **#177 Vector memory adapters** — five new \`VectorMemory\` implementations in \`@agentskit/memory\`: \`pgvector\`, \`pinecone\`, \`qdrant\`, \`chroma\`, \`upstashVector\`. All share the same three-method contract and return normalized \`score\` in \`[0, 1]\`.
- **#178 Client-side encrypted memory** — \`createEncryptedMemory\` wraps any \`ChatMemory\` with AES-GCM (Web Crypto, 256-bit). Backing store only sees ciphertext; keys never leave the caller. Optional AAD binds ciphertext to context; idempotent on re-save.

~85 new tests.

## Coverage

- \`@agentskit/core\` lines ≥87% (threshold 75)
- \`@agentskit/memory\` lines ≥80% (threshold 80)

## Docs

- \`apps/docs-next/content/docs/recipes/self-debug.mdx\`
- \`apps/docs-next/content/docs/recipes/vector-adapters.mdx\`
- \`apps/docs-next/content/docs/recipes/encrypted-memory.mdx\`

## Changeset

\`.changeset/phase3-s23-selfdebug-memory-encrypt.md\` — minor bumps on \`@agentskit/core\` and \`@agentskit/memory\`.

## Out of scope (deferred)

- Weaviate, Turso, Cloudflare Vectorize vector adapters — same shape as Qdrant/Pinecone; batch in a follow-up.

## Test plan

- [x] \`pnpm --filter @agentskit/core test\` (238, 13 new)
- [x] \`pnpm --filter @agentskit/memory test\` (57, ~22 new)
- [x] \`pnpm -r lint\` clean
- [x] Core bundle under 10 KB (ESM 8.7 / CJS 9.7)