### PR TITLE
chore(packages): fix license badges + expand READMEs

### DIFF
--- a/.changeset/readme-license-badges.md
+++ b/.changeset/readme-license-badges.md
@@ -1,0 +1,23 @@
+---
+'@agentskit/adapters': patch
+'@agentskit/angular': patch
+'@agentskit/cli': patch
+'@agentskit/core': patch
+'@agentskit/eval': patch
+'@agentskit/ink': patch
+'@agentskit/memory': patch
+'@agentskit/observability': patch
+'@agentskit/rag': patch
+'@agentskit/react': patch
+'@agentskit/react-native': patch
+'@agentskit/runtime': patch
+'@agentskit/sandbox': patch
+'@agentskit/skills': patch
+'@agentskit/solid': patch
+'@agentskit/svelte': patch
+'@agentskit/templates': patch
+'@agentskit/tools': patch
+'@agentskit/vue': patch
+---
+
+Add `license`, `homepage`, `repository`, `bugs`, `author` fields to every package.json (fixes "license missing" badge on npm). Swap bundlephobia badges for bundlejs (bundlephobia is rate-limited). Create READMEs for `vue`, `svelte`, `solid`, `react-native`, `angular`. Expand `tools` and `memory` READMEs to cover all currently shipped built-ins + wrappers (composer, self-debug, mandatory-sandbox; virtualized + auto-summarize memory).

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -4,8 +4,8 @@ Connect to any LLM provider — and swap between them — without touching your 
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/adapters?color=blue)](https://www.npmjs.com/package/@agentskit/adapters)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/adapters)](https://www.npmjs.com/package/@agentskit/adapters)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/adapters)](https://bundlephobia.com/package/@agentskit/adapters)
-[![license](https://img.shields.io/npm/l/@agentskit/adapters)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/adapters?label=bundle)](https://bundlejs.com/?q=@agentskit/adapters)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -61,5 +61,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "All 10+ adapters satisfy Adapter contract v1 (ADR 0001)."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/adapters",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/adapters"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,0 +1,82 @@
+# @agentskit/angular
+
+Angular 18+ service (Signal + RxJS) + headless chat components. Same `ChatReturn` contract every AgentsKit framework binding ships.
+
+[![npm version](https://img.shields.io/npm/v/@agentskit/angular?color=blue)](https://www.npmjs.com/package/@agentskit/angular)
+[![npm downloads](https://img.shields.io/npm/dm/@agentskit/angular)](https://www.npmjs.com/package/@agentskit/angular)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/angular?label=bundle)](https://bundlejs.com/?q=@agentskit/angular)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
+[![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
+
+**Tags:** `ai` · `agents` · `llm` · `agentskit` · `angular` · `signals` · `rxjs` · `chat` · `streaming`
+
+## Why
+
+- **One contract, every framework** — `AgentskitChat` service surfaces the exact same shape as the React / Vue / Svelte / Solid / RN / Ink bindings.
+- **Angular-native reactivity** — state exposed as `Signal`; events as RxJS `Observable`.
+- **Headless by default** — components emit `data-ak-*` attributes; style with your design system.
+- **Streaming, tools, HITL** — all core features work identically to `@agentskit/react`.
+
+## Install
+
+```bash
+npm install @agentskit/angular @agentskit/adapters
+```
+
+Peers: `@angular/core ^18 || ^19 || ^20`, `rxjs ^7`.
+
+## Quick example
+
+```ts
+import { Component, inject } from '@angular/core'
+import { AgentskitChat, ChatContainerComponent, MessageComponent, InputBarComponent } from '@agentskit/angular'
+import { anthropic } from '@agentskit/adapters'
+
+@Component({
+  standalone: true,
+  imports: [ChatContainerComponent, MessageComponent, InputBarComponent],
+  template: `
+    <ak-chat-container>
+      @for (m of chat.messages(); track m.id) {
+        <ak-message [message]="m" />
+      }
+      <ak-input-bar [chat]="chat" />
+    </ak-chat-container>
+  `,
+})
+export class ChatWidget {
+  chat = inject(AgentskitChat).configure({
+    adapter: anthropic({ apiKey: process.env.NG_APP_ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  })
+}
+```
+
+## API
+
+- `AgentskitChat` service — DI-friendly; `configure(config)` returns `ChatReturn` with `Signal` state + RxJS events.
+- Headless components: `<ak-chat-container>`, `<ak-message>`, `<ak-input-bar>`, `<ak-tool-call-view>`, `<ak-tool-confirmation>`, `<ak-thinking-indicator>`.
+
+## Ecosystem
+
+| Package | Role |
+|---------|------|
+| [@agentskit/core](https://www.npmjs.com/package/@agentskit/core) | `ChatReturn` contract |
+| [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) | LLM providers |
+| [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) | Built-in + integration tools |
+| [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Chat + vector backends |
+| [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · [vue](https://www.npmjs.com/package/@agentskit/vue) · [svelte](https://www.npmjs.com/package/@agentskit/svelte) · [solid](https://www.npmjs.com/package/@agentskit/solid) · [react-native](https://www.npmjs.com/package/@agentskit/react-native) · [ink](https://www.npmjs.com/package/@agentskit/ink) | Same contract, different host |
+
+## Contributors
+
+<a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=AgentsKit-io/agentskit" alt="AgentsKit contributors" />
+</a>
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).
+
+## Docs
+
+[Full documentation](https://www.agentskit.io/docs/packages/angular) · [GitHub](https://github.com/AgentsKit-io/agentskit)

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -56,5 +56,16 @@
   "agentskit": {
     "stability": "alpha",
     "stabilityNote": "Angular binding — same contract as @agentskit/react via Signals + BehaviorSubject."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/angular",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/angular"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,8 +4,8 @@ Chat with any LLM, scaffold projects, and run agents — all from your terminal.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/cli?color=blue)](https://www.npmjs.com/package/@agentskit/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/cli)](https://www.npmjs.com/package/@agentskit/cli)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/cli)](https://bundlephobia.com/package/@agentskit/cli)
-[![license](https://img.shields.io/npm/l/@agentskit/cli)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/cli?label=bundle)](https://bundlejs.com/?q=@agentskit/cli)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,5 +77,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "chat, init, run commands stable."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,8 +4,8 @@ The zero-dependency foundation that every AgentsKit package builds on — 5 KB g
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/core?color=blue)](https://www.npmjs.com/package/@agentskit/core)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/core)](https://www.npmjs.com/package/@agentskit/core)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/core)](https://bundlephobia.com/package/@agentskit/core)
-[![license](https://img.shields.io/npm/l/@agentskit/core)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/core?label=bundle)](https://bundlejs.com/?q=@agentskit/core)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,5 +111,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Sacred package. Contract-stable per ADRs 0001-0006."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -4,8 +4,8 @@ Measure agent quality with numbers, not vibes — ship with confidence.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/eval?color=blue)](https://www.npmjs.com/package/@agentskit/eval)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/eval)](https://www.npmjs.com/package/@agentskit/eval)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/eval)](https://bundlephobia.com/package/@agentskit/eval)
-[![license](https://img.shields.io/npm/l/@agentskit/eval)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/eval?label=bundle)](https://bundlejs.com/?q=@agentskit/eval)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-beta-yellow)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -79,5 +79,16 @@
   "agentskit": {
     "stability": "beta",
     "stabilityNote": "Core APIs stable; richer metrics and reporters coming."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/eval",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/eval"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/ink/README.md
+++ b/packages/ink/README.md
@@ -4,8 +4,8 @@ Build terminal AI chat interfaces with the exact same API as `@agentskit/react`.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/ink?color=blue)](https://www.npmjs.com/package/@agentskit/ink)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/ink)](https://www.npmjs.com/package/@agentskit/ink)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/ink)](https://bundlephobia.com/package/@agentskit/ink)
-[![license](https://img.shields.io/npm/l/@agentskit/ink)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/ink?label=bundle)](https://bundlejs.com/?q=@agentskit/ink)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -68,5 +68,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Terminal UI at parity with @agentskit/react."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/ink",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/ink"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -4,8 +4,8 @@ Persist conversations and add vector search to your agents — swap backends wit
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/memory?color=blue)](https://www.npmjs.com/package/@agentskit/memory)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/memory)](https://www.npmjs.com/package/@agentskit/memory)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/memory)](https://bundlephobia.com/package/@agentskit/memory)
-[![license](https://img.shields.io/npm/l/@agentskit/memory)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/memory?label=bundle)](https://bundlejs.com/?q=@agentskit/memory)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 
@@ -49,14 +49,38 @@ Use a **vector** backend with [`@agentskit/rag`](https://www.npmjs.com/package/@
 
 ## Features
 
-- **Chat memory:** `fileChatMemory`, `sqliteChatMemory`, `redisChatMemory` (on top of `createInMemoryMemory` / `createLocalStorageMemory` from core).
-- **Vector memory:** `fileVectorMemory`, `redisVectorMemory` + `pgvector`, `pinecone`, `qdrant`, `chroma`, `upstashVector` — same 3-method `VectorMemory` contract.
-- **Higher-order wrappers:**
-  - `createHierarchicalMemory` — MemGPT-style tiers (working / recall / archival). [Recipe](https://www.agentskit.io/docs/recipes/hierarchical-memory).
-  - `createEncryptedMemory` — AES-GCM over any `ChatMemory`; keys never leave the caller. [Recipe](https://www.agentskit.io/docs/recipes/encrypted-memory).
-  - `createInMemoryGraph` — knowledge graph (nodes + edges + BFS). [Recipe](https://www.agentskit.io/docs/recipes/graph-memory).
-  - `createInMemoryPersonalization` — per-user trait profile. [Recipe](https://www.agentskit.io/docs/recipes/personalization).
-- Memory contract v1 (ADR 0003) — substitutable across `runtime`, `useChat`, and every framework binding.
+### Chat memory (3)
+
+- `fileChatMemory({ path })` — JSON on disk; zero infra.
+- `sqliteChatMemory({ path })` — WAL-mode SQLite; indexed by session.
+- `redisChatMemory({ client, keyPrefix })` — distributed, serverless-friendly.
+
+All on top of `createInMemoryMemory` / `createLocalStorageMemory` from
+`@agentskit/core`.
+
+### Vector memory (7)
+
+- `fileVectorMemory` — pure-JS, file-persisted (good to ~10k vectors).
+- `redisVectorMemory` — Redis Stack / Redis 8+ HNSW.
+- `pgvector` — BYO SQL runner (`postgres.js`, `pg`, Drizzle, Prisma, Neon).
+- `pinecone` — managed; namespaces + metadata filters.
+- `qdrant` — self-hosted or cloud via HTTP.
+- `chroma` — HTTP collection client.
+- `upstashVector` — serverless HTTP.
+
+Same 3-method `VectorStore` contract — swap without touching agent code.
+
+### Higher-order wrappers (6)
+
+- `createHierarchicalMemory` — MemGPT-style tiers: working / recall / archival. [Recipe](https://www.agentskit.io/docs/recipes/hierarchical-memory).
+- `createVirtualizedMemory` — hot window + cold retriever for long sessions. [Recipe](https://www.agentskit.io/docs/recipes/virtualized-memory).
+- `createAutoSummarizingMemory` *(via `@agentskit/core/auto-summarize`)* — fold oldest turns into a running summary. [Recipe](https://www.agentskit.io/docs/recipes/auto-summarize).
+- `createEncryptedMemory` — AES-GCM-256 envelope over any `ChatMemory`; keys never leave the caller. [Recipe](https://www.agentskit.io/docs/recipes/encrypted-memory).
+- `createInMemoryGraph` — knowledge graph (nodes + edges + BFS). [Recipe](https://www.agentskit.io/docs/recipes/graph-memory).
+- `createInMemoryPersonalization` + `renderProfileContext` — per-user trait profile. [Recipe](https://www.agentskit.io/docs/recipes/personalization).
+
+Memory contract v1 (ADR 0003) — substitutable across `runtime`,
+`useChat`, and every framework binding.
 
 ## Ecosystem
 

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -62,5 +62,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "File/SQLite/Redis backends — Memory contract v1."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/memory",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/memory"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -4,8 +4,8 @@ See exactly what your agent does — every LLM call, tool execution, and reasoni
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/observability?color=blue)](https://www.npmjs.com/package/@agentskit/observability)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/observability)](https://www.npmjs.com/package/@agentskit/observability)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/observability)](https://bundlephobia.com/package/@agentskit/observability)
-[![license](https://img.shields.io/npm/l/@agentskit/observability)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/observability?label=bundle)](https://bundlejs.com/?q=@agentskit/observability)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-beta-yellow)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -61,5 +61,16 @@
   "agentskit": {
     "stability": "beta",
     "stabilityNote": "Observer contract stable; integration coverage growing."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/observability",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/observability"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -4,8 +4,8 @@ Plug-and-play retrieval-augmented generation: chunk documents, embed them, and r
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/rag?color=blue)](https://www.npmjs.com/package/@agentskit/rag)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/rag)](https://www.npmjs.com/package/@agentskit/rag)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/rag)](https://bundlephobia.com/package/@agentskit/rag)
-[![license](https://img.shields.io/npm/l/@agentskit/rag)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/rag?label=bundle)](https://bundlejs.com/?q=@agentskit/rag)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -59,5 +59,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Retriever contract v1. Ingest + retrieve shipped."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/rag",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/rag"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,0 +1,76 @@
+# @agentskit/react-native
+
+React Native / Expo hook + headless chat components. Metro-safe (no DOM deps). Same `ChatReturn` contract every AgentsKit framework binding ships.
+
+[![npm version](https://img.shields.io/npm/v/@agentskit/react-native?color=blue)](https://www.npmjs.com/package/@agentskit/react-native)
+[![npm downloads](https://img.shields.io/npm/dm/@agentskit/react-native)](https://www.npmjs.com/package/@agentskit/react-native)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/react-native?label=bundle)](https://bundlejs.com/?q=@agentskit/react-native)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
+[![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
+
+**Tags:** `ai` · `agents` · `llm` · `agentskit` · `react-native` · `expo` · `mobile` · `chat` · `streaming`
+
+## Why
+
+- **One contract, every framework** — `useChat` returns the exact same shape as the web React / Vue / Svelte / Solid / Angular / Ink bindings.
+- **Metro-safe** — no DOM APIs; works on iOS, Android, and Expo out of the box.
+- **Native components** — `<ChatContainer>` wraps `ScrollView`, `<InputBar>` wraps `TextInput`, all theme-aware.
+- **Streaming, tools, HITL** — all core features work identically to `@agentskit/react`.
+
+## Install
+
+```bash
+npm install @agentskit/react-native @agentskit/adapters
+```
+
+Peers: `react`, `react-native`.
+
+## Quick example
+
+```tsx
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react-native'
+import { anthropic } from '@agentskit/adapters'
+
+export function Chat() {
+  const chat = useChat({
+    adapter: anthropic({ apiKey: process.env.EXPO_PUBLIC_ANTHROPIC_API_KEY!, model: 'claude-sonnet-4-6' }),
+  })
+
+  return (
+    <ChatContainer>
+      {chat.messages.map((m) => <Message key={m.id} message={m} />)}
+      <InputBar chat={chat} />
+    </ChatContainer>
+  )
+}
+```
+
+## API
+
+- `useChat(config)` — hook returning `ChatReturn` (DOM-free).
+- Headless components: `ChatContainer`, `Message`, `InputBar`, `ToolCallView`, `ToolConfirmation`, `ThinkingIndicator`.
+
+## Ecosystem
+
+| Package | Role |
+|---------|------|
+| [@agentskit/core](https://www.npmjs.com/package/@agentskit/core) | `ChatReturn` contract |
+| [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) | LLM providers |
+| [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) | Built-in + integration tools |
+| [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Chat + vector backends |
+| [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · [vue](https://www.npmjs.com/package/@agentskit/vue) · [svelte](https://www.npmjs.com/package/@agentskit/svelte) · [solid](https://www.npmjs.com/package/@agentskit/solid) · [angular](https://www.npmjs.com/package/@agentskit/angular) · [ink](https://www.npmjs.com/package/@agentskit/ink) | Same contract, different host |
+
+## Contributors
+
+<a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=AgentsKit-io/agentskit" alt="AgentsKit contributors" />
+</a>
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).
+
+## Docs
+
+[Full documentation](https://www.agentskit.io/docs/packages/react-native) · [GitHub](https://github.com/AgentsKit-io/agentskit)

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -56,5 +56,16 @@
   "agentskit": {
     "stability": "alpha",
     "stabilityNote": "React Native / Expo binding — same contract as @agentskit/react."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/react-native",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/react-native"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -4,8 +4,8 @@ Add streaming AI chat to any React app in 10 lines of code.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/react?color=blue)](https://www.npmjs.com/package/@agentskit/react)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/react)](https://www.npmjs.com/package/@agentskit/react)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/react)](https://bundlephobia.com/package/@agentskit/react)
-[![license](https://img.shields.io/npm/l/@agentskit/react)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/react?label=bundle)](https://bundlejs.com/?q=@agentskit/react)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,5 +72,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Production-ready hooks and headless components."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/react",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/react"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,8 +4,8 @@ Run autonomous agents in 5 lines — no UI, no boilerplate, just results.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/runtime?color=blue)](https://www.npmjs.com/package/@agentskit/runtime)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/runtime)](https://www.npmjs.com/package/@agentskit/runtime)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/runtime)](https://bundlephobia.com/package/@agentskit/runtime)
-[![license](https://img.shields.io/npm/l/@agentskit/runtime)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/runtime?label=bundle)](https://bundlejs.com/?q=@agentskit/runtime)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -58,5 +58,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "ReAct loop and delegation per ADR 0006."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/runtime",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/runtime"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -4,8 +4,8 @@ Let agents write and run code safely — in isolated cloud VMs, not on your mach
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/sandbox?color=blue)](https://www.npmjs.com/package/@agentskit/sandbox)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/sandbox)](https://www.npmjs.com/package/@agentskit/sandbox)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/sandbox)](https://bundlephobia.com/package/@agentskit/sandbox)
-[![license](https://img.shields.io/npm/l/@agentskit/sandbox)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/sandbox?label=bundle)](https://bundlejs.com/?q=@agentskit/sandbox)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-beta-yellow)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -59,5 +59,16 @@
   "agentskit": {
     "stability": "beta",
     "stabilityNote": "E2B integration works; WebContainer fallback experimental."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/sandbox",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/sandbox"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -4,8 +4,8 @@ Pre-tuned agent personas that work out of the box — skills are what your agent
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/skills?color=blue)](https://www.npmjs.com/package/@agentskit/skills)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/skills)](https://www.npmjs.com/package/@agentskit/skills)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/skills)](https://bundlephobia.com/package/@agentskit/skills)
-[![license](https://img.shields.io/npm/l/@agentskit/skills)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/skills?label=bundle)](https://bundlejs.com/?q=@agentskit/skills)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -58,5 +58,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Pre-built skills — Skill contract v1."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/skills",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/skills"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,77 @@
+# @agentskit/solid
+
+SolidJS hook + headless chat components. Same `ChatReturn` contract every AgentsKit framework binding ships — swap frameworks without changing your agent.
+
+[![npm version](https://img.shields.io/npm/v/@agentskit/solid?color=blue)](https://www.npmjs.com/package/@agentskit/solid)
+[![npm downloads](https://img.shields.io/npm/dm/@agentskit/solid)](https://www.npmjs.com/package/@agentskit/solid)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/solid?label=bundle)](https://bundlejs.com/?q=@agentskit/solid)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
+[![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
+
+**Tags:** `ai` · `agents` · `llm` · `agentskit` · `solid` · `solidjs` · `signals` · `chat` · `streaming`
+
+## Why
+
+- **One contract, every framework** — `useChat` returns the exact same shape as the React / Vue / Svelte / Angular / RN / Ink bindings.
+- **Fine-grained reactivity** — values surface as Solid accessors; no diff, no rerender overhead.
+- **Headless by default** — components emit `data-ak-*` attributes; style however you want.
+- **Streaming, tools, HITL** — all core features work identically to `@agentskit/react`.
+
+## Install
+
+```bash
+npm install @agentskit/solid @agentskit/adapters
+```
+
+Peers: `solid-js ^1.8`.
+
+## Quick example
+
+```tsx
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/solid'
+import { For } from 'solid-js'
+import { anthropic } from '@agentskit/adapters'
+
+export function App() {
+  const chat = useChat({
+    adapter: anthropic({ apiKey: import.meta.env.VITE_ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+  })
+
+  return (
+    <ChatContainer>
+      <For each={chat.messages()}>{(m) => <Message message={m} />}</For>
+      <InputBar chat={chat} />
+    </ChatContainer>
+  )
+}
+```
+
+## API
+
+- `useChat(config)` — hook returning `ChatReturn` with Solid accessors.
+- Headless components: `ChatContainer`, `Message`, `InputBar`, `ToolCallView`, `ToolConfirmation`, `ThinkingIndicator`.
+
+## Ecosystem
+
+| Package | Role |
+|---------|------|
+| [@agentskit/core](https://www.npmjs.com/package/@agentskit/core) | `ChatReturn` contract |
+| [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) | LLM providers |
+| [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) | Built-in + integration tools |
+| [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Chat + vector backends |
+| [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · [vue](https://www.npmjs.com/package/@agentskit/vue) · [svelte](https://www.npmjs.com/package/@agentskit/svelte) · [react-native](https://www.npmjs.com/package/@agentskit/react-native) · [angular](https://www.npmjs.com/package/@agentskit/angular) · [ink](https://www.npmjs.com/package/@agentskit/ink) | Same contract, different host |
+
+## Contributors
+
+<a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=AgentsKit-io/agentskit" alt="AgentsKit contributors" />
+</a>
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).
+
+## Docs
+
+[Full documentation](https://www.agentskit.io/docs/packages/solid) · [GitHub](https://github.com/AgentsKit-io/agentskit)

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -53,5 +53,16 @@
   "agentskit": {
     "stability": "alpha",
     "stabilityNote": "Solid binding — same contract as @agentskit/react."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/solid",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/solid"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,79 @@
+# @agentskit/svelte
+
+Svelte 5 store + headless chat components. Same `ChatReturn` contract every AgentsKit framework binding ships — swap frameworks without changing your agent.
+
+[![npm version](https://img.shields.io/npm/v/@agentskit/svelte?color=blue)](https://www.npmjs.com/package/@agentskit/svelte)
+[![npm downloads](https://img.shields.io/npm/dm/@agentskit/svelte)](https://www.npmjs.com/package/@agentskit/svelte)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/svelte?label=bundle)](https://bundlejs.com/?q=@agentskit/svelte)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
+[![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
+
+**Tags:** `ai` · `agents` · `llm` · `agentskit` · `svelte` · `svelte5` · `runes` · `chat` · `streaming`
+
+## Why
+
+- **One contract, every framework** — `createChatStore` returns the exact same shape as the React / Vue / Solid / Angular / RN / Ink bindings.
+- **Svelte 5 runes** — reactive state without subscriptions; drops into `.svelte` files natively.
+- **Headless by default** — components emit `data-ak-*` attributes; style however you want.
+- **Streaming, tools, HITL** — all core features work identically to `@agentskit/react`.
+
+## Install
+
+```bash
+npm install @agentskit/svelte @agentskit/adapters
+```
+
+Peers: `svelte ^5`.
+
+## Quick example
+
+```svelte
+<script lang="ts">
+  import { createChatStore } from '@agentskit/svelte'
+  import ChatContainer from '@agentskit/svelte/ChatContainer.svelte'
+  import Message from '@agentskit/svelte/Message.svelte'
+  import InputBar from '@agentskit/svelte/InputBar.svelte'
+  import { anthropic } from '@agentskit/adapters'
+
+  const chat = createChatStore({
+    adapter: anthropic({ apiKey: import.meta.env.VITE_ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+  })
+</script>
+
+<ChatContainer>
+  {#each chat.messages as m (m.id)}
+    <Message message={m} />
+  {/each}
+  <InputBar {chat} />
+</ChatContainer>
+```
+
+## API
+
+- `createChatStore(config)` — returns `ChatReturn` with reactive values via Svelte 5 runes.
+- Headless components (all `.svelte`): `ChatContainer`, `Message`, `InputBar`, `ToolCallView`, `ToolConfirmation`, `ThinkingIndicator`.
+
+## Ecosystem
+
+| Package | Role |
+|---------|------|
+| [@agentskit/core](https://www.npmjs.com/package/@agentskit/core) | `ChatReturn` contract |
+| [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) | LLM providers |
+| [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) | Built-in + integration tools |
+| [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Chat + vector backends |
+| [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · [vue](https://www.npmjs.com/package/@agentskit/vue) · [solid](https://www.npmjs.com/package/@agentskit/solid) · [react-native](https://www.npmjs.com/package/@agentskit/react-native) · [angular](https://www.npmjs.com/package/@agentskit/angular) · [ink](https://www.npmjs.com/package/@agentskit/ink) | Same contract, different host |
+
+## Contributors
+
+<a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=AgentsKit-io/agentskit" alt="AgentsKit contributors" />
+</a>
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).
+
+## Docs
+
+[Full documentation](https://www.agentskit.io/docs/packages/svelte) · [GitHub](https://github.com/AgentsKit-io/agentskit)

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -53,5 +53,16 @@
   "agentskit": {
     "stability": "alpha",
     "stabilityNote": "Svelte 5 binding — same contract as @agentskit/react."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/svelte",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/svelte"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -4,8 +4,8 @@ Create, validate, and scaffold custom AgentsKit extensions — tools, skills, an
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/templates?color=blue)](https://www.npmjs.com/package/@agentskit/templates)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/templates)](https://www.npmjs.com/package/@agentskit/templates)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/templates)](https://bundlephobia.com/package/@agentskit/templates)
-[![license](https://img.shields.io/npm/l/@agentskit/templates)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/templates?label=bundle)](https://bundlejs.com/?q=@agentskit/templates)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -56,5 +56,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Authoring toolkit for custom skills/tools."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/templates",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/templates"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -4,8 +4,8 @@ Give your agents real-world capabilities without writing a single integration.
 
 [![npm version](https://img.shields.io/npm/v/@agentskit/tools?color=blue)](https://www.npmjs.com/package/@agentskit/tools)
 [![npm downloads](https://img.shields.io/npm/dm/@agentskit/tools)](https://www.npmjs.com/package/@agentskit/tools)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@agentskit/tools)](https://bundlephobia.com/package/@agentskit/tools)
-[![license](https://img.shields.io/npm/l/@agentskit/tools)](../../LICENSE)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/tools?label=bundle)](https://bundlejs.com/?q=@agentskit/tools)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
 [![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
 
@@ -88,13 +88,39 @@ For tools without Zod, use `defineTool` from `@agentskit/core` with a JSON Schem
 
 ## Features
 
-- `webSearch()` — live web search for agents.
-- `fetchUrl()` — safe HTTP GET with JSON / text handling.
-- `filesystem({ basePath })` — sandboxed read, write, list, delete.
-- `shell({ allowed })` — shell execution with command allow-list.
-- `defineZodTool` — Zod-based tool factory with runtime validation and type inference.
-- All tools follow `ToolDefinition` contract (ADR 0002) — parallel tool calling supported.
-- Works in `@agentskit/runtime`, `useChat`, or any custom loop.
+### Built-ins (4)
+
+- `webSearch()` — live web search with pluggable providers (Tavily, Brave, SerpAPI, custom).
+- `fetchUrl()` — safe HTTP GET with JSON / text handling, size cap, boilerplate stripping.
+- `filesystem({ basePath })` — sandboxed read, write, list, delete, stat, exists.
+- `shell({ allowed })` — shell execution with command allow-list + timeout.
+
+### Integrations (20+)
+
+`github`, `linear`, `slack`, `notion`, `discord`, `gmail`,
+`googleCalendar`, `stripe`, `postgres`, `s3`, `firecrawl`, `reader`,
+`documentParsers` (PDF / DOCX / XLSX), `openaiImages`, `elevenlabs`,
+`whisper`, `deepgram`, `maps`, `weather`, `coingecko`, `browserAgent`
+(Puppeteer). Each integration exports granular sub-tools (e.g.
+`githubCreateIssue`, `stripeCreatePaymentIntent`) alongside the bundled
+set.
+
+### Authoring + composition
+
+- `defineZodTool` — Zod-based factory with runtime validation + type inference.
+- `composeTool` — chain N tools into one macro tool (each step receives previous output).
+- `wrapToolWithSelfDebug` — LLM-corrected retries on schema-mismatch or execution failure.
+- `createMandatorySandbox` — policy wrapper: `allow` / `deny` / `requireSandbox` / `validators`.
+
+### MCP bridge
+
+- `createMcpClient` + `toolsFromMcpClient` — consume any MCP server's tools.
+- `createMcpServer` — publish AgentsKit tools to any MCP host.
+- Stdio + HTTP/SSE + in-memory transports.
+
+All tools honor the `ToolDefinition` contract (ADR 0002) — parallel
+tool calling works with any adapter, `@agentskit/runtime`, `useChat`,
+or a custom loop.
 
 ## Subpaths
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -70,5 +70,16 @@
   "agentskit": {
     "stability": "stable",
     "stabilityNote": "Web search, filesystem, shell tools — Tool contract v1."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/tools",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/tools"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,76 @@
+# @agentskit/vue
+
+Vue 3 composable + headless chat components. Same `ChatReturn` contract every AgentsKit framework binding ships — swap frameworks without changing your agent.
+
+[![npm version](https://img.shields.io/npm/v/@agentskit/vue?color=blue)](https://www.npmjs.com/package/@agentskit/vue)
+[![npm downloads](https://img.shields.io/npm/dm/@agentskit/vue)](https://www.npmjs.com/package/@agentskit/vue)
+[![bundle size](https://img.shields.io/bundlejs/size/@agentskit/vue?label=bundle)](https://bundlejs.com/?q=@agentskit/vue)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![stability](https://img.shields.io/badge/stability-stable-brightgreen)](../../docs/STABILITY.md)
+[![GitHub stars](https://img.shields.io/github/stars/AgentsKit-io/agentskit?style=social)](https://github.com/AgentsKit-io/agentskit)
+
+**Tags:** `ai` · `agents` · `llm` · `agentskit` · `vue` · `vue3` · `composable` · `chat` · `streaming`
+
+## Why
+
+- **One contract, every framework** — `useChat` returns the exact same shape as the React / Svelte / Solid / Angular / RN / Ink bindings.
+- **Composition API native** — values surface as `ref`s; drops into `<script setup>` with zero glue.
+- **Headless by default** — components emit `data-ak-*` attributes; bring your own styling.
+- **Streaming, tools, HITL** — all core features work identically to `@agentskit/react`.
+
+## Install
+
+```bash
+npm install @agentskit/vue @agentskit/adapters
+```
+
+Peers: `vue ^3.4`.
+
+## Quick example
+
+```vue
+<script setup lang="ts">
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/vue'
+import { anthropic } from '@agentskit/adapters'
+
+const chat = useChat({
+  adapter: anthropic({ apiKey: import.meta.env.VITE_ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+})
+</script>
+
+<template>
+  <ChatContainer>
+    <Message v-for="m in chat.messages.value" :key="m.id" :message="m" />
+    <InputBar :chat="chat" />
+  </ChatContainer>
+</template>
+```
+
+## API
+
+- `useChat(config)` — composable returning `ChatReturn` (messages, status, send, retry, stop, clear, approve, deny, edit).
+- Headless components: `<ChatContainer>`, `<Message>`, `<InputBar>`, `<ToolCallView>`, `<ToolConfirmation>`, `<ThinkingIndicator>`.
+
+## Ecosystem
+
+| Package | Role |
+|---------|------|
+| [@agentskit/core](https://www.npmjs.com/package/@agentskit/core) | `ChatReturn` contract |
+| [@agentskit/adapters](https://www.npmjs.com/package/@agentskit/adapters) | LLM providers |
+| [@agentskit/tools](https://www.npmjs.com/package/@agentskit/tools) | Built-in + integration tools |
+| [@agentskit/memory](https://www.npmjs.com/package/@agentskit/memory) | Chat + vector backends |
+| [@agentskit/react](https://www.npmjs.com/package/@agentskit/react) · [svelte](https://www.npmjs.com/package/@agentskit/svelte) · [solid](https://www.npmjs.com/package/@agentskit/solid) · [react-native](https://www.npmjs.com/package/@agentskit/react-native) · [angular](https://www.npmjs.com/package/@agentskit/angular) · [ink](https://www.npmjs.com/package/@agentskit/ink) | Same contract, different host |
+
+## Contributors
+
+<a href="https://github.com/AgentsKit-io/agentskit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=AgentsKit-io/agentskit" alt="AgentsKit contributors" />
+</a>
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).
+
+## Docs
+
+[Full documentation](https://www.agentskit.io/docs/packages/vue) · [GitHub](https://github.com/AgentsKit-io/agentskit)

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -54,5 +54,16 @@
   "agentskit": {
     "stability": "alpha",
     "stabilityNote": "Vue 3 binding — same contract as @agentskit/react."
-  }
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/vue",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/vue"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
 }


### PR DESCRIPTION
## Summary

### Badges
- Add `license: MIT` + `homepage`, `repository`, `bugs`, `author` to every `package.json` — fixes npm "license missing" badge.
- Replace `bundlephobia` shields (rate-limited on shields.io) with `bundlejs` shields across every package README.

### New READMEs (5)
Added READMEs for the split framework bindings — all follow the core template with badges, tags, why, install, quick example, API, ecosystem table, contributors, license, docs.
- `@agentskit/vue`
- `@agentskit/svelte`
- `@agentskit/solid`
- `@agentskit/react-native`
- `@agentskit/angular`

### Enriched READMEs
- `@agentskit/tools` — now covers all current built-ins + 20+ integrations + authoring helpers (`composeTool`, `wrapToolWithSelfDebug`, `createMandatorySandbox`) + MCP bridge.
- `@agentskit/memory` — now covers all 3 chat backends, 7 vector backends, and the 6 higher-order wrappers (including `createVirtualizedMemory` and `createAutoSummarizingMemory`).

### Changeset
`.changeset/readme-license-badges.md` — patch bump for every package.

## Test plan
- [x] `package.json` now has `license: MIT` on every package
- [x] README badges no longer use `bundlephobia.com` / `shields.io/npm/l`
- [ ] Visual review of rendered READMEs on GitHub preview
- [ ] Post-merge: confirm npm shows MIT license + bundle size on next publish