### PR TITLE
docs(data): per-backend / per-provider deep dives (step 4/11)

### DIFF
--- a/apps/docs-next/content/docs/data/memory/auto-summarize.mdx
+++ b/apps/docs-next/content/docs/data/memory/auto-summarize.mdx
@@ -1,0 +1,21 @@
+---
+title: createAutoSummarizingMemory
+description: Fold oldest messages into a running summary. Token-budget-friendly.
+---
+
+```ts
+import { createAutoSummarizingMemory } from '@agentskit/memory'
+
+const memory = createAutoSummarizingMemory({
+  summarize: async (msgs) => adapter.complete({
+    messages: [{ role: 'system', content: 'Summarize tersely' }, ...msgs],
+  }),
+  triggerAt: 30,
+  keep: 10,
+})
+```
+
+## Related
+
+- [Recipe: auto-summarize](/docs/recipes/auto-summarize)
+- [virtualized](./virtualized) · [hierarchical](./hierarchical)

--- a/apps/docs-next/content/docs/data/memory/chroma.mdx
+++ b/apps/docs-next/content/docs/data/memory/chroma.mdx
@@ -1,0 +1,26 @@
+---
+title: chroma
+description: Chroma vector DB via HTTP.
+---
+
+```ts
+import { chroma } from '@agentskit/memory'
+
+const store = chroma({
+  url: process.env.CHROMA_URL ?? 'http://localhost:8000',
+  collection: 'agentskit',
+})
+```
+
+## Options
+
+| Option | Type |
+|---|---|
+| `url` | `string` |
+| `collection` | `string` |
+| `tenant` | `string?` |
+| `database` | `string?` |
+
+## Related
+
+- [pinecone](./pinecone) · [qdrant](./qdrant)

--- a/apps/docs-next/content/docs/data/memory/encrypted.mdx
+++ b/apps/docs-next/content/docs/data/memory/encrypted.mdx
@@ -1,0 +1,29 @@
+---
+title: createEncryptedMemory
+description: AES-GCM-256 envelope over any ChatMemory. Keys never touch disk in plaintext.
+---
+
+```ts
+import { createEncryptedMemory } from '@agentskit/memory'
+
+const memory = await createEncryptedMemory(innerMemory, {
+  key: process.env.AK_ENCRYPTION_KEY!,
+})
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `key` | `string \| CryptoKey` | required |
+| `aad` | `Uint8Array` | empty |
+
+## What it does
+
+Wraps `append` / `list` calls: encrypts `parts` before write, decrypts
+on read. IVs generated per-message. Auth tag verified on read.
+
+## Related
+
+- [Recipe: encrypted memory](/docs/recipes/encrypted-memory)
+- [Security → PII](/docs/security/pii-redaction)

--- a/apps/docs-next/content/docs/data/memory/file-chat.mdx
+++ b/apps/docs-next/content/docs/data/memory/file-chat.mdx
@@ -1,0 +1,29 @@
+---
+title: fileChatMemory
+description: JSON-file-backed chat memory. Zero infra. Survives restarts.
+---
+
+```ts
+import { fileChatMemory } from '@agentskit/memory'
+
+const memory = fileChatMemory({ path: '.agentskit/chat.json' })
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `path` | `string` | required |
+| `maxMessages` | `number` | unlimited |
+| `encoding` | `'utf-8'` | `'utf-8'` |
+
+## Trade-offs
+
+- Good for: CLIs, local dev, desktop apps.
+- Bad for: multi-process writes (no locking), high-throughput web.
+
+## Related
+
+- [sqliteChatMemory](./sqlite) — concurrent, indexed.
+- [redisChatMemory](./redis-chat) — distributed.
+- [Concepts → Memory](/docs/concepts/memory)

