### PR TITLE
feat: graph memory + personalization + doc loaders + skill marketplace + skills (S24)

### DIFF
--- a/.changeset/phase3-s24-graph-personalization-loaders-skills.md
+++ b/.changeset/phase3-s24-graph-personalization-loaders-skills.md
@@ -1,0 +1,26 @@
+---
+'@agentskit/memory': minor
+'@agentskit/rag': minor
+'@agentskit/skills': minor
+---
+
+Phase 3 sprint S24 — issues #179, #180, #181, #182, #183.
+
+- `@agentskit/memory` — `createInMemoryGraph` implements a typed
+  knowledge graph (nodes + edges + BFS neighbors) against a
+  `GraphMemory` contract that Neo4j / Memgraph / Neptune can back.
+- `@agentskit/memory` — `createInMemoryPersonalization` +
+  `renderProfileContext`. Per-subject trait profile with
+  `get`/`set`/`merge`/`delete` + a system-prompt renderer that
+  skips empties.
+- `@agentskit/rag` — six document loaders: `loadUrl`,
+  `loadGitHubFile`, `loadGitHubTree`, `loadNotionPage`,
+  `loadConfluencePage`, `loadGoogleDriveFile`, `loadPdf` (BYO
+  parser). All accept custom `fetch` for mocking.
+- `@agentskit/skills` — `createSkillRegistry` + semver helpers
+  (`parseSemver`, `compareSemver`, `matchesRange`) form a minimal
+  marketplace: publish, list by publisher/tag, install by range.
+- `@agentskit/skills` — four new ready-made skills: `codeReviewer`,
+  `sqlGen`, `dataAnalyst`, `translator`.
+
+~65 new tests.

--- a/apps/docs-next/content/docs/recipes/doc-loaders.mdx
+++ b/apps/docs-next/content/docs/recipes/doc-loaders.mdx
@@ -1,0 +1,66 @@
+---
+title: Document loaders
+description: One-line fetchers for URL, GitHub, Notion, Confluence, Google Drive, and PDF into your RAG pipeline.
+---
+
+Every RAG pipeline starts with "turn an external document into an
+`InputDocument`". `@agentskit/rag` now ships six loaders that cover
+the common sources; each accepts a custom `fetch` for tests and
+returns `InputDocument[]` ready to pipe into `RAG.ingest`.
+
+## Install
+
+```bash
+npm install @agentskit/rag
+```
+
+## Loaders
+
+| Loader | Source |
+|---|---|
+| `loadUrl(url)` | Any HTTP URL (raw text / html) |
+| `loadGitHubFile(owner, repo, path, { ref?, token? })` | Single file via `raw.githubusercontent.com` |
+| `loadGitHubTree(owner, repo, { filter?, maxFiles? })` | Recursive repo tree, filtered |
+| `loadNotionPage(pageId, { token })` | Flattens paragraphs + headings |
+| `loadConfluencePage(pageId, { baseUrl, token })` | Atlassian storage body |
+| `loadGoogleDriveFile(fileId, { accessToken })` | Drive export as `text/plain` |
+| `loadPdf(url, { parsePdf })` | BYO PDF parser (`pdf-parse`, `pdfjs`, etc.) |
+
+## Example — RAG over a GitHub repo
+
+```ts
+import { createRAG, loadGitHubTree } from '@agentskit/rag'
+import { fileVectorMemory } from '@agentskit/memory'
+import { openaiEmbedder } from '@agentskit/adapters'
+
+const docs = await loadGitHubTree('my-org', 'my-repo', {
+  token: process.env.GITHUB_TOKEN!,
+  filter: path => path.endsWith('.md') || path.endsWith('.ts'),
+  maxFiles: 500,
+})
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY! }),
+  store: fileVectorMemory({ path: './kb.json' }),
+})
+await rag.ingest(docs)
+```
+
+## Example — PDF via any parser
+
+```ts
+import { loadPdf } from '@agentskit/rag'
+import pdfParse from 'pdf-parse'
+
+const docs = await loadPdf('https://example.com/report.pdf', {
+  parsePdf: async bytes => {
+    const result = await pdfParse(Buffer.from(bytes))
+    return { text: result.text, pages: result.numpages }
+  },
+})
+```
+
+## See also
+
+- [RAG chat](/docs/recipes/rag-chat)
+- [RAG reranking](/docs/recipes/rag-reranking)

--- a/apps/docs-next/content/docs/recipes/graph-memory.mdx
+++ b/apps/docs-next/content/docs/recipes/graph-memory.mdx
@@ -1,0 +1,53 @@
+---
+title: Graph memory
+description: Non-linear memory for entities and relationships. Backs anything from in-memory Maps to Neo4j.
+---
+
+Not every fact fits in a chat transcript. Facts about people,
+companies, products, and how they relate live longer than a
+conversation. `createInMemoryGraph` is the three-method reference
+implementation you can reach for locally; back the same `GraphMemory`
+contract with Neo4j / Memgraph / AWS Neptune for production.
+
+## Install
+
+Ships with `@agentskit/memory`.
+
+## Model facts
+
+```ts
+import { createInMemoryGraph } from '@agentskit/memory'
+
+const graph = createInMemoryGraph()
+
+await graph.upsertNode({ id: 'alice', kind: 'person', properties: { name: 'Alice' } })
+await graph.upsertNode({ id: 'acme', kind: 'company', properties: { name: 'Acme Inc.' } })
+await graph.upsertEdge({ id: 'e1', label: 'works-at', from: 'alice', to: 'acme' })
+
+const neighbors = await graph.neighbors('alice', { depth: 2 })
+```
+
+## Contract
+
+```ts
+interface GraphMemory {
+  upsertNode(node): Promise<GraphNode>
+  upsertEdge(edge): Promise<GraphEdge>
+  getNode(id): Promise<GraphNode | null>
+  findNodes(query?): Promise<GraphNode[]>
+  findEdges(query?): Promise<GraphEdge[]>
+  neighbors(id, { depth?, label? }): Promise<GraphNode[]>
+  deleteNode(id): Promise<void>  // cascades to touching edges
+  deleteEdge(id): Promise<void>
+  clear?(): Promise<void>
+}
+```
+
+BFS `neighbors` explores outward up to `depth`, optionally filtered by
+edge `label`. Matches the common agent use-case: "who is related to
+X through relationship Y, within N hops?"
+
+## See also
+
+- [Personalization](/docs/recipes/personalization)
+- [Hierarchical memory](/docs/recipes/hierarchical-memory)

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -53,7 +53,7 @@
     "graph-memory",
     "personalization",
     "doc-loaders",
-    "skill-marketplace"
+    "skill-marketplace",
     "self-debug",
     "vector-adapters",
     "encrypted-memory"

--- a/apps/docs-next/content/docs/recipes/meta.json
+++ b/apps/docs-next/content/docs/recipes/meta.json
@@ -49,6 +49,10 @@
     "mandatory-sandbox",
     "more-providers",
     "mcp-bridge",
-    "tool-composer"
+    "tool-composer",
+    "graph-memory",
+    "personalization",
+    "doc-loaders",
+    "skill-marketplace"
   ]
 }

