### PR TITLE
docs: capability deep dives (step 6/11)

### DIFF
--- a/apps/docs-next/content/docs/cli/ai.mdx
+++ b/apps/docs-next/content/docs/cli/ai.mdx
@@ -1,0 +1,26 @@
+---
+title: agentskit ai
+description: Natural language → typed AgentSchema + scaffold.
+---
+
+```bash
+agentskit ai "I want a Discord bot that answers questions from a Notion workspace"
+```
+
+Produces:
+1. `AgentSchema` JSON (typed, validated).
+2. Scaffold files (`tools.ts`, `runtime.ts`, optional UI).
+3. `.env.example` with required keys.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--out <dir>` | scaffold target |
+| `--schema-only` | emit only the AgentSchema JSON |
+| `--provider` / `--model` | LLM used for the authoring step |
+
+## Related
+
+- [Recipe: agentskit ai](/docs/recipes/agentskit-ai)
+- [Specs → AgentSchema](/docs/specs/agent-schema)

--- a/apps/docs-next/content/docs/cli/chat.mdx
+++ b/apps/docs-next/content/docs/cli/chat.mdx
@@ -1,0 +1,25 @@
+---
+title: agentskit chat
+description: Interactive terminal chat. Ink-based. No setup required.
+---
+
+```bash
+agentskit chat --provider openai --model gpt-4o
+```
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--provider` | `openai` · `anthropic` · `ollama` · ... |
+| `--model` | provider-specific model id |
+| `--api-key` | override env |
+| `--base-url` | OpenAI-compatible endpoints |
+| `--system` | system prompt string or `@path` |
+| `--memory <path>` | file-backed chat memory |
+| `--tools <glob>` | load tools from module path |
+
+## Related
+
+- [Package: ink](/docs/packages/ink)
+- [CLI → run](./run)

--- a/apps/docs-next/content/docs/cli/dev.mdx
+++ b/apps/docs-next/content/docs/cli/dev.mdx
@@ -1,0 +1,25 @@
+---
+title: agentskit dev
+description: Local dev server with hot-reload. Devtools + trace feed attached.
+---
+
+```bash
+agentskit dev
+```
+
+Starts:
+- Agent runtime with hot reload on tool / skill changes.
+- Local devtools UI at `http://localhost:4301`.
+- SSE trace feed for any external dashboard.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--port` | devtools port (default 4301) |
+| `--entry <path>` | runtime entry module |
+| `--watch <glob>` | extra reload paths |
+
+## Related
+
+- [Observability → Devtools](/docs/observability/devtools)

--- a/apps/docs-next/content/docs/cli/doctor.mdx
+++ b/apps/docs-next/content/docs/cli/doctor.mdx
@@ -1,0 +1,27 @@
+---
+title: agentskit doctor
+description: Diagnose your environment. Providers, keys, tooling, versions.
+---
+
+```bash
+agentskit doctor
+```
+
+Checks:
+- Node / Bun version
+- Provider API keys (reachable, valid)
+- Local runtimes (Ollama / LM Studio / vLLM)
+- MCP servers on PATH
+- Tunnel binaries
+- Disk permissions for default memory paths
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--json` | machine-readable report |
+| `--fix` | attempt automated fixes (install missing deps, etc.) |
+
+## Related
+
+- [CLI → init](./init)

--- a/apps/docs-next/content/docs/cli/init.mdx
+++ b/apps/docs-next/content/docs/cli/init.mdx
@@ -1,0 +1,33 @@
+---
+title: agentskit init
+description: Scaffold a new project — react, ink, runtime, or multi-agent template.
+---
+
+```bash
+pnpm dlx agentskit init
+# or
+npm create agentskit@latest
+```
+
+Interactive. Picks template + provider + memory backend.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--template <name>` | `react` / `ink` / `runtime` / `multi-agent` |
+| `--provider <name>` | `openai` / `anthropic` / `ollama` / ... |
+| `--name <dir>` | target directory |
+| `--no-install` | skip `pnpm install` |
+
+## Templates
+
+- **react** — Vite + `@agentskit/react` + `useChat` + headless components
+- **ink** — terminal chat via `@agentskit/ink`
+- **runtime** — standalone `createRuntime` with ReAct loop
+- **multi-agent** — supervisor topology starter
+
+## Related
+
+- [Packages → templates](/docs/packages/templates)
+- [CLI → ai](./ai)

--- a/apps/docs-next/content/docs/cli/meta.json
+++ b/apps/docs-next/content/docs/cli/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "CLI",
   "description": "agentskit init / chat / run / dev / doctor / ai / tunnel / rag / config.",
-  "pages": ["index"]
+  "pages": ["index", "init", "chat", "run", "ai", "dev", "doctor"]
 }

--- a/apps/docs-next/content/docs/cli/run.mdx
+++ b/apps/docs-next/content/docs/cli/run.mdx
@@ -1,0 +1,28 @@
+---
+title: agentskit run
+description: One-shot agent run from the terminal. Pipe inputs, capture outputs.
+---
+
+```bash
+agentskit run "Summarize today's PRs" --provider openai --model gpt-4o
+```
+
+Piped stdin:
+
+```bash
+cat README.md | agentskit run "Extract TODO items"
+```
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--provider` / `--model` / `--api-key` / `--base-url` | adapter config |
+| `--verbose` | print every step + tool call |
+| `--json` | machine-readable output |
+| `--schema <path>` | output schema (Zod or JSON Schema) |
+
+## Related
+
+- [CLI → chat](./chat) · [CLI → ai](./ai)
+- [Runtime](/docs/agents/runtime)

