### PR TITLE
docs(packages): per-package overview pages (step 2/11)

### DIFF
--- a/apps/docs-next/content/docs/packages/adapters.mdx
+++ b/apps/docs-next/content/docs/packages/adapters.mdx
@@ -1,0 +1,56 @@
+---
+title: '@agentskit/adapters'
+description: 20+ LLM chat + embedder adapters, plus router / ensemble / fallback. Swap providers with one import line.
+---
+
+## When to reach for it
+
+- You need to talk to a hosted LLM (Anthropic, OpenAI, Gemini, Mistral, Cohere, Groq, Together, Fireworks, OpenRouter, Hugging Face, …).
+- You want local-only (Ollama, LM Studio, vLLM, llama.cpp).
+- You want to compose multiple candidates (`createRouter`, `createEnsembleAdapter`, `createFallbackAdapter`).
+- You want to test agents without hitting a real LLM (`mockAdapter`, `recordingAdapter`, `replayAdapter`).
+
+## Install
+
+```bash
+npm install @agentskit/adapters
+```
+
+## Hello world
+
+```ts
+import { anthropic } from '@agentskit/adapters'
+
+const adapter = anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' })
+```
+
+## Surface
+
+Hosted: `anthropic` · `openai` · `gemini` · `grok` · `deepseek` · `kimi` · `mistral` · `cohere` · `together` · `groq` · `fireworks` · `openrouter` · `huggingface` · `langchain` · `langgraph` · `vercelAI` · `generic`
+
+Local: `ollama` · `lmstudio` · `vllm` · `llamacpp`
+
+Embedders: `openaiEmbedder` · `geminiEmbedder` · `ollamaEmbedder` · `deepseekEmbedder` · `grokEmbedder` · `kimiEmbedder` · `createOpenAICompatibleEmbedder`
+
+Higher-order: `createRouter` · `createEnsembleAdapter` · `createFallbackAdapter`
+
+Testing: `mockAdapter` · `recordingAdapter` · `replayAdapter` · `inMemorySink` · `simulateStream` · `chunkText` · `fetchWithRetry`
+
+## Recipes
+
+- [More providers](/docs/recipes/more-providers)
+- [Adapter router](/docs/recipes/adapter-router)
+- [Ensemble](/docs/recipes/adapter-ensemble)
+- [Fallback chain](/docs/recipes/fallback-chain)
+- [Custom adapter](/docs/recipes/custom-adapter)
+- [Simulate stream](/docs/recipes/simulate-stream)
+
+## Related
+
+- [Concepts: Adapter](/docs/concepts/adapter)
+- [Data → Providers](/docs/data/providers)
+- [For agents: adapters](/docs/for-agents/adapters)
+
+## Source
+
+npm: [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) · repo: [packages/adapters](https://github.com/AgentsKit-io/agentskit/tree/main/packages/adapters)

--- a/apps/docs-next/content/docs/packages/angular.mdx
+++ b/apps/docs-next/content/docs/packages/angular.mdx
@@ -1,0 +1,54 @@
+---
+title: '@agentskit/angular'
+description: Angular service exposing chat state as a Signal + RxJS Observable. Same contract as @agentskit/react.
+---
+
+## Install
+
+```bash
+npm install @agentskit/angular @angular/core rxjs @agentskit/adapters
+```
+
+## Hello world
+
+```ts
+import { Component, inject } from '@angular/core'
+import { AgentskitChat } from '@agentskit/angular'
+
+@Component({
+  selector: 'ak-chat',
+  standalone: true,
+  template: `
+    <div *ngFor="let m of chat.state()?.messages ?? []">{{ m.content }}</div>
+    <input [value]="chat.state()?.input ?? ''" (input)="chat.setInput($any($event.target).value)">
+    <button (click)="chat.send(chat.state()?.input ?? '')">Send</button>
+  `,
+})
+export class ChatComponent {
+  chat = inject(AgentskitChat)
+  constructor() {
+    this.chat.init({ adapter })
+  }
+}
+```
+
+## Surface
+
+- `AgentskitChat` — `@Injectable({ providedIn: 'root' })`:
+  - `init(config)` — bootstrap the controller.
+  - `state: WritableSignal<ChatState>` — template-friendly.
+  - `stream$: Observable<ChatState>` — RxJS.
+  - Actions: `send` · `stop` · `retry` · `setInput` · `clear` · `approve` · `deny`.
+
+## Siblings
+
+[React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [React Native](/docs/packages/react-native) · [Ink](/docs/packages/ink)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: angular](/docs/for-agents/angular)
+
+## Source
+
+npm: [@agentskit/angular](https://www.npmjs.com/package/@agentskit/angular) · repo: [packages/angular](https://github.com/AgentsKit-io/agentskit/tree/main/packages/angular)

--- a/apps/docs-next/content/docs/packages/cli.mdx
+++ b/apps/docs-next/content/docs/packages/cli.mdx
@@ -1,0 +1,50 @@
+---
+title: '@agentskit/cli'
+description: The agentskit CLI — init, chat, run, dev, doctor, ai, tunnel, rag, config.
+---
+
+## When to reach for it
+
+- You want to scaffold a new agent project.
+- You want to chat / run an agent from a terminal.
+- You want `agentskit ai "<description>"` to generate a typed scaffold from plain language.
+
+## Install
+
+```bash
+npx @agentskit/cli <command>
+# or globally:
+npm install -g @agentskit/cli
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `agentskit init` | Scaffold a new project (react / ink / runtime / multi-agent). |
+| `agentskit chat` | Interactive chat in the terminal (Ink). |
+| `agentskit run "<task>"` | Run an agent once. |
+| `agentskit dev` | Dev server with hot-reload. |
+| `agentskit doctor` | Diagnose env (providers, keys, tooling). |
+| `agentskit ai "<description>"` | NL → typed `AgentSchema` + scaffolded project. |
+| `agentskit tunnel` | ngrok-style tunnel for webhooks. |
+| `agentskit rag` | Local RAG helpers (ingest / search). |
+| `agentskit config` | Read / write local config. |
+
+## Programmatic helpers
+
+- `@agentskit/cli/ai` — `scaffoldAgent` · `writeScaffold` · `createAdapterPlanner`.
+
+## Recipes
+
+- [agentskit ai](/docs/recipes/agentskit-ai)
+
+## Related
+
+- [CLI (deep dive)](/docs/cli)
+- [Templates](/docs/packages/templates)
+- [For agents: cli](/docs/for-agents/cli)
+
+## Source
+
+npm: [@agentskit/cli](https://www.npmjs.com/package/@agentskit/cli) · repo: [packages/cli](https://github.com/AgentsKit-io/agentskit/tree/main/packages/cli)

--- a/apps/docs-next/content/docs/packages/eval.mdx
+++ b/apps/docs-next/content/docs/packages/eval.mdx
@@ -1,0 +1,60 @@
+---
+title: '@agentskit/eval'
+description: Eval suites + deterministic replay + snapshot testing + prompt diff + CI reporters.
+---
+
+## When to reach for it
+
+- You want to score agent quality with numbers, in CI.
+- You want deterministic replay (record once, replay forever).
+- You want Jest-style prompt snapshots with semantic tolerance.
+- You want a "git blame for prompts" — diff + attribution.
+
+## Install
+
+```bash
+npm install -D @agentskit/eval
+```
+
+## Hello world
+
+```ts
+import { runEval } from '@agentskit/eval'
+
+const result = await runEval({
+  agent: async (input) => (await runtime.run(input)).content,
+  suite: {
+    name: 'qa',
+    cases: [{ input: 'Capital of France?', expected: 'Paris' }],
+  },
+})
+console.log(`${result.passed}/${result.totalCases} passed`)
+```
+
+## Surface
+
+- `runEval({ agent, suite })`.
+- `/replay`: `createRecordingAdapter` · `createReplayAdapter` · cassettes · `createTimeTravelSession` · `replayAgainst` · `summarizeReplay`.
+- `/snapshot`: `matchPromptSnapshot`.
+- `/diff`: `promptDiff` · `attributePromptChange` · `formatDiff`.
+- `/ci`: `renderJUnit` · `renderMarkdown` · `renderGitHubAnnotations` · `reportToCi`.
+
+## Recipes
+
+- [Eval suite](/docs/recipes/eval-suite)
+- [Deterministic replay](/docs/recipes/deterministic-replay)
+- [Time-travel debug](/docs/recipes/time-travel-debug)
+- [Replay-different-model](/docs/recipes/replay-different-model)
+- [Prompt snapshots](/docs/recipes/prompt-snapshots)
+- [Prompt diff](/docs/recipes/prompt-diff)
+- [Evals in CI](/docs/recipes/evals-ci)
+
+## Related
+
+- [Evals (deep dive)](/docs/evals)
+- [Open Eval Format spec](/docs/specs)
+- [For agents: eval](/docs/for-agents/eval)
+
+## Source
+
+npm: [@agentskit/eval](https://www.npmjs.com/package/@agentskit/eval) · repo: [packages/eval](https://github.com/AgentsKit-io/agentskit/tree/main/packages/eval)

--- a/apps/docs-next/content/docs/packages/ink.mdx
+++ b/apps/docs-next/content/docs/packages/ink.mdx
@@ -1,0 +1,44 @@
+---
+title: '@agentskit/ink'
+description: Terminal chat UI on Ink. Same useChat contract as the React binding.
+---
+
+## When to reach for it
+
+- You need a CLI / terminal chat.
+- You want to embed an agent inside a dev tool.
+
+## Install
+
+```bash
+npm install @agentskit/ink ink @agentskit/adapters
+```
+
+## Hello world
+
+```tsx
+import { render } from 'ink'
+import { ChatContainer } from '@agentskit/ink'
+import { anthropic } from '@agentskit/adapters'
+
+render(<ChatContainer config={{ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }) }} />)
+```
+
+## Surface
+
+- `useChat(config): ChatReturn` — mirrors `@agentskit/react`.
+- `<ChatContainer>`, `<Message>`, `<InputBar>`, `<ToolCallView>`, `<ThinkingIndicator>`.
+
+## Siblings
+
+[React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [React Native](/docs/packages/react-native) · [Angular](/docs/packages/angular)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: ink](/docs/for-agents/ink)
+- [CLI](/docs/cli) (ships `agentskit chat` powered by Ink)
+
+## Source
+
+npm: [@agentskit/ink](https://www.npmjs.com/package/@agentskit/ink) · repo: [packages/ink](https://github.com/AgentsKit-io/agentskit/tree/main/packages/ink)

--- a/apps/docs-next/content/docs/packages/memory.mdx
+++ b/apps/docs-next/content/docs/packages/memory.mdx
@@ -1,0 +1,54 @@
+---
+title: '@agentskit/memory'
+description: Chat memory + vector stores + hierarchical / encrypted / graph / personalization wrappers.
+---
+
+## When to reach for it
+
+- You need persistent chat history (file / SQLite / Redis).
+- You need vector search (pgvector / Pinecone / Qdrant / Chroma / Upstash / Redis / file).
+- You need MemGPT-style tiered memory, or client-side encryption, or a knowledge graph.
+
+## Install
+
+```bash
+npm install @agentskit/memory
+```
+
+## Hello world
+
+```ts
+import { pgvector, createHierarchicalMemory } from '@agentskit/memory'
+import { Pool } from 'pg'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const vectors = pgvector({
+  runner: { query: async (sql, params) => ({ rows: (await pool.query(sql, params)).rows }) },
+})
+```
+
+## Surface
+
+- Chat: `fileChatMemory` · `sqliteChatMemory` · `redisChatMemory`.
+- Vector: `fileVectorMemory` · `redisVectorMemory` · `pgvector` · `pinecone` · `qdrant` · `chroma` · `upstashVector`.
+- HoF wrappers: `createHierarchicalMemory` · `createEncryptedMemory` · `createInMemoryGraph` · `createInMemoryPersonalization`.
+
+## Recipes
+
+- [Persistent memory](/docs/recipes/persistent-memory)
+- [Virtualized memory](/docs/recipes/virtualized-memory)
+- [Hierarchical memory](/docs/recipes/hierarchical-memory)
+- [Encrypted memory](/docs/recipes/encrypted-memory)
+- [Vector adapters](/docs/recipes/vector-adapters)
+- [Graph memory](/docs/recipes/graph-memory)
+- [Personalization](/docs/recipes/personalization)
+
+## Related
+
+- [Concepts: Memory](/docs/concepts/memory)
+- [Data → Memory](/docs/data/memory)
+- [For agents: memory](/docs/for-agents/memory)
+
+## Source
+
+npm: [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) · repo: [packages/memory](https://github.com/AgentsKit-io/agentskit/tree/main/packages/memory)

--- a/apps/docs-next/content/docs/packages/meta.json
+++ b/apps/docs-next/content/docs/packages/meta.json
@@ -1,8 +1,26 @@
 {
   "title": "Packages",
+  "description": "One page per package — what it does, when to reach for it, deep-dive links.",
   "pages": [
     "overview",
     "core",
+    "adapters",
+    "runtime",
+    "react",
+    "vue",
+    "svelte",
+    "solid",
+    "react-native",
+    "angular",
+    "ink",
+    "tools",
+    "memory",
+    "rag",
+    "skills",
+    "observability",
+    "eval",
+    "sandbox",
+    "cli",
     "templates"
   ]
 }

--- a/apps/docs-next/content/docs/packages/observability.mdx
+++ b/apps/docs-next/content/docs/packages/observability.mdx
@@ -1,0 +1,55 @@
+---
+title: '@agentskit/observability'
+description: Trace viewer, signed audit log, cost guard, devtools, token counters.
+---
+
+## When to reach for it
+
+- You need console / LangSmith / OpenTelemetry logging.
+- You want an offline HTML trace viewer.
+- You want a hard dollar ceiling (`costGuard`).
+- You want a tamper-evident audit log (SOC 2 / HIPAA friendly).
+- You want a live devtools feed (browser extension compatible).
+
+## Install
+
+```bash
+npm install @agentskit/observability
+```
+
+## Hello world
+
+```ts
+import { consoleLogger, costGuard } from '@agentskit/observability'
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({
+  adapter,
+  observers: [consoleLogger(), costGuard({ maxUsd: 0.5 })],
+})
+```
+
+## Surface
+
+- Loggers: `consoleLogger` · `langsmith` · `opentelemetry`.
+- Tracing: `createTraceTracker` · `createFileTraceSink` · `buildTraceReport` · `renderTraceViewerHtml`.
+- Cost + tokens: `costGuard` · `priceFor` · `computeCost` · `DEFAULT_PRICES` · `approximateCounter` · `countTokens` · `countTokensDetailed` · `createProviderCounter`.
+- Audit: `createSignedAuditLog` · `createInMemoryAuditStore`.
+- Devtools: `createDevtoolsServer` · `toSseFrame`.
+
+## Recipes
+
+- [Cost-guarded chat](/docs/recipes/cost-guarded-chat)
+- [Trace viewer](/docs/recipes/trace-viewer)
+- [Devtools server](/docs/recipes/devtools-server)
+- [Audit log](/docs/recipes/audit-log)
+
+## Related
+
+- [Observability (deep dive)](/docs/observability)
+- [Security](/docs/security)
+- [For agents: observability](/docs/for-agents/observability)
+
+## Source
+
+npm: [@agentskit/observability](https://www.npmjs.com/package/@agentskit/observability) · repo: [packages/observability](https://github.com/AgentsKit-io/agentskit/tree/main/packages/observability)

--- a/apps/docs-next/content/docs/packages/overview.mdx
+++ b/apps/docs-next/content/docs/packages/overview.mdx
@@ -1,37 +1,76 @@
 ---
 title: Packages overview
-description: "Fourteen focused packages under @agentskit/*. Install what you need; UI and runtime layers share @agentskit/core (no third-party deps in core)."
+description: Every AgentsKit package at a glance — what it does, when to reach for it, where to read the deep dive.
 ---
+
 import { ContributeCallout } from '@/components/contribute/contribute-callout'
 
-
-Fourteen focused packages under `@agentskit/*`. Install what you need; UI and runtime layers share **`@agentskit/core`** (no third-party deps in core).
+Twenty-one focused packages under `@agentskit/*`. Install what you need; every UI and runtime layer composes against the zero-dep **[@agentskit/core](./core)**.
 
 :::tip API reference
-
 Full signatures: **[TypeDoc HTML](pathname:///agentskit/api-reference/)** (generated on `pnpm --filter @agentskit/docs build`; for local dev run `pnpm --filter @agentskit/docs docs:api` once).
-
 :::
 
-## Package index
+## Foundation
 
-| Package | Role | Guide |
-|---------|------|--------|
-| [`@agentskit/core`](./core) | Types, chat controller, primitives, agent loop | [Core](./core) |
-| [`@agentskit/react`](../chat-uis/react) | React hooks + headless UI | [React](../chat-uis/react) |
-| [`@agentskit/ink`](../chat-uis/ink) | Terminal UI (Ink) | [Ink](../chat-uis/ink) |
-| [`@agentskit/adapters`](../data-layer/adapters) | LLM adapters + embedders | [Adapters](../data-layer/adapters) |
-| [`@agentskit/memory`](../data-layer/memory) | Chat + vector backends | [Memory](../data-layer/memory) |
-| [`@agentskit/rag`](../data-layer/rag) | Chunk, embed, retrieve | [RAG](../data-layer/rag) |
-| [`@agentskit/runtime`](../agents/runtime) | Headless ReAct runtime | [Runtime](../agents/runtime) |
-| [`@agentskit/tools`](../agents/tools) | Search, filesystem, shell tools | [Tools](../agents/tools) |
-| [`@agentskit/skills`](../agents/skills) | Built-in skill definitions | [Skills](../agents/skills) |
-| [`@agentskit/observability`](../infrastructure/observability) | Logging + tracing observers | [Observability](../infrastructure/observability) |
-| [`@agentskit/sandbox`](../infrastructure/sandbox) | Sandboxed code execution | [Sandbox](../infrastructure/sandbox) |
-| [`@agentskit/eval`](../infrastructure/eval) | Eval suites + CI metrics | [Eval](../infrastructure/eval) |
-| [`@agentskit/cli`](../infrastructure/cli) | `agentskit` CLI | [CLI](../infrastructure/cli) |
-| [`@agentskit/templates`](./templates) | Scaffold tools, skills, adapters | [Templates](./templates) |
+| Package | One-liner |
+|---|---|
+| [@agentskit/core](./core) | Contracts + chat controller + primitives. Under 10 KB gzipped, zero deps. |
 
-Maintainers: **[documentation checklist](../contributing/package-docs)**.
+## Model providers
 
-<ContributeCallout  />
+| Package | One-liner |
+|---|---|
+| [@agentskit/adapters](./adapters) | 20+ LLM chat + embedder adapters, plus router / ensemble / fallback. |
+
+## UI bindings (same contract)
+
+| Package | One-liner |
+|---|---|
+| [@agentskit/react](./react) | `useChat` hook + headless components. |
+| [@agentskit/ink](./ink) | Terminal chat UI on Ink. |
+| [@agentskit/vue](./vue) | Vue 3 composable + `ChatContainer`. |
+| [@agentskit/svelte](./svelte) | Svelte 5 store. |
+| [@agentskit/solid](./solid) | Solid hook. |
+| [@agentskit/react-native](./react-native) | React Native / Expo hook. |
+| [@agentskit/angular](./angular) | Angular service (Signal + RxJS). |
+
+## Agent runtime
+
+| Package | One-liner |
+|---|---|
+| [@agentskit/runtime](./runtime) | Standalone agent runtime + durable + topologies + speculate + background. |
+
+## Capabilities
+
+| Package | One-liner |
+|---|---|
+| [@agentskit/tools](./tools) | Built-in tools + 20 integrations + MCP bridge. |
+| [@agentskit/memory](./memory) | Chat + vector + hierarchical + encrypted + graph memory. |
+| [@agentskit/rag](./rag) | Chunk + retrieve + rerank + hybrid + six loaders. |
+| [@agentskit/skills](./skills) | Ready-made personas + marketplace. |
+
+## Observability + evaluation
+
+| Package | One-liner |
+|---|---|
+| [@agentskit/observability](./observability) | Trace viewer, audit log, cost guard, devtools. |
+| [@agentskit/eval](./eval) | Suites + replay + snapshots + diff + CI reporter. |
+
+## Infrastructure
+
+| Package | One-liner |
+|---|---|
+| [@agentskit/sandbox](./sandbox) | Secure code execution + mandatory-sandbox policy. |
+| [@agentskit/cli](./cli) | `agentskit init / chat / run / ai / dev / doctor`. |
+| [@agentskit/templates](./templates) | Starter templates used by `agentskit init`. |
+
+## See also
+
+- [For agents](/docs/for-agents) — dense LLM-friendly reference per package.
+- [Concepts](/docs/concepts) — the six contracts every package builds on.
+- [Comparison](/docs/comparison) — AgentsKit vs. LangChain / Vercel AI / Mastra / LlamaIndex.
+
+Maintainers: **[documentation checklist](/docs/contribute/package-docs)**.
+
+<ContributeCallout />

--- a/apps/docs-next/content/docs/packages/rag.mdx
+++ b/apps/docs-next/content/docs/packages/rag.mdx
@@ -1,0 +1,55 @@
+---
+title: '@agentskit/rag'
+description: Plug-and-play RAG. Chunk, embed, retrieve, rerank, hybrid — plus six document loaders.
+---
+
+## When to reach for it
+
+- You want retrieval-augmented generation in a few lines.
+- You need rerankers (BM25 / Cohere / BGE) or hybrid vector+keyword search.
+- You want document loaders for URL / GitHub / Notion / Confluence / Google Drive / PDF.
+
+## Install
+
+```bash
+npm install @agentskit/rag
+```
+
+## Hello world
+
+```ts
+import { createRAG } from '@agentskit/rag'
+import { fileVectorMemory } from '@agentskit/memory'
+import { openaiEmbedder } from '@agentskit/adapters'
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY! }),
+  store: fileVectorMemory({ path: './kb.json' }),
+})
+await rag.ingest([{ content: 'AgentsKit is a toolkit for AI agents.', source: 'intro' }])
+const hits = await rag.search('what is agentskit')
+```
+
+## Surface
+
+- `createRAG({ embed, store, chunkSize, chunkOverlap, topK, threshold })`.
+- `chunkText` — standalone splitter.
+- `createRerankedRetriever` · `createHybridRetriever` · `bm25Score` · `bm25Rerank`.
+- Loaders: `loadUrl` · `loadGitHubFile` · `loadGitHubTree` · `loadNotionPage` · `loadConfluencePage` · `loadGoogleDriveFile` · `loadPdf`.
+
+## Recipes
+
+- [RAG chat](/docs/recipes/rag-chat)
+- [PDF Q&A](/docs/recipes/pdf-qa)
+- [RAG reranking](/docs/recipes/rag-reranking)
+- [Doc loaders](/docs/recipes/doc-loaders)
+
+## Related
+
+- [Concepts: Retriever](/docs/concepts/retriever)
+- [Data → RAG](/docs/data/rag)
+- [For agents: rag](/docs/for-agents/rag)
+
+## Source
+
+npm: [@agentskit/rag](https://www.npmjs.com/package/@agentskit/rag) · repo: [packages/rag](https://github.com/AgentsKit-io/agentskit/tree/main/packages/rag)

--- a/apps/docs-next/content/docs/packages/react-native.mdx
+++ b/apps/docs-next/content/docs/packages/react-native.mdx
@@ -1,0 +1,45 @@
+---
+title: '@agentskit/react-native'
+description: React Native / Expo hook. Metro + Hermes safe. Same contract as @agentskit/react.
+---
+
+## Install
+
+```bash
+npm install @agentskit/react-native react react-native @agentskit/adapters
+```
+
+## Hello world
+
+```tsx
+import { useChat } from '@agentskit/react-native'
+import { View, TextInput, FlatList, Pressable, Text } from 'react-native'
+
+export function ChatScreen({ adapter }) {
+  const chat = useChat({ adapter })
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList data={chat.messages} keyExtractor={m => m.id} renderItem={({ item }) => <Text>{item.content}</Text>} />
+      <TextInput value={chat.input} onChangeText={chat.setInput} />
+      <Pressable onPress={() => chat.send(chat.input)}><Text>Send</Text></Pressable>
+    </View>
+  )
+}
+```
+
+## Surface
+
+- `useChat(config): ChatReturn` — mirrors `@agentskit/react`, no DOM imports.
+
+## Siblings
+
+[React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [Angular](/docs/packages/angular) · [Ink](/docs/packages/ink)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: react-native](/docs/for-agents/react-native)
+
+## Source
+
+npm: [@agentskit/react-native](https://www.npmjs.com/package/@agentskit/react-native) · repo: [packages/react-native](https://github.com/AgentsKit-io/agentskit/tree/main/packages/react-native)

--- a/apps/docs-next/content/docs/packages/react.mdx
+++ b/apps/docs-next/content/docs/packages/react.mdx
@@ -1,0 +1,60 @@
+---
+title: '@agentskit/react'
+description: React hooks + headless chat components driving the shared ChatController.
+---
+
+## When to reach for it
+
+- You're building a web chat UI in React.
+- You want streaming + tool calls + memory + skills in one hook.
+- You want headless components with `data-ak-*` attributes so you style everything with your own CSS / Tailwind / shadcn.
+
+## Install
+
+```bash
+npm install @agentskit/react @agentskit/core @agentskit/adapters
+```
+
+## Hello world
+
+```tsx
+import { useChat } from '@agentskit/react'
+import { anthropic } from '@agentskit/adapters'
+
+export function Chat() {
+  const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }) })
+  return (
+    <form onSubmit={e => { e.preventDefault(); chat.send(chat.input) }}>
+      {chat.messages.map(m => <div key={m.id}>{m.content}</div>)}
+      <input value={chat.input} onChange={e => chat.setInput(e.target.value)} />
+    </form>
+  )
+}
+```
+
+## Surface
+
+- `useChat(config): ChatReturn`.
+- `<ChatContainer>`, `<Message>`, `<InputBar>`, `<ToolCallView>`, `<ToolConfirmation>`, `<ThinkingIndicator>`, `<CodeBlock>`, `<Markdown>`.
+- Theme: `@agentskit/react/theme`.
+
+## Siblings (same contract)
+
+[Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [React Native](/docs/packages/react-native) · [Angular](/docs/packages/angular) · [Ink](/docs/packages/ink)
+
+## Recipes
+
+- [Cost-guarded chat](/docs/recipes/cost-guarded-chat)
+- [Confirmation-gated tool](/docs/recipes/confirmation-gated-tool)
+- [Edit and regenerate](/docs/recipes/edit-and-regenerate)
+- [RAG chat](/docs/recipes/rag-chat)
+
+## Related
+
+- [Concepts: Runtime](/docs/concepts/runtime)
+- [UI + hooks](/docs/ui)
+- [For agents: react](/docs/for-agents/react)
+
+## Source
+
+npm: [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · repo: [packages/react](https://github.com/AgentsKit-io/agentskit/tree/main/packages/react)

--- a/apps/docs-next/content/docs/packages/runtime.mdx
+++ b/apps/docs-next/content/docs/packages/runtime.mdx
@@ -1,0 +1,58 @@
+---
+title: '@agentskit/runtime'
+description: Standalone agent runtime. ReAct loop, durable execution, multi-agent topologies, speculative execution, background agents.
+---
+
+## When to reach for it
+
+- You want an agent without a UI.
+- You need durable execution (resume after a crash).
+- You want ready-made multi-agent topologies.
+- You want to race adapters (`speculate`) or run on cron / webhooks.
+
+## Install
+
+```bash
+npm install @agentskit/runtime @agentskit/adapters
+```
+
+## Hello world
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { anthropic } from '@agentskit/adapters'
+
+const runtime = createRuntime({
+  adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+})
+
+const result = await runtime.run('Summarize the quarterly report.')
+console.log(result.content)
+```
+
+## Surface
+
+- `createRuntime(config)` — headless agent with tools / memory / skills / observers.
+- `createSharedContext` — typed context across tools.
+- `createDurableRunner` + `createInMemoryStepLog` / `createFileStepLog` — Temporal-style step log.
+- `supervisor` · `swarm` · `hierarchical` · `blackboard` — multi-agent topologies.
+- `speculate` — race adapters, abort losers.
+- `createCronScheduler` + `createWebhookHandler` — background agents.
+
+## Recipes
+
+- [Durable execution](/docs/recipes/durable-execution)
+- [Multi-agent topologies](/docs/recipes/multi-agent-topologies)
+- [Speculative execution](/docs/recipes/speculative-execution)
+- [Background agents](/docs/recipes/background-agents)
+- [Research team](/docs/recipes/research-team)
+
+## Related
+
+- [Concepts: Runtime](/docs/concepts/runtime)
+- [Agents (deep dive)](/docs/agents)
+- [For agents: runtime](/docs/for-agents/runtime)
+
+## Source
+
+npm: [@agentskit/runtime](https://www.npmjs.com/package/@agentskit/runtime) · repo: [packages/runtime](https://github.com/AgentsKit-io/agentskit/tree/main/packages/runtime)

--- a/apps/docs-next/content/docs/packages/sandbox.mdx
+++ b/apps/docs-next/content/docs/packages/sandbox.mdx
@@ -1,0 +1,49 @@
+---
+title: '@agentskit/sandbox'
+description: Secure code execution (E2B / WebContainer) + mandatory-sandbox policy wrapper.
+---
+
+## When to reach for it
+
+- You want the model to run code safely.
+- You want a policy layer over every tool (allow / deny / require-sandbox / validators).
+
+## Install
+
+```bash
+npm install @agentskit/sandbox
+```
+
+## Hello world
+
+```ts
+import { sandboxTool, createMandatorySandbox } from '@agentskit/sandbox'
+import { shell, filesystem, webSearch } from '@agentskit/tools'
+
+const policy = createMandatorySandbox({
+  sandbox: sandboxTool(),
+  policy: { requireSandbox: ['shell'], deny: ['filesystem'] },
+})
+const safeTools = [shell(), filesystem({ basePath }), webSearch()].map(t => policy.wrap(t))
+```
+
+## Surface
+
+- `createSandbox(config?)` — default backend probes E2B.
+- `sandboxTool()` — ready-made `code_execution` tool (js / python).
+- `createE2BBackend(config)` — BYO E2B.
+- `createMandatorySandbox({ sandbox, policy })`.
+
+## Recipes
+
+- [Mandatory sandbox](/docs/recipes/mandatory-sandbox)
+
+## Related
+
+- [Security](/docs/security)
+- [For agents: sandbox](/docs/for-agents/sandbox)
+- [Tools](/docs/packages/tools) — tools to wrap.
+
+## Source
+
+npm: [@agentskit/sandbox](https://www.npmjs.com/package/@agentskit/sandbox) · repo: [packages/sandbox](https://github.com/AgentsKit-io/agentskit/tree/main/packages/sandbox)

--- a/apps/docs-next/content/docs/packages/skills.mdx
+++ b/apps/docs-next/content/docs/packages/skills.mdx
@@ -1,0 +1,46 @@
+---
+title: '@agentskit/skills'
+description: Ready-made personas + composition + marketplace registry with semver.
+---
+
+## When to reach for it
+
+- You want a preset persona (researcher / coder / planner / critic / summarizer / code-reviewer / sql-gen / data-analyst / translator).
+- You want to publish + install skills by semver.
+
+## Install
+
+```bash
+npm install @agentskit/skills
+```
+
+## Hello world
+
+```ts
+import { researcher } from '@agentskit/skills'
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({ adapter, systemPrompt: researcher.systemPrompt })
+```
+
+## Surface
+
+- Ready-made: `researcher` · `coder` · `planner` · `critic` · `summarizer` · `codeReviewer` · `sqlGen` · `dataAnalyst` · `translator`.
+- Composition: `composeSkills` · `listSkills`.
+- Marketplace: `createSkillRegistry` · `parseSemver` · `compareSemver` · `matchesRange`.
+
+## Recipes
+
+- [Skill marketplace](/docs/recipes/skill-marketplace)
+- [Code reviewer](/docs/recipes/code-reviewer)
+- [Research team](/docs/recipes/research-team)
+
+## Related
+
+- [Concepts: Skill](/docs/concepts/skill)
+- [Skills (deep dive)](/docs/skills)
+- [For agents: skills](/docs/for-agents/skills)
+
+## Source
+
+npm: [@agentskit/skills](https://www.npmjs.com/package/@agentskit/skills) · repo: [packages/skills](https://github.com/AgentsKit-io/agentskit/tree/main/packages/skills)

--- a/apps/docs-next/content/docs/packages/solid.mdx
+++ b/apps/docs-next/content/docs/packages/solid.mdx
@@ -1,0 +1,36 @@
+---
+title: '@agentskit/solid'
+description: Solid hook. Same contract as @agentskit/react.
+---
+
+## Install
+
+```bash
+npm install @agentskit/solid solid-js @agentskit/adapters
+```
+
+## Hello world
+
+```tsx
+import { useChat } from '@agentskit/solid'
+import { anthropic } from '@agentskit/adapters'
+
+const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }) })
+```
+
+## Surface
+
+- `useChat(config): ChatReturn` — Solid hook backed by `createStore` + `onCleanup`.
+
+## Siblings
+
+[React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [React Native](/docs/packages/react-native) · [Angular](/docs/packages/angular) · [Ink](/docs/packages/ink)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: solid](/docs/for-agents/solid)
+
+## Source
+
+npm: [@agentskit/solid](https://www.npmjs.com/package/@agentskit/solid) · repo: [packages/solid](https://github.com/AgentsKit-io/agentskit/tree/main/packages/solid)

--- a/apps/docs-next/content/docs/packages/svelte.mdx
+++ b/apps/docs-next/content/docs/packages/svelte.mdx
@@ -1,0 +1,45 @@
+---
+title: '@agentskit/svelte'
+description: Svelte 5 chat store. Same contract as @agentskit/react.
+---
+
+## Install
+
+```bash
+npm install @agentskit/svelte svelte @agentskit/adapters
+```
+
+## Hello world
+
+```svelte
+<script lang="ts">
+import { createChatStore } from '@agentskit/svelte'
+import { anthropic } from '@agentskit/adapters'
+
+const chat = createChatStore({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }) })
+</script>
+
+{#each $chat.messages as m (m.id)}
+  <p>{m.content}</p>
+{/each}
+<form on:submit|preventDefault={() => chat.send($chat.input)}>
+  <input bind:value={$chat.input} />
+</form>
+```
+
+## Surface
+
+- `createChatStore(config): SvelteChatStore` — `Readable<ChatState>` + action methods + `destroy()`.
+
+## Siblings
+
+[React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Solid](/docs/packages/solid) · [React Native](/docs/packages/react-native) · [Angular](/docs/packages/angular) · [Ink](/docs/packages/ink)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: svelte](/docs/for-agents/svelte)
+
+## Source
+
+npm: [@agentskit/svelte](https://www.npmjs.com/package/@agentskit/svelte) · repo: [packages/svelte](https://github.com/AgentsKit-io/agentskit/tree/main/packages/svelte)

--- a/apps/docs-next/content/docs/packages/tools.mdx
+++ b/apps/docs-next/content/docs/packages/tools.mdx
@@ -1,0 +1,56 @@
+---
+title: '@agentskit/tools'
+description: Built-in tools + 20 third-party integrations + bidirectional MCP bridge.
+---
+
+## When to reach for it
+
+- You need ready-made tools (web search, file I/O, shell).
+- You want GitHub / Linear / Slack / Notion / Stripe / Postgres / S3 / …
+- You want to speak MCP (consume or publish).
+
+## Install
+
+```bash
+npm install @agentskit/tools
+```
+
+## Hello world
+
+```ts
+import { webSearch, fetchUrl } from '@agentskit/tools'
+import { github } from '@agentskit/tools/integrations'
+import { createRuntime } from '@agentskit/runtime'
+
+const tools = [
+  webSearch(),
+  fetchUrl(),
+  ...github({ token: process.env.GITHUB_TOKEN! }),
+]
+const runtime = createRuntime({ adapter, tools })
+```
+
+## Surface
+
+- Main: `webSearch` · `fetchUrl` · `filesystem` · `shell` · `defineZodTool`.
+- `/integrations`: `github` · `linear` · `slack` · `notion` · `discord` · `gmail` · `googleCalendar` · `stripe` · `postgres` · `s3` · `firecrawl` · `reader` · `documentParsers` · `openaiImages` · `elevenlabs` · `whisper` · `deepgram` · `maps` · `weather` · `coingecko` · `browserAgent`.
+- `/mcp`: `createMcpClient` · `createMcpServer` · `toolsFromMcpClient` · `createStdioTransport` · `createInMemoryTransportPair`.
+
+## Recipes
+
+- [Integrations](/docs/recipes/integrations)
+- [More integrations (scraping / voice / maps / browser)](/docs/recipes/more-integrations)
+- [MCP bridge](/docs/recipes/mcp-bridge)
+- [Tool composer](/docs/recipes/tool-composer)
+- [Confirmation-gated tool](/docs/recipes/confirmation-gated-tool)
+- [Mandatory sandbox](/docs/recipes/mandatory-sandbox)
+
+## Related
+
+- [Concepts: Tool](/docs/concepts/tool)
+- [Tools (deep dive)](/docs/tools)
+- [For agents: tools](/docs/for-agents/tools)
+
+## Source
+
+npm: [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) · repo: [packages/tools](https://github.com/AgentsKit-io/agentskit/tree/main/packages/tools)

--- a/apps/docs-next/content/docs/packages/vue.mdx
+++ b/apps/docs-next/content/docs/packages/vue.mdx
@@ -1,0 +1,39 @@
+---
+title: '@agentskit/vue'
+description: Vue 3 composable + ChatContainer component. Same contract as @agentskit/react.
+---
+
+## Install
+
+```bash
+npm install @agentskit/vue vue @agentskit/adapters
+```
+
+## Hello world
+
+```ts
+import { useChat } from '@agentskit/vue'
+import { anthropic } from '@agentskit/adapters'
+
+const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }) })
+// chat.messages + chat.input are reactive
+// chat.send / chat.setInput / chat.stop / chat.retry / chat.clear
+```
+
+## Surface
+
+- `useChat(config): ChatReturn` — reactive via Vue's `reactive()` + auto-cleanup on scope dispose.
+- `<ChatContainer :config="...">` — headless container using `data-ak-*` attributes.
+
+## Siblings
+
+[React](/docs/packages/react) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [React Native](/docs/packages/react-native) · [Angular](/docs/packages/angular) · [Ink](/docs/packages/ink)
+
+## Related
+
+- [UI + hooks](/docs/ui)
+- [For agents: vue](/docs/for-agents/vue)
+
+## Source
+
+npm: [@agentskit/vue](https://www.npmjs.com/package/@agentskit/vue) · repo: [packages/vue](https://github.com/AgentsKit-io/agentskit/tree/main/packages/vue)


### PR DESCRIPTION
## Summary
- 20 per-package overview pages under `/docs/packages/*`
- Each page: install / hello world / surface / related / source link
- `packages/overview.mdx` now groups all packages by role (foundation, providers, UI bindings, runtime, capabilities, observability+eval, infrastructure)
- Follow-up to #405 (step 1/11 IA scaffold)

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (167 static pages)
- [x] No broken cross-links to deep-dive sections
- [ ] Visual review on preview deploy