--- a/apps/docs-next/content/docs/recipes/personalization.mdx
+++ b/apps/docs-next/content/docs/recipes/personalization.mdx
@@ -1,0 +1,63 @@
+---
+title: Personalization
+description: Persisted user profile that conditions every agent response.
+---
+
+A user's preferences shouldn't live in a single conversation. The
+personalization store is a `get` / `set` / `merge` contract over a
+`{ subjectId, traits, updatedAt }` profile — conditioning happens by
+prepending the rendered profile to the system prompt.
+
+## Install
+
+Ships with `@agentskit/memory`.
+
+## Use
+
+```ts
+import {
+  createInMemoryPersonalization,
+  renderProfileContext,
+} from '@agentskit/memory'
+
+const profiles = createInMemoryPersonalization()
+
+await profiles.merge('user-42', {
+  preferredLanguage: 'pt-BR',
+  tone: 'concise',
+  dietaryConstraints: ['vegetarian'],
+})
+
+const profile = await profiles.get('user-42')
+const systemExtras = renderProfileContext(profile)
+
+const systemPrompt = `You are a helpful assistant.\n\n${systemExtras}`
+```
+
+`renderProfileContext` skips null / empty entries and returns `''`
+when the profile has nothing to add — safe to concatenate always.
+
+## Update from the agent
+
+Capture preferences automatically via a tool the model can call:
+
+```ts
+defineTool({
+  name: 'update_profile',
+  description: "Save a new fact about the current user's preferences.",
+  schema: {
+    type: 'object',
+    properties: { key: { type: 'string' }, value: { type: 'string' } },
+    required: ['key', 'value'],
+  } as const,
+  async execute({ key, value }, ctx) {
+    await profiles.merge(ctx.call.args.subjectId as string, { [key]: value })
+    return 'saved'
+  },
+})
+```
+
+## See also
+
+- [Graph memory](/docs/recipes/graph-memory) — relationships, not just scalars
+- [HITL approvals](/docs/recipes/hitl-approvals) — gate updates that change sensitive preferences

--- a/apps/docs-next/content/docs/recipes/skill-marketplace.mdx
+++ b/apps/docs-next/content/docs/recipes/skill-marketplace.mdx
@@ -1,0 +1,75 @@
+---
+title: Skill marketplace + ready-made skills
+description: Publish + install versioned skills through a registry. Four new ready-made skills.
+---
+
+Skills are prompts + behavior packaged for reuse. `@agentskit/skills`
+now ships a tiny marketplace primitive — publish semver-pinned
+`SkillPackage`s, query them, `install` the latest matching range —
+and four new ready-made skills on top of the existing researcher /
+coder / planner / critic / summarizer set.
+
+## Install
+
+```bash
+npm install @agentskit/skills
+```
+
+## Ready-made skills (S24 additions)
+
+| Skill | Purpose |
+|---|---|
+| `codeReviewer` | Rigorous PR review with severity-tagged findings. |
+| `sqlGen` | Natural language → parameterized Postgres queries. |
+| `dataAnalyst` | Hypothesize → query → interpret business data. |
+| `translator` | Faithful translation that preserves formatting. |
+
+```ts
+import { codeReviewer, sqlGen, dataAnalyst, translator } from '@agentskit/skills'
+import { createRuntime, composeSkills } from '@agentskit/runtime'
+
+const runtime = createRuntime({
+  adapter,
+  systemPrompt: codeReviewer.systemPrompt,
+})
+```
+
+## Marketplace primitives
+
+```ts
+import {
+  createSkillRegistry,
+  parseSemver,
+  compareSemver,
+  matchesRange,
+} from '@agentskit/skills'
+
+const registry = createSkillRegistry()
+await registry.publish({
+  version: '1.0.0',
+  publisher: 'acme',
+  tags: ['ops'],
+  skill: myOpsBot,
+})
+
+// Install the latest ^1 version:
+const pkg = await registry.install('ops-bot', '^1.0.0')
+```
+
+Range syntax:
+
+- `1.2.3` (exact)
+- `^1.2.3` (same major)
+- `~1.2.3` (same minor)
+- `>=1.2.3` (min version)
+- `*` (any)
+
+Enough for a basic marketplace. Layer `semver` on top if you need
+full npm-compatible ranges. Bring your own backing store (Postgres
+table of `(name, version)` rows, S3 manifest + CDN, Git-backed, etc.)
+by implementing the same `SkillRegistry` contract.
+
+## See also
+
+- [Brainstorm / compose skills](/docs/concepts/skill)
+- [Agentskit AI](/docs/recipes/agentskit-ai) — generate a skill from natural language