--- a/apps/docs-next/content/docs/evals/ci.mdx
+++ b/apps/docs-next/content/docs/evals/ci.mdx
@@ -1,0 +1,39 @@
+---
+title: CI reporters
+description: JUnit, Markdown, GitHub annotations — for any CI stack.
+---
+
+```ts
+import {
+  reportToCi,
+  renderJUnit,
+  renderMarkdown,
+  renderGitHubAnnotations,
+} from '@agentskit/eval'
+
+const report = await runEval({ agent, suite })
+
+await reportToCi({
+  report,
+  output: [
+    { kind: 'junit', path: 'eval-report.xml' },
+    { kind: 'markdown', path: 'eval-report.md' },
+    { kind: 'github-annotations' }, // auto-writes to ::error / ::warning
+  ],
+})
+```
+
+## GitHub Actions
+
+```yaml
+- run: pnpm eval
+- uses: actions/upload-artifact@v4
+  with:
+    name: eval-report
+    path: eval-report.md
+```
+
+## Related
+
+- [Recipe: evals CI](/docs/recipes/evals-ci)
+- [Suites](./suites)

--- a/apps/docs-next/content/docs/evals/meta.json
+++ b/apps/docs-next/content/docs/evals/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Evals",
   "description": "Suites + replay + snapshots + diff + CI reporters.",
-  "pages": ["index"]
+  "pages": ["index", "suites", "replay", "snapshots", "ci"]
 }

--- a/apps/docs-next/content/docs/evals/replay.mdx
+++ b/apps/docs-next/content/docs/evals/replay.mdx
@@ -1,0 +1,57 @@
+---
+title: Deterministic replay
+description: Record once, replay forever. Test without hitting the network.
+---
+
+## Record
+
+```ts
+import { createRecordingAdapter } from '@agentskit/eval'
+
+const rec = createRecordingAdapter({
+  inner: openai({ apiKey }),
+  cassettePath: '.agentskit/cassettes/triage.jsonl',
+})
+```
+
+Run your suite once with `rec` — every call captured.
+
+## Replay
+
+```ts
+import { createReplayAdapter } from '@agentskit/eval'
+
+const replay = createReplayAdapter({
+  cassettePath: '.agentskit/cassettes/triage.jsonl',
+})
+```
+
+Use `replay` in CI — zero network, deterministic.
+
+## Time travel
+
+```ts
+import { createTimeTravelSession } from '@agentskit/eval'
+
+const session = createTimeTravelSession({ cassettePath })
+session.rewindTo(step)
+session.override(step, { output: 'alternate response' })
+const forked = session.fork()
+```
+
+## Replay against different model
+
+```ts
+import { replayAgainst } from '@agentskit/eval'
+
+const diff = await replayAgainst({
+  cassettePath,
+  adapter: anthropic(...),
+})
+```
+
+## Related
+
+- [Recipe: deterministic replay](/docs/recipes/deterministic-replay)
+- [Recipe: time-travel debug](/docs/recipes/time-travel-debug)
+- [Recipe: replay different model](/docs/recipes/replay-different-model)

--- a/apps/docs-next/content/docs/evals/snapshots.mdx
+++ b/apps/docs-next/content/docs/evals/snapshots.mdx
@@ -1,0 +1,32 @@
+---
+title: Prompt snapshots + diff
+description: Jest-style snapshots for prompts. Git-blame for every change.
+---
+
+## matchPromptSnapshot
+
+```ts
+import { matchPromptSnapshot } from '@agentskit/eval'
+
+await matchPromptSnapshot({
+  name: 'triage-v1',
+  actual: renderedPrompt,
+  mode: 'exact', // | 'normalized' | 'similarity'
+  path: '.agentskit/snapshots',
+  similarityThreshold: 0.95,
+})
+```
+
+## promptDiff + attributePromptChange
+
+```ts
+import { promptDiff, attributePromptChange } from '@agentskit/eval'
+
+const delta = promptDiff(before, after)
+const attribution = attributePromptChange(delta, history)
+```
+
+## Related
+
+- [Recipe: prompt snapshots](/docs/recipes/prompt-snapshots)
+- [Recipe: prompt diff](/docs/recipes/prompt-diff)

--- a/apps/docs-next/content/docs/evals/suites.mdx
+++ b/apps/docs-next/content/docs/evals/suites.mdx
@@ -1,0 +1,41 @@
+---
+title: Eval suites
+description: Run any async agent fn against an EvalSuite. Pass/fail per case.
+---
+
+```ts
+import { runEval } from '@agentskit/eval'
+
+const suite = {
+  name: 'support-triage',
+  cases: [
+    {
+      id: 'refund',
+      input: 'How do I get a refund?',
+      assert: (out) => out.includes('refund policy'),
+    },
+  ],
+}
+
+const report = await runEval({
+  agent: async (input) => runtime.run({ input }).then((r) => r.output),
+  suite,
+})
+
+console.log(report.passRate, report.failures)
+```
+
+## Assertions
+
+- boolean fn → pass/fail
+- async LLM-as-judge → `({ pass, rationale })`
+- regex → match required
+
+## Metrics
+
+Built-in: `passRate`, `latencyP50`, `latencyP95`, `tokensTotal`, `usdTotal`.
+
+## Related
+
+- [Replay](./replay) · [Snapshots](./snapshots) · [CI](./ci)
+- [Recipe: eval suite](/docs/recipes/eval-suite)

