### PR TITLE
docs(agents): runtime deep dives (step 5/11)

### DIFF
--- a/apps/docs-next/content/docs/agents/background.mdx
+++ b/apps/docs-next/content/docs/agents/background.mdx
@@ -1,0 +1,43 @@
+---
+title: Background agents
+description: Trigger runs on a schedule or HTTP webhook.
+---
+
+## Cron scheduler
+
+```ts
+import { createRuntime, createCronScheduler } from '@agentskit/runtime'
+
+const runtime = createRuntime({ adapter, tools })
+const scheduler = createCronScheduler({ runtime })
+
+scheduler.add({
+  id: 'daily-digest',
+  schedule: '0 9 * * *',
+  task: 'Summarize yesterday\'s PRs',
+})
+
+scheduler.start()
+```
+
+Zero-dep cron: `parseSchedule` + `cronMatches` are exported for custom
+triggers.
+
+## Webhooks
+
+```ts
+import { createRuntime, createWebhookHandler } from '@agentskit/runtime'
+
+const handler = createWebhookHandler({
+  runtime,
+  map: (req) => ({ task: `Handle ${req.body.event}` }),
+})
+
+// Wire into Next.js / Express / Hono / Bun / Deno
+export const POST = (req) => handler(req)
+```
+
+## Related
+
+- [Recipe: background agents](/docs/recipes/background-agents)
+- [Durable](./durable)

--- a/apps/docs-next/content/docs/agents/durable.mdx
+++ b/apps/docs-next/content/docs/agents/durable.mdx
@@ -1,0 +1,47 @@
+---
+title: Durable execution
+description: Persist every step. Resume after crash. Replay deterministically.
+---
+
+```ts
+import {
+  createRuntime,
+  createDurableRunner,
+  createFileStepLog,
+} from '@agentskit/runtime'
+
+const runtime = createRuntime({ adapter, tools })
+const durable = createDurableRunner({
+  runtime,
+  store: createFileStepLog({ path: '.agentskit/steps.jsonl' }),
+})
+
+await durable.run({ runId: 'r-42', input: 'refactor auth middleware' })
+// Crash → restart → resume from last completed step
+await durable.resume('r-42')
+```
+
+## Step log contract
+
+```ts
+type StepRecord = {
+  runId: string
+  seq: number
+  kind: 'llm' | 'tool' | 'event'
+  at: number
+  input: unknown
+  output?: unknown
+  error?: string
+}
+```
+
+## Stores
+
+- `createInMemoryStepLog()` — tests.
+- `createFileStepLog({ path })` — JSONL on disk.
+- BYO: implement `StepLogStore` (Redis, Postgres, S3, etc.).
+
+## Related
+
+- [Recipe: durable execution](/docs/recipes/durable-execution)
+- [Topologies](./topologies) · [Self-debug](./self-debug)

--- a/apps/docs-next/content/docs/agents/hitl.mdx
+++ b/apps/docs-next/content/docs/agents/hitl.mdx
@@ -1,0 +1,38 @@
+---
+title: Human-in-the-loop
+description: Gate tool calls behind approval. Surface reviews to humans before execution.
+---
+
+## Gate a tool
+
+```ts
+import { makeTool } from '@agentskit/tools'
+
+const deployTool = makeTool({
+  name: 'deploy',
+  description: 'Deploy to production',
+  schema: z.object({ service: z.string() }),
+  requiresConfirmation: true,
+  execute: async ({ service }) => deploy(service),
+})
+```
+
+Runtime pauses on invocation and emits
+`tool.awaiting-approval`. Resume with `chat.approve(toolCallId)` or
+`chat.deny(toolCallId, reason)`.
+
+## UI
+
+- [ToolConfirmation](/docs/ui/tool-confirmation) — drop-in React / Vue / etc.
+
+## Patterns
+
+- **Auto-approve low risk:** approve if cost under threshold; gate the rest.
+- **Review queue:** persist `awaiting-approval` to a DB; humans approve from dashboard.
+- **Double-sign:** require two approvers; track via shared context.
+
+## Related
+
+- [Recipe: HITL approvals](/docs/recipes/hitl-approvals)
+- [Recipe: confirmation-gated tool](/docs/recipes/confirmation-gated-tool)
+- [Security → mandatory sandbox](/docs/security/mandatory-sandbox)

--- a/apps/docs-next/content/docs/agents/index.mdx
+++ b/apps/docs-next/content/docs/agents/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Agents
+description: Everything that runs the loop — runtime, tools, skills, delegation, durable execution, topologies, background agents, HITL, self-debug.
+---
+
+The runtime is the engine. Everything else plugs into it.
+
+## Core
+
+- [Runtime](./runtime) — `createRuntime`, ReAct loop, events, cost + token accounting.
+- [Tools](./tools) — how tools are invoked, parallelism, confirmation.
+- [Skills](./skills) — prompts + behaviors bundled into reusable personas.
+- [Delegation](./delegation) — sub-agents, handoffs, shared context.
+
+## Scale
+
+- [Durable execution](./durable) — persist steps, replay, resume.
+- [Topologies](./topologies) — supervisor · swarm · hierarchical · blackboard.
+- [Background agents](./background) — cron + webhook triggers.
+- [Speculate](./speculate) — run N candidates, pick best.
+
+## Production
+
+- [Human-in-the-loop](./hitl) — approvals, gated tool calls, review queues.
+- [Self-debug](./self-debug) — agents that read their own traces and retry.
+
+## Related
+
+- [Package: runtime](/docs/packages/runtime)
+- [For agents: runtime](/docs/for-agents/runtime)
+- [Concepts: runtime](/docs/concepts/runtime)