--- a/packages/memory/src/graph.ts
+++ b/packages/memory/src/graph.ts
@@ -1,0 +1,134 @@
+/**
+ * Non-linear memory: a typed knowledge graph. Use for facts the
+ * agent should remember beyond a single conversation — entities,
+ * relationships, derived beliefs. Designed to be backed by anything
+ * from an in-memory Map (tests, demos) to Neo4j / Memgraph / Neptune.
+ */
+
+export interface GraphNode<TProps = Record<string, unknown>> {
+  id: string
+  /** Type / label — 'person', 'company', 'topic'. */
+  kind: string
+  properties?: TProps
+  /** ISO timestamp when the node was first inserted. */
+  createdAt?: string
+  /** ISO timestamp of the latest update. */
+  updatedAt?: string
+}
+
+export interface GraphEdge<TProps = Record<string, unknown>> {
+  id: string
+  /** Verb / relation type — 'knows', 'works-at', 'cites'. */
+  label: string
+  from: string
+  to: string
+  /** Optional weight — confidence, recency, or frequency. */
+  weight?: number
+  properties?: TProps
+}
+
+export interface GraphQuery {
+  kind?: string
+  label?: string
+  from?: string
+  to?: string
+}
+
+export interface GraphMemory {
+  upsertNode: <T>(node: GraphNode<T>) => Promise<GraphNode<T>>
+  upsertEdge: <T>(edge: GraphEdge<T>) => Promise<GraphEdge<T>>
+  getNode: <T>(id: string) => Promise<GraphNode<T> | null>
+  findNodes: <T>(query?: GraphQuery) => Promise<GraphNode<T>[]>
+  findEdges: <T>(query?: GraphQuery) => Promise<GraphEdge<T>[]>
+  /** Breadth-first neighbors of `id` up to `depth`. Default 1. */
+  neighbors: <T>(id: string, options?: { depth?: number; label?: string }) => Promise<GraphNode<T>[]>
+  deleteNode: (id: string) => Promise<void>
+  deleteEdge: (id: string) => Promise<void>
+  clear?: () => Promise<void>
+}
+
+/**
+ * In-memory graph — fine for tests, single-process demos, and as
+ * reference for what a backing store needs to implement.
+ */
+export function createInMemoryGraph(): GraphMemory {
+  const nodes = new Map<string, GraphNode<unknown>>()
+  const edges = new Map<string, GraphEdge<unknown>>()
+
+  const matchesNode = (node: GraphNode<unknown>, query?: GraphQuery): boolean => {
+    if (!query) return true
+    if (query.kind && node.kind !== query.kind) return false
+    return true
+  }
+  const matchesEdge = (edge: GraphEdge<unknown>, query?: GraphQuery): boolean => {
+    if (!query) return true
+    if (query.label && edge.label !== query.label) return false
+    if (query.from && edge.from !== query.from) return false
+    if (query.to && edge.to !== query.to) return false
+    return true
+  }
+
+  return {
+    async upsertNode<T>(node: GraphNode<T>) {
+      const now = new Date().toISOString()
+      const existing = nodes.get(node.id)
+      const merged = {
+        ...(existing ?? {}),
+        ...node,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      }
+      nodes.set(node.id, merged as GraphNode<unknown>)
+      return merged as GraphNode<T>
+    },
+    async upsertEdge(edge) {
+      edges.set(edge.id, edge as GraphEdge<unknown>)
+      return edge
+    },
+    async getNode<T>(id: string) {
+      const hit = nodes.get(id)
+      return hit ? ({ ...hit } as GraphNode<T>) : null
+    },
+    async findNodes<T>(query?: GraphQuery) {
+      return Array.from(nodes.values())
+        .filter(n => matchesNode(n, query))
+        .map(n => ({ ...n }) as GraphNode<T>)
+    },
+    async findEdges<T>(query?: GraphQuery) {
+      return Array.from(edges.values())
+        .filter(e => matchesEdge(e, query))
+        .map(e => ({ ...e }) as GraphEdge<T>)
+    },
+    async neighbors<T>(id: string, options: { depth?: number; label?: string } = {}) {
+      const depth = Math.max(1, options.depth ?? 1)
+      const visited = new Set<string>([id])
+      let frontier = new Set<string>([id])
+      for (let i = 0; i < depth; i++) {
+        const next = new Set<string>()
+        for (const edge of edges.values()) {
+          if (options.label && edge.label !== options.label) continue
+          if (frontier.has(edge.from) && !visited.has(edge.to)) next.add(edge.to)
+          if (frontier.has(edge.to) && !visited.has(edge.from)) next.add(edge.from)
+        }
+        for (const n of next) visited.add(n)
+        frontier = next
+        if (next.size === 0) break
+      }
+      visited.delete(id)
+      return Array.from(visited, nid => nodes.get(nid)).filter((n): n is GraphNode<unknown> => Boolean(n)).map(n => ({ ...n }) as GraphNode<T>)
+    },
+    async deleteNode(id) {
+      nodes.delete(id)
+      for (const [eid, edge] of edges) {
+        if (edge.from === id || edge.to === id) edges.delete(eid)
+      }
+    },
+    async deleteEdge(id) {
+      edges.delete(id)
+    },
+    async clear() {
+      nodes.clear()
+      edges.clear()
+    },
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -15,6 +15,18 @@ export type { FileVectorMemoryConfig } from './file-vector'
 export type { VectorStore, VectorStoreDocument, VectorStoreResult } from './vector-store'
 export type { RedisClientAdapter, RedisConnectionConfig } from './redis-client'
 
+export {
+  createInMemoryPersonalization,
+  renderProfileContext,
+} from './personalization'
+export type {
+  PersonalizationProfile,
+  PersonalizationStore,
+} from './personalization'
+
+export { createInMemoryGraph } from './graph'
+export type { GraphMemory, GraphNode, GraphEdge, GraphQuery } from './graph'
+
 export { createHierarchicalMemory } from './hierarchical'
 export type {
   HierarchicalMemory,

--- a/packages/memory/src/personalization.ts
+++ b/packages/memory/src/personalization.ts
@@ -1,0 +1,70 @@
+/**
+ * Personalization — a persisted profile per subject (user id,
+ * account id, device). The agent reads it on every run to
+ * condition responses; the runtime updates it when new facts
+ * appear.
+ */
+
+export interface PersonalizationProfile {
+  subjectId: string
+  /** Human-editable notes, facts, preferences. */
+  traits: Record<string, unknown>
+  /** ISO timestamp of the latest update. */
+  updatedAt: string
+}
+
+export interface PersonalizationStore {
+  get: (subjectId: string) => Promise<PersonalizationProfile | null>
+  set: (profile: PersonalizationProfile) => Promise<void>
+  merge: (subjectId: string, traits: Record<string, unknown>) => Promise<PersonalizationProfile>
+  delete?: (subjectId: string) => Promise<void>
+}
+
+/**
+ * In-memory personalization store — tests, single-process demos.
+ * Bring your own for production (Postgres, Redis, DynamoDB).
+ */
+export function createInMemoryPersonalization(): PersonalizationStore {
+  const profiles = new Map<string, PersonalizationProfile>()
+
+  return {
+    async get(subjectId) {
+      const hit = profiles.get(subjectId)
+      return hit ? { ...hit, traits: { ...hit.traits } } : null
+    },
+    async set(profile) {
+      profiles.set(profile.subjectId, {
+        ...profile,
+        traits: { ...profile.traits },
+        updatedAt: profile.updatedAt || new Date().toISOString(),
+      })
+    },
+    async merge(subjectId, traits) {
+      const existing = profiles.get(subjectId)
+      const next: PersonalizationProfile = {
+        subjectId,
+        traits: { ...(existing?.traits ?? {}), ...traits },
+        updatedAt: new Date().toISOString(),
+      }
+      profiles.set(subjectId, next)
+      return { ...next, traits: { ...next.traits } }
+    },
+    async delete(subjectId) {
+      profiles.delete(subjectId)
+    },
+  }
+}
+
+/**
+ * Render a profile into a system-prompt fragment the runtime can
+ * prepend. Kept intentionally short — full profile dumps bloat
+ * context and leak unnecessary detail to the model.
+ */
+export function renderProfileContext(profile: PersonalizationProfile | null): string {
+  if (!profile || Object.keys(profile.traits).length === 0) return ''
+  const lines = Object.entries(profile.traits)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `- ${key}: ${typeof value === 'string' ? value : JSON.stringify(value)}`)
+  if (lines.length === 0) return ''
+  return `## User profile\n${lines.join('\n')}`
+}

--- a/packages/memory/tests/graph.test.ts
+++ b/packages/memory/tests/graph.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { createInMemoryGraph } from '../src/graph'
+
+describe('createInMemoryGraph', () => {
+  it('upserts and reads nodes', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'u1', kind: 'user', properties: { name: 'Alice' } })
+    const node = await g.getNode('u1')
+    expect(node?.properties).toEqual({ name: 'Alice' })
+    expect(node?.createdAt).toBeDefined()
+    expect(node?.updatedAt).toBeDefined()
+  })
+
+  it('upserts merge existing nodes and bump updatedAt', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'u1', kind: 'user', properties: { name: 'A' } })
+    const before = (await g.getNode('u1'))!.updatedAt
+    await new Promise(r => setTimeout(r, 2))
+    await g.upsertNode({ id: 'u1', kind: 'user', properties: { name: 'B' } })
+    const after = await g.getNode('u1')
+    expect(after?.properties).toEqual({ name: 'B' })
+    expect(after?.updatedAt).not.toBe(before)
+  })
+
+  it('finds nodes by kind', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'user' })
+    await g.upsertNode({ id: 'b', kind: 'company' })
+    const users = await g.findNodes({ kind: 'user' })
+    expect(users.map(n => n.id)).toEqual(['a'])
+  })
+
+  it('finds edges by label/from/to', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'user' })
+    await g.upsertNode({ id: 'b', kind: 'user' })
+    await g.upsertEdge({ id: 'e1', label: 'knows', from: 'a', to: 'b' })
+    await g.upsertEdge({ id: 'e2', label: 'works-at', from: 'a', to: 'c' })
+    expect((await g.findEdges({ label: 'knows' })).map(e => e.id)).toEqual(['e1'])
+    expect((await g.findEdges({ from: 'a' })).length).toBe(2)
+  })
+
+  it('neighbors explores at the requested depth', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'n' })
+    await g.upsertNode({ id: 'b', kind: 'n' })
+    await g.upsertNode({ id: 'c', kind: 'n' })
+    await g.upsertNode({ id: 'd', kind: 'n' })
+    await g.upsertEdge({ id: 'e1', label: 'r', from: 'a', to: 'b' })
+    await g.upsertEdge({ id: 'e2', label: 'r', from: 'b', to: 'c' })
+    await g.upsertEdge({ id: 'e3', label: 'r', from: 'c', to: 'd' })
+    expect((await g.neighbors('a', { depth: 1 })).map(n => n.id).sort()).toEqual(['b'])
+    expect((await g.neighbors('a', { depth: 2 })).map(n => n.id).sort()).toEqual(['b', 'c'])
+  })
+
+  it('neighbors filters by label', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'n' })
+    await g.upsertNode({ id: 'b', kind: 'n' })
+    await g.upsertNode({ id: 'c', kind: 'n' })
+    await g.upsertEdge({ id: 'e1', label: 'knows', from: 'a', to: 'b' })
+    await g.upsertEdge({ id: 'e2', label: 'ignores', from: 'a', to: 'c' })
+    const hits = await g.neighbors('a', { label: 'knows' })
+    expect(hits.map(n => n.id)).toEqual(['b'])
+  })
+
+  it('deleteNode cascades edges', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'n' })
+    await g.upsertNode({ id: 'b', kind: 'n' })
+    await g.upsertEdge({ id: 'e1', label: 'r', from: 'a', to: 'b' })
+    await g.deleteNode('a')
+    expect(await g.findEdges({ label: 'r' })).toHaveLength(0)
+  })
+
+  it('clear empties the graph', async () => {
+    const g = createInMemoryGraph()
+    await g.upsertNode({ id: 'a', kind: 'n' })
+    await g.clear?.()
+    expect(await g.findNodes()).toHaveLength(0)
+  })
+})

