### PR TITLE
docs(concepts): index + implementations map (step 8/11)

### DIFF
--- a/apps/docs-next/content/docs/concepts/implementations.mdx
+++ b/apps/docs-next/content/docs/concepts/implementations.mdx
@@ -1,0 +1,137 @@
+---
+title: Implementations index
+description: Every concrete implementation of every AgentsKit contract. One page to answer "what ships with this?".
+---
+
+Scope: implementations bundled in official `@agentskit/*` packages.
+Community packages are listed in the [skill marketplace](/docs/skills/marketplace)
+and the [tool ecosystem](/docs/tools/integrations).
+
+## Adapter — LLM providers
+
+**Contract:** [concepts/adapter](./adapter) · **Package:** [@agentskit/adapters](/docs/packages/adapters)
+
+**Hosted (17):** `openai`, `anthropic`, `gemini`, `grok`, `deepseek`,
+`kimi`, `mistral`, `cohere`, `together`, `groq`, `fireworks`,
+`openrouter`, `huggingface`, `langchain`, `langgraph`, `vercelAI`,
+`generic` — [deep dive](/docs/data/providers/hosted)
+
+**Local (4):** `ollama`, `lmstudio`, `vllm`, `llamacpp` —
+[deep dive](/docs/data/providers/local)
+
+**Embedders (7):** `openaiEmbedder`, `geminiEmbedder`, `ollamaEmbedder`,
+`deepseekEmbedder`, `grokEmbedder`, `kimiEmbedder`,
+`createOpenAICompatibleEmbedder` — [deep dive](/docs/data/providers/embedders)
+
+**Higher-order:** `createRouter`, `createEnsembleAdapter`,
+`createFallbackAdapter` — [deep dive](/docs/data/providers/higher-order)
+
+## Tool — callable functions
+
+**Contract:** [concepts/tool](./tool) · **Package:** [@agentskit/tools](/docs/packages/tools)
+
+**Authoring:** `defineTool`, `defineZodTool`, `composeTool`,
+`wrapToolWithSelfDebug`, `createMandatorySandbox` —
+[deep dive](/docs/tools/authoring)
+
+**Built-ins:** `webSearch`, `fetchUrl`, `filesystem`, `shell` —
+[deep dive](/docs/tools/builtins)
+
+**Integrations (20+):** `github`, `linear`, `slack`, `notion`,
+`discord`, `gmail`, `googleCalendar`, `stripe`, `postgres`, `s3`,
+`firecrawl`, `reader`, `documentParsers`, `openaiImages`,
+`elevenlabs`, `whisper`, `deepgram`, `maps`, `weather`, `coingecko`,
+`browserAgent` — [deep dive](/docs/tools/integrations)
+
+**MCP:** `createMcpClient`, `toolsFromMcpClient`, `createMcpServer` —
+[deep dive](/docs/tools/mcp)
+
+## Skill — personas + prompts
+
+**Contract:** [concepts/skill](./skill) · **Package:** [@agentskit/skills](/docs/packages/skills)
+
+**Built-in personas (9):** `researcher`, `coder`, `codeReviewer`,
+`planner`, `critic`, `summarizer`, `sqlGen`, `dataAnalyst`,
+`translator` — [deep dive](/docs/skills/personas)
+
+**Authoring + composition:** `defineSkill`, `composeSkills`,
+`listSkills` — [deep dive](/docs/skills/authoring)
+
+**Marketplace:** `createSkillRegistry` with semver resolver —
+[deep dive](/docs/skills/marketplace)
+
+## Memory — chat + vector + wrappers
+
+**Contract:** [concepts/memory](./memory) · **Package:** [@agentskit/memory](/docs/packages/memory)
+
+**Chat:** `fileChatMemory`, `sqliteChatMemory`, `redisChatMemory` —
+[file](/docs/data/memory/file-chat) · [sqlite](/docs/data/memory/sqlite) ·
+[redis](/docs/data/memory/redis-chat)
+
+**Vector:** `fileVectorMemory`, `redisVectorMemory`, `pgvector`,
+`pinecone`, `qdrant`, `chroma`, `upstashVector` —
+[file](/docs/data/memory/file-vector) ·
+[redis](/docs/data/memory/redis-vector) ·
+[pgvector](/docs/data/memory/pgvector) ·
+[pinecone](/docs/data/memory/pinecone) ·
+[qdrant](/docs/data/memory/qdrant) ·
+[chroma](/docs/data/memory/chroma) ·
+[upstash](/docs/data/memory/upstash-vector)
+
+**Wrappers:** `createEncryptedMemory`, `createHierarchicalMemory`,
+`createVirtualizedMemory`, `createAutoSummarizingMemory`,
+`createInMemoryGraph`, `createInMemoryPersonalization` —
+[encrypted](/docs/data/memory/encrypted) ·
+[hierarchical](/docs/data/memory/hierarchical) ·
+[virtualized](/docs/data/memory/virtualized) ·
+[auto-summarize](/docs/data/memory/auto-summarize) ·
+[graph](/docs/data/memory/graph) ·
+[personalization](/docs/data/memory/personalization)
+
+## Retriever — RAG pipeline
+
+**Contract:** [concepts/retriever](./retriever) · **Package:** [@agentskit/rag](/docs/packages/rag)
+
+**Core:** `createRAG`, `chunkText` —
+[createRAG](/docs/data/rag/create-rag) · [chunking](/docs/data/rag/chunking)
+
+**Rerankers:** `createRerankedRetriever`, `cohereReranker`,
+`bgeReranker`, `bm25Reranker` — [deep dive](/docs/data/rag/rerank)
+
+**Hybrid:** `createHybridRetriever` — [deep dive](/docs/data/rag/hybrid)
+
+**Loaders (7):** `loadUrl`, `loadGitHubFile`, `loadGitHubTree`,
+`loadNotionPage`, `loadConfluencePage`, `loadGoogleDriveFile`,
+`loadPdf` — [deep dive](/docs/data/rag/loaders)
+
+## Runtime — orchestration loop
+
+**Contract:** [concepts/runtime](./runtime) · **Package:** [@agentskit/runtime](/docs/packages/runtime)
+
+**Core:** `createRuntime`, `createSharedContext` —
+[runtime](/docs/agents/runtime)
+
+**Durable:** `createDurableRunner`, `createInMemoryStepLog`,
+`createFileStepLog` — [deep dive](/docs/agents/durable)
+
+**Topologies:** `supervisor`, `swarm`, `hierarchical`, `blackboard` —
+[deep dive](/docs/agents/topologies)
+
+**Background:** `createCronScheduler`, `createWebhookHandler` —
+[deep dive](/docs/agents/background)
+
+**Speculate:** `speculate` — [deep dive](/docs/agents/speculate)
+
+## UI bindings — one contract, seven frameworks
+
+**Contract:** mirrors `ChatReturn` — [UI → useChat](/docs/ui/use-chat)
+
+**Packages:** [react](/docs/packages/react) · [vue](/docs/packages/vue) ·
+[svelte](/docs/packages/svelte) · [solid](/docs/packages/solid) ·
+[react-native](/docs/packages/react-native) · [angular](/docs/packages/angular) ·
+[ink](/docs/packages/ink)
+
+## Related
+
+- [Concepts overview](./) · [Mental model](./mental-model)
+- [Packages overview](/docs/packages/overview)

