### PR TITLE
docs(ui): component + hook matrix across frameworks (step 3/11)

### DIFF
--- a/apps/docs-next/content/docs/ui/chat-container.mdx
+++ b/apps/docs-next/content/docs/ui/chat-container.mdx
@@ -1,0 +1,49 @@
+---
+title: ChatContainer
+description: Headless scrollable transcript container. Auto-scroll on new messages, virtualized-ready.
+---
+
+Top-level wrapper for a chat transcript. Renders `data-ak-chat-container`
+with auto-scroll anchor. No hardcoded styles — theme via
+[data attributes](./data-attributes) and [CSS variables](./theming).
+
+## Props
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` | — |
+| `autoScroll` | `boolean` | `true` |
+| `className` | `string` | — |
+
+## Per-framework
+
+| Framework | Import |
+|---|---|
+| React | `import { ChatContainer } from '@agentskit/react'` |
+| Vue | `import { ChatContainer } from '@agentskit/vue'` |
+| Svelte | `import ChatContainer from '@agentskit/svelte/ChatContainer.svelte'` |
+| Solid | `import { ChatContainer } from '@agentskit/solid'` |
+| React Native | `import { ChatContainer } from '@agentskit/react-native'` — `ScrollView`-backed |
+| Angular | `<ak-chat-container>` — from `AgentskitUiModule` |
+| Ink | `import { ChatContainer } from '@agentskit/ink'` — Ink `<Box>` |
+
+## Example
+
+```tsx
+import { ChatContainer, Message, InputBar, useChat } from '@agentskit/react'
+
+export function App() {
+  const chat = useChat({ adapter: openai(...) })
+  return (
+    <ChatContainer>
+      {chat.messages.map((m) => <Message key={m.id} message={m} />)}
+      <InputBar chat={chat} />
+    </ChatContainer>
+  )
+}
+```
+
+## Related
+
+- [Message](./message) · [InputBar](./input-bar)
+- [Theming](./theming) · [Data attributes](./data-attributes)

--- a/apps/docs-next/content/docs/ui/data-attributes.mdx
+++ b/apps/docs-next/content/docs/ui/data-attributes.mdx
@@ -1,0 +1,34 @@
+---
+title: Data attributes
+description: AgentsKit UI components are headless. Every stylable hook is a data-ak-* attribute so your CSS (or your LLM) can target them reliably.
+---
+
+Components emit zero styles. They emit **data attributes**. Style with
+your favorite CSS stack; generate UI with an LLM and the attributes
+tell it exactly where to hook.
+
+## Reference
+
+| Attribute | Where | Values |
+|---|---|---|
+| `data-ak-chat-container` | root of [ChatContainer](./chat-container) | — |
+| `data-ak-message` | root of [Message](./message) | — |
+| `data-ak-role` | on `Message` root | `user` · `assistant` · `tool` · `system` |
+| `data-ak-streaming` | on `Message` root | `true` · `false` |
+| `data-ak-part` | every message part | `text` · `tool-call` · `tool-result` · `image` · `file` |
+| `data-ak-tool-call` | root of [ToolCallView](./tool-call-view) | — |
+| `data-ak-status` | on `ToolCallView` | `pending` · `running` · `done` · `error` · `awaiting-approval` |
+| `data-ak-input-bar` | root of [InputBar](./input-bar) | — |
+| `data-ak-thinking` | root of [ThinkingIndicator](./thinking-indicator) | — |
+| `data-ak-markdown` | root of `Markdown` | — |
+| `data-ak-code-block` | root of `CodeBlock` | — |
+
+## Generative UI
+
+Because selectors are stable and framework-agnostic, LLMs can generate
+CSS / className overrides that work cross-framework. See
+[Generative UI recipe](/docs/recipes/generative-ui).
+
+## Related
+
+- [Theming](./theming) — CSS variables + preset themes

--- a/apps/docs-next/content/docs/ui/index.mdx
+++ b/apps/docs-next/content/docs/ui/index.mdx
@@ -5,28 +5,40 @@ description: Every AgentsKit UI binding exposes the same contract. Pick the fram
 
 One hook, seven bindings. Every framework package mirrors
 `@agentskit/react`'s contract — same `useChat` return shape, same
-headless component data-attributes, same action methods.
+headless components, same `data-ak-*` hooks.
 
 ## Bindings
 
 | Package | Primitive | Peer dep |
 |---|---|---|
-| `@agentskit/react` | `useChat` + `<ChatContainer>` | `react ^18\|^19` |
-| `@agentskit/ink` | `useChat` + `<ChatContainer>` (terminal) | `ink ^5` |
-| `@agentskit/vue` | `useChat` composable + `<ChatContainer>` | `vue ^3.4` |
-| `@agentskit/svelte` | `createChatStore` | `svelte ^5` |
-| `@agentskit/solid` | `useChat` | `solid-js ^1.8` |
-| `@agentskit/react-native` | `useChat` (Metro-safe) | `react` + `react-native` |
-| `@agentskit/angular` | `AgentskitChat` service (Signal + RxJS) | `@angular/core ^18\|^19\|^20` |
+| [`@agentskit/react`](/docs/packages/react) | `useChat` + `<ChatContainer>` | `react ^18\|^19` |
+| [`@agentskit/ink`](/docs/packages/ink) | `useChat` + `<ChatContainer>` (terminal) | `ink ^5` |
+| [`@agentskit/vue`](/docs/packages/vue) | `useChat` composable + `<ChatContainer>` | `vue ^3.4` |
+| [`@agentskit/svelte`](/docs/packages/svelte) | `createChatStore` | `svelte ^5` |
+| [`@agentskit/solid`](/docs/packages/solid) | `useChat` | `solid-js ^1.8` |
+| [`@agentskit/react-native`](/docs/packages/react-native) | `useChat` (Metro-safe) | `react` + `react-native` |
+| [`@agentskit/angular`](/docs/packages/angular) | `AgentskitChat` service | `@angular/core ^18\|^19\|^20` |
 
-## Deep dives
+## The hook
 
-- Legacy home: [chat-uis](/docs/chat-uis) · [components](/docs/components) · [hooks](/docs/hooks) — redirected here.
+- [useChat](./use-chat) — contract, events, per-framework shape.
 
-*Sub-pages will land in step 3 of the docs IA rollout: per-component matrices (ChatContainer, Message, InputBar, ToolCallView, ThinkingIndicator) + per-hook documentation across every framework.*
+## Components
+
+- [ChatContainer](./chat-container)
+- [Message](./message)
+- [InputBar](./input-bar)
+- [ToolCallView](./tool-call-view)
+- [ToolConfirmation](./tool-confirmation)
+- [ThinkingIndicator](./thinking-indicator)
+
+## Styling
+
+- [Data attributes](./data-attributes) — every stylable hook.
+- [Theming](./theming) — CSS variables + presets.
 
 ## Related
 
-- [Concepts: Runtime](/docs/concepts/runtime)
-- [Packages: React](/docs/packages/react) · [Vue](/docs/packages/vue) · [Svelte](/docs/packages/svelte) · [Solid](/docs/packages/solid) · [Angular](/docs/packages/angular) · [React Native](/docs/packages/react-native) · [Ink](/docs/packages/ink)
-- [Theming](/docs/ui/theming)
+- [Concepts → Runtime](/docs/concepts/runtime)
+- [For agents → React](/docs/for-agents/react) · [Ink](/docs/for-agents/ink)
+- Legacy: [chat-uis](/docs/chat-uis) · [components](/docs/components) · [hooks](/docs/hooks) — redirected here.

--- a/apps/docs-next/content/docs/ui/input-bar.mdx
+++ b/apps/docs-next/content/docs/ui/input-bar.mdx
@@ -1,0 +1,33 @@
+---
+title: InputBar
+description: Text input + submit. Disabled while streaming. Keyboard shortcuts built in.
+---
+
+Controlled input tied to a `ChatReturn`. Submit on Enter, Shift+Enter
+for newline. Disabled whenever `chat.status === 'streaming'`. Emits
+`data-ak-input-bar`.
+
+## Props
+
+| Prop | Type | Default |
+|---|---|---|
+| `chat` | `ChatReturn` | — |
+| `placeholder` | `string` | `'Type a message...'` |
+| `disabled` | `boolean` | `false` |
+| `submitOn` | `'enter' \| 'mod+enter'` | `'enter'` |
+
+## Per-framework
+
+| Framework | Import |
+|---|---|
+| React | `import { InputBar } from '@agentskit/react'` |
+| Vue | `import { InputBar } from '@agentskit/vue'` |
+| Svelte | `import InputBar from '@agentskit/svelte/InputBar.svelte'` |
+| Solid | `import { InputBar } from '@agentskit/solid'` |
+| React Native | `import { InputBar } from '@agentskit/react-native'` — `TextInput`-backed |
+| Angular | `<ak-input-bar [chat]="chat">` |
+| Ink | `import { InputBar } from '@agentskit/ink'` — Ink `<TextInput>` |
+
+## Related
+
+- [ChatContainer](./chat-container) · [useChat](./use-chat)

--- a/apps/docs-next/content/docs/ui/message.mdx
+++ b/apps/docs-next/content/docs/ui/message.mdx
@@ -1,0 +1,46 @@
+---
+title: Message
+description: Renders one message — user, assistant, tool, or system. Streaming-aware, role-aware.
+---
+
+Headless single-message renderer. Role in `data-ak-role`. Streaming
+state in `data-ak-streaming`. Content chunks (text, tool-call,
+tool-result, image, file) each emit a `data-ak-part` wrapper.
+
+## Props
+
+| Prop | Type | Default |
+|---|---|---|
+| `message` | `Message` | — |
+| `avatar` | `ReactNode` | — |
+| `actions` | `ReactNode` | — |
+| `renderPart` | `(part) => ReactNode` | built-in |
+
+## Message shape
+
+```ts
+type Message = {
+  id: string
+  role: 'user' | 'assistant' | 'tool' | 'system'
+  parts: MessagePart[]
+  createdAt: number
+  streaming?: boolean
+}
+```
+
+## Per-framework
+
+| Framework | Import |
+|---|---|
+| React | `import { Message } from '@agentskit/react'` |
+| Vue | `import { Message } from '@agentskit/vue'` |
+| Svelte | `import Message from '@agentskit/svelte/Message.svelte'` |
+| Solid | `import { Message } from '@agentskit/solid'` |
+| React Native | `import { Message } from '@agentskit/react-native'` |
+| Angular | `<ak-message [message]="msg">` |
+| Ink | `import { Message } from '@agentskit/ink'` |
+
+## Related
+
+- [ChatContainer](./chat-container) · [ToolCallView](./tool-call-view)
+- [Theming](./theming)

--- a/apps/docs-next/content/docs/ui/meta.json
+++ b/apps/docs-next/content/docs/ui/meta.json
@@ -1,5 +1,16 @@
 {
   "title": "UI + hooks",
   "description": "Framework bindings (React, Vue, Svelte, Solid, RN, Angular, Ink) share the same contract — useChat + headless components.",
-  "pages": ["index"]
+  "pages": [
+    "index",
+    "use-chat",
+    "chat-container",
+    "message",
+    "input-bar",
+    "tool-call-view",
+    "tool-confirmation",
+    "thinking-indicator",
+    "data-attributes",
+    "theming"
+  ]
 }

--- a/apps/docs-next/content/docs/ui/theming.mdx
+++ b/apps/docs-next/content/docs/ui/theming.mdx
@@ -1,0 +1,62 @@
+---
+title: Theming
+description: CSS variables + optional preset themes. One source of truth across every framework binding.
+---
+
+AgentsKit ships headless components — theming is your call. Defaults
+come from a lightweight stylesheet at
+`@agentskit/react/theme` (equivalent for Vue / Svelte / Solid / RN).
+
+## Import a preset
+
+```ts
+import '@agentskit/react/theme'
+```
+
+## CSS variables
+
+```css
+:root {
+  --ak-bg: #0b0f17;
+  --ak-surface: #111827;
+  --ak-border: #1f2937;
+  --ak-text: #e5e7eb;
+  --ak-muted: #9ca3af;
+  --ak-accent: #6366f1;
+  --ak-danger: #ef4444;
+  --ak-radius: 12px;
+  --ak-font: ui-sans-serif, system-ui, sans-serif;
+  --ak-mono: ui-monospace, SFMono-Regular, monospace;
+}
+```
+
+## Dark / light
+
+Variables flip on `[data-theme="light"]` / `[data-theme="dark"]`.
+
+## Tailwind
+
+Wire Tailwind to the CSS variables:
+
+```js
+theme: {
+  extend: {
+    colors: {
+      ak: {
+        bg: 'var(--ak-bg)',
+        accent: 'var(--ak-accent)',
+      },
+    },
+  },
+}
+```
+
+## Native + terminal
+
+- **React Native:** theme via `ThemeProvider` prop (JS object, same keys).
+- **Ink:** ANSI palette from the same keys (`ak.accent` → chalk hex).
+
+## Related
+
+- [Data attributes](./data-attributes)
+- [Legacy theming reference](/docs/theming/overview)

--- a/apps/docs-next/content/docs/ui/thinking-indicator.mdx
+++ b/apps/docs-next/content/docs/ui/thinking-indicator.mdx
@@ -1,0 +1,35 @@
+---
+title: ThinkingIndicator
+description: Visibility flag for streaming / reasoning states.
+---
+
+Renders only while `visible`. Emits `data-ak-thinking`.
+
+## Props
+
+| Prop | Type | Default |
+|---|---|---|
+| `visible` | `boolean` | — |
+| `label` | `string` | `'Thinking...'` |
+
+## Usage
+
+```tsx
+<ThinkingIndicator visible={chat.status === 'streaming'} />
+```
+
+## Per-framework
+
+| Framework | Import |
+|---|---|
+| React | `import { ThinkingIndicator } from '@agentskit/react'` |
+| Vue | `import { ThinkingIndicator } from '@agentskit/vue'` |
+| Svelte | `import ThinkingIndicator from '@agentskit/svelte/ThinkingIndicator.svelte'` |
+| Solid | `import { ThinkingIndicator } from '@agentskit/solid'` |
+| React Native | `import { ThinkingIndicator } from '@agentskit/react-native'` |
+| Angular | `<ak-thinking-indicator [visible]="loading">` |
+| Ink | `import { ThinkingIndicator } from '@agentskit/ink'` — animated dots |
+
+## Related
+
+- [useChat](./use-chat) — read `status` for visibility

--- a/apps/docs-next/content/docs/ui/tool-call-view.mdx
+++ b/apps/docs-next/content/docs/ui/tool-call-view.mdx
@@ -1,0 +1,46 @@
+---
+title: ToolCallView
+description: Render a tool invocation — name, args, result, status. Works for all tools.
+---
+
+Shows one tool call's lifecycle: `pending` → `running` → `done` |
+`error`. Emits `data-ak-tool-call` with `data-ak-status`.
+
+## Props
+
+| Prop | Type | Default |
+|---|---|---|
+| `toolCall` | `ToolCall` | — |
+| `collapsed` | `boolean` | `false` |
+| `renderArgs` | `(args) => ReactNode` | JSON view |
+| `renderResult` | `(result) => ReactNode` | JSON view |
+
+## ToolCall shape
+
+```ts
+type ToolCall = {
+  id: string
+  name: string
+  args: unknown
+  status: 'pending' | 'running' | 'done' | 'error'
+  result?: unknown
+  error?: string
+}
+```
+
+## Per-framework
+
+| Framework | Import |
+|---|---|
+| React | `import { ToolCallView } from '@agentskit/react'` |
+| Vue | `import { ToolCallView } from '@agentskit/vue'` |
+| Svelte | `import ToolCallView from '@agentskit/svelte/ToolCallView.svelte'` |
+| Solid | `import { ToolCallView } from '@agentskit/solid'` |
+| React Native | `import { ToolCallView } from '@agentskit/react-native'` |
+| Angular | `<ak-tool-call-view [toolCall]="tc">` |
+| Ink | `import { ToolCallView } from '@agentskit/ink'` |
+
+## Related
+
+- [ToolConfirmation](./tool-confirmation) — human-in-the-loop approval gate
+- [Tools package](/docs/packages/tools)

--- a/apps/docs-next/content/docs/ui/tool-confirmation.mdx
+++ b/apps/docs-next/content/docs/ui/tool-confirmation.mdx
@@ -1,0 +1,42 @@
+---
+title: ToolConfirmation
+description: Human-in-the-loop approval UI for guarded tool calls.
+---
+
+Shown when a tool's `requiresConfirmation` is set. Approve or deny
+forwards to `chat.approve` / `chat.deny`. Blocks the run until
+resolved.
+
+## Props
+
+| Prop | Type |
+|---|---|
+| `toolCall` | `ToolCall` |
+| `onApprove` | `() => void` |
+| `onDeny` | `(reason?: string) => void` |
+
+## Example
+
+```tsx
+{chat.messages
+  .flatMap((m) => m.parts)
+  .filter((p) => p.type === 'tool-call' && p.status === 'awaiting-approval')
+  .map((tc) => (
+    <ToolConfirmation
+      key={tc.id}
+      toolCall={tc}
+      onApprove={() => chat.approve(tc.id)}
+      onDeny={(reason) => chat.deny(tc.id, reason)}
+    />
+  ))}
+```
+
+## Per-framework
+
+Surface is identical to [ToolCallView](./tool-call-view). Angular:
+`<ak-tool-confirmation>`.
+
+## Related
+
+- [HITL approvals recipe](/docs/recipes/hitl-approvals)
+- [Security → mandatory sandbox](/docs/security/mandatory-sandbox)

--- a/apps/docs-next/content/docs/ui/use-chat.mdx
+++ b/apps/docs-next/content/docs/ui/use-chat.mdx
@@ -1,0 +1,66 @@
+---
+title: useChat
+description: The one hook every framework binding exposes. Same input, same return, same events.
+---
+
+`useChat` is the contract every AgentsKit UI binding mirrors. It wraps
+`createChatController` from `@agentskit/core` with the idioms of your
+host framework (React hook, Vue composable, Svelte store, Solid
+signal, Angular service, React Native hook, Ink hook).
+
+## Contract
+
+```ts
+type ChatReturn = {
+  messages: Message[]
+  status: 'idle' | 'streaming' | 'error' | 'awaiting-tool'
+  error: Error | null
+  send: (text: string, opts?: SendOptions) => Promise<void>
+  retry: () => Promise<void>
+  stop: () => void
+  clear: () => void
+  approve: (toolCallId: string, result?: unknown) => void
+  deny: (toolCallId: string, reason?: string) => void
+  edit: (messageId: string, text: string) => Promise<void>
+}
+```
+
+## Inputs
+
+```ts
+type ChatConfig = {
+  adapter: Adapter
+  tools?: Tool[]
+  skills?: Skill[]
+  memory?: Memory
+  rag?: Retriever
+  system?: string
+  onEvent?: (e: ChatEvent) => void
+  onError?: (e: Error) => void
+}
+```
+
+## Per-framework usage
+
+| Framework | Import | Shape |
+|---|---|---|
+| React | `import { useChat } from '@agentskit/react'` | `const chat = useChat(config)` |
+| Vue | `import { useChat } from '@agentskit/vue'` | `const chat = useChat(config)` — values are `ref`s |
+| Svelte | `import { createChatStore } from '@agentskit/svelte'` | `const chat = createChatStore(config)` — Svelte 5 runes |
+| Solid | `import { useChat } from '@agentskit/solid'` | `const chat = useChat(config)` — accessors |
+| React Native | `import { useChat } from '@agentskit/react-native'` | Metro-safe, no DOM |
+| Angular | `import { AgentskitChat } from '@agentskit/angular'` | `constructor(private chat: AgentskitChat)` — `Signal` + `RxJS` |
+| Ink | `import { useChat } from '@agentskit/ink'` | Terminal-safe |
+
+## Events (`onEvent`)
+
+`chat.start` · `message.append` · `message.update` · `tool.call` ·
+`tool.result` · `error` · `status.change` · `chat.end`.
+
+Full schema: [Concepts → Events](/docs/concepts/events).
+
+## Related
+
+- Components: [ChatContainer](./chat-container) · [Message](./message) · [InputBar](./input-bar) · [ToolCallView](./tool-call-view) · [ThinkingIndicator](./thinking-indicator)
+- [Data attributes](./data-attributes) · [Theming](./theming)
+- [For agents → Contract](/docs/for-agents/contract)


### PR DESCRIPTION
## Summary
- 9 new pages under `/docs/ui/*` — one per hook/component + data-attributes + theming
- Each shows per-framework import/usage across React / Vue / Svelte / Solid / RN / Angular / Ink
- Headless-by-design emphasis: `data-ak-*` reference + CSS variable theming

## Pages
- `use-chat` — hook contract + inputs + events + per-framework shapes
- `chat-container`, `message`, `input-bar`, `tool-call-view`, `tool-confirmation`, `thinking-indicator`
- `data-attributes` — every stylable hook
- `theming` — CSS variables + Tailwind + native/terminal

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (171 static routes)
- [ ] Visual review on preview deploy