### PR TITLE
docs(packages): per-package v1.0 roadmap

### DIFF
--- a/apps/docs-next/content/docs/reference/packages/adapters.mdx
+++ b/apps/docs-next/content/docs/reference/packages/adapters.mdx
@@ -45,6 +45,13 @@ Testing: `mockAdapter` · `recordingAdapter` · `replayAdapter` · `inMemorySink
 - [Custom adapter](/docs/reference/recipes/custom-adapter)
 - [Simulate stream](/docs/reference/recipes/simulate-stream)
 
+## Stability
+
+- **Version:** `0.9.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Adapter](/docs/get-started/concepts/adapter)

--- a/apps/docs-next/content/docs/reference/packages/angular.mdx
+++ b/apps/docs-next/content/docs/reference/packages/angular.mdx
@@ -44,6 +44,13 @@ export class ChatComponent {
 
 [React](/docs/reference/packages/react) · [Vue](/docs/reference/packages/vue) · [Svelte](/docs/reference/packages/svelte) · [Solid](/docs/reference/packages/solid) · [React Native](/docs/reference/packages/react-native) · [Ink](/docs/reference/packages/ink)
 
+## Stability
+
+- **Version:** `0.2.0`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)

--- a/apps/docs-next/content/docs/reference/packages/cli.mdx
+++ b/apps/docs-next/content/docs/reference/packages/cli.mdx
@@ -39,6 +39,13 @@ npm install -g @agentskit/cli
 
 - [agentskit ai](/docs/reference/recipes/agentskit-ai)
 
+## Stability
+
+- **Version:** `0.8.2`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [CLI (deep dive)](/docs/production/cli)

--- a/apps/docs-next/content/docs/reference/packages/core.mdx
+++ b/apps/docs-next/content/docs/reference/packages/core.mdx
@@ -298,3 +298,10 @@ type SearchArgs = InferSchemaType<typeof schema>
 [Start here](../getting-started/read-this-first) · [Packages](./overview) · [TypeDoc](pathname:///agentskit/api-reference/) (`@agentskit/core`) · [React](../chat-uis/react) · [Ink](../chat-uis/ink) · [Adapters](../data-layer/adapters) · [Runtime](../agents/runtime) · [Tools](../agents/tools) · [Skills](../agents/skills) · [useChat](../hooks/use-chat) · [useStream](../hooks/use-stream) · [useReactive](../hooks/use-reactive)
 
 <ContributeCallout pkg="core" />
+
+## Stability
+
+- **Version:** `1.6.1`
+- **Tier:** stable
+- **Contract:** frozen
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/eval.mdx
+++ b/apps/docs-next/content/docs/reference/packages/eval.mdx
@@ -49,6 +49,13 @@ console.log(`${result.passed}/${result.totalCases} passed`)
 - [Prompt diff](/docs/reference/recipes/prompt-diff)
 - [Evals in CI](/docs/reference/recipes/evals-ci)
 
+## Stability
+
+- **Version:** `0.4.1`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Evals (deep dive)](/docs/production/evals)