--- a/apps/docs-next/content/docs/concepts/index.mdx
+++ b/apps/docs-next/content/docs/concepts/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Concepts
+description: Six contracts. Every AgentsKit package is an implementation of one of them.
+---
+
+AgentsKit has six stable contracts. Every package — every provider,
+every memory backend, every tool, every UI binding — plugs into one
+of them. Learn the shape once; swap implementations forever.
+
+## The six contracts
+
+| Contract | What it abstracts | Page |
+|---|---|---|
+| **Adapter** | LLM providers | [adapter](./adapter) |
+| **Tool** | callable functions | [tool](./tool) |
+| **Skill** | personas + prompts | [skill](./skill) |
+| **Memory** | conversation + vector state | [memory](./memory) |
+| **Retriever** | context retrieval | [retriever](./retriever) |
+| **Runtime** | the orchestration loop | [runtime](./runtime) |
+
+## Start here
+
+- [Mental model](./mental-model) — how the six contracts compose.
+- [Implementations](./implementations) — every concrete implementation per contract.
+- [Errors](./errors) — the error taxonomy every contract honors.
+
+## See also
+
+- [Packages overview](/docs/packages/overview) — packages grouped by role.
+- [For agents](/docs/for-agents) — dense LLM-friendly reference per contract.
+- [Comparison](/docs/comparison) — AgentsKit vs LangChain / Vercel AI / Mastra.

--- a/apps/docs-next/content/docs/concepts/meta.json
+++ b/apps/docs-next/content/docs/concepts/meta.json
@@ -1,4 +1,15 @@
 {
   "title": "Concepts",
-  "pages": ["mental-model", "adapter", "tool", "skill", "memory", "retriever", "runtime", "errors"]
+  "pages": [
+    "index",
+    "mental-model",
+    "adapter",
+    "tool",
+    "skill",
+    "memory",
+    "retriever",
+    "runtime",
+    "errors",
+    "implementations"
+  ]
 }


### PR DESCRIPTION
## Summary
- New `concepts/index.mdx` landing page — six contracts at a glance + quick links.
- New `concepts/implementations.mdx` — single page mapping every contract to every concrete implementation shipped under `@agentskit/*`, with deep-dive links into packages/data/tools/agents pages.
- `concepts/meta.json` updated to include both.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes (253 static routes)
- [ ] Visual review on preview deploy