--- a/apps/docs-next/content/docs/observability/audit-log.mdx
+++ b/apps/docs-next/content/docs/observability/audit-log.mdx
@@ -1,0 +1,29 @@
+---
+title: Signed audit log
+description: Hash-chained, HMAC-signed audit log. Tamper-evident record of every step.
+---
+
+```ts
+import { createSignedAuditLog } from '@agentskit/observability'
+
+const audit = createSignedAuditLog({
+  path: '.agentskit/audit.log',
+  key: process.env.AK_AUDIT_KEY!,
+})
+
+const runtime = createRuntime({ adapter, observers: [audit.observer] })
+```
+
+## Verify
+
+```ts
+const ok = await audit.verify() // throws on tamper
+```
+
+Each record contains `{ seq, at, kind, payload, prevHash, hmac }`.
+Tampering with any entry breaks the hash chain.
+
+## Related
+
+- [Recipe: audit log](/docs/recipes/audit-log)
+- [Security → PII](/docs/security/pii-redaction)

--- a/apps/docs-next/content/docs/observability/cost-guard.mdx
+++ b/apps/docs-next/content/docs/observability/cost-guard.mdx
@@ -1,0 +1,35 @@
+---
+title: Cost + token accounting
+description: Cap runs by dollars or tokens. Stop before you're surprised.
+---
+
+## costGuard
+
+```ts
+import { costGuard } from '@agentskit/observability'
+
+const runtime = createRuntime({
+  adapter,
+  observers: [costGuard({ maxUsd: 0.50, onExceed: 'throw' })],
+})
+```
+
+`onExceed`: `'throw' | 'stop' | 'warn'`.
+
+## Token counters
+
+```ts
+import { approximateCounter, createProviderCounter } from '@agentskit/observability'
+
+// Zero-dep heuristic
+const fast = approximateCounter()
+
+// Provider-accurate (uses adapter-reported usage when available)
+const exact = createProviderCounter({ adapter })
+```
+
+## Related
+
+- [Recipe: cost guard](/docs/recipes/cost-guard)
+- [Recipe: token budget](/docs/recipes/token-budget)
+- [Security → rate limiting](/docs/security/rate-limiting)

--- a/apps/docs-next/content/docs/observability/devtools.mdx
+++ b/apps/docs-next/content/docs/observability/devtools.mdx
@@ -1,0 +1,32 @@
+---
+title: Devtools server
+description: Live SSE feed of agent events. Power any custom dashboard.
+---
+
+```ts
+import { createDevtoolsServer, toSseFrame } from '@agentskit/observability'
+
+const devtools = createDevtoolsServer()
+
+const runtime = createRuntime({ adapter, observers: [devtools.observer] })
+
+// Next.js / Hono / Bun SSE route
+export const GET = () =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        devtools.subscribe((event) =>
+          controller.enqueue(new TextEncoder().encode(toSseFrame(event))),
+        )
+      },
+    }),
+    { headers: { 'content-type': 'text/event-stream' } },
+  )
+```
+
+Connect any web UI with `EventSource('/devtools')`.
+
+## Related
+
+- [Recipe: devtools server](/docs/recipes/devtools-server)
+- [Trace viewer](./trace-viewer)