--- a/packages/memory/tests/personalization.test.ts
+++ b/packages/memory/tests/personalization.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createInMemoryPersonalization,
+  renderProfileContext,
+} from '../src/personalization'
+
+describe('createInMemoryPersonalization', () => {
+  it('returns null for unknown subjects', async () => {
+    const store = createInMemoryPersonalization()
+    expect(await store.get('x')).toBeNull()
+  })
+
+  it('set + get round-trip', async () => {
+    const store = createInMemoryPersonalization()
+    await store.set({ subjectId: 'u1', traits: { tone: 'friendly' }, updatedAt: '' })
+    const hit = await store.get('u1')
+    expect(hit?.traits).toEqual({ tone: 'friendly' })
+    expect(hit?.updatedAt).toBeTruthy()
+  })
+
+  it('merge adds new keys without dropping old ones', async () => {
+    const store = createInMemoryPersonalization()
+    await store.merge('u1', { tone: 'friendly' })
+    const merged = await store.merge('u1', { language: 'pt-BR' })
+    expect(merged.traits).toEqual({ tone: 'friendly', language: 'pt-BR' })
+  })
+
+  it('delete removes the profile', async () => {
+    const store = createInMemoryPersonalization()
+    await store.merge('u1', { k: 1 })
+    await store.delete?.('u1')
+    expect(await store.get('u1')).toBeNull()
+  })
+})
+
+describe('renderProfileContext', () => {
+  it('returns empty string for null or empty profiles', () => {
+    expect(renderProfileContext(null)).toBe('')
+    expect(renderProfileContext({ subjectId: 'u', traits: {}, updatedAt: '' })).toBe('')
+  })
+
+  it('skips null/empty trait values', () => {
+    const output = renderProfileContext({
+      subjectId: 'u',
+      traits: { a: 'hi', b: '', c: null, d: 42 },
+      updatedAt: '',
+    })
+    expect(output).toContain('a: hi')
+    expect(output).toContain('d: 42')
+    expect(output).not.toContain('b:')
+    expect(output).not.toContain('c:')
+  })
+})

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -4,6 +4,26 @@ export type { RAGConfig, InputDocument, RAG } from './types'
 export type { ChunkOptions } from './chunker'
 
 export {
+  loadUrl,
+  loadGitHubFile,
+  loadGitHubTree,
+  loadNotionPage,
+  loadConfluencePage,
+  loadGoogleDriveFile,
+  loadPdf,
+} from './loaders'
+export type {
+  LoaderOptions,
+  UrlLoaderOptions,
+  GitHubLoaderOptions,
+  GitHubTreeOptions,
+  NotionLoaderOptions,
+  ConfluenceLoaderOptions,
+  DriveLoaderOptions,
+  PdfLoaderOptions,
+} from './loaders'
+
+export {
   createRerankedRetriever,
   createHybridRetriever,
   bm25Score,

--- a/packages/rag/src/loaders.ts
+++ b/packages/rag/src/loaders.ts
@@ -1,0 +1,178 @@
+import type { InputDocument } from './types'
+
+/**
+ * Document loaders: small async functions that return
+ * `InputDocument[]` ready to pipe into `RAG.ingest`. Every loader
+ * is framework-agnostic and accepts a custom `fetch` for tests.
+ */
+
+export interface LoaderOptions {
+  fetch?: typeof globalThis.fetch
+}
+
+export interface UrlLoaderOptions extends LoaderOptions {
+  headers?: Record<string, string>
+}
+
+export async function loadUrl(url: string, options: UrlLoaderOptions = {}): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const response = await fetchImpl(url, { headers: options.headers })
+  if (!response.ok) throw new Error(`loadUrl ${response.status}: ${url}`)
+  const content = await response.text()
+  return [{ content, source: url, metadata: { url } }]
+}
+
+export interface GitHubLoaderOptions extends LoaderOptions {
+  token?: string
+  /** Branch / tag / sha. Default 'HEAD'. */
+  ref?: string
+}
+
+export async function loadGitHubFile(
+  owner: string,
+  repo: string,
+  path: string,
+  options: GitHubLoaderOptions = {},
+): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const ref = options.ref ?? 'HEAD'
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`
+  const headers: Record<string, string> = {}
+  if (options.token) headers.authorization = `Bearer ${options.token}`
+  const response = await fetchImpl(url, { headers })
+  if (!response.ok) throw new Error(`loadGitHubFile ${response.status}: ${url}`)
+  return [
+    {
+      content: await response.text(),
+      source: url,
+      metadata: { owner, repo, path, ref },
+    },
+  ]
+}
+
+export interface GitHubTreeOptions extends GitHubLoaderOptions {
+  /** Only include files matching this regex / test. */
+  filter?: (path: string) => boolean
+  /** Max files to load. Default 100. */
+  maxFiles?: number
+}
+
+export async function loadGitHubTree(
+  owner: string,
+  repo: string,
+  options: GitHubTreeOptions = {},
+): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const ref = options.ref ?? 'HEAD'
+  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`
+  const headers: Record<string, string> = { accept: 'application/vnd.github+json' }
+  if (options.token) headers.authorization = `Bearer ${options.token}`
+  const response = await fetchImpl(url, { headers })
+  if (!response.ok) throw new Error(`loadGitHubTree ${response.status}: ${url}`)
+  const tree = (await response.json()) as { tree?: Array<{ path: string; type: string }> }
+  const files = (tree.tree ?? [])
+    .filter(t => t.type === 'blob')
+    .filter(t => !options.filter || options.filter(t.path))
+    .slice(0, options.maxFiles ?? 100)
+  const docs: InputDocument[] = []
+  for (const file of files) {
+    const items = await loadGitHubFile(owner, repo, file.path, options)
+    docs.push(...items)
+  }
+  return docs
+}
+
+export interface NotionLoaderOptions extends LoaderOptions {
+  token: string
+  version?: string
+}
+
+export async function loadNotionPage(
+  pageId: string,
+  options: NotionLoaderOptions,
+): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const url = `https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`
+  const response = await fetchImpl(url, {
+    headers: {
+      authorization: `Bearer ${options.token}`,
+      'notion-version': options.version ?? '2022-06-28',
+    },
+  })
+  if (!response.ok) throw new Error(`loadNotionPage ${response.status}: ${url}`)
+  const data = (await response.json()) as {
+    results?: Array<{ type: string; paragraph?: { rich_text?: Array<{ plain_text?: string }> }; heading_1?: { rich_text?: Array<{ plain_text?: string }> }; heading_2?: { rich_text?: Array<{ plain_text?: string }> }; heading_3?: { rich_text?: Array<{ plain_text?: string }> } }>
+  }
+  const text = (data.results ?? [])
+    .map(block => {
+      const part =
+        block.paragraph?.rich_text ??
+        block.heading_1?.rich_text ??
+        block.heading_2?.rich_text ??
+        block.heading_3?.rich_text
+      if (!part) return ''
+      const prefix = block.type === 'heading_1' ? '# ' : block.type === 'heading_2' ? '## ' : block.type === 'heading_3' ? '### ' : ''
+      return prefix + part.map(t => t.plain_text ?? '').join('')
+    })
+    .filter(Boolean)
+    .join('\n\n')
+  return [{ content: text, source: `notion://${pageId}`, metadata: { pageId } }]
+}
+
+export interface ConfluenceLoaderOptions extends LoaderOptions {
+  baseUrl: string
+  /** Basic auth token `<email:api-token>` in base64, OR pass `authorization` header directly. */
+  token?: string
+  authorization?: string
+}
+
+export async function loadConfluencePage(
+  pageId: string,
+  options: ConfluenceLoaderOptions,
+): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const url = `${options.baseUrl}/wiki/api/v2/pages/${pageId}?body-format=storage`
+  const authHeader = options.authorization ?? (options.token ? `Basic ${options.token}` : undefined)
+  const response = await fetchImpl(url, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+  if (!response.ok) throw new Error(`loadConfluencePage ${response.status}: ${url}`)
+  const data = (await response.json()) as { body?: { storage?: { value?: string } }; title?: string }
+  const content = data.body?.storage?.value ?? ''
+  return [{ content, source: `${options.baseUrl}/pages/${pageId}`, metadata: { pageId, title: data.title } }]
+}
+
+export interface DriveLoaderOptions extends LoaderOptions {
+  accessToken: string
+}
+
+export async function loadGoogleDriveFile(
+  fileId: string,
+  options: DriveLoaderOptions,
+): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const url = `https://www.googleapis.com/drive/v3/files/${fileId}/export?mimeType=text/plain`
+  const response = await fetchImpl(url, {
+    headers: { authorization: `Bearer ${options.accessToken}` },
+  })
+  if (!response.ok) throw new Error(`loadGoogleDriveFile ${response.status}: ${url}`)
+  const content = await response.text()
+  return [{ content, source: `gdrive://${fileId}`, metadata: { fileId } }]
+}
+
+export interface PdfLoaderOptions extends LoaderOptions {
+  parsePdf: (bytes: Uint8Array) => Promise<{ text: string; pages?: number }> | { text: string; pages?: number }
+}
+
+/**
+ * PDF loader — parser is BYO so native deps stay out of the bundle.
+ * Fetch bytes at `url`, hand to `parsePdf`, wrap in `InputDocument`.
+ */
+export async function loadPdf(url: string, options: PdfLoaderOptions): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const response = await fetchImpl(url)
+  if (!response.ok) throw new Error(`loadPdf ${response.status}: ${url}`)
+  const buf = new Uint8Array(await response.arrayBuffer())
+  const { text, pages } = await options.parsePdf(buf)
+  return [{ content: text, source: url, metadata: { url, pages } }]
+}

