### PR TITLE
feat(home): motion polish — FadeIn + Stagger + gradient wordmark

### DIFF
--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -5,6 +5,7 @@ import { HeroDemo } from './_components/hero-demo/hero-demo'
 import { ContributorWall } from '@/components/contribute/contributor-wall'
 import { AnimatedLogo } from '@/components/brand/animated-logo'
 import { JsonLd } from '@/components/seo/json-ld'
+import { FadeIn, Stagger, StaggerItem } from '@/components/motion/fade-in'
 
 export const metadata = {
   title: 'AgentsKit.js — Ship AI agents in JavaScript without gluing 8 libraries',
@@ -127,13 +128,18 @@ function Hero() {
             v1.0 · MIT · Built for the agent era
           </div>
 
-          <h1 className="mb-5 max-w-2xl text-[2rem] font-bold leading-[1.08] tracking-tight text-ak-foam sm:mb-6 sm:text-4xl md:text-5xl lg:text-6xl">
-            Ship AI agents in JavaScript.
-            <span className="block text-ak-graphite">
-              Without gluing 8 libraries together.
-            </span>
-          </h1>
+          <FadeIn>
+            <h1 className="mb-5 max-w-2xl text-[2rem] font-bold leading-[1.08] tracking-tight text-ak-foam sm:mb-6 sm:text-4xl md:text-5xl lg:text-6xl">
+              <span className="bg-gradient-to-r from-ak-foam via-ak-blue to-ak-foam bg-clip-text text-transparent">
+                Ship AI agents in JavaScript.
+              </span>
+              <span className="block text-ak-graphite">
+                Without gluing 8 libraries together.
+              </span>
+            </h1>
+          </FadeIn>
 
+          <FadeIn delay={0.1}>
           <p className="mb-7 max-w-xl text-base leading-relaxed text-ak-graphite sm:mb-8 sm:text-lg">
             AgentsKit gives you chat UI, tools, memory, RAG, and runtime — one
             toolkit, zero lock-in. Swap{' '}
@@ -141,8 +147,11 @@ function Hero() {
             terminal, in-memory for vector DB.{' '}
             <span className="text-ak-foam">Nothing breaks.</span>
           </p>
+          </FadeIn>
 
-          <InstallCommand />
+          <FadeIn delay={0.2}>
+            <InstallCommand />
+          </FadeIn>
 
           <div className="mt-5 flex flex-wrap items-center gap-2.5 sm:mt-6 sm:gap-3">
             <Link
@@ -322,12 +331,12 @@ function SolutionSection() {
             <p className="mb-4 text-center font-mono text-[11px] uppercase tracking-[0.2em] text-ak-graphite">
               ↓ click any package to open its docs
             </p>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+            <Stagger className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4" stagger={0.04}>
               {PACKAGE_CARDS.map(pkg => (
+                <StaggerItem key={pkg.name}>
                 <Link
-                  key={pkg.name}
                   href={pkg.href}
-                  className="group flex min-w-0 items-center justify-between gap-1.5 rounded-md border border-ak-border bg-ak-surface px-2.5 py-2 text-center font-mono text-[12px] text-ak-foam transition hover:border-ak-blue hover:text-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)] sm:gap-2 sm:px-3 sm:text-sm"
+                  className="group flex min-w-0 items-center justify-between gap-1.5 rounded-md border border-ak-border bg-ak-surface px-2.5 py-2 text-center font-mono text-[12px] text-ak-foam transition hover:-translate-y-0.5 hover:border-ak-blue hover:text-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)] sm:gap-2 sm:px-3 sm:text-sm"
                   aria-label={`Open docs for ${pkg.name}`}
                 >
                   <span className="min-w-0 flex-1 truncate text-left">{pkg.name}</span>
@@ -335,8 +344,9 @@ function SolutionSection() {
                     →
                   </span>
                 </Link>
+                </StaggerItem>
               ))}
-            </div>
+            </Stagger>
             <p className="mt-4 text-center font-mono text-[11px] text-ak-graphite">
               every card links to its docs ·{' '}
               <Link href="/docs" className="underline decoration-dotted underline-offset-2 hover:text-ak-blue">
@@ -482,12 +492,12 @@ function EcosystemStats() {
         <h2 className="mb-8 max-w-3xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-10 sm:text-3xl md:text-4xl">
           Everything you need. Nothing you don&apos;t.
         </h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4">
+        <Stagger className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4" stagger={0.05}>
           {stats.map((s) => (
+            <StaggerItem key={s.label}>
             <Link
-              key={s.label}
               href={s.href}
-              className="group rounded-xl border border-ak-border bg-ak-surface p-5 transition hover:border-ak-blue"
+              className="group block rounded-xl border border-ak-border bg-ak-surface p-5 transition hover:-translate-y-0.5 hover:border-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)]"
             >
               <div className="mb-1 font-mono text-2xl font-bold text-ak-foam transition group-hover:text-ak-blue sm:text-3xl">
                 {s.value}
@@ -496,8 +506,9 @@ function EcosystemStats() {
                 {s.label}
               </div>
             </Link>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
         <p className="mt-6 text-sm text-ak-graphite">
           Every number above is a click-through. Install what you need; the core stays under 10 KB gzipped.
         </p>

--- a/apps/docs-next/components/motion/fade-in.tsx
+++ b/apps/docs-next/components/motion/fade-in.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { motion, useReducedMotion } from 'motion/react'
+import type { ReactNode } from 'react'
+
+export type FadeInProps = {
+  children: ReactNode
+  className?: string
+  delay?: number
+  y?: number
+  once?: boolean
+}
+
+export function FadeIn({
+  children,
+  className,
+  delay = 0,
+  y = 12,
+  once = true,
+}: FadeInProps) {
+  const reduce = useReducedMotion()
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: reduce ? 0 : y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once, margin: '-80px' }}
+      transition={{ duration: 0.5, ease: 'easeOut', delay: reduce ? 0 : delay }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export type StaggerProps = {
+  children: ReactNode
+  className?: string
+  stagger?: number
+  once?: boolean
+}
+
+export function Stagger({
+  children,
+  className,
+  stagger = 0.05,
+  once = true,
+}: StaggerProps) {
+  const reduce = useReducedMotion()
+  return (
+    <motion.div
+      className={className}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once, margin: '-80px' }}
+      variants={{
+        visible: { transition: { staggerChildren: reduce ? 0 : stagger } },
+        hidden: {},
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export function StaggerItem({
+  children,
+  className,
+  y = 12,
+}: {
+  children: ReactNode
+  className?: string
+  y?: number
+}) {
+  const reduce = useReducedMotion()
+  return (
+    <motion.div
+      className={className}
+      variants={{
+        hidden: { opacity: 0, y: reduce ? 0 : y },
+        visible: { opacity: 1, y: 0, transition: { duration: 0.45, ease: 'easeOut' } },
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -18,6 +18,7 @@
     "fumadocs-mdx": "^14.3.0",
     "fumadocs-ui": "^16.7.15",
     "mermaid": "^11.14.0",
+    "motion": "^12.38.0",
     "next": "^16.2.4",
     "postcss": "^8.5.10",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
+      motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next:
         specifier: ^16.2.4
         version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -250,7 +253,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/angular:
     dependencies:
@@ -363,7 +366,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eval:
     dependencies:
@@ -8842,7 +8845,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:


### PR DESCRIPTION
## Summary
Adds motion primitives and wires them into the homepage for a Langchain-caliber first-paint.

### Primitives (`components/motion/fade-in.tsx`)
Wrap `motion/react` (Framer Motion 12+) with `prefers-reduced-motion` respect:
- `<FadeIn delay y />` — single-element reveal.
- `<Stagger stagger>` + `<StaggerItem>` — group reveal.

### Homepage wiring
- **Hero headline** — gradient wordmark (foam → blue → foam) + fade-in.
- **Paragraph + install command** — staggered delays (0.1s, 0.2s).
- **Package grid** (21 cards) — `0.04s` stagger, `hover: -translate-y-0.5`.
- **Ecosystem stats** (8 tiles) — `0.05s` stagger, hover-lift, blue-glow shadow.

### Dep
Adds `motion ^12.38.0` to `apps/docs-next/package.json`. All animations collapse to opacity-only (or static) when user has `prefers-reduced-motion` set.

## Test plan
- [x] `pnpm --filter @agentskit/docs-next build` passes
- [ ] Preview: hero text fades in; gradient on headline visible
- [ ] Preview: package grid + stats stagger sequentially
- [ ] Preview with reduced-motion enabled — all reveals collapse to opacity-only