### PR TITLE
docs(skills): handcrafted per-skill pages (9)

### DIFF
--- a/apps/docs-next/content/docs/agents/skills/code-reviewer.mdx
+++ b/apps/docs-next/content/docs/agents/skills/code-reviewer.mdx
@@ -1,0 +1,42 @@
+---
+title: codeReviewer
+description: Reviews diffs for bugs, security, style. Comments in PR-review format.
+---
+
+```ts
+import { codeReviewer } from '@agentskit/skills'
+import { github } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [codeReviewer],
+  tools: [...github({ token: process.env.GITHUB_TOKEN! })],
+})
+
+await runtime.run('Review PR #123 on AgentsKit-io/agentskit')
+```
+
+## When to reach for it
+
+- Automated PR review bot.
+- Snippet review without a PR context (use with the forthcoming [generic codeReviewerSkill](https://github.com/AgentsKit-io/agentskit/issues/448)).
+- Pre-commit quality gate.
+
+## Behavior
+
+- Reads diff hunk by hunk; comments inline-style with line refs.
+- Flags bugs > security > style (priority order).
+- Rejects drive-by nitpicks; prefers actionable suggestions.
+- Returns `approve` / `request changes` / `comment` with rationale.
+
+## Pairs well with
+
+- `github` tool (comment on PRs)
+- `linear` tool (file follow-up tickets)
+- [HITL approvals](/docs/agents/hitl) (gate the final "approve")
+
+## Related
+
+- [Skills overview](./) · [coder](./coder) · [critic](./critic)
+- Issue #310 — [prReviewerSkill](https://github.com/AgentsKit-io/agentskit/issues/310)
+- Issue #454 — [securityAuditorSkill](https://github.com/AgentsKit-io/agentskit/issues/454)

--- a/apps/docs-next/content/docs/agents/skills/coder.mdx
+++ b/apps/docs-next/content/docs/agents/skills/coder.mdx
@@ -1,0 +1,52 @@
+---
+title: coder
+description: Implements features from specs — TypeScript-first, TDD-leaning, opinionated about code quality.
+---
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { coder } from '@agentskit/skills'
+import { filesystem, shell } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [coder],
+  tools: [
+    ...filesystem({ basePath: './workspace' }),
+    shell({ allowed: ['pnpm', 'node', 'git'] }),
+  ],
+})
+```
+
+## When to reach for it
+
+- Agent needs to write real code (not snippets).
+- Multi-file edits, package additions, refactors.
+- Works best when paired with a sandboxed filesystem.
+
+## Behavior
+
+- Reads before writing — lists files, opens existing implementations.
+- Writes TypeScript strict; prefers named exports.
+- Tests alongside code (Vitest conventions).
+- Avoids unsafe casts, runs type-check before declaring done.
+
+## Tools it expects
+
+| Tool | Why |
+|---|---|
+| `filesystem` | Scoped read/write. |
+| `shell` (allowlisted) | `pnpm`, `node`, `git`. |
+
+## Compose
+
+Pair with [`codeReviewer`](./code-reviewer) for a self-review pass, or delegate to the [`critic`](./critic) skill to stress-test output.
+
+## Safety
+
+Always sandbox with `filesystem({ basePath })` and `shell({ allowed })` — coder writes files. For mutation flows use [mandatory sandbox](/docs/production/security/mandatory-sandbox).
+
+## Related
+
+- [Skills overview](./) · [codeReviewer](./code-reviewer)
+- Recipe: [code-reviewer](/docs/reference/recipes/code-reviewer)

--- a/apps/docs-next/content/docs/agents/skills/critic.mdx
+++ b/apps/docs-next/content/docs/agents/skills/critic.mdx
@@ -1,0 +1,37 @@
+---
+title: critic
+description: Stress-tests proposals. Finds flaws, missing cases, weak assumptions — before they ship.
+---
+
+```ts
+import { researcher, critic } from '@agentskit/skills'
+import { composeSkills } from '@agentskit/skills'
+
+const thorough = composeSkills(researcher, critic)
+```
+
+## When to reach for it
+
+- Second-pass review after [coder](./coder) or [researcher](./researcher).
+- Red-team on architecture proposals.
+- Pair with [planner](./planner) for "plan → critique → revise" loops.
+
+## Behavior
+
+- Takes an artifact (plan, code, doc) and produces structured critique.
+- Categorizes findings: blockers → risks → nits.
+- Offers alternatives, not just objections.
+- Never invents criteria — grounds critique in stated goals.
+
+## Pair patterns
+
+| Pattern | Skill chain |
+|---|---|
+| Plan-critique-revise | `planner` → `critic` → `planner` (revise) |
+| Research then stress | `researcher` → `critic` |
+| Review committed PRs | `codeReviewer` → `critic` (find what the reviewer missed) |
+
+## Related
+
+- [Skills overview](./) · [planner](./planner)
+- [Agents → Topologies](/docs/agents/topologies#swarm)

--- a/apps/docs-next/content/docs/agents/skills/data-analyst.mdx
+++ b/apps/docs-next/content/docs/agents/skills/data-analyst.mdx
@@ -1,0 +1,37 @@
+---
+title: dataAnalyst
+description: Analyzes tabular data — loads, inspects, profiles, and explains findings in plain English.
+---
+
+```ts
+import { dataAnalyst } from '@agentskit/skills'
+import { s3, documentParsers } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [dataAnalyst],
+  tools: [
+    ...s3({ client, bucket: 'datasets' }),
+    ...documentParsers({ parseXlsx }),
+  ],
+})
+```
+
+## When to reach for it
+
+- "Look at this CSV and tell me what's interesting."
+- Column-profile + anomaly hunting.
+- Lightweight EDA before handing off to a BI tool.
+
+## Behavior
+
+- Loads file → reads schema + head/tail.
+- Reports shape, dtypes, null %, basic stats.
+- Highlights outliers + correlations worth investigating.
+- Never fabricates a column that isn't there.
+
+## Related
+
+- [Skills overview](./) · [sqlGen](./sql-gen)
+- Issue #451 — [dataAnalystSkill v2 (tabular-aware)](https://github.com/AgentsKit-io/agentskit/issues/451)
+- [documentParsers](/docs/agents/tools/integrations/document-parsers)

--- a/apps/docs-next/content/docs/agents/skills/meta.json
+++ b/apps/docs-next/content/docs/agents/skills/meta.json
@@ -1,5 +1,20 @@
 {
   "title": "Skills",
   "description": "Ready-made personas + composition + marketplace with semver.",
-  "pages": ["index", "authoring", "personas", "marketplace"]
+  "pages": [
+    "index",
+    "authoring",
+    "personas",
+    "marketplace",
+    "---Personas---",
+    "researcher",
+    "coder",
+    "code-reviewer",
+    "planner",
+    "critic",
+    "summarizer",
+    "sql-gen",
+    "data-analyst",
+    "translator"
+  ]
 }

--- a/apps/docs-next/content/docs/agents/skills/personas.mdx
+++ b/apps/docs-next/content/docs/agents/skills/personas.mdx
@@ -5,15 +5,15 @@ description: Nine skills bundled with @agentskit/skills. Importable, composable.
 
 | Skill | Purpose |
 |---|---|
-| `researcher` | gather + cite sources |
-| `coder` | write code from specs |
-| `codeReviewer` | critique diffs, flag bugs |
-| `planner` | decompose tasks into steps |
-| `critic` | stress-test a proposal |
-| `summarizer` | terse summaries |
-| `sqlGen` | schema → SQL |
-| `dataAnalyst` | analyze tabular data |
-| `translator` | natural language → natural language |
+| [`researcher`](./researcher) | gather + cite sources |
+| [`coder`](./coder) | write code from specs |
+| [`codeReviewer`](./code-reviewer) | critique diffs, flag bugs |
+| [`planner`](./planner) | decompose tasks into steps |
+| [`critic`](./critic) | stress-test a proposal |
+| [`summarizer`](./summarizer) | terse summaries |
+| [`sqlGen`](./sql-gen) | schema → SQL |
+| [`dataAnalyst`](./data-analyst) | analyze tabular data |
+| [`translator`](./translator) | natural language → natural language |
 
 ## Usage
 

--- a/apps/docs-next/content/docs/agents/skills/planner.mdx
+++ b/apps/docs-next/content/docs/agents/skills/planner.mdx
@@ -1,0 +1,36 @@
+---
+title: planner
+description: Decomposes vague goals into ordered steps with clear success criteria. Ideal as the top node in a supervisor topology.
+---
+
+```ts
+import { planner, coder } from '@agentskit/skills'
+import { supervisor } from '@agentskit/runtime'
+
+const team = supervisor({
+  planner: { runtime: createRuntime({ adapter, skills: [planner] }) },
+  workers: {
+    coder: { runtime: createRuntime({ adapter, skills: [coder] }) },
+  },
+})
+
+await team.run('Ship a feature flag API with SDK + docs.')
+```
+
+## When to reach for it
+
+- Tasks that span multiple specialists.
+- Problems that need decomposition before execution.
+- Top-of-tree node in a [supervisor topology](/docs/agents/topologies).
+
+## Behavior
+
+- Breaks goals into numbered steps with success criteria.
+- Routes each step to the named worker best suited for it.
+- Detects blockers early ("need API key", "need design review").
+- Closes the loop: verifies each worker's output meets the step's success criterion.
+
+## Related
+
+- [Skills overview](./) · [critic](./critic)
+- [Agents → Topologies](/docs/agents/topologies) · [Delegation](/docs/agents/delegation)

--- a/apps/docs-next/content/docs/agents/skills/researcher.mdx
+++ b/apps/docs-next/content/docs/agents/skills/researcher.mdx
@@ -1,0 +1,57 @@
+---
+title: researcher
+description: Methodical web-search persona that finds, cross-references, and summarizes with citations.
+---
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { researcher } from '@agentskit/skills'
+import { webSearch } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [researcher],
+  tools: [webSearch()],
+})
+```
+
+## When to reach for it
+
+- You need sourced answers, not opinion.
+- You want the agent to flag uncertainty instead of speculating.
+- You're ingesting RAG context and need disciplined citation output.
+
+## Behavior
+
+- Breaks the question into sub-queries and searches each independently.
+- Cross-references across sources; flags contradictions.
+- Output leads with a direct answer, then cited claims, then a confidence assessment.
+
+## Tools it expects
+
+| Tool | Why |
+|---|---|
+| `web_search` | Mandatory — required by the system prompt. |
+| any RAG retriever | Optional — pairs with [`createRAG`](/docs/data/rag/create-rag) for internal corpora. |
+
+## Example output
+
+> **Q:** Main differences between PostgreSQL and MySQL for a new web app?
+>
+> **A:** PostgreSQL excels at complex queries, JSONB, and strict SQL. MySQL is simpler to set up and faster for read-heavy simple schemas.
+> Sources: [1] PostgreSQL docs, [2] MySQL reference manual, [3] DB-Engines comparison.
+> Confidence: high — well-documented, stable differences.
+
+## Compose
+
+Pair with [`summarizer`](./summarizer) for long reports, or [`critic`](./critic) to stress-test conclusions:
+
+```ts
+import { composeSkills } from '@agentskit/skills'
+const thorough = composeSkills(researcher, critic)
+```
+
+## Related
+
+- [Skills overview](./) · [Authoring](./authoring) · [Marketplace](./marketplace)
+- Issue #453 — [researcherSkill v2 (citation-first)](https://github.com/AgentsKit-io/agentskit/issues/453)