--- a/apps/docs-next/content/docs/observability/loggers.mdx
+++ b/apps/docs-next/content/docs/observability/loggers.mdx
@@ -1,0 +1,35 @@
+---
+title: Loggers + tracers
+description: Console, LangSmith, OpenTelemetry. Pick one; attach to runtime.
+---
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { consoleLogger, langsmith, opentelemetry } from '@agentskit/observability'
+
+const runtime = createRuntime({
+  adapter,
+  tools,
+  observers: [
+    consoleLogger(),
+    langsmith({ apiKey: process.env.LANGSMITH_API_KEY!, project: 'prod' }),
+    opentelemetry({ serviceName: 'agent-worker' }),
+  ],
+})
+```
+
+## Observers
+
+| Observer | Purpose | Env |
+|---|---|---|
+| `consoleLogger()` | dev | — |
+| `langsmith({ apiKey, project })` | traces UI | `LANGSMITH_API_KEY` |
+| `opentelemetry({ serviceName })` | OTel pipeline | OTLP endpoint |
+| `createTraceTracker()` | BYO span lifecycle | — |
+
+Every observer receives the same event stream — `chat.start`,
+`llm.call`, `tool.call`, `tool.result`, `error`, `chat.end`.
+
+## Related
+
+- [Trace viewer](./trace-viewer) · [Devtools](./devtools)

--- a/apps/docs-next/content/docs/observability/meta.json
+++ b/apps/docs-next/content/docs/observability/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Observability",
   "description": "Tracing, logging, audit, cost, devtools — everything you need to trust an agent in production.",
-  "pages": ["index"]
+  "pages": ["index", "loggers", "trace-viewer", "devtools", "cost-guard", "audit-log"]
 }

--- a/apps/docs-next/content/docs/observability/trace-viewer.mdx
+++ b/apps/docs-next/content/docs/observability/trace-viewer.mdx
@@ -1,0 +1,23 @@
+---
+title: Trace viewer
+description: Offline Jaeger-style HTML trace of every run. No hosting required.
+---
+
+```ts
+import { createFileTraceSink, renderTraceViewerHtml } from '@agentskit/observability'
+
+const sink = createFileTraceSink({ path: '.agentskit/traces.jsonl' })
+
+const runtime = createRuntime({ adapter, observers: [sink.observer] })
+await runtime.run(task)
+
+const html = await renderTraceViewerHtml({ source: '.agentskit/traces.jsonl' })
+await Bun.write('.agentskit/trace.html', html)
+```
+
+Open the generated file in any browser. Zero server. Zero tracking.
+
+## Related
+
+- [Recipe: trace viewer](/docs/recipes/trace-viewer)
+- [Devtools](./devtools) · [Loggers](./loggers)

--- a/apps/docs-next/content/docs/security/mandatory-sandbox.mdx
+++ b/apps/docs-next/content/docs/security/mandatory-sandbox.mdx
@@ -1,0 +1,37 @@
+---
+title: Mandatory sandbox
+description: Policy wrapper for tools — allow, deny, require-sandbox, validators.
+---
+
+```ts
+import { createMandatorySandbox } from '@agentskit/tools'
+import { shell } from '@agentskit/tools'
+
+const guarded = createMandatorySandbox(shell(), {
+  allow: ['ls', 'cat', 'grep'],
+  deny: ['rm', 'sudo', 'curl', 'wget'],
+  requireSandbox: true,
+  validators: [
+    (args) => args.cmd.length < 256 || 'command too long',
+  ],
+})
+```
+
+## Modes
+
+| Rule | Effect |
+|---|---|
+| `allow: string[]` | only listed cmds pass |
+| `deny: string[]` | listed cmds rejected |
+| `requireSandbox: true` | execute via [@agentskit/sandbox](/docs/packages/sandbox) |
+| `validators: Fn[]` | return `string` to reject with message |
+
+## Sandbox backends
+
+E2B (default) · WebContainer · Deno worker — see
+[sandbox package](/docs/packages/sandbox).
+
+## Related
+
+- [Recipe: mandatory sandbox](/docs/recipes/mandatory-sandbox)
+- [HITL](/docs/agents/hitl)

--- a/apps/docs-next/content/docs/security/meta.json
+++ b/apps/docs-next/content/docs/security/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Security",
   "description": "PII redaction, prompt injection detection, rate limits, audit, sandbox policy.",
-  "pages": ["index"]
+  "pages": ["index", "pii-redaction", "prompt-injection", "rate-limiting", "mandatory-sandbox"]
 }

--- a/apps/docs-next/content/docs/security/pii-redaction.mdx
+++ b/apps/docs-next/content/docs/security/pii-redaction.mdx
@@ -1,0 +1,39 @@
+---
+title: PII redaction
+description: Scrub emails, phones, SSNs, keys before they leave your process.
+---
+
+```ts
+import { createPIIRedactor, DEFAULT_PII_RULES } from '@agentskit/core/security'
+
+const redactor = createPIIRedactor({ rules: DEFAULT_PII_RULES })
+
+const clean = redactor.redact('Ping me at ada@example.com, SSN 123-45-6789')
+// => 'Ping me at [EMAIL], SSN [SSN]'
+```
+
+## Built-in rules
+
+`EMAIL` · `PHONE` · `SSN` · `CREDIT_CARD` · `IPV4` · `IPV6` ·
+`API_KEY_PREFIX` · `AWS_ACCESS_KEY_ID`.
+
+## Custom rules
+
+```ts
+createPIIRedactor({
+  rules: [
+    ...DEFAULT_PII_RULES,
+    { name: 'ORG_ID', pattern: /org_[a-zA-Z0-9]{16}/g, replacement: '[ORG]' },
+  ],
+})
+```
+
+## Pipeline integration
+
+Attach as observer to redact events, or pre-process user input before
+`chat.send`.
+
+## Related
+
+- [Recipe: PII redaction](/docs/recipes/pii-redaction)
+- [Encrypted memory](/docs/data/memory/encrypted)

--- a/apps/docs-next/content/docs/security/prompt-injection.mdx
+++ b/apps/docs-next/content/docs/security/prompt-injection.mdx
@@ -1,0 +1,41 @@
+---
+title: Prompt injection
+description: Detect and block jailbreak patterns in user input or tool results.
+---
+
+```ts
+import { createInjectionDetector } from '@agentskit/core/security'
+
+const detector = createInjectionDetector({
+  classifier: async (text) => {
+    // Optional LLM-based classifier
+    return adapter.complete({ ... })
+  },
+})
+
+const verdict = await detector.check(userInput)
+if (verdict.blocked) throw new Error(verdict.reason)
+```
+
+## Heuristic layer
+
+Catches common patterns zero-cost:
+- "ignore previous instructions"
+- role-swap attempts
+- system-prompt leak probes
+- fenced payloads (`<|system|>`, etc.)
+
+## Model classifier layer
+
+Pluggable. Use any adapter to score high-risk inputs.
+
+## Where to run it
+
+- User input → `chat.send` preprocess.
+- Tool results → before feeding back into the loop (tool-output can be attacker-controlled).
+- RAG retrievals → classify each chunk before context-injection.
+
+## Related
+
+- [Recipe: prompt injection](/docs/recipes/prompt-injection)
+- [Mandatory sandbox](./mandatory-sandbox)

--- a/apps/docs-next/content/docs/security/rate-limiting.mdx
+++ b/apps/docs-next/content/docs/security/rate-limiting.mdx
@@ -1,0 +1,30 @@
+---
+title: Rate limiting
+description: Token bucket per user / IP / key. Works with any adapter.
+---
+
+```ts
+import { createRateLimiter } from '@agentskit/core/security'
+
+const limiter = createRateLimiter({
+  capacity: 10,
+  refillPerSecond: 1,
+  keyBy: (req) => req.userId,
+})
+
+app.post('/chat', async (req) => {
+  const { allowed, retryAfterMs } = await limiter.take(req)
+  if (!allowed) return new Response('Too Many Requests', { status: 429, headers: { 'retry-after': `${Math.ceil(retryAfterMs / 1000)}` } })
+  // ... run agent
+})
+```
+
+## Storage
+
+- In-memory (default) — single-host.
+- BYO store via `{ get, set }` — Redis / Upstash / any K/V for multi-host.
+
+## Related
+
+- [Recipe: rate limiting](/docs/recipes/rate-limiting)
+- [Cost guard](/docs/observability/cost-guard)

--- a/apps/docs-next/content/docs/skills/authoring.mdx
+++ b/apps/docs-next/content/docs/skills/authoring.mdx
@@ -1,0 +1,41 @@
+---
+title: Authoring skills
+description: A skill = prompt + behavior + metadata. Versioned, composable, shippable.
+---
+
+```ts
+import { defineSkill } from '@agentskit/skills'
+
+export const triageSkill = defineSkill({
+  name: 'triage',
+  version: '1.0.0',
+  description: 'Classify support tickets into categories',
+  systemPrompt: `You are a triage assistant. Categorize into: billing, tech, feedback.`,
+  examples: [
+    { input: 'Charge declined', output: 'billing' },
+    { input: 'App crashes', output: 'tech' },
+  ],
+  temperature: 0.2,
+})
+```
+
+## Fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `name` | `string` | registry id |
+| `version` | `semver` | compatibility |
+| `systemPrompt` | `string` | prepended to conversation |
+| `examples` | `{ input, output }[]` | few-shot |
+| `temperature` / `topP` / `maxTokens` | `number` | sampling overrides |
+
+## Use
+
+```ts
+const runtime = createRuntime({ adapter, skills: [triageSkill] })
+```
+
+## Related
+
+- [Marketplace](./marketplace) · [Personas](./personas)
+- [Concepts → Skill](/docs/concepts/skill)

--- a/apps/docs-next/content/docs/skills/marketplace.mdx
+++ b/apps/docs-next/content/docs/skills/marketplace.mdx
@@ -1,0 +1,32 @@
+---
+title: Skill marketplace
+description: Publish, install, version skills. Semver range resolution.
+---
+
+```ts
+import { createSkillRegistry } from '@agentskit/skills'
+
+const registry = createSkillRegistry({
+  storage: fileStorage({ path: '.agentskit/skills' }),
+})
+
+await registry.publish(triageSkill)
+const resolved = await registry.install('triage', '^1.0.0')
+```
+
+## API
+
+| Method | Purpose |
+|---|---|
+| `publish(skill)` | add a version |
+| `install(name, range)` | resolve semver range |
+| `list()` | all available |
+| `unpublish(name, version)` | remove |
+
+## Ranges
+
+`1.2.3` · `^1.2.3` · `~1.2.3` · `>=1.2.0 <2.0.0` · `*`.
+
+## Related
+
+- [Recipe: skill marketplace](/docs/recipes/skill-marketplace)

--- a/apps/docs-next/content/docs/skills/meta.json
+++ b/apps/docs-next/content/docs/skills/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Skills",
   "description": "Ready-made personas + composition + marketplace with semver.",
-  "pages": ["index"]
+  "pages": ["index", "authoring", "personas", "marketplace"]
 }

--- a/apps/docs-next/content/docs/skills/personas.mdx
+++ b/apps/docs-next/content/docs/skills/personas.mdx
@@ -1,0 +1,37 @@
+---
+title: Ready-made personas
+description: Nine skills bundled with @agentskit/skills. Importable, composable.
+---
+
+| Skill | Purpose |
+|---|---|
+| `researcher` | gather + cite sources |
+| `coder` | write code from specs |
+| `codeReviewer` | critique diffs, flag bugs |
+| `planner` | decompose tasks into steps |
+| `critic` | stress-test a proposal |
+| `summarizer` | terse summaries |
+| `sqlGen` | schema → SQL |
+| `dataAnalyst` | analyze tabular data |
+| `translator` | natural language → natural language |
+
+## Usage
+
+```ts
+import { researcher, summarizer, composeSkills } from '@agentskit/skills'
+
+const combined = composeSkills(researcher, summarizer)
+const runtime = createRuntime({ adapter, skills: [combined] })
+```
+
+## Listing
+
+```ts
+import { listSkills } from '@agentskit/skills'
+
+for (const s of listSkills()) console.log(s.name, s.version)
+```
+
+## Related
+
+- [Authoring](./authoring) · [Marketplace](./marketplace)

--- a/apps/docs-next/content/docs/specs/a2a.mdx
+++ b/apps/docs-next/content/docs/specs/a2a.mdx
@@ -1,0 +1,43 @@
+---
+title: A2A — Agent-to-Agent
+description: JSON-RPC 2.0 contract for one agent to invoke another across process or network.
+---
+
+Subpath: `@agentskit/core/a2a`.
+
+## Methods
+
+| Method | Purpose |
+|---|---|
+| `agent/card` | discovery — returns agent metadata, tools, skills |
+| `task/invoke` | start a task |
+| `task/cancel` | abort running task |
+| `task/approve` | HITL approval |
+| `task/status` | poll state |
+
+## Request shape
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "task/invoke",
+  "params": { "input": "summarize last week's PRs", "context": {} }
+}
+```
+
+## Implementation
+
+```ts
+import { createA2AServer, createA2AClient } from '@agentskit/core/a2a'
+
+const server = createA2AServer({ runtime })
+const client = createA2AClient({ url: 'https://agent.example.com/rpc' })
+
+const { taskId } = await client.invoke({ input: '...' })
+```
+
+## Related
+
+- [Specs overview](./) · [Manifest](./manifest)
+- [Recipe: open specs](/docs/recipes/open-specs)