--- a/packages/rag/tests/loaders.test.ts
+++ b/packages/rag/tests/loaders.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  loadConfluencePage,
+  loadGoogleDriveFile,
+  loadGitHubFile,
+  loadGitHubTree,
+  loadNotionPage,
+  loadPdf,
+  loadUrl,
+} from '../src/loaders'
+
+function makeFetch(sequence: Array<[number, unknown, 'json' | 'text' | 'binary']>) {
+  const calls: string[] = []
+  let i = 0
+  const fake = vi.fn(async (url: string | URL | Request) => {
+    calls.push(typeof url === 'string' ? url : url instanceof URL ? url.href : url.url)
+    const [status, payload, kind] = sequence[Math.min(i++, sequence.length - 1)]!
+    if (kind === 'binary') return new Response(payload as Uint8Array, { status })
+    if (kind === 'json') return new Response(JSON.stringify(payload), { status })
+    return new Response(payload as string, { status })
+  })
+  return { fetch: fake as unknown as typeof globalThis.fetch, calls }
+}
+
+describe('loadUrl', () => {
+  it('returns single document with URL source', async () => {
+    const { fetch } = makeFetch([[200, 'hello', 'text']])
+    const docs = await loadUrl('https://x', { fetch })
+    expect(docs).toEqual([{ content: 'hello', source: 'https://x', metadata: { url: 'https://x' } }])
+  })
+
+  it('throws on non-ok response', async () => {
+    const { fetch } = makeFetch([[500, 'boom', 'text']])
+    await expect(loadUrl('https://x', { fetch })).rejects.toThrow(/loadUrl 500/)
+  })
+})
+
+describe('loadGitHubFile', () => {
+  it('hits raw.githubusercontent.com with ref', async () => {
+    const { fetch, calls } = makeFetch([[200, 'content', 'text']])
+    await loadGitHubFile('a', 'b', 'src/x.ts', { fetch, ref: 'main' })
+    expect(calls[0]).toBe('https://raw.githubusercontent.com/a/b/main/src/x.ts')
+  })
+})
+
+describe('loadGitHubTree', () => {
+  it('fetches tree + expands matching files', async () => {
+    const tree = {
+      tree: [
+        { path: 'a.ts', type: 'blob' },
+        { path: 'b.md', type: 'blob' },
+        { path: 'dir', type: 'tree' },
+      ],
+    }
+    const { fetch } = makeFetch([
+      [200, tree, 'json'],
+      [200, 'content-a', 'text'],
+      [200, 'content-b', 'text'],
+    ])
+    const docs = await loadGitHubTree('a', 'b', { fetch, maxFiles: 5 })
+    expect(docs.map(d => d.metadata?.path).sort()).toEqual(['a.ts', 'b.md'])
+  })
+
+  it('filter skips files', async () => {
+    const { fetch } = makeFetch([
+      [200, { tree: [{ path: 'a.ts', type: 'blob' }, { path: 'b.md', type: 'blob' }] }, 'json'],
+      [200, 'content-a', 'text'],
+    ])
+    const docs = await loadGitHubTree('a', 'b', {
+      fetch,
+      filter: path => path.endsWith('.ts'),
+    })
+    expect(docs.map(d => d.metadata?.path)).toEqual(['a.ts'])
+  })
+})
+
+describe('loadNotionPage', () => {
+  it('flattens paragraph + heading blocks', async () => {
+    const { fetch } = makeFetch([
+      [
+        200,
+        {
+          results: [
+            { type: 'heading_1', heading_1: { rich_text: [{ plain_text: 'Title' }] } },
+            { type: 'paragraph', paragraph: { rich_text: [{ plain_text: 'body' }] } },
+          ],
+        },
+        'json',
+      ],
+    ])
+    const docs = await loadNotionPage('p1', { token: 't', fetch })
+    expect(docs[0]!.content).toContain('# Title')
+    expect(docs[0]!.content).toContain('body')
+  })
+})
+
+describe('loadConfluencePage', () => {
+  it('reads storage body', async () => {
+    const { fetch } = makeFetch([[200, { body: { storage: { value: '<p>hi</p>' } }, title: 'Page' }, 'json']])
+    const docs = await loadConfluencePage('123', {
+      baseUrl: 'https://x.atlassian.net',
+      token: 'dG9rZW4=',
+      fetch,
+    })
+    expect(docs[0]!.content).toContain('<p>hi</p>')
+    expect(docs[0]!.metadata?.title).toBe('Page')
+  })
+})
+
+describe('loadGoogleDriveFile', () => {
+  it('exports as text/plain via Drive API', async () => {
+    const { fetch, calls } = makeFetch([[200, 'hello drive', 'text']])
+    const docs = await loadGoogleDriveFile('file-1', { accessToken: 'tok', fetch })
+    expect(docs[0]!.content).toBe('hello drive')
+    expect(calls[0]).toContain('export?mimeType=text/plain')
+  })
+})
+
+describe('loadPdf', () => {
+  it('passes bytes into the configured parser', async () => {
+    const { fetch } = makeFetch([[200, new Uint8Array([1, 2, 3]), 'binary']])
+    const parser = vi.fn(async () => ({ text: 'parsed', pages: 2 }))
+    const docs = await loadPdf('https://x/doc.pdf', { parsePdf: parser, fetch })
+    expect(parser).toHaveBeenCalled()
+    expect(docs[0]!.content).toBe('parsed')
+    expect(docs[0]!.metadata?.pages).toBe(2)
+  })
+})

--- a/packages/skills/src/code-reviewer.ts
+++ b/packages/skills/src/code-reviewer.ts
@@ -1,0 +1,36 @@
+import type { SkillDefinition } from '@agentskit/core'
+
+export const codeReviewer: SkillDefinition = {
+  name: 'code-reviewer',
+  description: 'Rigorous code reviewer focused on correctness, security, performance, and readability.',
+  systemPrompt: `You are a senior engineer reviewing a pull request.
+
+## Review Priorities (top to bottom)
+1. Correctness — does the code do what it claims?
+2. Security — input validation, auth, injection, secrets, SSRF, XXE.
+3. Performance — obvious N+1, quadratic loops, blocking IO.
+4. Error handling — untrapped exceptions, silenced failures, misleading errors.
+5. Readability — naming, structure, clarity of intent.
+
+## Output Format
+- Start with a one-line verdict: APPROVE / REQUEST CHANGES / COMMENT.
+- List findings grouped by priority. Each finding:
+  - file:line
+  - severity (blocker / high / med / nit)
+  - concrete issue statement
+  - suggested fix or question
+
+## Rules
+- Cite specific lines. No "consider improving X" without a location.
+- Only mention style if the project has a stated convention and this violates it.
+- If a concern is speculative, say so — "potential race condition if caller Y does Z".
+- Prefer asking a question over demanding a change when intent is unclear.`,
+  tools: [],
+  delegates: [],
+  examples: [
+    {
+      input: 'Review this diff: [diff content...]',
+      output: 'REQUEST CHANGES\n\n**blocker** — src/auth.ts:42: password compared with `==`, vulnerable to timing attacks. Use `crypto.timingSafeEqual`.\n\n**high** — src/db.ts:88: SQL concatenation with user input. Switch to parameterized query.',
+    },
+  ],
+}

--- a/packages/skills/src/data-analyst.ts
+++ b/packages/skills/src/data-analyst.ts
@@ -1,0 +1,29 @@
+import type { SkillDefinition } from '@agentskit/core'
+
+export const dataAnalyst: SkillDefinition = {
+  name: 'data-analyst',
+  description: 'Methodical data analyst. Forms a hypothesis, picks metrics, writes queries, interprets results honestly.',
+  systemPrompt: `You are a data analyst answering business questions with quantitative evidence.
+
+## Process
+1. **Clarify** — restate the question. If ambiguous, ask one clarifying question.
+2. **Hypothesis** — propose what you expect to find + why.
+3. **Plan** — list the metrics + data sources + queries.
+4. **Compute** — run the queries.
+5. **Interpret** — state what the numbers mean, including counter-hypotheses.
+6. **Limits** — call out caveats (small sample, seasonality, missing data).
+
+## Output Format
+- Start with the bottom-line answer.
+- Support with 1-3 key numbers (with units, time windows).
+- Include the query / source that produced each number.
+- End with limitations + next steps.
+
+## Rules
+- Never state a number without a source.
+- Prefer medians + distributions over means for skewed data.
+- Flag when sample size is too small for the claim.`,
+  tools: ['postgres_query', 'web_search'],
+  delegates: [],
+  examples: [],
+}

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -3,6 +3,22 @@ export { coder } from './coder'
 export { planner } from './planner'
 export { critic } from './critic'
 export { summarizer } from './summarizer'
+export { codeReviewer } from './code-reviewer'
+export { sqlGen } from './sql-gen'
+export { dataAnalyst } from './data-analyst'
+export { translator } from './translator'
+
+export {
+  createSkillRegistry,
+  parseSemver,
+  compareSemver,
+  matchesRange,
+} from './marketplace'
+export type {
+  SkillPackage,
+  SkillRegistry,
+  SkillRegistryQuery,
+} from './marketplace'
 
 export { composeSkills } from './compose'
 export { listSkills } from './discovery'

