### PR TITLE
chore: stub CHANGELOG.md for new framework packages

### DIFF
--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/angular

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/react-native

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/solid

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/svelte

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/vue


### PR DESCRIPTION
## Summary
Fixes the release workflow crash:
\`\`\`
Error: ENOENT: no such file or directory, open '/.../packages/angular/CHANGELOG.md'
\`\`\`

`changesets/action@v1` expects `CHANGELOG.md` to exist for every package listed in a changeset. The five new framework bindings (`angular`, `vue`, `svelte`, `solid`, `react-native`) never had one, so the versioning step failed when it tried to prepend the new entry.

Seed empty stubs so changesets can populate them on the next version bump.

## Test plan
- [ ] Re-run the release workflow; `pnpm changeset version` should now succeed.