--- a/apps/docs-next/content/docs/specs/agent-schema.mdx
+++ b/apps/docs-next/content/docs/specs/agent-schema.mdx
@@ -1,0 +1,43 @@
+---
+title: AgentSchema
+description: Typed, validated definition of an agent — adapter, tools, skills, memory, rag, observers.
+---
+
+Subpath: `@agentskit/core/agent-schema`.
+
+## Shape
+
+```json
+{
+  "name": "support-bot",
+  "adapter": { "kind": "openai", "model": "gpt-4o" },
+  "tools": ["webSearch", "github"],
+  "skills": ["triage", "summarizer"],
+  "memory": { "kind": "sqlite", "path": ".agentskit/chat.db" },
+  "rag": { "kind": "file-vector", "path": ".agentskit/vec.json", "dim": 1536 },
+  "observers": [{ "kind": "costGuard", "maxUsd": 0.5 }]
+}
+```
+
+## Validation
+
+```ts
+import { parseAgentSchema, buildRuntime } from '@agentskit/core/agent-schema'
+
+const schema = parseAgentSchema(json) // throws on invalid
+const runtime = await buildRuntime(schema)
+```
+
+## CLI
+
+`agentskit ai` emits this shape. See [CLI → ai](/docs/cli/ai).
+
+## Generative UI
+
+Render the full agent as a form; edit live. See
+[Generative UI](./generative-ui).
+
+## Related
+
+- [CLI → ai](/docs/cli/ai)
+- [Manifest](./manifest) · [A2A](./a2a)

