### PR TITLE
docs: expand 6 package READMEs + comparison page

### DIFF
--- a/.changeset/docs-overhaul-fullsite.md
+++ b/.changeset/docs-overhaul-fullsite.md
@@ -1,6 +1,27 @@
 ---
 '@agentskit/core': patch
+'@agentskit/adapters': patch
+'@agentskit/runtime': patch
+'@agentskit/memory': patch
+'@agentskit/rag': patch
+'@agentskit/tools': patch
+'@agentskit/react': patch
 ---
 
-docs: expand README with subpaths table + full ecosystem coverage.
+docs: expand package READMEs with subpath tables + full ecosystem
+coverage, reflecting every feature shipped through Phase 3.
+
+- `@agentskit/core`: 11 subpath exports documented.
+- `@agentskit/adapters`: 20+ providers + higher-order adapters
+  (router / ensemble / fallback).
+- `@agentskit/runtime`: durable execution + topologies + speculate
+  + background agents.
+- `@agentskit/memory`: pgvector / Pinecone / Qdrant / Chroma /
+  Upstash + encrypted / hierarchical / graph / personalization.
+- `@agentskit/rag`: rerankers (BM25 / Cohere / BGE) + hybrid +
+  document loaders.
+- `@agentskit/tools`: MCP bridge + 20 provider integrations.
+- `@agentskit/react`: cross-link to Vue / Svelte / Solid / RN /
+  Angular / Ink bindings.
+
 No code changes.