--- a/apps/docs-next/content/docs/agents/skills/sql-gen.mdx
+++ b/apps/docs-next/content/docs/agents/skills/sql-gen.mdx
@@ -1,0 +1,45 @@
+---
+title: sqlGen
+description: Natural language → SQL with dialect awareness + safety rails.
+---
+
+```ts
+import { sqlGen } from '@agentskit/skills'
+import { postgres } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [sqlGen],
+  tools: [...postgres({ run, readonly: true, maxRows: 100 })],
+})
+
+await runtime.run('How many users signed up last 7 days vs the previous 7 days?')
+```
+
+## When to reach for it
+
+- Data Q&A agent over a SQL DB.
+- Dashboard copilots.
+- Schema-aware natural-language querying.
+
+## Behavior
+
+- Asks for schema if none provided; remembers in session.
+- Emits parameterized queries with explicit `LIMIT`.
+- Flags risky statements (`DROP`, `UPDATE` without WHERE) and refuses by default.
+- Dialect-aware: SQLite / Postgres / MySQL / DuckDB.
+
+## Tools it expects
+
+- `postgresQuery` or `sqliteQueryTool` (issue #433).
+- `readonly: true` by default. See [postgres integration](/docs/agents/tools/integrations/postgres).
+
+## Safety
+
+- Always run readonly first. Opt-in to writes via a separate, gated tool.
+- Cap results with `maxRows`. LLMs love `SELECT *` — protect from OOM.
+
+## Related
+
+- [Skills overview](./)
+- Issue #449 — [sqlAnalystSkill](https://github.com/AgentsKit-io/agentskit/issues/449) (sibling).

--- a/apps/docs-next/content/docs/agents/skills/summarizer.mdx
+++ b/apps/docs-next/content/docs/agents/skills/summarizer.mdx
@@ -1,0 +1,47 @@
+---
+title: summarizer
+description: Compresses long inputs into short, faithful summaries. Length-aware; preserves citations.
+---
+
+```ts
+import { summarizer } from '@agentskit/skills'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [summarizer],
+})
+
+await runtime.run('Summarize this 40-page PDF into 10 bullets.')
+```
+
+## When to reach for it
+
+- Digest long docs (PDFs, meeting transcripts, threads).
+- Rollup: summarize many sources into one.
+- Pair with [researcher](./researcher) for sourced summaries.
+
+## Behavior
+
+- Respects explicit length targets ("10 bullets", "under 100 words").
+- Preserves citations + speaker attribution when present.
+- Declines to summarize when the input contains critical fine-print that must not be collapsed.
+
+## Memory recipe
+
+Use alongside `createAutoSummarizingMemory` to fold old turns automatically:
+
+```ts
+import { createAutoSummarizingMemory } from '@agentskit/memory'
+
+const memory = createAutoSummarizingMemory({
+  summarize: async (msgs) => runtime.run({ input: msgs, skill: summarizer }),
+  triggerAt: 30,
+  keep: 10,
+})
+```
+
+## Related
+
+- [Skills overview](./)
+- [Memory → auto-summarize](/docs/data/memory/auto-summarize)
+- Recipe: [auto-summarize](/docs/reference/recipes/auto-summarize)

--- a/apps/docs-next/content/docs/agents/skills/translator.mdx
+++ b/apps/docs-next/content/docs/agents/skills/translator.mdx
@@ -1,0 +1,37 @@
+---
+title: translator
+description: High-quality translation between natural languages. Preserves formatting, tone, terminology.
+---
+
+```ts
+import { translator } from '@agentskit/skills'
+
+const runtime = createRuntime({
+  adapter,
+  skills: [translator],
+})
+
+await runtime.run('Translate this product page to pt-BR preserving markdown.')
+```
+
+## When to reach for it
+
+- App i18n copy drafts (always human-review).
+- Localizing docs + blog posts.
+- Transcript translation paired with [whisper](/docs/agents/tools/integrations/whisper).
+
+## Behavior
+
+- Preserves markdown / HTML / code blocks exactly.
+- Keeps product-name + brand terms untranslated unless told otherwise.
+- Flags untranslatable idioms; proposes locale-aware alternatives.
+- Maintains tone (formal / friendly / technical) from source.
+
+## Glossary mode (v2 — issue #452)
+
+Future version takes a glossary map to force specific term translations. Track: [skill: translatorSkill v2](https://github.com/AgentsKit-io/agentskit/issues/452).
+
+## Related
+
+- [Skills overview](./)
+- [whisper](/docs/agents/tools/integrations/whisper) — translate audio.


### PR DESCRIPTION
## Summary
Add a dedicated page for each bundled persona under `/docs/agents/skills/*`:

- researcher, coder, codeReviewer, planner, critic, summarizer, sqlGen, dataAnalyst, translator

Each page: when to reach for it, behavior, tools it expects, compose patterns, safety notes, issue links for v2 variants, cross-links to related skills + recipes.

`meta.json` groups personas under a separator; `personas.mdx` linkifies every entry to the new deep-dives.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes