### PR TITLE
feat(docs): interactive MDX components — Stackblitz, CodeSandbox, GIF

### DIFF
--- a/apps/docs-next/components/mdx/codesandbox-embed.tsx
+++ b/apps/docs-next/components/mdx/codesandbox-embed.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+
+export type CodeSandboxEmbedProps = {
+  /** Sandbox id (e.g. `abcd123`) or `github/owner/repo/tree/branch/path`. */
+  sandbox: string
+  file?: string
+  height?: number
+  title?: string
+  lazy?: boolean
+}
+
+function buildUrl({ sandbox, file }: Pick<CodeSandboxEmbedProps, 'sandbox' | 'file'>) {
+  const isGithub = sandbox.startsWith('github/')
+  const base = isGithub
+    ? `https://codesandbox.io/embed/${sandbox}`
+    : `https://codesandbox.io/embed/${sandbox}`
+  const params = new URLSearchParams({
+    theme: 'dark',
+    ...(file ? { module: file } : {}),
+    fontsize: '14',
+    hidenavigation: '1',
+  })
+  return `${base}?${params.toString()}`
+}
+
+export function CodeSandboxEmbed({
+  sandbox,
+  file,
+  height = 520,
+  title,
+  lazy = true,
+}: CodeSandboxEmbedProps) {
+  const [open, setOpen] = useState(!lazy)
+  const url = buildUrl({ sandbox, file })
+  const safeTitle = title ?? `CodeSandbox — ${sandbox}${file ? ` / ${file}` : ''}`
+
+  if (!open) {
+    return (
+      <div
+        data-ak-codesandbox-placeholder
+        className="my-6 flex flex-col items-center justify-center gap-3 rounded-lg border border-ak-border bg-ak-surface p-8 text-center"
+      >
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+          Live sandbox
+        </div>
+        <p className="max-w-md text-sm text-ak-foam">
+          Click to load the CodeSandbox for{' '}
+          <code className="rounded bg-ak-midnight px-1.5 py-0.5 font-mono text-xs">
+            {sandbox}
+          </code>
+          .
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md bg-ak-foam px-4 py-2 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+        >
+          Load sandbox →
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <iframe
+      data-ak-codesandbox
+      src={url}
+      title={safeTitle}
+      height={height}
+      style={{ width: '100%', border: 0, borderRadius: 12 }}
+      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+      loading="lazy"
+    />
+  )
+}

--- a/apps/docs-next/components/mdx/gif-embed.tsx
+++ b/apps/docs-next/components/mdx/gif-embed.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export type GifEmbedProps = {
+  src: string
+  alt: string
+  /** Optional still-frame PNG shown before playback + for reduced-motion. */
+  poster?: string
+  /** Auto-play on viewport intersect (default: true). */
+  autoplay?: boolean
+  width?: number
+  height?: number
+  caption?: string
+}
+
+/**
+ * Accessible GIF embed.
+ * - Respects prefers-reduced-motion — shows the poster instead.
+ * - Defers loading until in view (reduces bandwidth).
+ * - Exposes data-ak-gif so the theme can style it uniformly.
+ */
+export function GifEmbed({
+  src,
+  alt,
+  poster,
+  autoplay = true,
+  width,
+  height,
+  caption,
+}: GifEmbedProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [shouldPlay, setShouldPlay] = useState(false)
+  const [reducedMotion, setReducedMotion] = useState(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReducedMotion(mq.matches)
+    const onChange = () => setReducedMotion(mq.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  useEffect(() => {
+    if (!autoplay || reducedMotion || shouldPlay) return
+    const el = ref.current
+    if (!el) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) setShouldPlay(true)
+      },
+      { rootMargin: '200px' }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [autoplay, reducedMotion, shouldPlay])
+
+  const showStatic = reducedMotion || (!shouldPlay && !!poster)
+  const imgSrc = showStatic && poster ? poster : src
+
+  return (
+    <figure data-ak-gif ref={ref} className="my-6">
+      <img
+        src={imgSrc}
+        alt={alt}
+        width={width}
+        height={height}
+        loading="lazy"
+        decoding="async"
+        className="w-full rounded-lg border border-ak-border"
+      />
+      {caption ? (
+        <figcaption className="mt-2 text-center font-mono text-xs text-ak-graphite">
+          {caption}
+        </figcaption>
+      ) : null}
+      {reducedMotion && poster ? (
+        <p className="mt-1 text-center font-mono text-[11px] text-ak-graphite">
+          Motion disabled by system preference. <a href={src} className="underline decoration-dotted underline-offset-2 hover:text-ak-blue">view the animation</a>.
+        </p>
+      ) : null}
+    </figure>
+  )
+}

--- a/apps/docs-next/components/mdx/stackblitz-embed.tsx
+++ b/apps/docs-next/components/mdx/stackblitz-embed.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+
+export type StackblitzEmbedProps = {
+  /** GitHub path (`owner/repo/tree/branch/path`) or Stackblitz project id. */
+  project: string
+  /** File to open (e.g. `src/App.tsx`). */
+  file?: string
+  /** Optional height in px (default 520). */
+  height?: number
+  /** Iframe title for a11y. */
+  title?: string
+  /** Show on load, or wait for user click (lighter LCP). */
+  lazy?: boolean
+}
+
+function buildUrl({ project, file }: Pick<StackblitzEmbedProps, 'project' | 'file'>) {
+  const isGithub = project.includes('/')
+  const base = isGithub
+    ? `https://stackblitz.com/github/${project}`
+    : `https://stackblitz.com/edit/${project}`
+  const params = new URLSearchParams({
+    embed: '1',
+    theme: 'dark',
+    view: 'both',
+    ...(file ? { file } : {}),
+    ctl: '1',
+  })
+  return `${base}?${params.toString()}`
+}
+
+export function StackblitzEmbed({
+  project,
+  file,
+  height = 520,
+  title,
+  lazy = true,
+}: StackblitzEmbedProps) {
+  const [open, setOpen] = useState(!lazy)
+  const url = buildUrl({ project, file })
+  const safeTitle = title ?? `Stackblitz — ${project}${file ? ` / ${file}` : ''}`
+
+  if (!open) {
+    return (
+      <div
+        data-ak-stackblitz-placeholder
+        className="my-6 flex flex-col items-center justify-center gap-3 rounded-lg border border-ak-border bg-ak-surface p-8 text-center"
+      >
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+          Live sandbox
+        </div>
+        <p className="max-w-md text-sm text-ak-foam">
+          Click to load the editable Stackblitz for{' '}
+          <code className="rounded bg-ak-midnight px-1.5 py-0.5 font-mono text-xs">
+            {project}
+          </code>
+          {file ? ` (${file})` : ''}.
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md bg-ak-foam px-4 py-2 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+        >
+          Load sandbox →
+        </button>
+        <a
+          href={url.replace('embed=1', 'embed=0')}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-xs text-ak-graphite underline decoration-dotted underline-offset-2 hover:text-ak-blue"
+        >
+          open in new tab
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <iframe
+      data-ak-stackblitz
+      src={url}
+      title={safeTitle}
+      height={height}
+      style={{ width: '100%', border: 0, borderRadius: 12 }}
+      allow="cross-origin-isolated; clipboard-read; clipboard-write"
+      loading="lazy"
+    />
+  )
+}

--- a/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
+++ b/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
@@ -1,0 +1,78 @@
+---
+title: Docs MDX components
+description: Embeddable components available inside every .mdx file — Stackblitz, CodeSandbox, GIFs, Mermaid.
+---
+
+Every MDX page under `/docs` has access to these components. No import required.
+
+## `<StackblitzEmbed />`
+
+Live editable sandbox for any GitHub path.
+
+```mdx
+<StackblitzEmbed
+  project="AgentsKit-io/agentskit/tree/main/apps/example-react"
+  file="src/App.tsx"
+  height={520}
+/>
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `project` | `string` | required — `owner/repo/tree/branch/path` or Stackblitz id |
+| `file` | `string` | — |
+| `height` | `number` | 520 |
+| `title` | `string` | auto |
+| `lazy` | `boolean` | `true` (click-to-load, keeps LCP fast) |
+
+## `<CodeSandboxEmbed />`
+
+Mirror shape for CodeSandbox-hosted examples.
+
+```mdx
+<CodeSandboxEmbed sandbox="abcd123" file="/src/App.tsx" height={520} />
+```
+
+## `<GifEmbed />`
+
+A11y-aware GIF with reduced-motion fallback.
+
+```mdx
+<GifEmbed
+  src="/demos/streaming-chat.gif"
+  poster="/demos/streaming-chat.png"
+  alt="Streaming chat response with tool calls"
+  caption="RAG chat responding with sources"
+/>
+```
+
+Respects `prefers-reduced-motion` — shows the PNG poster + a link to the animation for users with motion sensitivity.
+
+## `<Mermaid />`
+
+Inline diagrams. See [`components/mermaid.tsx`](https://github.com/AgentsKit-io/agentskit/blob/main/apps/docs-next/components/mermaid.tsx).
+
+## Using all together
+
+A typical recipe page mixes code blocks, a GIF showing the outcome, and a live Stackblitz:
+
+```mdx
+## What you'll build
+
+<GifEmbed src="/demos/rag-chat.gif" alt="RAG chat UI streaming" />
+
+## Live sandbox
+
+<StackblitzEmbed project="AgentsKit-io/agentskit/tree/main/apps/example-react" file="src/App.tsx" />
+
+## Copy-paste
+
+\`\`\`ts
+// ...
+\`\`\`
+```
+
+## Related
+
+- [Contribute → package docs](./package-docs)
+- Issue #481/#482/#483/#484 — future MDX components (LivePlayground, better GIF helpers).

--- a/apps/docs-next/content/docs/reference/contribute/meta.json
+++ b/apps/docs-next/content/docs/reference/contribute/meta.json
@@ -6,6 +6,7 @@
     "local-setup",
     "commit-style",
     "package-docs",
+    "docs-components",
     "rfc-process",
     "roadmap"
   ]

--- a/apps/docs-next/content/docs/reference/recipes/rag-chat.mdx
+++ b/apps/docs-next/content/docs/reference/recipes/rag-chat.mdx
@@ -5,6 +5,8 @@ description: A streaming React chat that answers from your own documents. Vector
 
 A working chat UI grounded in your own content. The model answers using whatever docs you ingest — nothing else.
 
+<StackblitzEmbed project="AgentsKit-io/agentskit/tree/main/apps/example-react" file="src/App.tsx" title="RAG chat — live sandbox" />
+
 ## Install
 
 ```bash

--- a/apps/docs-next/mdx-components.tsx
+++ b/apps/docs-next/mdx-components.tsx
@@ -1,11 +1,17 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import type { MDXComponents } from 'mdx/types'
 import { Mermaid } from '@/components/mermaid'
+import { StackblitzEmbed } from '@/components/mdx/stackblitz-embed'
+import { CodeSandboxEmbed } from '@/components/mdx/codesandbox-embed'
+import { GifEmbed } from '@/components/mdx/gif-embed'
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     Mermaid,
+    StackblitzEmbed,
+    CodeSandboxEmbed,
+    GifEmbed,
     ...components,
   }
 }


### PR DESCRIPTION
## Summary
Three embeddable MDX components, registered globally so any `.mdx` page can use them without imports.

- **`<StackblitzEmbed />`** — GitHub path → live editable sandbox. Lazy by default (click-to-load → preserves LCP).
- **`<CodeSandboxEmbed />`** — same shape for CodeSandbox.
- **`<GifEmbed />`** — a11y-aware GIF:
  - IntersectionObserver-triggered playback.
  - `prefers-reduced-motion` fallback to a poster PNG + explicit link.
  - `data-ak-gif` attribute for uniform theming.

Registered in `apps/docs-next/mdx-components.tsx`. First use wired into the `rag-chat` recipe. Full prop reference added at `/docs/reference/contribute/docs-components`.

Satisfies issues #481, #482, #484.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes
- [ ] Preview: Stackblitz placeholder renders, click-to-load works
- [ ] Preview: GIF still-frame shows with reduced-motion set