--- a/apps/docs-next/content/docs/data/memory/file-vector.mdx
+++ b/apps/docs-next/content/docs/data/memory/file-vector.mdx
@@ -1,0 +1,28 @@
+---
+title: fileVectorMemory
+description: Pure-JS file-persisted vector store. Zero infra.
+---
+
+```ts
+import { fileVectorMemory } from '@agentskit/memory'
+
+const store = fileVectorMemory({ path: '.agentskit/vectors.json', dim: 1536 })
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `path` | `string` | required |
+| `dim` | `number` | required |
+| `metric` | `'cosine' \| 'dot' \| 'euclidean'` | `cosine` |
+
+## Scale
+
+Fine up to ~10k vectors. For larger corpora use
+[pgvector](./pgvector), [pinecone](./pinecone), [qdrant](./qdrant),
+[chroma](./chroma), [upstash-vector](./upstash-vector).
+
+## Related
+
+- [RAG](/docs/data/rag) · [Recipe: vector adapters](/docs/recipes/vector-adapters)

--- a/apps/docs-next/content/docs/data/memory/graph.mdx
+++ b/apps/docs-next/content/docs/data/memory/graph.mdx
@@ -1,0 +1,24 @@
+---
+title: createInMemoryGraph
+description: Knowledge graph memory — nodes + edges, queryable.
+---
+
+```ts
+import { createInMemoryGraph } from '@agentskit/memory'
+
+const graph = createInMemoryGraph()
+graph.upsertNode({ id: 'u1', type: 'user', props: { name: 'Ada' } })
+graph.upsertEdge({ from: 'u1', to: 'p1', type: 'owns' })
+
+const related = graph.query({ from: 'u1', edgeType: 'owns' })
+```
+
+## Types
+
+- `GraphNode` — `{ id, type, props }`
+- `GraphEdge` — `{ from, to, type, props? }`
+- `GraphQuery` — traversal filters.
+
+## Related
+
+- [Recipe: graph memory](/docs/recipes/graph-memory)

--- a/apps/docs-next/content/docs/data/memory/hierarchical.mdx
+++ b/apps/docs-next/content/docs/data/memory/hierarchical.mdx
@@ -1,0 +1,30 @@
+---
+title: createHierarchicalMemory
+description: MemGPT-style tiers — working / recall / archival.
+---
+
+```ts
+import { createHierarchicalMemory } from '@agentskit/memory'
+
+const memory = createHierarchicalMemory({
+  working: inMemory,
+  recall: sqlite,
+  archival: vector,
+  workingLimit: 20,
+  recallLimit: 500,
+})
+```
+
+## Tiers
+
+| Tier | Purpose | Typical store |
+|---|---|---|
+| working | hot, in-context | in-memory |
+| recall | session history | SQLite / Redis |
+| archival | semantic long-term | vector |
+
+Overflow cascades: working → recall → archival summary.
+
+## Related
+
+- [Recipe: hierarchical memory](/docs/recipes/hierarchical-memory)

--- a/apps/docs-next/content/docs/data/memory/meta.json
+++ b/apps/docs-next/content/docs/data/memory/meta.json
@@ -1,5 +1,23 @@
 {
   "title": "Memory",
-  "description": "Chat memory + vector stores + higher-order wrappers.",
-  "pages": ["index"]
+  "description": "Chat memory backends, vector stores, and higher-order wrappers.",
+  "pages": [
+    "index",
+    "file-chat",
+    "sqlite",
+    "redis-chat",
+    "file-vector",
+    "redis-vector",
+    "pgvector",
+    "pinecone",
+    "qdrant",
+    "chroma",
+    "upstash-vector",
+    "encrypted",
+    "hierarchical",
+    "virtualized",
+    "auto-summarize",
+    "graph",
+    "personalization"
+  ]
 }

--- a/apps/docs-next/content/docs/data/memory/personalization.mdx
+++ b/apps/docs-next/content/docs/data/memory/personalization.mdx
@@ -1,0 +1,21 @@
+---
+title: createInMemoryPersonalization
+description: Per-subject profile store. Inject into system prompt.
+---
+
+```ts
+import { createInMemoryPersonalization, renderProfileContext } from '@agentskit/memory'
+
+const profiles = createInMemoryPersonalization()
+await profiles.set('user-42', { name: 'Ada', tz: 'UTC', likes: ['jazz'] })
+
+const context = renderProfileContext(await profiles.get('user-42'))
+```
+
+## API
+
+- `get(subject)` · `set(subject, profile)` · `patch(subject, partial)` · `delete(subject)`.
+
+## Related
+
+- [Recipe: personalization](/docs/recipes/personalization)

--- a/apps/docs-next/content/docs/data/memory/pgvector.mdx
+++ b/apps/docs-next/content/docs/data/memory/pgvector.mdx
@@ -1,0 +1,34 @@
+---
+title: pgvector
+description: Postgres + pgvector adapter. BYO SQL runner.
+---
+
+```ts
+import { pgvector } from '@agentskit/memory'
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL!)
+const store = pgvector({
+  run: async (query, params) => sql.unsafe(query, params as unknown[]),
+  table: 'embeddings',
+  dim: 1536,
+})
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `run` | `PgVectorRunner` | required |
+| `table` | `string` | `embeddings` |
+| `dim` | `number` | required |
+| `metric` | `'cosine' \| 'l2' \| 'ip'` | `cosine` |
+
+## Why BYO runner
+
+Keeps the adapter client-agnostic — works with `postgres.js`, `pg`,
+Drizzle, Prisma raw, Neon serverless.
+
+## Related
+
+- [Recipe: vector adapters](/docs/recipes/vector-adapters)