--- a/apps/docs-next/content/docs/specs/eval-format.mdx
+++ b/apps/docs-next/content/docs/specs/eval-format.mdx
@@ -1,0 +1,45 @@
+---
+title: Eval format
+description: Portable JSON for eval datasets + run results. Tool-agnostic.
+---
+
+Subpath: `@agentskit/core/eval-format`.
+
+## Dataset
+
+```json
+{
+  "name": "triage-v1",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "id": "refund",
+      "input": "How do I get a refund?",
+      "expect": { "kind": "regex", "value": "refund policy" }
+    }
+  ]
+}
+```
+
+## Expectation kinds
+
+| Kind | Match rule |
+|---|---|
+| `literal` | exact string equality |
+| `regex` | RegExp test |
+| `normalized` | whitespace + case-insensitive |
+| `similarity` | cosine ≥ threshold (needs embedder) |
+
+## API
+
+```ts
+import { matchesExpectation, parseEvalSuite } from '@agentskit/core/eval-format'
+
+const suite = parseEvalSuite(json)
+const ok = matchesExpectation(output, suite.cases[0].expect)
+```
+
+## Related
+
+- [Evals → Suites](/docs/evals/suites)
+- [A2A](./a2a) · [Manifest](./manifest)

--- a/apps/docs-next/content/docs/specs/generative-ui.mdx
+++ b/apps/docs-next/content/docs/specs/generative-ui.mdx
@@ -1,0 +1,36 @@
+---
+title: Generative UI
+description: Schema-driven renderers. LLM outputs typed JSON; UI reflects it.
+---
+
+Subpath: `@agentskit/core/generative-ui`.
+
+## Shape
+
+```ts
+type GenerativeBlock =
+  | { kind: 'text'; content: string }
+  | { kind: 'table'; columns: string[]; rows: unknown[][] }
+  | { kind: 'form'; fields: FormField[]; onSubmit: { tool: string } }
+  | { kind: 'chart'; spec: ChartSpec }
+  | { kind: 'citation'; url: string; title?: string }
+```
+
+## Validator
+
+```ts
+import { parseGenerativeBlock } from '@agentskit/core/generative-ui'
+
+const block = parseGenerativeBlock(llmOutput)
+```
+
+## Renderer contract
+
+Every UI binding (React / Vue / Svelte / Solid / Angular / RN / Ink)
+ships a `<GenerativeBlock>` component. Swap kinds without changing the
+render call.
+
+## Related
+
+- [Recipe: generative UI](/docs/recipes/generative-ui)
+- [UI → Data attributes](/docs/ui/data-attributes)