--- a/apps/docs-next/content/docs/agents/meta.json
+++ b/apps/docs-next/content/docs/agents/meta.json
@@ -1,9 +1,16 @@
 {
   "title": "Agents",
   "pages": [
+    "index",
     "runtime",
     "tools",
     "skills",
-    "delegation"
+    "delegation",
+    "durable",
+    "topologies",
+    "background",
+    "speculate",
+    "hitl",
+    "self-debug"
   ]
 }

--- a/apps/docs-next/content/docs/agents/self-debug.mdx
+++ b/apps/docs-next/content/docs/agents/self-debug.mdx
@@ -1,0 +1,31 @@
+---
+title: Self-debug
+description: Agents that read their own traces, diagnose failures, retry with corrections.
+---
+
+## Pattern
+
+1. Run fails or produces low-confidence output.
+2. Feed the trace (steps, tool calls, errors) back to the agent.
+3. Agent proposes a fix (different tool, different arg, smaller step).
+4. Retry with the fix applied.
+
+## Sketch
+
+```ts
+import { createDurableRunner } from '@agentskit/runtime'
+
+const res = await durable.run({ runId, input })
+if (res.status === 'error') {
+  const trace = await durable.getTrace(runId)
+  const fix = await debuggerRuntime.run({
+    input: `Trace failed. Diagnose and suggest fix.\n\n${JSON.stringify(trace)}`,
+  })
+  await durable.run({ runId: `${runId}-retry`, input: fix.output })
+}
+```
+
+## Related
+
+- [Durable](./durable) · [Recipe: self-debug](/docs/recipes/self-debug)
+- [Recipe: time-travel debug](/docs/recipes/time-travel-debug)

--- a/apps/docs-next/content/docs/agents/speculate.mdx
+++ b/apps/docs-next/content/docs/agents/speculate.mdx
@@ -1,0 +1,28 @@
+---
+title: Speculate
+description: Run N candidates in parallel. Pick the best by a user-defined scorer.
+---
+
+```ts
+import { speculate } from '@agentskit/runtime'
+
+const { best, candidates } = await speculate({
+  candidates: [
+    { name: 'gpt-4o', run: () => runtime1.run(task) },
+    { name: 'claude', run: () => runtime2.run(task) },
+    { name: 'gemini', run: () => runtime3.run(task) },
+  ],
+  pick: (results) => results.reduce((a, b) => (b.score > a.score ? b : a)),
+})
+```
+
+## When to use
+
+- Cross-model reliability on hard prompts.
+- Latency reduction (fire all, take first success).
+- Cost/quality trade-offs evaluated per run.
+
+## Related
+
+- [Recipe: speculative execution](/docs/recipes/speculative-execution)
+- [createFallbackAdapter](/docs/data/providers/higher-order)

--- a/apps/docs-next/content/docs/agents/topologies.mdx
+++ b/apps/docs-next/content/docs/agents/topologies.mdx
@@ -1,0 +1,73 @@
+---
+title: Topologies
+description: Four proven multi-agent patterns — supervisor, swarm, hierarchical, blackboard.
+---
+
+## supervisor
+
+One planner routes tasks to specialists. Specialists return; planner
+decides next step.
+
+```ts
+import { supervisor } from '@agentskit/runtime'
+
+const team = supervisor({
+  planner: { runtime: plannerRuntime, name: 'planner' },
+  workers: {
+    coder: { runtime: coderRuntime },
+    reviewer: { runtime: reviewerRuntime },
+  },
+})
+await team.run('Ship a new auth endpoint')
+```
+
+## swarm
+
+Peer agents pass control directly via handoff tools. No central
+planner.
+
+```ts
+import { swarm } from '@agentskit/runtime'
+
+const team = swarm({
+  agents: {
+    triage: { runtime: triageRuntime, handoffsTo: ['billing', 'tech'] },
+    billing: { runtime: billingRuntime, handoffsTo: ['tech'] },
+    tech: { runtime: techRuntime, handoffsTo: ['billing'] },
+  },
+  entry: 'triage',
+})
+```
+
+## hierarchical
+
+Tree of supervisors. Great for large problem decomposition.
+
+```ts
+import { hierarchical } from '@agentskit/runtime'
+
+const org = hierarchical({
+  root: { runtime: ceo },
+  children: [
+    { runtime: engLead, children: [{ runtime: backend }, { runtime: frontend }] },
+    { runtime: designLead },
+  ],
+})
+```
+
+## blackboard
+
+Shared scratchpad. Agents read + write to a common context; triggers
+based on state.
+
+```ts
+import { blackboard, createSharedContext } from '@agentskit/runtime'
+
+const context = createSharedContext({ todo: [], done: [] })
+const board = blackboard({ context, agents: { ... } })
+```
+
+## Related
+
+- [Recipe: multi-agent topologies](/docs/recipes/multi-agent-topologies)
+- [Delegation](./delegation) · [Durable](./durable)


### PR DESCRIPTION
## Summary
7 new pages under `/docs/agents/*`:

- `index` — new landing grouping existing + new pages
- `durable` — `createDurableRunner`, step log stores, resume semantics
- `topologies` — supervisor, swarm, hierarchical, blackboard
- `background` — cron + webhook triggers
- `speculate` — multi-candidate race + pick
- `hitl` — confirmation-gated tool calls + review queues
- `self-debug` — agents that read their traces and retry

Fills the gap between the existing runtime / tools / skills / delegation pages and the full `@agentskit/runtime` public surface.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (220 static routes)
- [ ] Visual review on preview deploy