--- a/apps/docs-next/content/docs/data/memory/pinecone.mdx
+++ b/apps/docs-next/content/docs/data/memory/pinecone.mdx
@@ -1,0 +1,27 @@
+---
+title: pinecone
+description: Managed vector DB. Namespaces + metadata filters.
+---
+
+```ts
+import { pinecone } from '@agentskit/memory'
+
+const store = pinecone({
+  apiKey: process.env.PINECONE_API_KEY!,
+  indexHost: process.env.PINECONE_INDEX_HOST!,
+  namespace: 'prod',
+})
+```
+
+## Options
+
+| Option | Type |
+|---|---|
+| `apiKey` | `string` |
+| `indexHost` | `string` |
+| `namespace` | `string` |
+| `fetch` | `typeof fetch` |
+
+## Related
+
+- [qdrant](./qdrant) · [chroma](./chroma) · [upstash-vector](./upstash-vector)

--- a/apps/docs-next/content/docs/data/memory/qdrant.mdx
+++ b/apps/docs-next/content/docs/data/memory/qdrant.mdx
@@ -1,0 +1,27 @@
+---
+title: qdrant
+description: Self-hosted or cloud Qdrant via HTTP.
+---
+
+```ts
+import { qdrant } from '@agentskit/memory'
+
+const store = qdrant({
+  url: process.env.QDRANT_URL!,
+  apiKey: process.env.QDRANT_API_KEY,
+  collection: 'agentskit',
+})
+```
+
+## Options
+
+| Option | Type |
+|---|---|
+| `url` | `string` |
+| `apiKey` | `string?` |
+| `collection` | `string` |
+| `fetch` | `typeof fetch` |
+
+## Related
+
+- [pinecone](./pinecone) · [chroma](./chroma)