--- a/apps/docs-next/content/docs/comparison.mdx
+++ b/apps/docs-next/content/docs/comparison.mdx
@@ -1,0 +1,73 @@
+---
+title: AgentsKit vs. alternatives
+description: How AgentsKit compares to LangChain.js, Vercel AI SDK, Mastra, and LlamaIndex.js across the surface area that actually matters in production.
+---
+
+AgentsKit is one of several ways to build agents in JavaScript. This
+page is opinionated but honest — each column lists what each
+framework genuinely optimizes for, with a link you can follow to
+verify.
+
+## Positioning in one line
+
+| Framework | Positioning |
+|-----------|-------------|
+| **AgentsKit** | One toolkit — same contracts across chat UI, runtime, memory, RAG, tools, observability. Zero lock-in; swap pieces without breaking the agent. |
+| [LangChain.js](https://js.langchain.com/docs/introduction/) | Huge integration catalog. Heavy on abstractions; focused on chains + agents. |
+| [Vercel AI SDK](https://sdk.vercel.ai/) | Best-in-class streaming + React hooks. Chat-first; less coverage beyond the message loop. |
+| [Mastra](https://mastra.ai/) | TypeScript-first agent framework with workflows + memory built-in. |
+| [LlamaIndex.js](https://ts.llamaindex.ai/) | RAG-first. Strong indexing + query engines. |
+
+## Feature comparison
+
+| Capability | AgentsKit | LangChain.js | Vercel AI SDK | Mastra | LlamaIndex.js |
+|------------|:--------:|:------------:|:-------------:|:------:|:-------------:|
+| Streaming chat controller | ✅ | ✅ | ✅ | ✅ | ✅ |
+| React hook (`useChat`) | ✅ | partial | ✅ | partial | — |
+| Vue / Svelte / Solid / Angular / RN bindings | ✅ (same contract) | — | community | — | — |
+| Terminal UI | ✅ (`@agentskit/ink`) | — | — | — | — |
+| ReAct runtime | ✅ | ✅ | — | ✅ | ✅ |
+| Deterministic replay | ✅ (`@agentskit/eval/replay`) | — | — | — | — |
+| Multi-agent topologies (supervisor / swarm / blackboard / hierarchical) | ✅ | partial (LangGraph) | — | partial | — |
+| Durable execution (step log) | ✅ | via LangGraph | — | ✅ | — |
+| Human-in-the-loop primitives | ✅ (`@agentskit/core/hitl`) | partial | — | ✅ | — |
+| Built-in prompt injection detector | ✅ (`@agentskit/core/security`) | — | — | — | — |
+| Built-in signed audit log | ✅ (`@agentskit/observability`) | — | — | — | — |
+| Token-bucket rate limiting | ✅ | — | — | — | — |
+| Mandatory tool sandbox policy | ✅ (`@agentskit/sandbox`) | — | — | — | — |
+| Bidirectional MCP bridge | ✅ (`@agentskit/tools/mcp`) | client only | partial | client only | client only |
+| Vector backends | pgvector, Pinecone, Qdrant, Chroma, Upstash, Redis, file | 30+ | — | Postgres, SQLite | 30+ |
+| Document loaders (URL / GitHub / Notion / Confluence / Drive / PDF) | ✅ | ✅ (largest catalog) | — | partial | ✅ |
+| Evals in CI (JUnit + step-summary annotations) | ✅ (`@agentskit/eval/ci`) | partial | — | — | partial |
+| Core bundle size | **&lt; 10 KB gzipped** | &gt; 100 KB | ~30 KB | ~50 KB | &gt; 100 KB |
+| Zero runtime deps (core) | ✅ | — | — | — | — |
+| Edge / Deno / Bun runtime | ✅ | partial | ✅ | partial | partial |
+
+"partial" means the capability exists but requires stitching multiple
+packages or a community port — not a built-in, contract-level feature.
+
+## When to pick which
+
+- **AgentsKit** — you want one mental model across web, terminal,
+  mobile, and server; you care about bundle size, observability, and
+  production gates (HITL, rate limits, audit, sandbox).
+- **LangChain.js** — you need the widest catalog of prebuilt
+  integrations today and are happy to wrap them yourself.
+- **Vercel AI SDK** — you only need a streaming chat hook inside a
+  Next.js / React app and don't want extra surface area.
+- **Mastra** — you want a workflow-first agent framework with
+  built-in memory and agent registry.
+- **LlamaIndex.js** — your product is a retrieval engine; you want
+  sophisticated query engines out of the box.
+
+## Migration guides
+
+- [Migrate from LangChain.js](/docs/migrating)
+- [Migrate from Vercel AI SDK](/docs/migrating)
+- [Migrate from Mastra](/docs/migrating)
+
+## See also
+
+- [Mental model](/docs/concepts/mental-model)
+- [Recipes](/docs/recipes)
+- [For-agents reference](/docs/for-agents)

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -9,8 +9,10 @@ AgentsKit.js is a family of small, plug-and-play packages that cover the entire 
 
 - **[Quick start](/docs/getting-started/quickstart)** — a working chat in under 10 lines
 - **[Concepts](/docs/concepts/mental-model)** — the mental model behind every package
-- **[Recipes](/docs/recipes)** — copy-paste solutions for common scenarios
+- **[Recipes](/docs/recipes)** — 60+ copy-paste solutions for common scenarios
+- **[For agents](/docs/for-agents)** — dense LLM-friendly reference per package
 - **[Examples](/docs/examples)** — live interactive demos
+- **[Comparison](/docs/comparison)** — AgentsKit vs. LangChain / Vercel AI / Mastra / LlamaIndex
 - **[Migrating from another framework](/docs/migrating)** — Vercel AI SDK, LangChain.js, Mastra
 - **[Contribute →](/docs/contribute)** — AgentsKit.js is built in the open. Your PR helps.
 - **[Join the Discord →](https://discord.gg/zx6z2p4jVb)** — Office Hours every Friday, direct line to maintainers.

--- a/apps/docs-next/content/docs/meta.json
+++ b/apps/docs-next/content/docs/meta.json
@@ -7,6 +7,7 @@
     "concepts",
     "recipes",
     "for-agents",
+    "comparison",
     "migrating",
     "adapters",
     "agents",

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -14,7 +14,7 @@ Connect to any LLM provider — and swap between them — without touching your 
 ## Why adapters
 
 - **Vendor independence** — switch from OpenAI to Anthropic to a local Ollama model by changing one line; your hooks, runtime, and tools stay untouched
-- **10+ providers included** — Anthropic, OpenAI, Gemini, Ollama, DeepSeek, Grok, Kimi, LangChain, Vercel AI SDK, and any raw `ReadableStream`
+- **20+ providers included** — Anthropic, OpenAI, Gemini, Ollama, DeepSeek, Grok, Kimi, Mistral, Cohere, Together, Groq, Fireworks, OpenRouter, Hugging Face, LM Studio, vLLM, llama.cpp, LangChain, Vercel AI SDK, and any raw `ReadableStream`
 - **Embedder functions built in** — the same adapter pattern covers text embeddings, so you can reuse provider config for both chat and RAG
 - **One-line local AI** — `ollama({ model: 'llama3.1' })` for fully offline agents with no API key required
 
@@ -57,10 +57,28 @@ const rag = createRAG({
 
 ## Features
 
-- Providers: Anthropic, OpenAI, Gemini, Ollama, DeepSeek, Grok, Kimi, LangChain, LangGraph, Vercel AI SDK, generic `ReadableStream`
-- Embedders: `openaiEmbedder`, `geminiEmbedder`, `ollamaEmbedder`
+- Providers: Anthropic, OpenAI, Gemini, Ollama, DeepSeek, Grok, Kimi, Mistral, Cohere, Together, Groq, Fireworks, OpenRouter, Hugging Face, LM Studio, vLLM, llama.cpp, LangChain, LangGraph, Vercel AI SDK, generic `ReadableStream`
+- Embedders: `openaiEmbedder`, `geminiEmbedder`, `ollamaEmbedder`, `deepseekEmbedder`, `grokEmbedder`, `kimiEmbedder`, `createOpenAICompatibleEmbedder`
 - All adapters satisfy `Adapter` contract v1 (ADR 0001) — substitutable anywhere in the ecosystem
 - Custom adapter authoring via `createAdapter()`
+- Higher-order adapters: `createRouter` (cost/latency/classifier), `createEnsembleAdapter` (fan-out + merge), `createFallbackAdapter` (ordered try-next)
+
+## Higher-order adapters
+
+```ts
+import { createRouter, anthropic, openai } from '@agentskit/adapters'
+
+// Auto-pick cheapest capable candidate per request.
+const router = createRouter({
+  candidates: [
+    { id: 'haiku', adapter: anthropic({ model: 'claude-haiku-4-5' }), cost: 0.25 },
+    { id: 'sonnet', adapter: anthropic({ model: 'claude-sonnet-4-6' }), cost: 3 },
+    { id: 'gpt-mini', adapter: openai({ model: 'gpt-4o-mini' }), cost: 0.15 },
+  ],
+})
+```
+
+See [Adapter router](https://www.agentskit.io/docs/recipes/adapter-router), [Ensemble](https://www.agentskit.io/docs/recipes/adapter-ensemble), and [Fallback chain](https://www.agentskit.io/docs/recipes/fallback-chain).
 
 ## Ecosystem
 

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -49,10 +49,14 @@ Use a **vector** backend with [`@agentskit/rag`](https://www.npmjs.com/package/@
 
 ## Features
 
-- Chat memory: `inMemoryChatMemory`, `sqliteChatMemory`, `redisChatMemory`, `fileChatMemory`
-- Vector memory: `fileVectorMemory` (pure JS), `redisVectorMemory`
-- `VectorMemory` interface — 3 methods, bring any custom store
-- Memory contract v1 (ADR 0003) — substitutable across `runtime`, `useChat`, and `@agentskit/ink`
+- **Chat memory:** `fileChatMemory`, `sqliteChatMemory`, `redisChatMemory` (on top of `createInMemoryMemory` / `createLocalStorageMemory` from core).
+- **Vector memory:** `fileVectorMemory`, `redisVectorMemory` + `pgvector`, `pinecone`, `qdrant`, `chroma`, `upstashVector` — same 3-method `VectorMemory` contract.
+- **Higher-order wrappers:**
+  - `createHierarchicalMemory` — MemGPT-style tiers (working / recall / archival). [Recipe](https://www.agentskit.io/docs/recipes/hierarchical-memory).
+  - `createEncryptedMemory` — AES-GCM over any `ChatMemory`; keys never leave the caller. [Recipe](https://www.agentskit.io/docs/recipes/encrypted-memory).
+  - `createInMemoryGraph` — knowledge graph (nodes + edges + BFS). [Recipe](https://www.agentskit.io/docs/recipes/graph-memory).
+  - `createInMemoryPersonalization` — per-user trait profile. [Recipe](https://www.agentskit.io/docs/recipes/personalization).
+- Memory contract v1 (ADR 0003) — substitutable across `runtime`, `useChat`, and every framework binding.
 
 ## Ecosystem
 

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -64,12 +64,14 @@ You can also call `rag.retrieve({ query, messages })` to satisfy the core `Retri
 
 ## Features
 
-- `createRAG({ embed, store })` — single entry point for ingest + retrieve
-- `rag.ingest(docs)` — chunk, embed, and store documents
-- `rag.search(query, { topK })` — semantic similarity search
-- `rag.retrieve({ query, messages })` — `Retriever` contract v1 for runtime/controller injection
-- Configurable chunking: `chunkSize`, `chunkOverlap`, custom `split`
-- Works with any `EmbedFn` and any `VectorMemory`
+- `createRAG({ embed, store })` — single entry point for ingest + retrieve.
+- `rag.ingest(docs)` — chunk, embed, and store documents.
+- `rag.search(query, { topK })` — semantic similarity search.
+- `rag.retrieve({ query, messages })` — `Retriever` contract v1 for runtime/controller injection.
+- Configurable chunking: `chunkSize`, `chunkOverlap`, custom `split`.
+- Works with any `EmbedFn` and any `VectorMemory`.
+- **Rerankers:** `createRerankedRetriever` (Cohere Rerank, BGE, BM25 default), `createHybridRetriever` (vector + BM25 blend), standalone `bm25Score`. [Recipe](https://www.agentskit.io/docs/recipes/rag-reranking).
+- **Document loaders:** `loadUrl`, `loadGitHubFile`, `loadGitHubTree`, `loadNotionPage`, `loadConfluencePage`, `loadGoogleDriveFile`, `loadPdf` (BYO parser). [Recipe](https://www.agentskit.io/docs/recipes/doc-loaders).
 
 ## Ecosystem
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -52,6 +52,19 @@ function Chat() {
 - Theme via `@agentskit/react/theme` — opt-in CSS variables, override per component
 - Works with React 18 and 19
 
+## Other framework bindings (same contract)
+
+Every binding exposes the same `ChatReturn` surface. Pick the one for your stack:
+
+| Package | API |
+|---------|-----|
+| [@agentskit/vue](https://www.npmjs.com/package/@agentskit/vue) | `useChat` composable + `ChatContainer` component |
+| [@agentskit/svelte](https://www.npmjs.com/package/@agentskit/svelte) | `createChatStore` — Svelte 5 store |
+| [@agentskit/solid](https://www.npmjs.com/package/@agentskit/solid) | `useChat` hook (Solid `createStore`) |
+| [@agentskit/react-native](https://www.npmjs.com/package/@agentskit/react-native) | `useChat` (Metro / Hermes safe) |
+| [@agentskit/angular](https://www.npmjs.com/package/@agentskit/angular) | `AgentskitChat` service (Signal + RxJS) |
+| [@agentskit/ink](https://www.npmjs.com/package/@agentskit/ink) | Terminal `useChat` + components |
+
 ## Ecosystem
 
 | Package | Role |

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -59,13 +59,22 @@ console.log(result.content)
 
 ## Features
 
-- `createRuntime` — single entry point for headless agent execution
-- ReAct loop: observe → think → act → repeat until done
-- Returns `{ content, steps, toolCalls, durationMs }` — fully inspectable
-- `AbortSignal` cancellation support
-- Tool `init` / `dispose` lifecycle hooks
-- `AgentEvent` emissions for observability integrations
-- `retriever` option for RAG context injection
+- `createRuntime` — single entry point for headless agent execution.
+- ReAct loop: observe → think → act → repeat until done.
+- Returns `{ content, steps, toolCalls, durationMs }` — fully inspectable.
+- `AbortSignal` cancellation support.
+- Tool `init` / `dispose` lifecycle hooks.
+- `AgentEvent` emissions for observability integrations.
+- `retriever` option for RAG context injection.
+
+## Advanced primitives
+
+| Primitive | Purpose | Docs |
+|-----------|---------|------|
+| `createDurableRunner` + `createFileStepLog` | Temporal-style step log; resume on crash | [Durable execution](https://www.agentskit.io/docs/recipes/durable-execution) |
+| `supervisor` / `swarm` / `hierarchical` / `blackboard` | Ready-made multi-agent topologies | [Topologies](https://www.agentskit.io/docs/recipes/multi-agent-topologies) |
+| `speculate` | Fan-out N adapters, race + abort losers | [Speculative execution](https://www.agentskit.io/docs/recipes/speculative-execution) |
+| `createCronScheduler` + `createWebhookHandler` | Background agents, cron + webhooks | [Background agents](https://www.agentskit.io/docs/recipes/background-agents) |
 
 ## Ecosystem
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -88,12 +88,20 @@ For tools without Zod, use `defineTool` from `@agentskit/core` with a JSON Schem
 
 ## Features
 
-- `webSearch()` — live web search for agents
-- `filesystem({ basePath })` — sandboxed read, write, list, delete
-- `shell({ allowed })` — shell execution with command allowlist
-- `defineZodTool` — Zod-based tool factory with runtime validation and type inference
-- All tools follow `ToolDefinition` contract (ADR 0002) — parallel tool calling supported
-- Works in `@agentskit/runtime`, `useChat`, or any custom loop
+- `webSearch()` — live web search for agents.
+- `fetchUrl()` — safe HTTP GET with JSON / text handling.
+- `filesystem({ basePath })` — sandboxed read, write, list, delete.
+- `shell({ allowed })` — shell execution with command allow-list.
+- `defineZodTool` — Zod-based tool factory with runtime validation and type inference.
+- All tools follow `ToolDefinition` contract (ADR 0002) — parallel tool calling supported.
+- Works in `@agentskit/runtime`, `useChat`, or any custom loop.
+
+## Subpaths
+
+| Subpath | Contents |
+|---------|----------|
+| `@agentskit/tools/mcp` | `createMcpClient`, `createMcpServer`, `toolsFromMcpClient`, stdio + in-memory transports. [MCP bridge recipe](https://www.agentskit.io/docs/recipes/mcp-bridge). |
+| `@agentskit/tools/integrations` | `github`, `linear`, `slack`, `notion`, `discord`, `gmail`, `googleCalendar`, `stripe`, `postgres`, `s3`, `firecrawl`, `reader`, `documentParsers`, `openaiImages`, `elevenlabs`, `whisper`, `deepgram`, `maps`, `weather`, `coingecko`, `browserAgent`. [Integrations recipe](https://www.agentskit.io/docs/recipes/integrations) + [More integrations](https://www.agentskit.io/docs/recipes/more-integrations). |
 
 ## Ecosystem
 


### PR DESCRIPTION
## Summary

Second pass of the documentation overhaul. First pass (#402) shipped the \`/docs/for-agents\` LLM-friendly reference + mobile install CTA fix + \`@agentskit/core\` README. This PR expands the remaining READMEs and adds a comparison page.

### READMEs expanded

| Package | What's new |
|---------|------------|
| \`@agentskit/adapters\` | "10+ providers" → "20+", full list (Mistral, Cohere, Together, Groq, Fireworks, OpenRouter, Hugging Face, LM Studio, vLLM, llama.cpp, …); higher-order adapters section (router / ensemble / fallback) with recipe links |
| \`@agentskit/runtime\` | Advanced primitives table — durable execution, topologies, speculate, background agents |
| \`@agentskit/memory\` | Documents pgvector / Pinecone / Qdrant / Chroma / Upstash + hierarchical / encrypted / graph / personalization wrappers |
| \`@agentskit/rag\` | Rerankers (BM25 default, Cohere Rerank, BGE), hybrid vector+BM25, six document loaders |
| \`@agentskit/tools\` | \`/mcp\` + \`/integrations\` subpath catalog (GitHub, Linear, Slack, Notion, Stripe, Postgres, S3, and 14 more) |
| \`@agentskit/react\` | New "Other framework bindings" table cross-linking Vue / Svelte / Solid / RN / Angular / Ink |

### New docs page

- \`/docs/comparison\` — AgentsKit vs LangChain.js / Vercel AI SDK / Mastra / LlamaIndex.js. Honest feature matrix + positioning + when-to-pick-which guidance. Linked from homepage nav.

### Homepage

- Nav now includes \`For agents\`, \`Comparison\`, and "60+ recipes" callout.

## Changeset

\`.changeset/docs-overhaul-fullsite.md\` — patch bumps across \`@agentskit/core\`, \`adapters\`, \`runtime\`, \`memory\`, \`rag\`, \`tools\`, \`react\` (READMEs ship with the npm package).

## Test plan

- [x] \`pnpm --filter @agentskit/docs-next lint\`.
- [x] \`pnpm --filter @agentskit/docs-next build\` — 131 static pages, no errors.
- [x] Every recipe link in the updated READMEs resolves to a live docs route.

## Follow-ups (not in this PR)

- Remaining READMEs (eval, observability, sandbox, skills, cli, ink, templates) — next pass.
- Per-concept cross-reference footer sweep.
- More landing-page storytelling polish.