--- a/apps/docs-next/content/docs/specs/manifest.mdx
+++ b/apps/docs-next/content/docs/specs/manifest.mdx
@@ -1,0 +1,46 @@
+---
+title: Manifest
+description: Portable packaging for skills + tools. MCP-compatible tool entries.
+---
+
+Subpath: `@agentskit/core/manifest`.
+
+## Shape
+
+```json
+{
+  "name": "my-skills",
+  "version": "0.1.0",
+  "skills": [
+    { "name": "triage", "version": "1.0.0", "systemPrompt": "..." }
+  ],
+  "tools": [
+    {
+      "name": "search_docs",
+      "description": "Search internal docs",
+      "inputSchema": {
+        "type": "object",
+        "properties": { "query": { "type": "string" } }
+      }
+    }
+  ]
+}
+```
+
+## Validator
+
+```ts
+import { parseManifest } from '@agentskit/core/manifest'
+
+const manifest = parseManifest(json) // throws on invalid
+```
+
+## MCP compatibility
+
+`tools[].inputSchema` mirrors MCP exactly — manifests round-trip into
+MCP servers.
+
+## Related
+
+- [A2A](./a2a) · [AgentSchema](./agent-schema)
+- [Tools → MCP bridge](/docs/tools/mcp)

--- a/apps/docs-next/content/docs/specs/meta.json
+++ b/apps/docs-next/content/docs/specs/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Open specs",
-  "description": "A2A + Manifest + Eval Format — portable JSON contracts.",
-  "pages": ["index"]
+  "description": "A2A + Manifest + Eval Format + AgentSchema + Generative UI — portable JSON contracts.",
+  "pages": ["index", "a2a", "manifest", "eval-format", "agent-schema", "generative-ui"]
 }

--- a/apps/docs-next/content/docs/tools/authoring.mdx
+++ b/apps/docs-next/content/docs/tools/authoring.mdx
@@ -1,0 +1,87 @@
+---
+title: Authoring tools
+description: Define, validate, compose, guard. One contract, multiple flavors.
+---
+
+## defineTool
+
+Zero-runtime-dep path. JSON Schema inferred from TS types.
+
+```ts
+import { defineTool } from '@agentskit/core'
+
+export const addTodo = defineTool({
+  name: 'add_todo',
+  description: 'Add a todo item',
+  schema: {
+    type: 'object',
+    properties: { text: { type: 'string' } },
+    required: ['text'],
+  },
+  execute: async ({ text }) => ({ id: crypto.randomUUID(), text }),
+})
+```
+
+## defineZodTool
+
+Runtime validation. Fails fast on bad args.
+
+```ts
+import { defineZodTool } from '@agentskit/tools'
+import { z } from 'zod'
+
+export const addTodo = defineZodTool({
+  name: 'add_todo',
+  description: 'Add a todo item',
+  schema: z.object({ text: z.string().min(1) }),
+  execute: async ({ text }) => ({ id: crypto.randomUUID(), text }),
+})
+```
+
+## composeTool
+
+Chain N tools into one macro. Each receives previous output.
+
+```ts
+import { composeTool } from '@agentskit/tools'
+
+const research = composeTool({
+  name: 'research',
+  steps: [webSearch, fetchUrl, summarize],
+})
+```
+
+[Recipe](/docs/recipes/tool-composer).
+
+## wrapToolWithSelfDebug
+
+LLM-corrected retry on schema-mismatch or error.
+
+```ts
+import { wrapToolWithSelfDebug } from '@agentskit/tools'
+
+const safeDeploy = wrapToolWithSelfDebug(deployTool, { adapter, maxRetries: 3 })
+```
+
+[Recipe](/docs/recipes/self-debug).
+
+## createMandatorySandbox
+
+Policy wrapper: allow / deny / require-sandbox / validators.
+
+```ts
+import { createMandatorySandbox } from '@agentskit/tools'
+
+const sandboxed = createMandatorySandbox(shellTool, {
+  allow: ['ls', 'cat'],
+  deny: ['rm', 'sudo'],
+  requireSandbox: true,
+})
+```
+
+[Recipe](/docs/recipes/mandatory-sandbox) · [Security](/docs/security/mandatory-sandbox).
+
+## Related
+
+- [Built-ins](./builtins) · [Integrations](./integrations) · [MCP](./mcp)
+- [Concepts → Tool](/docs/concepts/tool)