--- a/apps/docs-next/content/docs/data/memory/redis-chat.mdx
+++ b/apps/docs-next/content/docs/data/memory/redis-chat.mdx
@@ -1,0 +1,31 @@
+---
+title: redisChatMemory
+description: Redis-backed chat memory for multi-instance + serverless.
+---
+
+```ts
+import { redisChatMemory } from '@agentskit/memory'
+import { createClient } from 'redis'
+
+const client = createClient({ url: process.env.REDIS_URL })
+await client.connect()
+
+const memory = redisChatMemory({ client, keyPrefix: 'ak:chat:' })
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `client` | `RedisClientAdapter` | required |
+| `keyPrefix` | `string` | `ak:chat:` |
+| `ttlSeconds` | `number` | unset |
+
+## Storage layout
+
+Each session = one Redis list. Messages pushed as JSON strings.
+Optional TTL per key.
+
+## Related
+
+- [redisVectorMemory](./redis-vector) · [sqliteChatMemory](./sqlite)

--- a/apps/docs-next/content/docs/data/memory/redis-vector.mdx
+++ b/apps/docs-next/content/docs/data/memory/redis-vector.mdx
@@ -1,0 +1,27 @@
+---
+title: redisVectorMemory
+description: Redis Stack / Redis 8+ vector index. Metadata filtering + HNSW.
+---
+
+```ts
+import { redisVectorMemory } from '@agentskit/memory'
+import { createClient } from 'redis'
+
+const client = createClient({ url: process.env.REDIS_URL })
+await client.connect()
+
+const store = redisVectorMemory({
+  client,
+  indexName: 'ak-idx',
+  dim: 1536,
+  distance: 'COSINE',
+})
+```
+
+## Requirements
+
+Redis Stack or Redis 8+ with the Search module.
+
+## Related
+
+- [redisChatMemory](./redis-chat)

--- a/apps/docs-next/content/docs/data/memory/sqlite.mdx
+++ b/apps/docs-next/content/docs/data/memory/sqlite.mdx
@@ -1,0 +1,32 @@
+---
+title: sqliteChatMemory
+description: SQLite-backed chat memory. Indexed by session + timestamp.
+---
+
+```ts
+import { sqliteChatMemory } from '@agentskit/memory'
+
+const memory = sqliteChatMemory({ path: '.agentskit/chat.db' })
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `path` | `string` | required |
+| `table` | `string` | `messages` |
+| `pragma` | `Record<string, string>` | WAL |
+
+## Schema
+
+`messages(id TEXT PRIMARY KEY, session_id TEXT, role TEXT, parts JSON, created_at INTEGER)`
+
+## Trade-offs
+
+- Good for: embedded apps, CLI, single-host servers, Electron.
+- Uses WAL by default — safe for concurrent readers.
+
+## Related
+
+- [fileChatMemory](./file-chat) · [redisChatMemory](./redis-chat)
+- [Concepts → Memory](/docs/concepts/memory)

--- a/apps/docs-next/content/docs/data/memory/upstash-vector.mdx
+++ b/apps/docs-next/content/docs/data/memory/upstash-vector.mdx
@@ -1,0 +1,26 @@
+---
+title: upstashVector
+description: Serverless HTTP vector DB from Upstash.
+---
+
+```ts
+import { upstashVector } from '@agentskit/memory'
+
+const store = upstashVector({
+  url: process.env.UPSTASH_VECTOR_REST_URL!,
+  token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+  namespace: 'prod',
+})
+```
+
+## Options
+
+| Option | Type |
+|---|---|
+| `url` | `string` |
+| `token` | `string` |
+| `namespace` | `string?` |
+
+## Related
+
+- [pinecone](./pinecone) · [qdrant](./qdrant)

--- a/apps/docs-next/content/docs/data/memory/virtualized.mdx
+++ b/apps/docs-next/content/docs/data/memory/virtualized.mdx
@@ -1,0 +1,23 @@
+---
+title: createVirtualizedMemory
+description: Hot-window + cold retriever. Keep recent messages; retrieve old ones on demand.
+---
+
+```ts
+import { createVirtualizedMemory } from '@agentskit/memory'
+
+const memory = createVirtualizedMemory({
+  window: 20,
+  cold: vectorStore,
+  embed: openaiEmbedder({ apiKey }),
+})
+```
+
+## When to use
+
+Long-running sessions where most context is stale but some old turns
+matter. Cheaper than always-on full history.
+
+## Related
+
+- [Recipe: virtualized memory](/docs/recipes/virtualized-memory)

--- a/apps/docs-next/content/docs/data/providers/embedders.mdx
+++ b/apps/docs-next/content/docs/data/providers/embedders.mdx
@@ -1,0 +1,38 @@
+---
+title: Embedders
+description: Turn text into vectors. Used by RAG + vector memory.
+---
+
+| Embedder | Import | Model examples |
+|---|---|---|
+| OpenAI | `openaiEmbedder` | `text-embedding-3-small`, `...-large` |
+| Gemini | `geminiEmbedder` | `text-embedding-004` |
+| Ollama | `ollamaEmbedder` | `nomic-embed-text`, `mxbai-embed-large` |
+| DeepSeek | `deepseekEmbedder` | provider defaults |
+| Grok | `grokEmbedder` | provider defaults |
+| Kimi | `kimiEmbedder` | provider defaults |
+| OpenAI-compatible | `createOpenAICompatibleEmbedder` | any `/v1/embeddings` endpoint |
+
+## Contract
+
+```ts
+type Embedder = {
+  embed: (texts: string[]) => Promise<number[][]>
+  dim: number
+}
+```
+
+## Usage
+
+```ts
+import { openaiEmbedder } from '@agentskit/adapters'
+
+const embed = openaiEmbedder({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: 'text-embedding-3-small',
+})
+```
+
+## Related
+
+- [RAG](/docs/data/rag) · [Memory backends](/docs/data/memory)