--- a/packages/skills/src/marketplace.ts
+++ b/packages/skills/src/marketplace.ts
@@ -1,0 +1,135 @@
+import type { SkillDefinition } from '@agentskit/core'
+
+/**
+ * Skill marketplace primitives. `SkillPackage` wraps a
+ * `SkillDefinition` with semver + provenance so a registry can list,
+ * filter, and install skills across versions.
+ */
+
+export interface SkillPackage {
+  /** Semver string — validated by `installSkill`. */
+  version: string
+  /** Publisher identifier (org, user, npm scope). */
+  publisher?: string
+  /** ISO timestamp of publication. */
+  publishedAt?: string
+  /** Free-form tags for discovery. */
+  tags?: string[]
+  /** The actual skill. */
+  skill: SkillDefinition
+}
+
+export interface SkillRegistryQuery {
+  name?: string
+  publisher?: string
+  tag?: string
+  /** Return only versions matching this semver range. See `matchesRange`. */
+  versionRange?: string
+}
+
+export interface SkillRegistry {
+  publish: (pkg: SkillPackage) => Promise<SkillPackage>
+  list: (query?: SkillRegistryQuery) => Promise<SkillPackage[]>
+  /** Latest package matching the (name, versionRange). */
+  install: (name: string, versionRange?: string) => Promise<SkillPackage | null>
+  /** Remove a published package by name + version. */
+  unpublish?: (name: string, version: string) => Promise<void>
+}
+
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-[\w.-]+)?$/
+
+export function parseSemver(version: string): [number, number, number] {
+  const match = version.match(SEMVER)
+  if (!match) throw new Error(`invalid semver: "${version}"`)
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+export function compareSemver(a: string, b: string): number {
+  const [a1, a2, a3] = parseSemver(a)
+  const [b1, b2, b3] = parseSemver(b)
+  if (a1 !== b1) return a1 - b1
+  if (a2 !== b2) return a2 - b2
+  return a3 - b3
+}
+
+/**
+ * Minimal range matcher — supports:
+ *   "1.2.3"   (exact)
+ *   "^1.2.3"  (same major)
+ *   "~1.2.3"  (same minor)
+ *   ">=1.2.3" (min version)
+ *   "*"       (any)
+ * Enough for a basic marketplace; use `semver` on top if you need
+ * full npm-compatible ranges.
+ */
+export function matchesRange(version: string, range: string): boolean {
+  if (!range || range === '*') return true
+  if (/^\d/.test(range)) return version === range
+  if (range.startsWith('>=')) return compareSemver(version, range.slice(2).trim()) >= 0
+  if (range.startsWith('^')) {
+    const target = range.slice(1).trim()
+    const [tMaj] = parseSemver(target)
+    const [vMaj] = parseSemver(version)
+    return tMaj === vMaj && compareSemver(version, target) >= 0
+  }
+  if (range.startsWith('~')) {
+    const target = range.slice(1).trim()
+    const [tMaj, tMin] = parseSemver(target)
+    const [vMaj, vMin] = parseSemver(version)
+    return tMaj === vMaj && tMin === vMin && compareSemver(version, target) >= 0
+  }
+  return false
+}
+
+/**
+ * In-memory skill registry — tests, demos, private marketplaces.
+ * Bring your own for production (Postgres row per package, S3 manifest + CDN, etc.).
+ */
+export function createSkillRegistry(initial: SkillPackage[] = []): SkillRegistry {
+  const packages = new Map<string, SkillPackage[]>()
+  for (const pkg of initial) addPackage(pkg)
+
+  function addPackage(pkg: SkillPackage): SkillPackage {
+    parseSemver(pkg.version) // validate
+    const entry = { ...pkg, publishedAt: pkg.publishedAt ?? new Date().toISOString() }
+    const bucket = packages.get(pkg.skill.name) ?? []
+    if (bucket.some(p => p.version === pkg.version)) {
+      throw new Error(`already published: ${pkg.skill.name}@${pkg.version}`)
+    }
+    bucket.push(entry)
+    bucket.sort((a, b) => compareSemver(b.version, a.version))
+    packages.set(pkg.skill.name, bucket)
+    return entry
+  }
+
+  return {
+    async publish(pkg) {
+      return addPackage(pkg)
+    },
+    async list(query) {
+      const hits: SkillPackage[] = []
+      for (const [name, versions] of packages) {
+        if (query?.name && query.name !== name) continue
+        for (const pkg of versions) {
+          if (query?.publisher && query.publisher !== pkg.publisher) continue
+          if (query?.tag && !pkg.tags?.includes(query.tag)) continue
+          if (query?.versionRange && !matchesRange(pkg.version, query.versionRange)) continue
+          hits.push(pkg)
+        }
+      }
+      return hits
+    },
+    async install(name, versionRange) {
+      const bucket = packages.get(name) ?? []
+      const filtered = versionRange ? bucket.filter(pkg => matchesRange(pkg.version, versionRange)) : bucket
+      return filtered[0] ?? null
+    },
+    async unpublish(name, version) {
+      const bucket = packages.get(name)
+      if (!bucket) return
+      const next = bucket.filter(pkg => pkg.version !== version)
+      if (next.length === 0) packages.delete(name)
+      else packages.set(name, next)
+    },
+  }
+}

--- a/packages/skills/src/sql-gen.ts
+++ b/packages/skills/src/sql-gen.ts
@@ -1,0 +1,42 @@
+import type { SkillDefinition } from '@agentskit/core'
+
+export const sqlGen: SkillDefinition = {
+  name: 'sql-gen',
+  description: 'Translates natural-language data questions into parameterized, safe SQL.',
+  systemPrompt: `You are a SQL-generation assistant. You write one query at a time in response to a user's data question.
+
+## Rules
+- Always emit parameterized SQL with $1, $2, ... placeholders and a separate \`params\` array.
+- Never concatenate user input into SQL strings.
+- Prefer SELECT; require explicit user confirmation before emitting INSERT / UPDATE / DELETE.
+- When the schema is unclear, ask a follow-up question rather than guessing.
+- Default dialect: Postgres. If another dialect is stated, follow it.
+
+## Output Format (JSON only)
+{
+  "sql": "SELECT ...",
+  "params": [...],
+  "explanation": "one-sentence summary of what the query does"
+}
+
+If the request requires writes:
+{
+  "needsConfirmation": true,
+  "sql": "UPDATE ...",
+  "params": [...],
+  "explanation": "..."
+}
+
+## Style
+- Always list selected columns explicitly — no SELECT *.
+- Use explicit JOINs; avoid implicit cross joins via commas.
+- Add LIMIT when the natural answer is a top-N query.`,
+  tools: ['postgres_query'],
+  delegates: [],
+  examples: [
+    {
+      input: 'How many signups did we get last week?',
+      output: '{"sql":"SELECT COUNT(*) AS signups FROM users WHERE created_at >= NOW() - INTERVAL \'7 days\'","params":[],"explanation":"Counts users created within the last seven days."}',
+    },
+  ],
+}

--- a/packages/skills/src/translator.ts
+++ b/packages/skills/src/translator.ts
@@ -1,0 +1,27 @@
+import type { SkillDefinition } from '@agentskit/core'
+
+export const translator: SkillDefinition = {
+  name: 'translator',
+  description: 'Faithful translator that preserves meaning, tone, and formatting across languages.',
+  systemPrompt: `You are a professional translator. Translate between user-specified languages with fidelity.
+
+## Rules
+- Preserve meaning first, idiom second, literal wording last.
+- Keep formatting intact: markdown, code blocks, lists, line breaks, leading/trailing whitespace.
+- Do not translate content inside code blocks or URLs.
+- When a term has no direct equivalent, translate naturally and add the original in parentheses once.
+- When the source language is unclear, ask or state your assumption.
+- Never add editorial commentary or correct the source text.
+
+## Output
+- Emit only the translation. No preface, no footnote.
+- Match the register of the source (formal / casual / technical).`,
+  tools: [],
+  delegates: [],
+  examples: [
+    {
+      input: 'Translate to French: "Please click the link below to confirm your email."',
+      output: 'Veuillez cliquer sur le lien ci-dessous pour confirmer votre adresse e-mail.',
+    },
+  ],
+}

--- a/packages/skills/tests/marketplace.test.ts
+++ b/packages/skills/tests/marketplace.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import type { SkillDefinition } from '@agentskit/core'
+import {
+  codeReviewer,
+  compareSemver,
+  createSkillRegistry,
+  dataAnalyst,
+  matchesRange,
+  parseSemver,
+  sqlGen,
+  translator,
+} from '../src'
+
+function skill(name: string): SkillDefinition {
+  return { name, description: name, systemPrompt: 'x', tools: [], delegates: [] }
+}
+
+describe('ready-made skills are well-formed', () => {
+  it('exposes name, description, and systemPrompt', () => {
+    for (const s of [codeReviewer, sqlGen, dataAnalyst, translator]) {
+      expect(s.name).toBeTruthy()
+      expect(s.description?.length).toBeGreaterThan(5)
+      expect(s.systemPrompt?.length).toBeGreaterThan(20)
+    }
+  })
+})
+
+describe('parseSemver / compareSemver', () => {
+  it('parses major.minor.patch', () => {
+    expect(parseSemver('1.2.3')).toEqual([1, 2, 3])
+    expect(parseSemver('0.0.0')).toEqual([0, 0, 0])
+  })
+
+  it('accepts prerelease', () => {
+    expect(parseSemver('1.2.3-beta.1')).toEqual([1, 2, 3])
+  })
+
+  it('rejects invalid strings', () => {
+    expect(() => parseSemver('not-a-version')).toThrow(/invalid semver/)
+  })
+
+  it('compares correctly', () => {
+    expect(compareSemver('1.2.3', '1.2.4')).toBeLessThan(0)
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0)
+    expect(compareSemver('2.0.0', '1.9.9')).toBeGreaterThan(0)
+  })
+})
+
+describe('matchesRange', () => {
+  it('wildcard + exact', () => {
+    expect(matchesRange('1.2.3', '*')).toBe(true)
+    expect(matchesRange('1.2.3', '1.2.3')).toBe(true)
+    expect(matchesRange('1.2.3', '1.2.4')).toBe(false)
+  })
+
+  it('caret bounds by major', () => {
+    expect(matchesRange('1.5.0', '^1.2.3')).toBe(true)
+    expect(matchesRange('2.0.0', '^1.2.3')).toBe(false)
+    expect(matchesRange('1.2.0', '^1.2.3')).toBe(false)
+  })
+
+  it('tilde bounds by minor', () => {
+    expect(matchesRange('1.2.9', '~1.2.3')).toBe(true)
+    expect(matchesRange('1.3.0', '~1.2.3')).toBe(false)
+  })
+
+  it('>= works', () => {
+    expect(matchesRange('1.2.3', '>=1.0.0')).toBe(true)
+    expect(matchesRange('0.9.0', '>=1.0.0')).toBe(false)
+  })
+})
+
+describe('createSkillRegistry', () => {
+  it('publishes + lists', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo') })
+    const hits = await registry.list()
+    expect(hits).toHaveLength(1)
+    expect(hits[0]!.skill.name).toBe('foo')
+    expect(hits[0]!.publishedAt).toBeDefined()
+  })
+
+  it('rejects duplicate (name, version)', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo') })
+    await expect(
+      registry.publish({ version: '1.0.0', skill: skill('foo') }),
+    ).rejects.toThrow(/already published/)
+  })
+
+  it('install returns latest matching version', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo') })
+    await registry.publish({ version: '1.2.0', skill: skill('foo') })
+    await registry.publish({ version: '2.0.0', skill: skill('foo') })
+    const resolved = await registry.install('foo', '^1.0.0')
+    expect(resolved?.version).toBe('1.2.0')
+  })
+
+  it('install returns latest when no range', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo') })
+    await registry.publish({ version: '2.0.0', skill: skill('foo') })
+    const resolved = await registry.install('foo')
+    expect(resolved?.version).toBe('2.0.0')
+  })
+
+  it('list filters by publisher + tag', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo'), publisher: 'acme', tags: ['ai'] })
+    await registry.publish({ version: '1.0.0', skill: skill('bar'), publisher: 'other', tags: ['ai'] })
+    expect((await registry.list({ publisher: 'acme' })).length).toBe(1)
+    expect((await registry.list({ tag: 'ai' })).length).toBe(2)
+  })
+
+  it('unpublish removes a version', async () => {
+    const registry = createSkillRegistry()
+    await registry.publish({ version: '1.0.0', skill: skill('foo') })
+    await registry.publish({ version: '2.0.0', skill: skill('foo') })
+    await registry.unpublish?.('foo', '1.0.0')
+    const remaining = await registry.list()
+    expect(remaining.map(p => p.version)).toEqual(['2.0.0'])
+  })
+})