--- a/apps/docs-next/content/docs/tools/builtins.mdx
+++ b/apps/docs-next/content/docs/tools/builtins.mdx
@@ -1,0 +1,51 @@
+---
+title: Built-in tools
+description: Ship-ready tools — web, fetch, filesystem, shell.
+---
+
+| Tool | Import | Notes |
+|---|---|---|
+| `webSearch` | `@agentskit/tools` | BYO provider (Tavily, Brave, SerpAPI, etc.) |
+| `fetchUrl` | `@agentskit/tools` | HTTP GET + content extraction |
+| `filesystem` | `@agentskit/tools` | read/write/list, scoped to a root |
+| `shell` | `@agentskit/tools` | exec commands, sandbox-friendly |
+
+## webSearch
+
+```ts
+import { webSearch, tavilyProvider } from '@agentskit/tools'
+
+const tool = webSearch({ provider: tavilyProvider({ apiKey: process.env.TAVILY_API_KEY! }) })
+```
+
+## fetchUrl
+
+```ts
+import { fetchUrl } from '@agentskit/tools'
+
+const tool = fetchUrl({ stripBoilerplate: true, maxBytes: 500_000 })
+```
+
+## filesystem
+
+```ts
+import { filesystem } from '@agentskit/tools'
+
+const tool = filesystem({ root: '/tmp/agent-work', readonly: false })
+```
+
+## shell
+
+```ts
+import { shell, createMandatorySandbox } from '@agentskit/tools'
+
+const tool = createMandatorySandbox(shell({ cwd: '/tmp/agent-work' }), {
+  deny: ['rm -rf', 'sudo'],
+  requireSandbox: true,
+})
+```
+
+## Related
+
+- [Authoring](./authoring) · [Integrations](./integrations)
+- [Security → mandatory sandbox](/docs/security/mandatory-sandbox)

--- a/apps/docs-next/content/docs/tools/integrations.mdx
+++ b/apps/docs-next/content/docs/tools/integrations.mdx
@@ -1,0 +1,39 @@
+---
+title: Integrations
+description: 20+ ready-made connectors for the services agents actually need.
+---
+
+| Category | Tools |
+|---|---|
+| Dev / chat | `github` · `linear` · `slack` · `notion` · `discord` |
+| Google | `gmail` · `googleCalendar` |
+| Business | `stripe` · `postgres` · `s3` |
+| Scraping | `firecrawl` · `reader` · `documentParsers` |
+| Voice + image | `openaiImages` · `elevenlabs` · `whisper` · `deepgram` |
+| Data | `maps` · `weather` · `coingecko` |
+| Browser | `browserAgent` (Puppeteer) |
+
+## Usage
+
+```ts
+import { github, slack } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  tools: [
+    github({ token: process.env.GITHUB_TOKEN! }),
+    slack({ token: process.env.SLACK_BOT_TOKEN! }),
+  ],
+})
+```
+
+Each integration module exports granular sub-tools (e.g. `github.createIssue`, `github.searchCode`). Import the whole integration for the full set, or cherry-pick.
+
+## Credentials
+
+Every integration reads a token from its `config`. No process-env magic.
+
+## Related
+
+- [Authoring](./authoring) — wrap what's missing
+- [Recipe: integrations](/docs/recipes/integrations) · [more integrations](/docs/recipes/more-integrations)

--- a/apps/docs-next/content/docs/tools/mcp.mdx
+++ b/apps/docs-next/content/docs/tools/mcp.mdx
@@ -1,0 +1,44 @@
+---
+title: MCP bridge
+description: Consume or publish Model Context Protocol tools. Interop with Claude Desktop, Cursor, Continue, etc.
+---
+
+## Consume an MCP server
+
+```ts
+import { createMcpClient, toolsFromMcpClient } from '@agentskit/tools'
+
+const client = await createMcpClient({
+  transport: 'stdio',
+  command: 'my-mcp-server',
+})
+
+const mcpTools = await toolsFromMcpClient(client)
+
+const runtime = createRuntime({ adapter, tools: [...mcpTools, ...myTools] })
+```
+
+## Publish AgentsKit tools as MCP
+
+```ts
+import { createMcpServer } from '@agentskit/tools'
+
+const server = createMcpServer({
+  name: 'agentskit-devtools',
+  version: '0.1.0',
+  tools: [github(...), slack(...)],
+})
+
+await server.listen({ transport: 'stdio' })
+```
+
+## Transports
+
+- `stdio` — sub-process pipe
+- `http` — HTTP/SSE
+- `ws` — WebSocket
+
+## Related
+
+- [Recipe: MCP bridge](/docs/recipes/mcp-bridge)
+- [Specs → A2A](/docs/specs/a2a)

--- a/apps/docs-next/content/docs/tools/meta.json
+++ b/apps/docs-next/content/docs/tools/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Tools",
   "description": "Built-in tools, 20+ provider integrations, MCP bridge, tool authoring.",
-  "pages": ["index"]
+  "pages": ["index", "authoring", "builtins", "integrations", "mcp"]
 }


### PR DESCRIPTION
## Summary
30 new pages across seven capability sections.

**Tools (4):** authoring, builtins, integrations, MCP bridge.
**Observability (5):** loggers, trace-viewer, devtools, cost-guard, audit-log.
**Security (4):** PII, prompt injection, rate limiting, mandatory sandbox.
**Evals (4):** suites, replay, snapshots, CI.
**CLI (6):** init, chat, run, ai, dev, doctor.
**Skills (3):** authoring, personas, marketplace.
**Specs (5):** A2A, manifest, eval-format, agent-schema, generative-ui.

Every page: one-liner, install snippet, options/API, cross-links.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (244 static routes)
- [ ] Visual review on preview deploy