--- a/apps/docs-next/content/docs/data/providers/higher-order.mdx
+++ b/apps/docs-next/content/docs/data/providers/higher-order.mdx
@@ -1,0 +1,50 @@
+---
+title: Higher-order adapters
+description: Compose adapters — route, ensemble, fallback.
+---
+
+## createRouter
+
+Pick an adapter per request by cost, latency, tags, or custom policy.
+
+```ts
+import { createRouter, openai, anthropic } from '@agentskit/adapters'
+
+const adapter = createRouter({
+  candidates: { fast: openai(...), smart: anthropic(...) },
+  route: (req) => (req.tags?.includes('code') ? 'smart' : 'fast'),
+})
+```
+
+[Recipe](/docs/recipes/adapter-router).
+
+## createEnsembleAdapter
+
+Fan out to N candidates, merge per strategy (first, majority, custom).
+
+```ts
+import { createEnsembleAdapter } from '@agentskit/adapters'
+
+const adapter = createEnsembleAdapter({
+  candidates: [openai(...), anthropic(...), gemini(...)],
+  strategy: 'first-success',
+})
+```
+
+[Recipe](/docs/recipes/adapter-ensemble).
+
+## createFallbackAdapter
+
+Try candidates in order until one succeeds.
+
+```ts
+import { createFallbackAdapter } from '@agentskit/adapters'
+
+const adapter = createFallbackAdapter([primary, secondary, tertiary])
+```
+
+[Recipe](/docs/recipes/fallback-chain).
+
+## Related
+
+- [Hosted](./hosted) · [Local](./local)