--- a/apps/docs-next/content/docs/reference/packages/ink.mdx
+++ b/apps/docs-next/content/docs/reference/packages/ink.mdx
@@ -33,6 +33,13 @@ render(<ChatContainer config={{ adapter: anthropic({ apiKey, model: 'claude-sonn
 
 [React](/docs/reference/packages/react) · [Vue](/docs/reference/packages/vue) · [Svelte](/docs/reference/packages/svelte) · [Solid](/docs/reference/packages/solid) · [React Native](/docs/reference/packages/react-native) · [Angular](/docs/reference/packages/angular)
 
+## Stability
+
+- **Version:** `0.7.4`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)

--- a/apps/docs-next/content/docs/reference/packages/memory.mdx
+++ b/apps/docs-next/content/docs/reference/packages/memory.mdx
@@ -43,6 +43,13 @@ const vectors = pgvector({
 - [Graph memory](/docs/reference/recipes/graph-memory)
 - [Personalization](/docs/reference/recipes/personalization)
 
+## Stability
+
+- **Version:** `0.6.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Memory](/docs/get-started/concepts/memory)

--- a/apps/docs-next/content/docs/reference/packages/meta.json
+++ b/apps/docs-next/content/docs/reference/packages/meta.json
@@ -3,6 +3,7 @@
   "description": "One page per package — what it does, when to reach for it, deep-dive links.",
   "pages": [
     "overview",
+    "roadmap",
     "core",
     "adapters",
     "runtime",

--- a/apps/docs-next/content/docs/reference/packages/observability.mdx
+++ b/apps/docs-next/content/docs/reference/packages/observability.mdx
@@ -44,6 +44,13 @@ const runtime = createRuntime({
 - [Devtools server](/docs/reference/recipes/devtools-server)
 - [Audit log](/docs/reference/recipes/audit-log)
 
+## Stability
+
+- **Version:** `0.5.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Observability (deep dive)](/docs/production/observability)

--- a/apps/docs-next/content/docs/reference/packages/overview.mdx
+++ b/apps/docs-next/content/docs/reference/packages/overview.mdx
@@ -67,6 +67,7 @@ Full signatures: **[TypeDoc HTML](pathname:///agentskit/api-reference/)** (gener
 
 ## See also
 
+- [Roadmap](./roadmap) — stability tier + path to v1.0 for every package.
 - [For agents](/docs/for-agents) — dense LLM-friendly reference per package.
 - [Concepts](/docs/get-started/concepts) — the six contracts every package builds on.
 - [Comparison](/docs/get-started/comparison) — AgentsKit vs. LangChain / Vercel AI / Mastra / LlamaIndex.

--- a/apps/docs-next/content/docs/reference/packages/rag.mdx
+++ b/apps/docs-next/content/docs/reference/packages/rag.mdx
@@ -44,6 +44,13 @@ const hits = await rag.search('what is agentskit')
 - [RAG reranking](/docs/reference/recipes/rag-reranking)
 - [Doc loaders](/docs/reference/recipes/doc-loaders)
 
+## Stability
+
+- **Version:** `0.2.1`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Retriever](/docs/get-started/concepts/retriever)

--- a/apps/docs-next/content/docs/reference/packages/react-native.mdx
+++ b/apps/docs-next/content/docs/reference/packages/react-native.mdx
@@ -35,6 +35,13 @@ export function ChatScreen({ adapter }) {
 
 [React](/docs/reference/packages/react) · [Vue](/docs/reference/packages/vue) · [Svelte](/docs/reference/packages/svelte) · [Solid](/docs/reference/packages/solid) · [Angular](/docs/reference/packages/angular) · [Ink](/docs/reference/packages/ink)
 
+## Stability
+
+- **Version:** `0.2.0`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)

--- a/apps/docs-next/content/docs/reference/packages/react.mdx
+++ b/apps/docs-next/content/docs/reference/packages/react.mdx
@@ -49,6 +49,13 @@ export function Chat() {
 - [Edit and regenerate](/docs/reference/recipes/edit-and-regenerate)
 - [RAG chat](/docs/reference/recipes/rag-chat)
 
+## Stability
+
+- **Version:** `0.5.8`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Runtime](/docs/get-started/concepts/runtime)

--- a/apps/docs-next/content/docs/reference/packages/roadmap.mdx
+++ b/apps/docs-next/content/docs/reference/packages/roadmap.mdx
@@ -1,0 +1,66 @@
+---
+title: Roadmap
+description: Per-package stability status, current version, and what each package needs to reach v1.0.
+---
+
+AgentsKit follows a **package-level semver** model. Each package declares its
+own stability tier and ships independently. The core is already v1;
+everything else is tracked below on its path to v1.
+
+## Stability tiers
+
+| Tier | Meaning | Breaking changes |
+|---|---|---|
+| **stable** | v1.0 or later. Contract frozen per ADRs. | Only via major bump, with deprecation + codemod. |
+| **beta** | v0.x, surface settled, tests + docs complete. | Possible, but announced in [#beta-log](/docs/get-started/announcements) one release in advance. |
+| **alpha** | v0.x, API still evolving. | Expected. Follow the changelog. |
+
+## Package status
+
+| Package | Version | Stability | Contract | Path to v1.0 |
+|---|---|---|---|---|
+| [`@agentskit/core`](./core) | 1.6.x | **stable** | frozen (ADRs 0001–0006) | Shipped. Contract frozen. |
+| [`@agentskit/adapters`](./adapters) | 0.9.x | **beta** | evolving | Finalize tool-call delta shape across providers; add Bedrock + Cohere + Vertex; adapter contract tests; publish 1.0 |
+| [`@agentskit/runtime`](./runtime) | 0.6.x | **beta** | evolving | Speculate API finalization; topology API finalization; durable step-log format frozen; publish 1.0 |
+| [`@agentskit/tools`](./tools) | 0.7.x | **beta** | evolving | Stabilize `composeTool` + `wrapToolWithSelfDebug` APIs; grow integrations to 35+; finalize MCP bridge shape; publish 1.0 |
+| [`@agentskit/memory`](./memory) | 0.6.x | **beta** | evolving | Stabilize `VectorStore` v1 (metadata filters); add Weaviate + Milvus + Turso + Supabase; publish 1.0 |
+| [`@agentskit/rag`](./rag) | 0.2.x | **alpha** | evolving | Finalize chunking strategies; reranker contract v1; add 3 more loaders; ship hybrid scorer defaults |
+| [`@agentskit/skills`](./skills) | 0.5.x | **beta** | evolving | `SkillDefinition` v1; marketplace resolver frozen; grow personas to 15; publish 1.0 |
+| [`@agentskit/observability`](./observability) | 0.5.x | **beta** | evolving | Trace event schema v1; audit-log format frozen; cost counter parity per adapter; publish 1.0 |
+| [`@agentskit/eval`](./eval) | 0.4.x | **alpha** | evolving | Suite format v1; replay cassette v1; CI reporter contract v1; snapshots stabilized |
+| [`@agentskit/sandbox`](./sandbox) | 0.3.x | **alpha** | evolving | E2B backend GA; WebContainer fallback feature parity; policy API v1 |
+| [`@agentskit/react`](./react) | 0.5.x | **beta** | evolving | `ChatReturn` shape frozen (shared across bindings); theme contract v1; a11y audit pass |
+| [`@agentskit/vue`](./vue) | 0.2.x | **alpha** | evolving | Parity with React surface; Vue 3 SSR tests; theme contract v1 |
+| [`@agentskit/svelte`](./svelte) | 0.2.x | **alpha** | evolving | Parity with React surface; Svelte 5 runes API; theme contract v1 |
+| [`@agentskit/solid`](./solid) | 0.2.x | **alpha** | evolving | Parity with React surface; Solid accessors; theme contract v1 |
+| [`@agentskit/react-native`](./react-native) | 0.2.x | **alpha** | evolving | Parity with React surface; Expo template; Android+iOS test matrix |
+| [`@agentskit/angular`](./angular) | 0.2.x | **alpha** | evolving | Parity with React surface; standalone-component template; Signal + RxJS contract v1 |
+| [`@agentskit/ink`](./ink) | 0.7.x | **beta** | evolving | Parity with React surface; keyboard UX pass; theme contract v1 |
+| [`@agentskit/cli`](./cli) | 0.8.x | **beta** | evolving | `agentskit init` template gallery; `agentskit ai` prompt hardening; `agentskit doctor` auto-fixes |
+| [`@agentskit/templates`](./templates) | 0.1.x | **alpha** | evolving | Grow to 8 framework starters; Stackblitz + CodeSandbox links per template |
+
+## Release cadence
+
+- **core:** patches only unless an ADR ratifies a major change (rare, deprecation window).
+- **beta packages:** minor releases every 2–3 weeks; patches as needed.
+- **alpha packages:** ship when ready; may include breaking changes in minors.
+- **changesets:** every PR adds a changeset; CI blocks merges without one.
+
+## How to follow
+
+- [Announcements](/docs/get-started/announcements) — narrative release notes.
+- [GitHub Releases](https://github.com/AgentsKit-io/agentskit/releases) — per-tag notes.
+- [Changesets](https://github.com/AgentsKit-io/agentskit/tree/main/.changeset) — in-flight bumps.
+- [Project board](https://github.com/orgs/AgentsKit-io/projects/1) — open issues grouped by phase.
+
+## Want to help a package reach v1?
+
+Every package lists "path to v1.0" items above as GitHub issues with
+`type-*` + `package-*` labels. Pick one, open a PR, we ship together.
+
+Start with [good first issues](https://github.com/AgentsKit-io/agentskit/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+## Related
+
+- [Packages overview](./overview) · [Core](./core)
+- [Contribute](/docs/reference/contribute) · [RFC process](/docs/reference/contribute/rfc-process)

--- a/apps/docs-next/content/docs/reference/packages/runtime.mdx
+++ b/apps/docs-next/content/docs/reference/packages/runtime.mdx
@@ -47,6 +47,13 @@ console.log(result.content)
 - [Background agents](/docs/reference/recipes/background-agents)
 - [Research team](/docs/reference/recipes/research-team)
 
+## Stability
+
+- **Version:** `0.6.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Runtime](/docs/get-started/concepts/runtime)

--- a/apps/docs-next/content/docs/reference/packages/sandbox.mdx
+++ b/apps/docs-next/content/docs/reference/packages/sandbox.mdx
@@ -38,6 +38,13 @@ const safeTools = [shell(), filesystem({ basePath }), webSearch()].map(t => poli
 
 - [Mandatory sandbox](/docs/reference/recipes/mandatory-sandbox)
 
+## Stability
+
+- **Version:** `0.3.1`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Security](/docs/production/security)

--- a/apps/docs-next/content/docs/reference/packages/skills.mdx
+++ b/apps/docs-next/content/docs/reference/packages/skills.mdx
@@ -35,6 +35,13 @@ const runtime = createRuntime({ adapter, systemPrompt: researcher.systemPrompt }
 - [Code reviewer](/docs/reference/recipes/code-reviewer)
 - [Research team](/docs/reference/recipes/research-team)
 
+## Stability
+
+- **Version:** `0.5.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Skill](/docs/get-started/concepts/skill)

--- a/apps/docs-next/content/docs/reference/packages/solid.mdx
+++ b/apps/docs-next/content/docs/reference/packages/solid.mdx
@@ -26,6 +26,13 @@ const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }
 
 [React](/docs/reference/packages/react) · [Vue](/docs/reference/packages/vue) · [Svelte](/docs/reference/packages/svelte) · [React Native](/docs/reference/packages/react-native) · [Angular](/docs/reference/packages/angular) · [Ink](/docs/reference/packages/ink)
 
+## Stability
+
+- **Version:** `0.2.0`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)

--- a/apps/docs-next/content/docs/reference/packages/svelte.mdx
+++ b/apps/docs-next/content/docs/reference/packages/svelte.mdx
@@ -35,6 +35,13 @@ const chat = createChatStore({ adapter: anthropic({ apiKey, model: 'claude-sonne
 
 [React](/docs/reference/packages/react) · [Vue](/docs/reference/packages/vue) · [Solid](/docs/reference/packages/solid) · [React Native](/docs/reference/packages/react-native) · [Angular](/docs/reference/packages/angular) · [Ink](/docs/reference/packages/ink)
 
+## Stability
+
+- **Version:** `0.2.0`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)

--- a/apps/docs-next/content/docs/reference/packages/templates.mdx
+++ b/apps/docs-next/content/docs/reference/packages/templates.mdx
@@ -124,3 +124,10 @@ Register scaffolded packages like any other tool, skill, or adapter via [`create
 [Start here](../getting-started/read-this-first) · [Packages](./overview) · [TypeDoc](pathname:///agentskit/api-reference/) (`@agentskit/templates`) · [@agentskit/core](./core) · [Tools](../agents/tools) · [Skills](../agents/skills) · [Adapters](../data-layer/adapters)
 
 <ContributeCallout pkg="templates" />
+
+## Stability
+
+- **Version:** `0.1.10`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/tools.mdx
+++ b/apps/docs-next/content/docs/reference/packages/tools.mdx
@@ -45,6 +45,13 @@ const runtime = createRuntime({ adapter, tools })
 - [Confirmation-gated tool](/docs/reference/recipes/confirmation-gated-tool)
 - [Mandatory sandbox](/docs/reference/recipes/mandatory-sandbox)
 
+## Stability
+
+- **Version:** `0.7.1`
+- **Tier:** beta
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [Concepts: Tool](/docs/get-started/concepts/tool)

--- a/apps/docs-next/content/docs/reference/packages/vue.mdx
+++ b/apps/docs-next/content/docs/reference/packages/vue.mdx
@@ -29,6 +29,13 @@ const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }
 
 [React](/docs/reference/packages/react) · [Svelte](/docs/reference/packages/svelte) · [Solid](/docs/reference/packages/solid) · [React Native](/docs/reference/packages/react-native) · [Angular](/docs/reference/packages/angular) · [Ink](/docs/reference/packages/ink)
 
+## Stability
+
+- **Version:** `0.2.0`
+- **Tier:** alpha
+- **Contract:** evolving
+- **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.
+
 ## Related
 
 - [UI + hooks](/docs/ui)


### PR DESCRIPTION
## Summary

New `/docs/reference/packages/roadmap` page holding the full stability matrix — current version, tier (alpha / beta / stable), contract state (frozen / evolving), and what every package needs to reach v1.0. Matches the three-tier stability model we use informally in changesets but never surfaced in docs.

| Tier | Count | Examples |
|---|---|---|
| **stable** | 1 | core (contract frozen per ADRs 0001–0006) |
| **beta** | 8 | adapters, runtime, tools, memory, skills, observability, react, ink, cli |
| **alpha** | 10 | rag, eval, sandbox, vue, svelte, solid, react-native, angular, templates |

Each individual package page (all 19) picks up a new **Stability** section with version / tier / contract / link back to the aggregator.

Closes #248 partially (docs versioning lane — roadmap is now linked from every package page).

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes
- [ ] Spot-check: each package page renders its Stability block
- [ ] Roadmap matrix renders correctly on desktop + mobile