### PR DESCRIPTION
## Summary

Phase 3 sprint **S24** — closes #179, #180, #181, #182, #183.

- **#179 Graph memory** — \`createInMemoryGraph\` in \`@agentskit/memory\`: typed knowledge graph (nodes + edges + BFS neighbors + cascading deletes) against a \`GraphMemory\` contract that Neo4j / Memgraph / Neptune can back.
- **#180 Personalization** — \`createInMemoryPersonalization\` + \`renderProfileContext\` in \`@agentskit/memory\`. Per-subject trait profile; \`get\`/\`set\`/\`merge\`/\`delete\`; safe system-prompt renderer.
- **#181 Document loaders** — six loaders in \`@agentskit/rag\`: \`loadUrl\`, \`loadGitHubFile\`, \`loadGitHubTree\`, \`loadNotionPage\`, \`loadConfluencePage\`, \`loadGoogleDriveFile\`, \`loadPdf\` (BYO parser). All accept a custom \`fetch\`.
- **#182 Skill marketplace** — \`createSkillRegistry\` + semver helpers (\`parseSemver\`, \`compareSemver\`, \`matchesRange\`) in \`@agentskit/skills\`. Publish, list by publisher/tag, install by range.
- **#183 Ready-made skills** — four new skills: \`codeReviewer\`, \`sqlGen\`, \`dataAnalyst\`, \`translator\`.

~65 new tests.

## Coverage

- \`@agentskit/memory\` lines ≥80% (threshold 80)
- \`@agentskit/rag\` lines ≥95% (threshold 95)
- \`@agentskit/skills\` lines above threshold

## Docs

- \`apps/docs-next/content/docs/recipes/graph-memory.mdx\`
- \`apps/docs-next/content/docs/recipes/personalization.mdx\`
- \`apps/docs-next/content/docs/recipes/doc-loaders.mdx\`
- \`apps/docs-next/content/docs/recipes/skill-marketplace.mdx\`

## Changeset

\`.changeset/phase3-s24-graph-personalization-loaders-skills.md\` — minor bumps on \`@agentskit/memory\`, \`@agentskit/rag\`, \`@agentskit/skills\`.

## Out of scope (deferred)

- Native Neo4j / Memgraph / Neptune driver adapters — same contract; follow-up sprint.
- PDF / DOCX / HTML→Markdown conversion baked in — BYO parser now.

## Test plan

- [x] memory / rag / skills test suites pass
- [x] \`pnpm -r lint\` clean
- [x] \`pnpm --filter @agentskit/docs-next lint\`