--- a/apps/docs-next/content/docs/data/providers/hosted.mdx
+++ b/apps/docs-next/content/docs/data/providers/hosted.mdx
@@ -1,0 +1,41 @@
+---
+title: Hosted chat adapters
+description: 17 managed-LLM adapters. Same contract; swap by changing one import.
+---
+
+All return `Adapter` — call `.complete()` or `.stream()`.
+
+## Adapters
+
+| Adapter | Import | Env |
+|---|---|---|
+| OpenAI | `openai` | `OPENAI_API_KEY` |
+| Anthropic | `anthropic` | `ANTHROPIC_API_KEY` |
+| Google Gemini | `gemini` | `GOOGLE_API_KEY` |
+| xAI Grok | `grok` | `XAI_API_KEY` |
+| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` |
+| Kimi (Moonshot) | `kimi` | `KIMI_API_KEY` |
+| Mistral | `mistral` | `MISTRAL_API_KEY` |
+| Cohere | `cohere` | `COHERE_API_KEY` |
+| Together | `together` | `TOGETHER_API_KEY` |
+| Groq | `groq` | `GROQ_API_KEY` |
+| Fireworks | `fireworks` | `FIREWORKS_API_KEY` |
+| OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |
+| Hugging Face | `huggingface` | `HF_TOKEN` |
+| LangChain | `langchain` | — |
+| LangGraph | `langgraph` | — |
+| Vercel AI SDK | `vercelAI` | — |
+| Generic | `generic` | BYO `ReadableStream` |
+
+## Usage
+
+```ts
+import { openai } from '@agentskit/adapters'
+
+const adapter = openai({ apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o' })
+```
+
+## Related
+
+- [Local runtimes](./local) · [Embedders](./embedders) · [Higher-order](./higher-order)
+- [Recipe: more providers](/docs/recipes/more-providers)

--- a/apps/docs-next/content/docs/data/providers/local.mdx
+++ b/apps/docs-next/content/docs/data/providers/local.mdx
@@ -1,0 +1,23 @@
+---
+title: Local runtimes
+description: Run fully offline — Ollama, LM Studio, vLLM, llama.cpp.
+---
+
+| Adapter | Import | Default URL |
+|---|---|---|
+| Ollama | `ollama` | `http://localhost:11434` |
+| LM Studio | `lmstudio` | `http://localhost:1234/v1` |
+| vLLM | `vllm` | `http://localhost:8000/v1` |
+| llama.cpp | `llamacpp` | `http://localhost:8080` |
+
+## Usage
+
+```ts
+import { ollama } from '@agentskit/adapters'
+
+const adapter = ollama({ model: 'llama3.2', url: 'http://localhost:11434' })
+```
+
+## Related
+
+- [Hosted](./hosted) · [Embedders](./embedders)

--- a/apps/docs-next/content/docs/data/providers/meta.json
+++ b/apps/docs-next/content/docs/data/providers/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "Providers",
   "description": "LLM chat + embedder adapters + higher-order router / ensemble / fallback.",
-  "pages": ["index"]
+  "pages": [
+    "index",
+    "hosted",
+    "local",
+    "embedders",
+    "higher-order"
+  ]
 }

--- a/apps/docs-next/content/docs/data/rag/chunking.mdx
+++ b/apps/docs-next/content/docs/data/rag/chunking.mdx
@@ -1,0 +1,32 @@
+---
+title: Chunking
+description: Split docs before embedding. Sensible defaults; override per doc type.
+---
+
+```ts
+import { chunkText } from '@agentskit/rag'
+
+const chunks = chunkText(longDoc, {
+  chunkSize: 800,
+  chunkOverlap: 120,
+  split: 'paragraph',
+})
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `chunkSize` | `number` | `1000` |
+| `chunkOverlap` | `number` | `100` |
+| `split` | `'sentence' \| 'paragraph' \| 'markdown' \| 'code' \| 'char'` | `paragraph` |
+
+## Rules of thumb
+
+- Prose: `paragraph`, 800/120.
+- Markdown: `markdown`, 1200/150.
+- Code: `code`, 1500/0.
+
+## Related
+
+- [RAG overview](./) · [createRAG](./create-rag)

--- a/apps/docs-next/content/docs/data/rag/create-rag.mdx
+++ b/apps/docs-next/content/docs/data/rag/create-rag.mdx
@@ -1,0 +1,36 @@
+---
+title: createRAG
+description: One-liner RAG pipeline — chunk, embed, store, retrieve, search.
+---
+
+```ts
+import { createRAG } from '@agentskit/rag'
+import { openaiEmbedder } from '@agentskit/adapters'
+import { fileVectorMemory } from '@agentskit/memory'
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: process.env.OPENAI_API_KEY! }),
+  store: fileVectorMemory({ path: '.agentskit/vec.json', dim: 1536 }),
+})
+
+await rag.ingest([{ id: 'doc-1', text: longDoc }])
+const hits = await rag.retrieve('How does token budgeting work?')
+```
+
+## API
+
+| Method | Purpose |
+|---|---|
+| `ingest(docs, opts?)` | chunk + embed + store |
+| `retrieve(query, opts?)` | vector top-k |
+| `search(query, opts?)` | alias for retrieve with filters |
+| `delete(ids)` | remove docs |
+
+## Options
+
+- `chunkSize` / `chunkOverlap` / `split` — passed to [chunking](./chunking).
+- `topK` — default retrieve count.
+
+## Related
+
+- [Rerank](./rerank) · [Hybrid](./hybrid) · [Loaders](./loaders)

--- a/apps/docs-next/content/docs/data/rag/hybrid.mdx
+++ b/apps/docs-next/content/docs/data/rag/hybrid.mdx
@@ -1,0 +1,23 @@
+---
+title: Hybrid search
+description: Vector + BM25 blend with weighted normalization.
+---
+
+```ts
+import { createHybridRetriever } from '@agentskit/rag'
+
+const retriever = createHybridRetriever({
+  vector: rag,
+  lexical: bm25Index,
+  weights: { vector: 0.7, lexical: 0.3 },
+})
+```
+
+## When to use
+
+Queries with rare keywords or exact tokens (error codes, SKUs,
+identifiers) that vector alone misses.
+
+## Related
+
+- [Rerank](./rerank) · [createRAG](./create-rag)

--- a/apps/docs-next/content/docs/data/rag/loaders.mdx
+++ b/apps/docs-next/content/docs/data/rag/loaders.mdx
@@ -1,0 +1,60 @@
+---
+title: Document loaders
+description: Fetch + normalize documents from URLs, GitHub, Notion, Confluence, Google Drive, PDFs.
+---
+
+All loaders return `LoadedDocument[]` ready for `rag.ingest`.
+
+## URL
+
+```ts
+import { loadUrl } from '@agentskit/rag'
+const docs = await loadUrl('https://example.com/post')
+```
+
+Strips boilerplate; keeps main content + title.
+
+## GitHub
+
+```ts
+import { loadGitHubFile, loadGitHubTree } from '@agentskit/rag'
+
+const single = await loadGitHubFile({ owner, repo, path: 'README.md', ref: 'main' })
+const tree = await loadGitHubTree({ owner, repo, ref: 'main', include: ['**/*.md'] })
+```
+
+Requires `GITHUB_TOKEN` for private repos.
+
+## Notion
+
+```ts
+import { loadNotionPage } from '@agentskit/rag'
+const docs = await loadNotionPage({ token: process.env.NOTION_TOKEN!, pageId })
+```
+
+## Confluence
+
+```ts
+import { loadConfluencePage } from '@agentskit/rag'
+const docs = await loadConfluencePage({ baseUrl, auth, pageId })
+```
+
+## Google Drive
+
+```ts
+import { loadGoogleDriveFile } from '@agentskit/rag'
+const docs = await loadGoogleDriveFile({ fileId, accessToken })
+```
+
+## PDF
+
+```ts
+import { loadPdf } from '@agentskit/rag'
+const docs = await loadPdf({ buffer, parse: myPdfParse })
+```
+
+BYO parser (e.g. `pdf-parse`, `unpdf`) to keep core deps zero.
+
+## Related
+
+- [createRAG](./create-rag) · [Recipe: doc loaders](/docs/recipes/doc-loaders)

--- a/apps/docs-next/content/docs/data/rag/meta.json
+++ b/apps/docs-next/content/docs/data/rag/meta.json
@@ -1,5 +1,12 @@
 {
   "title": "RAG",
   "description": "Chunk, embed, retrieve, rerank, hybrid — plus six document loaders.",
-  "pages": ["index"]
+  "pages": [
+    "index",
+    "create-rag",
+    "chunking",
+    "rerank",
+    "hybrid",
+    "loaders"
+  ]
 }

--- a/apps/docs-next/content/docs/data/rag/rerank.mdx
+++ b/apps/docs-next/content/docs/data/rag/rerank.mdx
@@ -1,0 +1,24 @@
+---
+title: Rerank
+description: Post-retrieval reranker. Cohere / BGE / built-in BM25.
+---
+
+```ts
+import { createRerankedRetriever, cohereReranker } from '@agentskit/rag'
+
+const retriever = createRerankedRetriever({
+  retriever: rag,
+  rerank: cohereReranker({ apiKey: process.env.COHERE_API_KEY! }),
+  topN: 5,
+})
+```
+
+## Rerankers
+
+- `cohereReranker({ apiKey, model? })`
+- `bgeReranker({ url, model? })` — self-hosted.
+- `bm25Reranker()` — zero-dep fallback.
+
+## Related
+
+- [Hybrid](./hybrid) · [Recipe: RAG reranking](/docs/recipes/rag-reranking)


### PR DESCRIPTION
## Summary
25 new pages under `/docs/data/*`.

**Memory (16):** file-chat, sqlite, redis-chat, file-vector, redis-vector, pgvector, pinecone, qdrant, chroma, upstash-vector, encrypted, hierarchical, virtualized, auto-summarize, graph, personalization.

**RAG (5):** createRAG, chunking, rerank, hybrid, loaders.

**Providers (4):** hosted (17 adapters), local (4 runtimes), embedders (7), higher-order (router / ensemble / fallback).

Each page: one-liner, install snippet, options/trade-offs, cross-links.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (204 static routes)
- [ ] Visual review on preview deploy