### PR TITLE
docs: dead-link sweep (step 10/11)

### DIFF
--- a/apps/docs-next/content/docs/for-agents/core.mdx
+++ b/apps/docs-next/content/docs/for-agents/core.mdx
@@ -64,7 +64,7 @@ await controller.send('Hello')
 ## Common patterns
 
 - Wire a controller into any framework via `getState` + `subscribe`
-  (see the framework bindings under [For agents](/docs/for-agents/index)).
+  (see the framework bindings under [For agents](/docs/for-agents)).
 - Compose tools with [`composeTool`](/docs/recipes/tool-composer) or
   wrap failing ones with
   [`wrapToolWithSelfDebug`](/docs/recipes/self-debug).

--- a/apps/docs-next/content/docs/getting-started/read-this-first.mdx
+++ b/apps/docs-next/content/docs/getting-started/read-this-first.mdx
@@ -3,7 +3,7 @@ title: Start here
 description: Quick Start — copy-paste a streaming chat; swap the adapter in one line.
 ---
 
-1. **[Quick Start](./quick-start)** — copy-paste a streaming chat; swap the adapter in one line.
+1. **[Quick Start](./quickstart)** — copy-paste a streaming chat; swap the adapter in one line.
 2. **[Packages overview](../packages/overview)** — all fourteen `@agentskit/*` packages and links to each guide.
 3. **Open the guide for what you ship** — React, Ink, runtime, RAG, etc., from that table.
 


### PR DESCRIPTION
## Summary
Fix two dead links discovered during the cross-reference sweep:
- `getting-started/read-this-first.mdx`: `./quick-start` → `./quickstart` (file is `quickstart.mdx`)
- `for-agents/core.mdx`: `/docs/for-agents/index` → `/docs/for-agents`

Five other dead links flagged point at pages added in pending step 2–8 PRs — they resolve on merge (`/docs/concepts/events`, `/docs/for-agents/contract`, `/docs/concepts`, `/docs/contribute/package-docs`). Step 11 will re-run the sweep once all earlier PRs are merged.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes
- [ ] Post-merge sweep in step 11