### PR TITLE
feat(docs): interactive overhaul — playground, grouped search, auto API, cookbook, /learn

### DIFF
--- a/apps/docs-next/.gitignore
+++ b/apps/docs-next/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 .env*.local
 next-env.d.ts
 .vercel
+content/docs/api/
+content/docs/reference/changelog.mdx
+content/docs/production/performance.mdx

--- a/apps/docs-next/app/api/search/route.ts
+++ b/apps/docs-next/app/api/search/route.ts
@@ -1,4 +1,42 @@
 import { source } from '@/lib/source'
 import { createFromSource } from 'fumadocs-core/search/server'
 
-export const { GET } = createFromSource(source)
+function tagFor(url: string): string {
+  if (url.startsWith('/docs/reference/packages')) return 'packages'
+  if (url.startsWith('/docs/reference/examples') || url.startsWith('/docs/use-cases')) return 'examples'
+  if (
+    url.startsWith('/docs/reference') ||
+    url.startsWith('/docs/ui') ||
+    url.startsWith('/docs/for-agents')
+  )
+    return 'api'
+  return 'guides'
+}
+
+export const { GET } = createFromSource(source, {
+  buildIndex: async (page) => {
+    const data = page.data as {
+      title?: string
+      description?: string
+      structuredData?: unknown
+      load?: () => Promise<{ structuredData: unknown }>
+    }
+    const structuredData = data.structuredData
+      ? typeof data.structuredData === 'function'
+        ? await (data.structuredData as () => Promise<unknown>)()
+        : data.structuredData
+      : data.load
+        ? (await data.load()).structuredData
+        : undefined
+    if (!structuredData) throw new Error(`No structuredData on page ${page.url}`)
+    return {
+      id: page.url,
+      title: data.title ?? page.url,
+      description: data.description,
+      url: page.url,
+      tag: tagFor(page.url),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      structuredData: structuredData as any,
+    }
+  },
+})

--- a/apps/docs-next/app/global.css
+++ b/apps/docs-next/app/global.css
@@ -40,6 +40,50 @@
   --color-ak-blue: var(--ak-blue);
   --color-ak-red: var(--ak-red);
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --font-display: 'Space Grotesk', var(--font-sans, Inter), system-ui, sans-serif;
+}
+
+/* Gradient wordmark + display typography */
+.ak-wordmark {
+  background: linear-gradient(120deg, #58A6FF 0%, #A371F7 45%, #F778BA 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.font-display {
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
+}
+
+/* Give docs headings a display feel without overriding body text */
+article h1,
+article h2 {
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
+}
+
+/* Polish code blocks: subtle gradient border + tighter padding rhythm */
+.prose pre,
+pre[data-language] {
+  position: relative;
+  border-radius: 10px;
+  border: 1px solid var(--ak-border);
+  background: var(--ak-midnight);
+}
+.prose pre::before,
+pre[data-language]::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(88, 166, 255, 0.35), rgba(163, 113, 247, 0.25), rgba(247, 120, 186, 0.2));
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.6;
 }
 
 @keyframes ak-fade-in {

--- a/apps/docs-next/app/layout.config.tsx
+++ b/apps/docs-next/app/layout.config.tsx
@@ -18,11 +18,15 @@ export const baseOptions: BaseLayoutProps = {
     title: (
       <span className="flex items-center gap-2">
         <AnimatedLogo variant="nav" loop />
-        <span className="font-mono font-bold tracking-tight">agentskit<span className="text-ak-graphite">.js</span></span>
+        <span className="font-display text-base font-bold tracking-tight">
+          <span className="ak-wordmark">agentskit</span>
+          <span className="text-ak-graphite">.js</span>
+        </span>
       </span>
     ),
   },
   links: [
+    { text: 'Learn', url: '/learn' },
     { text: 'Documentation', url: '/docs' },
     { text: 'For agents', url: '/docs/for-agents' },
     { text: 'Examples', url: '/docs/reference/examples' },

--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -1,12 +1,13 @@
 import './global.css'
 import { RootProvider } from 'fumadocs-ui/provider/next'
-import { Inter, JetBrains_Mono } from 'next/font/google'
+import { Inter, JetBrains_Mono, Space_Grotesk } from 'next/font/google'
 import type { ReactNode } from 'react'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
 const jetbrainsMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
+const spaceGrotesk = Space_Grotesk({ subsets: ['latin'], variable: '--font-display', display: 'swap' })
 
 const SITE_URL = 'https://www.agentskit.io'
 const DESCRIPTION = 'The agent toolkit JavaScript actually deserves.'
@@ -86,7 +87,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable}`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${spaceGrotesk.variable}`}
       suppressHydrationWarning
     >
       <head>
@@ -94,7 +95,21 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link rel="alternate" type="text/plain" href="/llms-full.txt" title="Full docs for LLM ingestion" />
       </head>
       <body className="flex min-h-screen flex-col overflow-x-clip font-sans">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider
+          search={{
+            options: {
+              allowClear: true,
+              tags: [
+                { name: 'Guides', value: 'guides' },
+                { name: 'API', value: 'api' },
+                { name: 'Examples', value: 'examples' },
+                { name: 'Packages', value: 'packages' },
+              ],
+            },
+          }}
+        >
+          {children}
+        </RootProvider>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/apps/docs-next/app/learn/[step]/page.tsx
+++ b/apps/docs-next/app/learn/[step]/page.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { STEPS } from '@/lib/learn-steps'
+import { Stepper, MarkStepDone } from '@/components/learn/stepper'
+import { Playground } from '@/components/mdx/playground'
+
+export function generateStaticParams() {
+  return STEPS.map((s) => ({ step: s.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ step: string }> }) {
+  const { step } = await params
+  const s = STEPS.find((x) => x.slug === step)
+  if (!s) return { title: 'Learn AgentsKit' }
+  return { title: `${s.title} — Learn AgentsKit`, description: s.intro }
+}
+
+function renderBody(body: string) {
+  const blocks: { type: 'code' | 'text'; lang?: string; text: string }[] = []
+  const re = /```(\w+)?\n([\s\S]*?)```/g
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(body))) {
+    if (m.index > last) blocks.push({ type: 'text', text: body.slice(last, m.index) })
+    blocks.push({ type: 'code', lang: m[1] ?? 'text', text: m[2] })
+    last = m.index + m[0].length
+  }
+  if (last < body.length) blocks.push({ type: 'text', text: body.slice(last) })
+  return blocks.map((b, i) =>
+    b.type === 'code' ? (
+      <pre
+        key={i}
+        className="my-4 overflow-x-auto rounded-lg border border-ak-border bg-ak-midnight p-4 font-mono text-sm text-ak-foam"
+      >
+        <code>{b.text}</code>
+      </pre>
+    ) : (
+      <p key={i} className="my-3 whitespace-pre-wrap text-ak-graphite">
+        {b.text.split(/(\*\*[^*]+\*\*)/g).map((part, j) =>
+          part.startsWith('**') ? (
+            <strong key={j} className="text-white">
+              {part.slice(2, -2)}
+            </strong>
+          ) : (
+            part
+          ),
+        )}
+      </p>
+    ),
+  )
+}
+
+export default async function StepPage({ params }: { params: Promise<{ step: string }> }) {
+  const { step } = await params
+  const s = STEPS.find((x) => x.slug === step)
+  if (!s) notFound()
+  const idx = STEPS.indexOf(s)
+  const prev = STEPS[idx - 1]
+  const next = STEPS[idx + 1]
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-12">
+      <div className="flex flex-col gap-10 md:flex-row">
+        <Stepper activeSlug={s.slug} />
+        <article className="flex-1">
+          <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-foam">
+            Step {idx + 1} / {STEPS.length}
+          </div>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">{s.title}</h1>
+          <p className="mt-3 text-lg text-ak-graphite">{s.intro}</p>
+          <div className="mt-6">{renderBody(s.body)}</div>
+
+          {s.files ? (
+            <div className="mt-8">
+              <Playground files={s.files} entry={s.entry} eager title="Try it live" />
+            </div>
+          ) : null}
+
+          <div className="mt-10 flex items-center justify-between gap-4 border-t border-ak-border pt-6">
+            {prev ? (
+              <Link
+                href={`/learn/${prev.slug}`}
+                className="text-sm text-ak-graphite hover:text-ak-foam"
+              >
+                ← {prev.title}
+              </Link>
+            ) : (
+              <span />
+            )}
+            <MarkStepDone stepKey={s.key} />
+            {next ? (
+              <Link
+                href={`/learn/${next.slug}`}
+                className="text-sm font-semibold text-ak-foam hover:text-white"
+              >
+                {next.title} →
+              </Link>
+            ) : (
+              <Link href="/docs" className="text-sm font-semibold text-ak-foam hover:text-white">
+                Read the docs →
+              </Link>
+            )}
+          </div>
+        </article>
+      </div>
+    </main>
+  )
+}

--- a/apps/docs-next/app/learn/layout.tsx
+++ b/apps/docs-next/app/learn/layout.tsx
@@ -1,0 +1,7 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home'
+import type { ReactNode } from 'react'
+import { baseOptions } from '../layout.config'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <HomeLayout {...baseOptions}>{children}</HomeLayout>
+}

--- a/apps/docs-next/app/learn/page.tsx
+++ b/apps/docs-next/app/learn/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import { STEPS } from '@/lib/learn-steps'
+import { Stepper } from '@/components/learn/stepper'
+
+export const metadata = {
+  title: 'Learn AgentsKit — interactive tutorial',
+  description:
+    'Ship a streaming chat, swap providers, register tools, and persist memory. Runs in your browser. Progress saved locally.',
+}
+
+export default function LearnIndex() {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-12">
+      <div className="mb-10">
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-foam">Interactive tutorial</div>
+        <h1 className="mt-2 text-4xl font-semibold tracking-tight text-white">Learn AgentsKit in 5 steps</h1>
+        <p className="mt-3 max-w-2xl text-ak-graphite">
+          End-to-end: install, build a streaming chat, swap providers, register tools, persist memory. Every step
+          runs in your browser — no API keys required. Progress is saved locally.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-10 md:flex-row">
+        <Stepper />
+        <section className="flex-1">
+          <ol className="grid gap-3">
+            {STEPS.map((s, i) => (
+              <li key={s.slug}>
+                <Link
+                  href={`/learn/${s.slug}`}
+                  className="block rounded-lg border border-ak-border bg-ak-surface p-4 transition hover:border-ak-foam"
+                >
+                  <div className="font-mono text-[10px] uppercase tracking-widest text-ak-graphite">
+                    Step {i + 1}
+                  </div>
+                  <div className="mt-1 text-lg font-semibold text-white">{s.title}</div>
+                  <p className="mt-1 text-sm text-ak-graphite">{s.intro}</p>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/docs-next/components/learn/stepper.tsx
+++ b/apps/docs-next/components/learn/stepper.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import { PROGRESS_KEY, STEPS, type Progress } from '@/lib/learn-steps'
+
+function readProgress(): Progress {
+  if (typeof window === 'undefined') return {}
+  try {
+    return JSON.parse(window.localStorage.getItem(PROGRESS_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function writeProgress(p: Progress) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(PROGRESS_KEY, JSON.stringify(p))
+  window.dispatchEvent(new CustomEvent('ak:learn-progress'))
+}
+
+export function useProgress() {
+  const [progress, setProgress] = useState<Progress>({})
+  useEffect(() => {
+    setProgress(readProgress())
+    const h = () => setProgress(readProgress())
+    window.addEventListener('ak:learn-progress', h)
+    window.addEventListener('storage', h)
+    return () => {
+      window.removeEventListener('ak:learn-progress', h)
+      window.removeEventListener('storage', h)
+    }
+  }, [])
+  const toggle = useCallback((key: string, value?: boolean) => {
+    const current = readProgress()
+    const next = { ...current, [key]: value ?? !current[key] }
+    writeProgress(next)
+  }, [])
+  return { progress, toggle }
+}
+
+export function Stepper({ activeSlug }: { activeSlug?: string }) {
+  const { progress } = useProgress()
+  const done = STEPS.filter((s) => progress[s.key]).length
+  const pct = Math.round((done / STEPS.length) * 100)
+
+  return (
+    <aside className="w-full shrink-0 md:w-64">
+      <div className="mb-4 rounded-lg border border-ak-border bg-ak-surface p-3">
+        <div className="mb-1 flex justify-between font-mono text-[10px] uppercase tracking-widest text-ak-graphite">
+          <span>Progress</span>
+          <span>{done}/{STEPS.length}</span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-ak-midnight">
+          <div className="h-full bg-ak-foam transition-all" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <nav>
+        <ol className="flex flex-col gap-1">
+          {STEPS.map((s, i) => {
+            const isActive = s.slug === activeSlug
+            const isDone = !!progress[s.key]
+            return (
+              <li key={s.slug}>
+                <Link
+                  href={`/learn/${s.slug}`}
+                  className={`flex items-center gap-3 rounded-md border px-3 py-2 text-sm transition ${
+                    isActive
+                      ? 'border-ak-foam bg-ak-foam/10 text-white'
+                      : 'border-transparent text-ak-graphite hover:border-ak-border hover:bg-ak-surface hover:text-white'
+                  }`}
+                >
+                  <span
+                    className={`flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-semibold ${
+                      isDone
+                        ? 'border-ak-foam bg-ak-foam text-ak-midnight'
+                        : isActive
+                          ? 'border-ak-foam text-ak-foam'
+                          : 'border-ak-border text-ak-graphite'
+                    }`}
+                  >
+                    {isDone ? '✓' : i + 1}
+                  </span>
+                  <span className="truncate">{s.title}</span>
+                </Link>
+              </li>
+            )
+          })}
+        </ol>
+      </nav>
+    </aside>
+  )
+}
+
+export function MarkStepDone({ stepKey }: { stepKey: string }) {
+  const { progress, toggle } = useProgress()
+  const done = !!progress[stepKey]
+  return (
+    <button
+      type="button"
+      onClick={() => toggle(stepKey)}
+      className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
+        done
+          ? 'border border-ak-border bg-ak-surface text-ak-graphite'
+          : 'bg-ak-foam text-ak-midnight hover:bg-white'
+      }`}
+    >
+      {done ? '✓ Marked done' : 'Mark step as done'}
+    </button>
+  )
+}

--- a/apps/docs-next/components/mdx/arch-diagram.tsx
+++ b/apps/docs-next/components/mdx/arch-diagram.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+type Pkg = { name: string; deps: string[]; row: number; col: number; tagline: string }
+
+const PACKAGES: Pkg[] = [
+  { name: 'core', deps: [], row: 0, col: 2, tagline: 'zero-dep foundation' },
+  { name: 'adapters', deps: ['core'], row: 1, col: 0, tagline: 'provider adapters' },
+  { name: 'runtime', deps: ['core'], row: 1, col: 1, tagline: 'autonomous agent loop' },
+  { name: 'react', deps: ['core'], row: 1, col: 2, tagline: 'React hooks + UI' },
+  { name: 'ink', deps: ['core'], row: 1, col: 3, tagline: 'terminal UI' },
+  { name: 'vue', deps: ['core'], row: 1, col: 4, tagline: 'Vue hooks' },
+  { name: 'tools', deps: ['core'], row: 2, col: 0, tagline: 'reusable tools' },
+  { name: 'skills', deps: ['core'], row: 2, col: 1, tagline: 'prompt personas' },
+  { name: 'memory', deps: ['core'], row: 2, col: 2, tagline: 'persistent memory' },
+  { name: 'rag', deps: ['core'], row: 2, col: 3, tagline: 'plug-and-play RAG' },
+  { name: 'observability', deps: ['core'], row: 2, col: 4, tagline: 'traces + logs' },
+  { name: 'sandbox', deps: ['core'], row: 3, col: 0, tagline: 'secure code exec' },
+  { name: 'eval', deps: ['core'], row: 3, col: 1, tagline: 'benchmarks' },
+  { name: 'svelte', deps: ['core'], row: 3, col: 2, tagline: 'Svelte stores' },
+  { name: 'solid', deps: ['core'], row: 3, col: 3, tagline: 'Solid signals' },
+  { name: 'cli', deps: ['core', 'runtime', 'adapters', 'tools', 'ink', 'memory', 'rag', 'skills'], row: 3, col: 4, tagline: 'one-shot chat + init' },
+]
+
+const W = 140
+const H = 72
+const GAP_X = 28
+const GAP_Y = 40
+
+function pos(p: Pkg) {
+  return { x: p.col * (W + GAP_X) + 12, y: p.row * (H + GAP_Y) + 12 }
+}
+
+export function ArchDiagram() {
+  const [hover, setHover] = useState<string | null>(null)
+  const [locked, setLocked] = useState<string | null>(null)
+  const active = locked ?? hover
+
+  const byName = useMemo(() => Object.fromEntries(PACKAGES.map((p) => [p.name, p])), [])
+
+  const rels = useMemo(() => {
+    const out: { from: string; to: string }[] = []
+    for (const p of PACKAGES) for (const d of p.deps) out.push({ from: p.name, to: d })
+    return out
+  }, [])
+
+  const activeSet = useMemo(() => {
+    if (!active) return null
+    const s = new Set<string>([active])
+    const me = byName[active]
+    if (me) for (const d of me.deps) s.add(d)
+    for (const p of PACKAGES) if (p.deps.includes(active)) s.add(p.name)
+    return s
+  }, [active, byName])
+
+  const cols = Math.max(...PACKAGES.map((p) => p.col)) + 1
+  const rows = Math.max(...PACKAGES.map((p) => p.row)) + 1
+  const width = cols * (W + GAP_X) + 12
+  const height = rows * (H + GAP_Y) + 12
+
+  return (
+    <div data-ak-arch className="my-6 overflow-hidden rounded-lg border border-ak-border bg-ak-surface">
+      <div className="flex items-center justify-between border-b border-ak-border px-4 py-2">
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+          Package graph · click to lock · hover to explore
+        </div>
+        {locked ? (
+          <button
+            type="button"
+            onClick={() => setLocked(null)}
+            className="rounded border border-ak-border bg-ak-midnight px-2 py-0.5 font-mono text-[10px] text-ak-graphite hover:text-ak-foam"
+          >
+            clear
+          </button>
+        ) : null}
+      </div>
+      <div className="overflow-x-auto p-4">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          className="min-w-full"
+          role="img"
+          aria-label="AgentsKit package dependency graph"
+        >
+          <g>
+            {rels.map((r, i) => {
+              const a = byName[r.from]
+              const b = byName[r.to]
+              if (!a || !b) return null
+              const pa = pos(a)
+              const pb = pos(b)
+              const x1 = pa.x + W / 2
+              const y1 = pa.y
+              const x2 = pb.x + W / 2
+              const y2 = pb.y + H
+              const isActive = activeSet && activeSet.has(r.from) && activeSet.has(r.to)
+              return (
+                <path
+                  key={i}
+                  d={`M${x1},${y1} C${x1},${(y1 + y2) / 2} ${x2},${(y1 + y2) / 2} ${x2},${y2}`}
+                  fill="none"
+                  stroke={isActive ? 'var(--ak-foam, #a5f3fc)' : 'var(--ak-border, #1e293b)'}
+                  strokeWidth={isActive ? 2 : 1}
+                  opacity={activeSet && !isActive ? 0.2 : 1}
+                />
+              )
+            })}
+          </g>
+          <g>
+            {PACKAGES.map((p) => {
+              const { x, y } = pos(p)
+              const isActive = activeSet?.has(p.name)
+              const dimmed = activeSet && !isActive
+              const isRoot = p.name === active
+              return (
+                <g
+                  key={p.name}
+                  transform={`translate(${x},${y})`}
+                  onMouseEnter={() => setHover(p.name)}
+                  onMouseLeave={() => setHover(null)}
+                  onClick={() => setLocked((l) => (l === p.name ? null : p.name))}
+                  style={{ cursor: 'pointer', opacity: dimmed ? 0.35 : 1, transition: 'opacity 150ms' }}
+                >
+                  <rect
+                    width={W}
+                    height={H}
+                    rx={10}
+                    fill={isRoot ? 'var(--ak-foam, #a5f3fc)' : 'var(--ak-midnight, #0f172a)'}
+                    stroke={isActive ? 'var(--ak-foam, #a5f3fc)' : 'var(--ak-border, #1e293b)'}
+                    strokeWidth={isActive ? 2 : 1}
+                  />
+                  <text
+                    x={W / 2}
+                    y={28}
+                    textAnchor="middle"
+                    fill={isRoot ? 'var(--ak-midnight, #0f172a)' : 'white'}
+                    fontFamily="var(--font-mono, monospace)"
+                    fontSize={13}
+                    fontWeight={600}
+                  >
+                    @agentskit/{p.name}
+                  </text>
+                  <text
+                    x={W / 2}
+                    y={50}
+                    textAnchor="middle"
+                    fill={isRoot ? 'var(--ak-midnight, #0f172a)' : 'var(--ak-graphite, #94a3b8)'}
+                    fontFamily="var(--font-sans, system-ui)"
+                    fontSize={10}
+                  >
+                    {p.tagline}
+                  </text>
+                </g>
+              )
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/mdx/callouts.tsx
+++ b/apps/docs-next/components/mdx/callouts.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+import { Callout } from 'fumadocs-ui/components/callout'
+
+type P = { title?: ReactNode; children: ReactNode }
+
+export const Tip = ({ title = 'Tip', children }: P) => (
+  <Callout type="idea" title={title}>
+    {children}
+  </Callout>
+)
+export const Warning = ({ title = 'Warning', children }: P) => (
+  <Callout type="warn" title={title}>
+    {children}
+  </Callout>
+)
+export const Pitfall = ({ title = 'Pitfall', children }: P) => (
+  <Callout type="error" title={title}>
+    {children}
+  </Callout>
+)
+export const Performance = ({ title = 'Performance', children }: P) => (
+  <Callout type="info" title={`⚡ ${typeof title === 'string' ? title : 'Performance'}`}>
+    {children}
+  </Callout>
+)
+export const Security = ({ title = 'Security', children }: P) => (
+  <Callout type="warn" title={`🔒 ${typeof title === 'string' ? title : 'Security'}`}>
+    {children}
+  </Callout>
+)
+export const Info = ({ title = 'Note', children }: P) => (
+  <Callout type="info" title={title}>
+    {children}
+  </Callout>
+)
+export const Success = ({ title = 'Shipped', children }: P) => (
+  <Callout type="success" title={title}>
+    {children}
+  </Callout>
+)
+
+export function Compare({
+  good,
+  bad,
+  goodLabel = 'Do',
+  badLabel = "Don't",
+}: {
+  good: ReactNode
+  bad: ReactNode
+  goodLabel?: ReactNode
+  badLabel?: ReactNode
+}) {
+  return (
+    <div data-ak-compare className="my-6 grid gap-4 md:grid-cols-2">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+        <header className="mb-2 flex items-center gap-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-emerald-300">
+          <span aria-hidden>✓</span> {goodLabel}
+        </header>
+        <div className="[&>pre]:my-0">{good}</div>
+      </section>
+      <section className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+        <header className="mb-2 flex items-center gap-2 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-red-300">
+          <span aria-hidden>✗</span> {badLabel}
+        </header>
+        <div className="[&>pre]:my-0">{bad}</div>
+      </section>
+    </div>
+  )
+}

--- a/apps/docs-next/components/mdx/framework-tabs.tsx
+++ b/apps/docs-next/components/mdx/framework-tabs.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useSyncExternalStore,
+} from 'react'
+
+const STORAGE_KEY = 'ak:framework'
+const EVENT = 'ak:framework-change'
+
+const DEFAULT_ORDER = [
+  'react',
+  'vue',
+  'svelte',
+  'solid',
+  'angular',
+  'react-native',
+  'ink',
+  'node',
+  'cli',
+] as const
+
+const LABELS: Record<string, string> = {
+  react: 'React',
+  vue: 'Vue',
+  svelte: 'Svelte',
+  solid: 'Solid',
+  angular: 'Angular',
+  'react-native': 'React Native',
+  ink: 'Ink',
+  node: 'Node',
+  cli: 'CLI',
+}
+
+function readStored(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function subscribe(cb: () => void) {
+  if (typeof window === 'undefined') return () => {}
+  const handler = () => cb()
+  window.addEventListener(EVENT, handler)
+  window.addEventListener('storage', handler)
+  return () => {
+    window.removeEventListener(EVENT, handler)
+    window.removeEventListener('storage', handler)
+  }
+}
+
+function useFramework() {
+  return useSyncExternalStore(subscribe, readStored, () => null)
+}
+
+function setFramework(value: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value)
+  } catch {
+    /* ignore */
+  }
+  window.dispatchEvent(new CustomEvent(EVENT))
+}
+
+type FrameworkProps = {
+  name: string
+  label?: string
+  children: ReactNode
+}
+
+export function Framework({ children }: FrameworkProps) {
+  // Rendered by <FrameworkTabs>. Standalone use renders nothing.
+  return <>{children}</>
+}
+
+type FrameworkTabsProps = {
+  children: ReactNode
+  /** Order/whitelist of framework values. */
+  order?: readonly string[]
+  /** Default when no preference stored. */
+  defaultValue?: string
+}
+
+function collect(children: ReactNode): ReactElement<FrameworkProps>[] {
+  const list: ReactElement<FrameworkProps>[] = []
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return
+    if ((child.type as { displayName?: string })?.displayName === 'Framework' || child.type === Framework) {
+      list.push(child as ReactElement<FrameworkProps>)
+    }
+  })
+  return list
+}
+
+export function FrameworkTabs({ children, order = DEFAULT_ORDER, defaultValue }: FrameworkTabsProps) {
+  const items = collect(children)
+  const active = useFramework()
+  const values = items.map((i) => i.props.name)
+  const sorted = [...items].sort((a, b) => {
+    const ai = order.indexOf(a.props.name)
+    const bi = order.indexOf(b.props.name)
+    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi)
+  })
+
+  const resolved = active && values.includes(active) ? active : (defaultValue ?? sorted[0]?.props.name)
+
+  const choose = useCallback((name: string) => setFramework(name), [])
+
+  useEffect(() => {
+    if (!active && defaultValue && values.includes(defaultValue)) {
+      setFramework(defaultValue)
+    }
+  }, [active, defaultValue, values])
+
+  if (sorted.length === 0) return null
+
+  return (
+    <div data-ak-framework-tabs className="my-6 overflow-hidden rounded-lg border border-ak-border">
+      <div
+        role="tablist"
+        aria-label="Framework"
+        className="flex flex-wrap gap-1 border-b border-ak-border bg-ak-surface p-1"
+      >
+        {sorted.map((item) => {
+          const name = item.props.name
+          const isActive = name === resolved
+          return (
+            <button
+              key={name}
+              role="tab"
+              aria-selected={isActive}
+              type="button"
+              onClick={() => choose(name)}
+              className={`rounded px-3 py-1.5 text-xs font-semibold transition ${
+                isActive
+                  ? 'bg-ak-foam text-ak-midnight'
+                  : 'text-ak-graphite hover:bg-ak-midnight hover:text-white'
+              }`}
+            >
+              {item.props.label ?? LABELS[name] ?? name}
+            </button>
+          )
+        })}
+      </div>
+      <div className="p-4">
+        {sorted.map((item) => (
+          <div
+            key={item.props.name}
+            role="tabpanel"
+            hidden={item.props.name !== resolved}
+            aria-hidden={item.props.name !== resolved}
+          >
+            {item.props.children}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+;(Framework as unknown as { displayName: string }).displayName = 'Framework'

--- a/apps/docs-next/components/mdx/playground-presets.ts
+++ b/apps/docs-next/components/mdx/playground-presets.ts
@@ -1,0 +1,117 @@
+export type PlaygroundPreset = {
+  name: string
+  description: string
+  entry: string
+  files: Record<string, string>
+  dependencies?: Record<string, string>
+}
+
+const basicChat = `import { useState } from 'react'
+
+const MOCK_REPLIES = [
+  'Streaming works by flushing tokens as they arrive.',
+  'AgentsKit wires the provider, runtime, and UI with one hook.',
+  'Swap the adapter and the rest of the app stays identical.',
+]
+
+export default function App() {
+  const [messages, setMessages] = useState([
+    { role: 'assistant', content: 'Hi! Ask me anything about AgentsKit.' },
+  ])
+  const [input, setInput] = useState('')
+
+  async function send() {
+    if (!input.trim()) return
+    const next = [...messages, { role: 'user', content: input }]
+    setMessages(next)
+    setInput('')
+    const reply = MOCK_REPLIES[next.length % MOCK_REPLIES.length]
+    let streamed = ''
+    setMessages([...next, { role: 'assistant', content: '' }])
+    for (const char of reply) {
+      await new Promise((r) => setTimeout(r, 12))
+      streamed += char
+      setMessages([...next, { role: 'assistant', content: streamed }])
+    }
+  }
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 16, maxWidth: 520 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            style={{
+              alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start',
+              background: m.role === 'user' ? '#2563eb' : '#1e293b',
+              color: 'white',
+              padding: '8px 12px',
+              borderRadius: 12,
+              maxWidth: '80%',
+            }}
+          >
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && send()}
+          placeholder="Type a message…"
+          style={{ flex: 1, padding: 8, borderRadius: 8, border: '1px solid #334155' }}
+        />
+        <button onClick={send} style={{ padding: '8px 16px', borderRadius: 8, background: '#2563eb', color: 'white', border: 0 }}>
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}
+`
+
+const toolCall = `import { useState } from 'react'
+
+const TOOLS = {
+  get_weather: ({ city }) => ({ city, tempC: 22, condition: 'sunny' }),
+  search_docs: ({ query }) => ({ query, hits: ['intro.mdx', 'runtime.mdx'] }),
+}
+
+export default function App() {
+  const [log, setLog] = useState([])
+
+  function runTool(name, args) {
+    const result = TOOLS[name](args)
+    setLog((l) => [...l, { name, args, result }])
+  }
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 16 }}>
+      <h3 style={{ marginTop: 0 }}>Tool calls</h3>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <button onClick={() => runTool('get_weather', { city: 'Lisbon' })}>get_weather(Lisbon)</button>
+        <button onClick={() => runTool('search_docs', { query: 'runtime' })}>search_docs(runtime)</button>
+      </div>
+      <pre style={{ background: '#0f172a', color: '#e2e8f0', padding: 12, borderRadius: 8, fontSize: 12 }}>
+        {JSON.stringify(log, null, 2) || '// run a tool'}
+      </pre>
+    </div>
+  )
+}
+`
+
+export const PRESETS: Record<string, PlaygroundPreset> = {
+  'basic-chat': {
+    name: 'Basic chat',
+    description: 'Streaming chat with a mock adapter.',
+    entry: '/App.tsx',
+    files: { '/App.tsx': basicChat },
+  },
+  'tool-call': {
+    name: 'Tool call',
+    description: 'Invoke deterministic tools and view results.',
+    entry: '/App.tsx',
+    files: { '/App.tsx': toolCall },
+  },
+}

--- a/apps/docs-next/components/mdx/playground.tsx
+++ b/apps/docs-next/components/mdx/playground.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { lazy, Suspense, useMemo, useState } from 'react'
+import { PRESETS, type PlaygroundPreset } from './playground-presets'
+
+const SandpackLazy = lazy(async () => {
+  const mod = await import('@codesandbox/sandpack-react')
+  return {
+    default: function SandpackInner(props: {
+      files: Record<string, string>
+      entry: string
+      dependencies?: Record<string, string>
+    }) {
+      const { Sandpack } = mod
+      return (
+        <Sandpack
+          template="react"
+          theme="dark"
+          files={props.files}
+          options={{
+            showLineNumbers: true,
+            showInlineErrors: true,
+            editorHeight: 480,
+            activeFile: props.entry,
+          }}
+          customSetup={{
+            dependencies: {
+              react: '^19.0.0',
+              'react-dom': '^19.0.0',
+              ...(props.dependencies ?? {}),
+            },
+          }}
+        />
+      )
+    },
+  }
+})
+
+export type PlaygroundProps = {
+  /** Preset name from playground-presets (e.g. `basic-chat`). */
+  preset?: keyof typeof PRESETS
+  /** Inline files. Overrides preset if set. */
+  files?: Record<string, string>
+  /** Entry file path (default `/App.tsx`). */
+  entry?: string
+  /** Extra npm deps. */
+  dependencies?: Record<string, string>
+  /** Render immediately instead of requiring a click (heavier LCP). */
+  eager?: boolean
+  /** Optional title shown above the playground. */
+  title?: string
+}
+
+export function Playground({
+  preset,
+  files,
+  entry,
+  dependencies,
+  eager = false,
+  title,
+}: PlaygroundProps) {
+  const [open, setOpen] = useState(eager)
+
+  const resolved = useMemo<PlaygroundPreset | null>(() => {
+    if (files) {
+      return {
+        name: title ?? 'Playground',
+        description: '',
+        entry: entry ?? '/App.tsx',
+        files,
+        dependencies,
+      }
+    }
+    if (preset && PRESETS[preset]) {
+      const p = PRESETS[preset]
+      return { ...p, entry: entry ?? p.entry, dependencies: dependencies ?? p.dependencies }
+    }
+    return null
+  }, [preset, files, entry, dependencies, title])
+
+  if (!resolved) {
+    return (
+      <div className="my-6 rounded-lg border border-red-500/40 bg-red-500/5 p-4 text-sm text-red-300">
+        Playground: unknown preset <code>{String(preset)}</code>. Pass <code>files</code> or a valid <code>preset</code>.
+      </div>
+    )
+  }
+
+  if (!open) {
+    return (
+      <div
+        data-ak-playground-placeholder
+        className="my-6 flex flex-col items-center justify-center gap-3 rounded-lg border border-ak-border bg-ak-surface p-8 text-center"
+      >
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+          Live playground · runs in your browser
+        </div>
+        <div className="font-display text-lg font-semibold text-white">{resolved.name}</div>
+        {resolved.description ? (
+          <p className="max-w-md text-sm text-ak-foam">{resolved.description}</p>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md bg-ak-foam px-4 py-2 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+        >
+          Run playground →
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div data-ak-playground className="my-6 overflow-hidden rounded-lg border border-ak-border">
+      {title ? (
+        <div className="border-b border-ak-border bg-ak-surface px-4 py-2 font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite">
+          {title}
+        </div>
+      ) : null}
+      <Suspense
+        fallback={
+          <div className="flex h-[480px] items-center justify-center bg-ak-midnight text-sm text-ak-graphite">
+            Loading playground…
+          </div>
+        }
+      >
+        <SandpackLazy
+          files={resolved.files}
+          entry={resolved.entry}
+          dependencies={resolved.dependencies}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/apps/docs-next/components/mdx/run-code.tsx
+++ b/apps/docs-next/components/mdx/run-code.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { Playground } from './playground'
+import { PRESETS } from './playground-presets'
+
+export type RunCodeProps = {
+  /** Preset key from playground-presets. */
+  preset?: keyof typeof PRESETS
+  /** Inline files, overrides preset. */
+  files?: Record<string, string>
+  /** Entry file if passing `files`. */
+  entry?: string
+  /** Extra deps. */
+  dependencies?: Record<string, string>
+  /** The rendered code block from MDX. */
+  children: ReactNode
+}
+
+export function RunCode({ preset, files, entry, dependencies, children }: RunCodeProps) {
+  const [running, setRunning] = useState(false)
+
+  if (running) {
+    return (
+      <div data-ak-runcode className="my-6">
+        <Playground preset={preset} files={files} entry={entry} dependencies={dependencies} eager />
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setRunning(false)}
+            className="rounded-md border border-ak-border bg-ak-surface px-3 py-1 font-mono text-xs text-ak-graphite hover:text-ak-foam"
+          >
+            ← back to code
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div data-ak-runcode className="relative my-6">
+      {children}
+      <button
+        type="button"
+        onClick={() => setRunning(true)}
+        className="absolute right-3 top-3 rounded-md bg-ak-foam px-3 py-1 font-mono text-xs font-semibold text-ak-midnight shadow-lg transition hover:bg-white"
+        aria-label="Run this code in a live playground"
+      >
+        Run ▶
+      </button>
+    </div>
+  )
+}

--- a/apps/docs-next/components/mdx/since.tsx
+++ b/apps/docs-next/components/mdx/since.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+export type SinceProps = {
+  /** Version this API landed in, e.g. `0.4.0`. */
+  v: string
+  /** Optional pkg prefix, e.g. `react`. Defaults to `core`. */
+  pkg?: string
+  children?: ReactNode
+}
+
+export function Since({ v, pkg = 'core', children }: SinceProps) {
+  return (
+    <span
+      data-ak-since
+      className="ml-2 inline-flex items-center gap-1 rounded-full border border-ak-border bg-ak-surface px-2 py-0.5 align-middle font-mono text-[10px] uppercase tracking-widest text-ak-foam"
+      title={`Available in @agentskit/${pkg} since v${v}`}
+    >
+      <span aria-hidden>✦</span>
+      <span>
+        since <code className="text-white">@agentskit/{pkg}</code>@<code className="text-white">{v}</code>
+      </span>
+      {children ? <span className="text-ak-graphite">· {children}</span> : null}
+    </span>
+  )
+}

--- a/apps/docs-next/content/docs/cookbook/auth.mdx
+++ b/apps/docs-next/content/docs/cookbook/auth.mdx
@@ -1,0 +1,32 @@
+---
+title: Auth in tool calls
+description: Scope tool execution to the current authenticated user. Never trust the model with who is calling.
+---
+
+Tools run with the permissions of whoever invokes them. The LLM can suggest a `userId` — it should never decide one. Bind the current user in the execution context.
+
+```ts
+import { defineTool, createRunContext } from '@agentskit/tools'
+
+const getOrders = defineTool({
+  name: 'get_orders',
+  description: 'List the current user\'s orders',
+  schema: {}, // no userId from the model
+  async execute(_args, ctx) {
+    const userId = ctx.get('userId')
+    if (!userId) throw new Error('unauthenticated')
+    return db.query('select * from orders where user_id = ?', [userId])
+  },
+})
+
+// In your route handler
+export async function POST(req: Request) {
+  const userId = await getSessionUserId(req)
+  const ctx = createRunContext({ userId })
+  return runtime.run(userMessage, { tools: [getOrders], ctx })
+}
+```
+
+<Security>
+Never include `userId`, tenant, or role fields in the **tool schema**. The model will hallucinate them. Always read those from a trusted server-side context.
+</Security>

--- a/apps/docs-next/content/docs/cookbook/error-boundary.mdx
+++ b/apps/docs-next/content/docs/cookbook/error-boundary.mdx
@@ -1,0 +1,41 @@
+---
+title: Error boundary
+description: Surface LLM and tool errors without crashing the UI or silently hiding failures.
+---
+
+Agents fail in interesting ways: timeouts, malformed tool args, provider outages, budget exceeded. Show the user something useful instead of a spinning loader that never ends.
+
+```tsx
+import { useChat, type ChatError } from '@agentskit/react'
+
+export function Chat() {
+  const { messages, error, retry } = useChat({ adapter })
+
+  return (
+    <>
+      {messages.map((m) => (
+        <p key={m.id}>{m.content}</p>
+      ))}
+      {error ? <ErrorBox error={error} onRetry={retry} /> : null}
+    </>
+  )
+}
+
+function ErrorBox({ error, onRetry }: { error: ChatError; onRetry: () => void }) {
+  if (error.code === 'budget_exceeded') {
+    return <p>You hit your daily token limit. Resets at midnight UTC.</p>
+  }
+  if (error.code === 'tool_failed') {
+    return (
+      <p>
+        Action <code>{error.toolName}</code> couldn't run. <button onClick={onRetry}>Try again</button>
+      </p>
+    )
+  }
+  return <p>Something went wrong. <button onClick={onRetry}>Retry</button></p>
+}
+```
+
+<Tip>
+`ChatError` is a **discriminated union**. Let TypeScript narrow each branch — never `catch (e: any)` and render `String(e)`.
+</Tip>

--- a/apps/docs-next/content/docs/cookbook/index.mdx
+++ b/apps/docs-next/content/docs/cookbook/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Cookbook
+description: Copy-paste recipes for the things every agent app needs. Each recipe stands on its own.
+---
+
+Short. Self-contained. Production-ready. Drop a recipe into a real app, wire it to your stack, ship.
+
+| Recipe | What it shows |
+|---|---|
+| [Streaming chat](/docs/cookbook/streaming) | `useChat` + abort + back-pressure |
+| [Tools + memory together](/docs/cookbook/tools-memory) | The common "chat with state and actions" loop |
+| [Auth in tool calls](/docs/cookbook/auth) | Scoping tool execution to the current user |
+| [Rate limiting](/docs/cookbook/rate-limit) | Token bucket per user, per tool |
+| [Error boundary](/docs/cookbook/error-boundary) | Graceful failure for LLM + tool errors |
+| [Structured output](/docs/cookbook/structured-output) | Validated JSON responses with zod |
+| [Multi-agent delegation](/docs/cookbook/multi-agent) | Planner → worker → reviewer |
+| [RAG in 15 lines](/docs/cookbook/rag) | `createRAG` with a file loader |
+
+<Tip>Every recipe is designed to paste into a real file. No bespoke imports, no "imagine that…" setup.</Tip>

--- a/apps/docs-next/content/docs/cookbook/meta.json
+++ b/apps/docs-next/content/docs/cookbook/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Cookbook",
+  "description": "Short, self-contained recipes you can copy into a real app.",
+  "pages": [
+    "index",
+    "streaming",
+    "tools-memory",
+    "auth",
+    "rate-limit",
+    "error-boundary",
+    "structured-output",
+    "multi-agent",
+    "rag"
+  ]
+}

--- a/apps/docs-next/content/docs/cookbook/multi-agent.mdx
+++ b/apps/docs-next/content/docs/cookbook/multi-agent.mdx
@@ -1,0 +1,39 @@
+---
+title: Multi-agent delegation
+description: Planner → worker → reviewer. Three focused agents beat one over-prompted one.
+---
+
+One agent with fifteen tools and a mega-prompt usually loses the plot. Decompose by role.
+
+```ts
+import { runtime, defineAgent } from '@agentskit/runtime'
+import { webSearch, fileRead } from '@agentskit/tools'
+
+const planner = defineAgent({
+  role: 'planner',
+  systemPrompt: 'Break the user goal into 3–5 concrete steps.',
+})
+
+const researcher = defineAgent({
+  role: 'researcher',
+  systemPrompt: 'Execute one step. Use tools. Return findings.',
+  tools: [webSearch, fileRead],
+})
+
+const reviewer = defineAgent({
+  role: 'reviewer',
+  systemPrompt: 'Verify findings against the plan. Flag gaps.',
+})
+
+export async function run(userGoal: string) {
+  const plan = await runtime.run(userGoal, { agent: planner })
+  const findings = await Promise.all(
+    plan.steps.map((step) => runtime.run(step, { agent: researcher })),
+  )
+  return runtime.run({ plan, findings }, { agent: reviewer })
+}
+```
+
+<Tip>
+Each agent gets its **own memory scope** by default — the reviewer doesn't see the researcher's internal thoughts, only its findings. This keeps context windows tight and prevents prompt bleed.
+</Tip>

--- a/apps/docs-next/content/docs/cookbook/rag.mdx
+++ b/apps/docs-next/content/docs/cookbook/rag.mdx
@@ -1,0 +1,30 @@
+---
+title: RAG in 15 lines
+description: createRAG with a file loader and in-memory vector store. Working retrieval in under a screen of code.
+---
+
+RAG does not require a vector database, a cluster, or a PhD. Start here, swap pieces later.
+
+```ts
+import { createRAG } from '@agentskit/rag'
+import { fileLoader } from '@agentskit/rag/loaders'
+import { inMemoryStore } from '@agentskit/memory/vector'
+
+const rag = createRAG({
+  store: inMemoryStore(),
+  loaders: [fileLoader({ glob: './docs/**/*.md' })],
+  embed: { model: 'text-embedding-3-small' },
+})
+
+await rag.ingest() // chunks + embeds every doc
+
+const context = await rag.retrieve('how do streams work?', { topK: 5 })
+```
+
+<Tip>
+Swap `inMemoryStore()` for `lanceStore({ path: './vectors.lance' })` when your corpus outgrows RAM. Zero code change anywhere else.
+</Tip>
+
+<Performance>
+`rag.ingest()` is **idempotent** — reruns only re-embed chunks whose source content changed. Safe to call on every deploy.
+</Performance>

--- a/apps/docs-next/content/docs/cookbook/rate-limit.mdx
+++ b/apps/docs-next/content/docs/cookbook/rate-limit.mdx
@@ -1,0 +1,34 @@
+---
+title: Rate limiting
+description: Token bucket per user, per tool. Stop a runaway model from draining budget.
+---
+
+LLMs can loop. Tools can fan out. Add a per-user token bucket to every request so a single conversation can't blow the budget.
+
+```ts
+import { runtime } from '@agentskit/runtime'
+import { tokenBucket } from '@agentskit/core'
+
+const userBucket = tokenBucket({ capacity: 50_000, refillPerMinute: 10_000 })
+const toolBucket = tokenBucket({ capacity: 200, refillPerMinute: 100 })
+
+export async function POST(req: Request) {
+  const { userId, message } = await req.json()
+  if (!userBucket.take(userId, 1)) {
+    return new Response('rate limited', { status: 429 })
+  }
+  return runtime.run(message, {
+    onToolCall: ({ name }) => {
+      if (!toolBucket.take(`${userId}:${name}`, 1)) {
+        throw new Error(`tool ${name} rate limited`)
+      }
+    },
+  })
+}
+```
+
+<Performance>
+The bucket lives in memory by default. For horizontal scale, back it with Redis and `INCR` + TTL — the interface is identical.
+</Performance>
+
+<Tip>Set `onTokenBudgetExceeded` on the runtime too — it stops the ReAct loop from burning tokens in a flawed plan.</Tip>

--- a/apps/docs-next/content/docs/cookbook/streaming.mdx
+++ b/apps/docs-next/content/docs/cookbook/streaming.mdx
@@ -1,0 +1,48 @@
+---
+title: Streaming chat
+description: useChat + abort + back-pressure. The minimum viable streaming chat, production-ready.
+---
+
+The shortest path to a real streaming chat with cancel support and smooth rendering.
+
+```tsx
+import { useChat } from '@agentskit/react'
+import { openai } from '@agentskit/adapters/openai'
+
+const adapter = openai({ model: 'gpt-4o-mini' })
+
+export function Chat() {
+  const { messages, input, setInput, send, stop, status } = useChat({ adapter })
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        send(input)
+        setInput('')
+      }}
+    >
+      {messages.map((m) => (
+        <p key={m.id} data-role={m.role}>
+          {m.content}
+        </p>
+      ))}
+      <input value={input} onChange={(e) => setInput(e.target.value)} />
+      {status === 'streaming' ? (
+        <button type="button" onClick={stop}>
+          Stop
+        </button>
+      ) : (
+        <button type="submit">Send</button>
+      )}
+    </form>
+  )
+}
+```
+
+<Playground preset="basic-chat" />
+
+<Tip>The adapter is a pure function — no singletons, no side effects. Safe to create per-request.</Tip>
+
+<Performance>
+`useChat` batches stream chunks on `requestAnimationFrame`. That's why fast token streams still render smoothly — the UI never gets spammed with re-renders faster than the browser paints.
+</Performance>

--- a/apps/docs-next/content/docs/cookbook/structured-output.mdx
+++ b/apps/docs-next/content/docs/cookbook/structured-output.mdx
@@ -1,0 +1,30 @@
+---
+title: Structured output
+description: Validated JSON responses with zod. No more regex-parsing the model's guess.
+---
+
+When you need a data payload, don't parse prose. Give the model a schema and let the adapter enforce it.
+
+```ts
+import { z } from 'zod'
+import { runtime } from '@agentskit/runtime'
+
+const Ticket = z.object({
+  priority: z.enum(['low', 'medium', 'high', 'urgent']),
+  summary: z.string().max(140),
+  tags: z.array(z.string()).max(5),
+})
+
+const result = await runtime.run(userMessage, {
+  responseFormat: Ticket,
+})
+// result.data is fully typed — z.infer<typeof Ticket>
+```
+
+<Info>
+Providers that support structured output natively (OpenAI `response_format`, Anthropic `tool_use`, Gemini `responseSchema`) get first-class treatment. Others fall back to zod validation on the generated text with automatic retry on parse failure.
+</Info>
+
+<Pitfall>
+Keep schemas **flat** when you can. Deeply nested objects increase the chance of parse failures on smaller models, which forces retries and burns tokens.
+</Pitfall>

--- a/apps/docs-next/content/docs/cookbook/tools-memory.mdx
+++ b/apps/docs-next/content/docs/cookbook/tools-memory.mdx
@@ -1,0 +1,50 @@
+---
+title: Tools + memory together
+description: The "chat with state and actions" loop — persistent memory plus tool execution.
+---
+
+Most real agent apps need both **memory** (recall past turns) and **tools** (perform actions). Here's the minimum viable wiring.
+
+```tsx
+import { useChat } from '@agentskit/react'
+import { openai } from '@agentskit/adapters/openai'
+import { defineTool } from '@agentskit/tools'
+import { sqliteMemory } from '@agentskit/memory/sqlite'
+
+const adapter = openai({ model: 'gpt-4o-mini' })
+
+const getOrders = defineTool({
+  name: 'get_orders',
+  description: 'List orders for the current user',
+  schema: { userId: 'string' },
+  async execute({ userId }) {
+    return db.query('select * from orders where user_id = ?', [userId])
+  },
+})
+
+const memory = sqliteMemory({ path: './threads.sqlite' })
+
+export function Support() {
+  const { messages, input, setInput, send } = useChat({
+    adapter,
+    memory,
+    tools: [getOrders],
+    threadId: 'user-123',
+  })
+  // …render as in the Streaming recipe
+}
+```
+
+<Pitfall>
+Do not pass a fresh `sqliteMemory(...)` inline to `useChat`. Create the memory once at the module level — otherwise you'll open a new database handle on every render.
+</Pitfall>
+
+<Compare
+  good={<pre>{`const memory = sqliteMemory({ path: './threads.sqlite' })
+// …
+useChat({ adapter, memory })`}</pre>}
+  bad={<pre>{`useChat({
+  adapter,
+  memory: sqliteMemory({ path: './threads.sqlite' }), // new handle every render
+})`}</pre>}
+/>

--- a/apps/docs-next/content/docs/meta.json
+++ b/apps/docs-next/content/docs/meta.json
@@ -9,6 +9,8 @@
     "data",
     "production",
     "for-agents",
-    "reference"
+    "cookbook",
+    "reference",
+    "api"
   ]
 }

--- a/apps/docs-next/content/docs/production/meta.json
+++ b/apps/docs-next/content/docs/production/meta.json
@@ -11,6 +11,8 @@
     "security",
     "---Evaluation---",
     "evals",
+    "---Performance---",
+    "performance",
     "---CLI---",
     "cli"
   ]

--- a/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
+++ b/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
@@ -5,6 +5,140 @@ description: Embeddable components available inside every .mdx file — Stackbli
 
 Every MDX page under `/docs` has access to these components. No import required.
 
+## `<Playground />`
+
+Inline runnable playground. Runs in-browser via Sandpack — no remote cold-start.
+
+```mdx
+<Playground preset="basic-chat" />
+```
+
+Custom files:
+
+```mdx
+<Playground
+  title="Custom demo"
+  entry="/App.tsx"
+  files={{
+    '/App.tsx': `export default function App() { return <h1>hi</h1> }`,
+  }}
+/>
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `preset` | `'basic-chat' \| 'tool-call'` | — |
+| `files` | `Record<string, string>` | overrides preset |
+| `entry` | `string` | `/App.tsx` |
+| `dependencies` | `Record<string, string>` | — |
+| `eager` | `boolean` | `false` (click-to-load) |
+| `title` | `string` | — |
+
+Presets live in `components/mdx/playground-presets.ts`. Add new ones by exporting another entry.
+
+<Playground preset="basic-chat" />
+
+## `<FrameworkTabs />`
+
+Framework picker with **global persistence**. Pick React once; every tab on every page switches automatically.
+
+````mdx
+<FrameworkTabs defaultValue="react">
+  <Framework name="react">
+    ```tsx
+    import { useChat } from '@agentskit/react'
+    ```
+  </Framework>
+  <Framework name="vue">
+    ```ts
+    import { useChat } from '@agentskit/vue'
+    ```
+  </Framework>
+  <Framework name="svelte">
+    ```ts
+    import { useChat } from '@agentskit/svelte'
+    ```
+  </Framework>
+</FrameworkTabs>
+````
+
+Known `name` values: `react`, `vue`, `svelte`, `solid`, `angular`, `react-native`, `ink`, `node`, `cli`. Unknown names accepted — label falls back to the raw `name`. Override the label per framework with `<Framework label="…" />`.
+
+Preference persists in `localStorage` under `ak:framework` and syncs across every mounted tab group via a custom event.
+
+## Callouts
+
+Pick the right one and the reader's eye will land on it.
+
+```mdx
+<Tip>Caching the adapter result is usually safe.</Tip>
+<Warning>The runtime aborts on the first unhandled tool error.</Warning>
+<Pitfall>Do not mutate the `messages` prop. Clone it first.</Pitfall>
+<Performance>Stream chunks on `requestAnimationFrame` for 60fps.</Performance>
+<Security>Never render tool output as raw HTML.</Security>
+<Info>Accepted in all runtimes since v0.3.</Info>
+<Success>Shipped in v0.6.</Success>
+```
+
+<Tip>Caching the adapter result is usually safe.</Tip>
+<Warning>The runtime aborts on the first unhandled tool error.</Warning>
+<Pitfall>Do not mutate the `messages` prop. Clone it first.</Pitfall>
+<Performance>Stream chunks on `requestAnimationFrame` for 60fps.</Performance>
+<Security>Never render tool output as raw HTML.</Security>
+
+## `<Compare />`
+
+Side-by-side do-vs-don't.
+
+```mdx
+<Compare
+  good={<pre>{`useChat({ adapter, memory })`}</pre>}
+  bad={<pre>{`useChat({ adapter, memory: new Memory() }) // new ref each render`}</pre>}
+/>
+```
+
+## `<Since />`
+
+Version badge for APIs.
+
+```mdx
+### useChat <Since v="0.4.0" pkg="react" />
+```
+
+## `<ArchDiagram />`
+
+Interactive package dependency graph. Click any node to pin it; hover to explore neighbors.
+
+```mdx
+<ArchDiagram />
+```
+
+<ArchDiagram />
+
+## `<RunCode />`
+
+Wrap any fenced code block to get a "Run ▶" button in its top-right corner. Clicking swaps the snippet for a live Sandpack playground using a preset or inline files.
+
+````mdx
+<RunCode preset="basic-chat">
+```tsx
+import { useChat } from '@agentskit/react'
+
+export function App() {
+  const { messages } = useChat()
+  return messages.map((m) => <p key={m.id}>{m.content}</p>)
+}
+```
+</RunCode>
+````
+
+| Prop | Type | Default |
+|---|---|---|
+| `preset` | `'basic-chat' \| 'tool-call'` | — |
+| `files` | `Record<string, string>` | overrides preset |
+| `entry` | `string` | `/App.tsx` |
+| `dependencies` | `Record<string, string>` | — |
+
 ## `<StackblitzEmbed />`
 
 Live editable sandbox for any GitHub path.

--- a/apps/docs-next/content/docs/reference/meta.json
+++ b/apps/docs-next/content/docs/reference/meta.json
@@ -13,6 +13,8 @@
     "---Specs---",
     "specs",
     "---Contribute---",
-    "contribute"
+    "contribute",
+    "---Changelog---",
+    "changelog"
   ]
 }

--- a/apps/docs-next/lib/learn-steps.ts
+++ b/apps/docs-next/lib/learn-steps.ts
@@ -1,0 +1,180 @@
+import type { PlaygroundPreset } from '@/components/mdx/playground-presets'
+
+export type LearnStep = {
+  slug: string
+  title: string
+  intro: string
+  body: string
+  preset?: string
+  files?: Record<string, string>
+  entry?: string
+  key: string
+}
+
+const chatAppFiles: Record<string, string> = {
+  '/App.tsx': `import { useState } from 'react'
+
+const FAKE_REPLIES = [
+  'Welcome to AgentsKit. Streaming is on by default.',
+  'Swap the adapter in 1 line to change providers.',
+  'Tools and memory are optional — compose what you need.',
+]
+
+export default function App() {
+  const [messages, setMessages] = useState([
+    { role: 'assistant', content: 'Hi, ask me something.' },
+  ])
+  const [input, setInput] = useState('')
+
+  async function send() {
+    if (!input.trim()) return
+    const next = [...messages, { role: 'user', content: input }]
+    setMessages(next)
+    setInput('')
+    const reply = FAKE_REPLIES[next.length % FAKE_REPLIES.length]
+    let streamed = ''
+    setMessages([...next, { role: 'assistant', content: '' }])
+    for (const ch of reply) {
+      await new Promise((r) => setTimeout(r, 14))
+      streamed += ch
+      setMessages([...next, { role: 'assistant', content: streamed }])
+    }
+  }
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 16, maxWidth: 520 }}>
+      {messages.map((m, i) => (
+        <div
+          key={i}
+          style={{
+            margin: '6px 0',
+            padding: '8px 12px',
+            background: m.role === 'user' ? '#2563eb' : '#1e293b',
+            color: 'white',
+            borderRadius: 12,
+            alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start',
+            maxWidth: '80%',
+          }}
+        >
+          {m.content}
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && send()}
+          style={{ flex: 1, padding: 8, borderRadius: 8, border: '1px solid #334155' }}
+        />
+        <button onClick={send}>Send</button>
+      </div>
+    </div>
+  )
+}
+`,
+}
+
+const toolFiles: Record<string, string> = {
+  '/App.tsx': `import { useState } from 'react'
+
+const tools = {
+  get_weather: ({ city }) => ({ city, tempC: 22 }),
+  get_time: () => ({ time: new Date().toLocaleTimeString() }),
+}
+
+export default function App() {
+  const [out, setOut] = useState({})
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 16 }}>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={() => setOut(tools.get_weather({ city: 'Lisbon' }))}>weather</button>
+        <button onClick={() => setOut(tools.get_time())}>time</button>
+      </div>
+      <pre>{JSON.stringify(out, null, 2)}</pre>
+    </div>
+  )
+}
+`,
+}
+
+export const STEPS: LearnStep[] = [
+  {
+    slug: 'install',
+    key: 'learn:install',
+    title: 'Install AgentsKit',
+    intro: 'Start from zero. One package. Zero build config.',
+    body: `AgentsKit is installable **per package**. Pick only what you need:
+
+\`\`\`bash
+pnpm add @agentskit/react @agentskit/core
+\`\`\`
+
+Each package is tree-shakable, dual-format (ESM + CJS), and ships its own types.`,
+  },
+  {
+    slug: 'chat',
+    key: 'learn:chat',
+    title: 'Ship a streaming chat UI',
+    intro: 'Build a complete chat interface with streaming — without a backend.',
+    body: `\`useChat\` wires state, streaming, abort, and retries. Drop it into any component.
+
+\`\`\`tsx
+import { useChat } from '@agentskit/react'
+\`\`\`
+
+The playground below runs a mock adapter. Try it: send a message, watch it stream.`,
+    files: chatAppFiles,
+    entry: '/App.tsx',
+  },
+  {
+    slug: 'adapter',
+    key: 'learn:adapter',
+    title: 'Swap the provider',
+    intro: 'Change one line to switch from mock to OpenAI, Anthropic, or Gemini.',
+    body: `Adapters are pure contracts. Swap the import, keep the rest of your app identical.
+
+\`\`\`ts
+import { openai } from '@agentskit/adapters/openai'
+export const adapter = openai({ model: 'gpt-4o-mini' })
+\`\`\`
+
+The UI does not need to know which provider is behind it.`,
+  },
+  {
+    slug: 'tools',
+    key: 'learn:tools',
+    title: 'Give the agent tools',
+    intro: 'Register functions the model can call.',
+    body: `A tool is a named function with a schema. AgentsKit runs it when the model decides to.
+
+\`\`\`ts
+import { defineTool } from '@agentskit/tools'
+
+export const getWeather = defineTool({
+  name: 'get_weather',
+  description: 'Get current weather for a city',
+  schema: { city: 'string' },
+  async execute({ city }) { return { city, tempC: 22 } },
+})
+\`\`\``,
+    files: toolFiles,
+    entry: '/App.tsx',
+  },
+  {
+    slug: 'memory',
+    key: 'learn:memory',
+    title: 'Persist the conversation',
+    intro: 'Swap ephemeral state for SQLite, Redis, or a vector store.',
+    body: `Memory is another contract. Default is in-memory; for production, pick an adapter.
+
+\`\`\`ts
+import { fileMemory } from '@agentskit/memory/file'
+export const memory = fileMemory({ path: './threads.json' })
+\`\`\`
+
+Hydration, serialization, and long-term storage work the same across every memory backend.`,
+  },
+]
+
+export type Progress = Record<string, boolean>
+export const PROGRESS_KEY = 'ak:learn-progress'

--- a/apps/docs-next/mdx-components.tsx
+++ b/apps/docs-next/mdx-components.tsx
@@ -4,6 +4,12 @@ import { Mermaid } from '@/components/mermaid'
 import { StackblitzEmbed } from '@/components/mdx/stackblitz-embed'
 import { CodeSandboxEmbed } from '@/components/mdx/codesandbox-embed'
 import { GifEmbed } from '@/components/mdx/gif-embed'
+import { Playground } from '@/components/mdx/playground'
+import { FrameworkTabs, Framework } from '@/components/mdx/framework-tabs'
+import { RunCode } from '@/components/mdx/run-code'
+import { ArchDiagram } from '@/components/mdx/arch-diagram'
+import { Since } from '@/components/mdx/since'
+import { Tip, Warning, Pitfall, Performance, Security, Info, Success, Compare } from '@/components/mdx/callouts'
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -12,6 +18,20 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     StackblitzEmbed,
     CodeSandboxEmbed,
     GifEmbed,
+    Playground,
+    FrameworkTabs,
+    Framework,
+    RunCode,
+    ArchDiagram,
+    Since,
+    Tip,
+    Warning,
+    Pitfall,
+    Performance,
+    Security,
+    Info,
+    Success,
+    Compare,
     ...components,
   }
 }

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -3,14 +3,19 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "prebuild": "node scripts/gen-api.mjs && node scripts/gen-changelog.mjs && node scripts/gen-performance.mjs",
+    "gen:changelog": "node scripts/gen-changelog.mjs",
+    "gen:performance": "node scripts/gen-performance.mjs",
     "build": "next build",
     "dev": "next dev --turbo",
     "docs": "next dev --turbo",
     "start": "next start",
     "lint": "tsc --noEmit",
+    "gen:api": "node scripts/gen-api.mjs",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@codesandbox/sandpack-react": "^2.20.0",
     "@tailwindcss/postcss": "^4.0.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
@@ -30,6 +35,8 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^6.0.3"
   }
 }

--- a/apps/docs-next/scripts/gen-api.mjs
+++ b/apps/docs-next/scripts/gen-api.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Auto-generate fumadocs-ready API reference MDX from TypeScript sources.
+// Usage: pnpm --filter @agentskit/docs-next gen:api
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '../../..')
+const OUT_ROOT = resolve(__dirname, '../content/docs/api')
+
+const PACKAGES = [
+  { name: 'core', entry: 'packages/core/src/index.ts' },
+  { name: 'react', entry: 'packages/react/src/index.ts' },
+  { name: 'runtime', entry: 'packages/runtime/src/index.ts' },
+  { name: 'adapters', entry: 'packages/adapters/src/index.ts' },
+  { name: 'tools', entry: 'packages/tools/src/index.ts' },
+  { name: 'memory', entry: 'packages/memory/src/index.ts' },
+  { name: 'rag', entry: 'packages/rag/src/index.ts' },
+  { name: 'observability', entry: 'packages/observability/src/index.ts' },
+]
+
+function run(pkg) {
+  const entry = resolve(ROOT, pkg.entry)
+  if (!existsSync(entry)) {
+    console.warn(`skip ${pkg.name}: ${entry} missing`)
+    return false
+  }
+  const pkgTsconfig = resolve(ROOT, `packages/${pkg.name}/tsconfig.json`)
+  if (!existsSync(pkgTsconfig)) {
+    console.warn(`skip ${pkg.name}: ${pkgTsconfig} missing`)
+    return false
+  }
+  const outDir = join(OUT_ROOT, pkg.name)
+  rmSync(outDir, { recursive: true, force: true })
+  mkdirSync(outDir, { recursive: true })
+
+  const args = [
+    'typedoc',
+    '--entryPoints',
+    entry,
+    '--tsconfig',
+    pkgTsconfig,
+    '--skipErrorChecking',
+    'true',
+    '--plugin',
+    'typedoc-plugin-markdown',
+    '--out',
+    outDir,
+    '--readme',
+    'none',
+    '--hideBreadcrumbs',
+    'true',
+    '--hidePageHeader',
+    'true',
+    '--useHTMLEncodedBrackets',
+    'true',
+    '--gitRevision',
+    'main',
+    '--githubPages',
+    'false',
+    '--excludePrivate',
+    '--excludeInternal',
+    '--excludeProtected',
+    '--sort',
+    'alphabetical',
+  ]
+  try {
+    execFileSync('npx', args, { stdio: 'inherit', cwd: ROOT })
+  } catch (err) {
+    console.error(`typedoc failed for ${pkg.name}:`, err.message)
+    return false
+  }
+  postprocess(outDir, pkg.name)
+  return true
+}
+
+// Escape `{` `}` and bare `<` outside fenced code blocks so MDX doesn't parse them as expressions/tags.
+function escapeMdx(raw) {
+  const lines = raw.split('\n')
+  let inFence = false
+  return lines
+    .map((line) => {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        inFence = !inFence
+        return line
+      }
+      if (inFence) return line
+      return line
+        .replace(/\\\{|\\\}|\{|\}/g, (m) => (m === '{' ? '\\{' : m === '}' ? '\\}' : m))
+        .replace(/<(?=[A-Za-z][A-Za-z0-9_-]*[^>]*>)/g, '&lt;')
+    })
+    .join('\n')
+}
+
+function postprocess(dir, pkgName) {
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name)
+      if (entry.isDirectory()) {
+        walk(p)
+        continue
+      }
+      if (!entry.name.endsWith('.md')) continue
+      const raw = readFileSync(p, 'utf8')
+      const isReadme = entry.name === 'README.md'
+      const title = isReadme ? `@agentskit/${pkgName}` : entry.name.replace(/\.md$/, '')
+      const description = `Auto-generated API reference for ${title}.`
+      const frontmatter = `---\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(description)}\n---\n\n`
+      const body = escapeMdx(raw)
+      const newPath = isReadme ? join(d, 'index.md') : p
+      writeFileSync(newPath, frontmatter + body)
+      if (newPath !== p) rmSync(p)
+    }
+  }
+  walk(dir)
+}
+
+function writeMeta() {
+  const available = PACKAGES.map((p) => p.name).filter((n) => existsSync(join(OUT_ROOT, n)))
+  mkdirSync(OUT_ROOT, { recursive: true })
+  writeFileSync(
+    join(OUT_ROOT, 'meta.json'),
+    JSON.stringify({ title: 'API', pages: available }, null, 2) + '\n',
+  )
+  writeFileSync(
+    join(OUT_ROOT, 'index.mdx'),
+    `---\ntitle: API reference\ndescription: Auto-generated from TypeScript sources via typedoc. Regenerate with \`pnpm --filter @agentskit/docs-next gen:api\`.\n---\n\nPick a package:\n\n${available
+      .map((p) => `- [\`@agentskit/${p}\`](/docs/api/${p})`)
+      .join('\n')}\n`,
+  )
+}
+
+let ran = 0
+for (const pkg of PACKAGES) if (run(pkg)) ran++
+writeMeta()
+console.log(`\ngen-api: generated ${ran}/${PACKAGES.length} packages → ${OUT_ROOT}`)

--- a/apps/docs-next/scripts/gen-changelog.mjs
+++ b/apps/docs-next/scripts/gen-changelog.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Aggregate the root CHANGELOG.md plus per-package CHANGELOG.md files into a single docs page.
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '../../..')
+const OUT = resolve(__dirname, '../content/docs/reference/changelog.mdx')
+
+function esc(s) {
+  // Escape `{` `}` and bare `<Tag>` so MDX doesn't interpret them.
+  const lines = s.split('\n')
+  let inFence = false
+  return lines
+    .map((line) => {
+      const t = line.trimStart()
+      if (t.startsWith('```') || t.startsWith('~~~')) {
+        inFence = !inFence
+        return line
+      }
+      if (inFence) return line
+      return line
+        .replace(/\{|\}/g, (m) => (m === '{' ? '\\{' : '\\}'))
+        .replace(/<(?=[A-Za-z])/g, '&lt;')
+    })
+    .join('\n')
+}
+
+function sectionFor(name, body) {
+  return `\n## ${name}\n\n${esc(body).trim()}\n`
+}
+
+const rootLog = existsSync(join(ROOT, 'CHANGELOG.md')) ? readFileSync(join(ROOT, 'CHANGELOG.md'), 'utf8') : ''
+
+const pkgDir = join(ROOT, 'packages')
+const pkgs = existsSync(pkgDir)
+  ? readdirSync(pkgDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort()
+  : []
+
+let body = ''
+if (rootLog.trim()) body += sectionFor('Project', rootLog.replace(/^#\s+Changelog\s*/i, '').trim())
+
+for (const name of pkgs) {
+  const p = join(pkgDir, name, 'CHANGELOG.md')
+  if (!existsSync(p)) continue
+  const content = readFileSync(p, 'utf8').replace(/^#\s+.+\s*/m, '').trim()
+  if (!content) continue
+  body += sectionFor(`@agentskit/${name}`, content)
+}
+
+const frontmatter = `---
+title: Changelog
+description: Release notes across every @agentskit package, generated from CHANGELOG.md files.
+---
+
+Every AgentsKit package follows semver and publishes release notes via [changesets](https://github.com/changesets/changesets). Below is the aggregated history.
+
+`
+
+mkdirSync(dirname(OUT), { recursive: true })
+writeFileSync(OUT, frontmatter + body)
+console.log(`changelog: wrote ${OUT}`)

--- a/apps/docs-next/scripts/gen-performance.mjs
+++ b/apps/docs-next/scripts/gen-performance.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Generate /docs/production/performance.mdx from .size-limit.json budgets.
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '../../..')
+const OUT = resolve(__dirname, '../content/docs/production/performance.mdx')
+
+const configPath = join(ROOT, '.size-limit.json')
+if (!existsSync(configPath)) {
+  console.warn('no .size-limit.json found, skipping')
+  process.exit(0)
+}
+
+const entries = JSON.parse(readFileSync(configPath, 'utf8'))
+
+const rows = entries.map((e) => {
+  const name = e.name ?? e.path
+  const limit = e.limit ?? '—'
+  const format = name.includes('(CJS)') ? 'CJS' : name.includes('(ESM)') ? 'ESM' : '—'
+  const pkg = name.replace(/\s*\((ESM|CJS)\)$/, '').trim()
+  return { pkg, format, limit, path: e.path, gzip: !!e.gzip }
+}).sort((a, b) => a.pkg.localeCompare(b.pkg) || a.format.localeCompare(b.format))
+
+const frontmatter = `---
+title: Performance budgets
+description: Bundle size ceilings per package, enforced in CI via size-limit. Generated from .size-limit.json.
+---
+
+Every \`@agentskit/\` package has a **gzipped size budget** enforced on every PR via [size-limit](https://github.com/ai/size-limit). Exceed the limit and CI fails — no surprise bundle bloat.
+
+| Package | Format | Limit (gzip) |
+|---|---|---|
+${rows.map((r) => `| \`${r.pkg}\` | ${r.format} | **${r.limit}** |`).join('\n')}
+
+> Run \`pnpm size\` locally to measure actual sizes. Use \`pnpm size:why\` to break down which imports consume bytes.
+
+## Runtime budgets
+
+| Concern | Target |
+|---|---|
+| First token latency (streaming) | < 400 ms p95 |
+| Chunk render rate | 60 fps (batched on \`requestAnimationFrame\`) |
+| Memory read (in-memory adapter) | < 1 ms |
+| Memory read (SQLite adapter) | < 5 ms |
+| Tool call overhead | < 2 ms per call |
+
+## How bundle budgets are chosen
+
+- **core**: must stay < 10 KB gzipped — it ships in every install.
+- **react/ink/vue**: aim for < 15 KB — UI layer only, zero adapter bundled.
+- **adapters**: sum of individual provider imports; tree-shakable.
+- **runtime**: includes ReAct loop + planner primitives — aim for < 20 KB.
+- **cli**: no budget — terminal tool, size is not on the critical path.
+
+<Tip>The limits are not aspirational. Every PR runs \`pnpm size\` in CI and will fail if it regresses.</Tip>
+`
+
+mkdirSync(dirname(OUT), { recursive: true })
+writeFileSync(OUT, frontmatter)
+console.log(`performance: wrote ${OUT}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
 
   apps/docs-next:
     dependencies:
+      '@codesandbox/sandpack-react':
+        specifier: ^2.20.0
+        version: 2.20.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.2
@@ -111,6 +114,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      typedoc:
+        specifier: ^0.28.19
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: ^4.11.0
+        version: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -988,6 +997,45 @@ packages:
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
 
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@codesandbox/nodebox@0.1.8':
+    resolution: {integrity: sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==}
+
+  '@codesandbox/sandpack-client@2.19.8':
+    resolution: {integrity: sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==}
+
+  '@codesandbox/sandpack-react@2.20.0':
+    resolution: {integrity: sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1402,6 +1450,9 @@ packages:
       tailwindcss:
         optional: true
 
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
@@ -1755,11 +1806,32 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -2326,6 +2398,16 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-hook/intersection-observer@3.1.2':
+    resolution: {integrity: sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/passive-layout-effect@1.2.1':
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+
   '@react-native/assets-registry@0.85.1':
     resolution: {integrity: sha512-QODQ15teXThKaKdb7lnx4RifNUGnsGZ/NMKtkNBE89nJuK93+mPsb1ozp5xkGyLw7ZNVYO4Nkqsp4MsBOuAX8g==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
@@ -2665,9 +2747,15 @@ packages:
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.0.2':
     resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.0.2':
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
@@ -2677,6 +2765,9 @@ packages:
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/themes@4.0.2':
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
@@ -2684,6 +2775,9 @@ packages:
   '@shikijs/transformers@4.0.2':
     resolution: {integrity: sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==}
     engines: {node: '>=20'}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
@@ -2707,6 +2801,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stitches/core@1.2.8':
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
@@ -3235,6 +3332,9 @@ packages:
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
 
+  anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -3490,6 +3590,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  clean-set@1.1.2:
+    resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+
   cli-boxes@4.0.1:
     resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
     engines: {node: '>=18.20 <19 || >=20.10'}
@@ -3613,6 +3716,9 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3787,6 +3893,10 @@ packages:
   d3@7.9.0:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
+
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
 
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
@@ -3993,6 +4103,17 @@ packages:
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -4013,6 +4134,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -4030,6 +4154,10 @@ packages:
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -4075,6 +4203,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -4092,6 +4223,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -4552,6 +4686,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  intersection-observer@0.10.0:
+    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
+    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -4836,6 +4974,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4886,6 +5027,9 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4906,6 +5050,10 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4991,6 +5139,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -5302,6 +5453,9 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
@@ -5416,6 +5570,9 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  outvariant@1.4.0:
+    resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -5621,6 +5778,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5644,6 +5805,9 @@ packages:
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
+
+  react-devtools-inline@4.4.0:
+    resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -5995,6 +6159,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  static-browser-server@1.0.3:
+    resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -6005,6 +6172,9 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  strict-event-emitter@0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -6042,6 +6212,9 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -6251,10 +6424,29 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
+  typedoc-plugin-markdown@4.11.0:
+    resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
@@ -6482,6 +6674,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7075,6 +7270,114 @@ snapshots:
 
   '@chevrotain/utils@12.0.0': {}
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codesandbox/nodebox@0.1.8':
+    dependencies:
+      outvariant: 1.4.3
+      strict-event-emitter: 0.4.6
+
+  '@codesandbox/sandpack-client@2.19.8':
+    dependencies:
+      '@codesandbox/nodebox': 0.1.8
+      buffer: 6.0.3
+      dequal: 2.0.3
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+      static-browser-server: 1.0.3
+
+  '@codesandbox/sandpack-react@2.20.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@codesandbox/sandpack-client': 2.19.8
+      '@lezer/highlight': 1.2.3
+      '@react-hook/intersection-observer': 3.1.2(react@19.2.5)
+      '@stitches/core': 1.2.8
+      anser: 2.3.5
+      clean-set: 1.1.2
+      dequal: 2.0.3
+      escape-carriage: 1.3.1
+      lz-string: 1.5.0
+      react: 19.2.5
+      react-devtools-inline: 4.4.0
+      react-dom: 19.2.5(react@19.2.5)
+      react-is: 17.0.2
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -7315,6 +7618,14 @@ snapshots:
     optionalDependencies:
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
+
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -7606,6 +7917,34 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -7621,6 +7960,8 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -8176,6 +8517,16 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-hook/intersection-observer@3.1.2(react@19.2.5)':
+    dependencies:
+      '@react-hook/passive-layout-effect': 1.2.1(react@19.2.5)
+      intersection-observer: 0.10.0
+      react: 19.2.5
+
+  '@react-hook/passive-layout-effect@1.2.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
   '@react-native/assets-registry@0.85.1': {}
 
   '@react-native/codegen@0.85.1(@babel/core@7.29.0)':
@@ -8410,10 +8761,19 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.5
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.0.2':
     dependencies:
@@ -8425,6 +8785,10 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
@@ -8433,6 +8797,11 @@ snapshots:
     dependencies:
       '@shikijs/core': 4.0.2
       '@shikijs/types': 4.0.2
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.2':
     dependencies:
@@ -8450,6 +8819,8 @@ snapshots:
       size-limit: 12.1.0(jiti@2.6.1)
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stitches/core@1.2.8': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
     dependencies:
@@ -8993,6 +9364,8 @@ snapshots:
 
   anser@1.4.10: {}
 
+  anser@2.3.5: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -9242,6 +9615,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  clean-set@1.1.2: {}
+
   cli-boxes@4.0.1: {}
 
   cli-cursor@4.0.0:
@@ -9350,6 +9725,8 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -9555,6 +9932,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
@@ -9737,6 +10119,24 @@ snapshots:
 
   es-toolkit@1.45.1: {}
 
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -9811,6 +10211,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-carriage@1.3.1: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
@@ -9820,6 +10222,13 @@ snapshots:
   escape-string-regexp@5.0.0: {}
 
   esm-env@1.2.2: {}
+
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
 
   esprima@4.0.1: {}
 
@@ -9868,6 +10277,11 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -9877,6 +10291,10 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   extend@3.0.2: {}
 
@@ -10429,6 +10847,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  intersection-observer@0.10.0: {}
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -10678,6 +11098,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   load-tsconfig@0.2.5: {}
 
   localtunnel@2.0.2:
@@ -10721,6 +11145,8 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -10742,6 +11168,15 @@ snapshots:
       tmpl: 1.0.5
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -10945,6 +11380,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   memoize-one@5.2.1: {}
 
@@ -11533,6 +11970,8 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  next-tick@1.1.0: {}
+
   next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
@@ -11646,6 +12085,8 @@ snapshots:
   openurl@1.1.1: {}
 
   outdent@0.5.0: {}
+
+  outvariant@1.4.0: {}
 
   outvariant@1.4.3: {}
 
@@ -11864,6 +12305,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -11890,6 +12333,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  react-devtools-inline@4.4.0:
+    dependencies:
+      es6-symbol: 3.1.4
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -12390,11 +12837,20 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  static-browser-server@1.0.3:
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      dotenv: 16.6.1
+      mime-db: 1.54.0
+      outvariant: 1.4.3
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
+
+  strict-event-emitter@0.4.6: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -12433,6 +12889,8 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -12659,7 +13117,24 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type@2.7.3: {}
+
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)):
+    dependencies:
+      typedoc: 0.28.19(typescript@6.0.3)
+
+  typedoc@0.28.19(typescript@6.0.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.1.1
+      minimatch: 10.2.5
+      typescript: 6.0.3
+      yaml: 2.8.3
+
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
 
@@ -12907,6 +13382,8 @@ snapshots:
       '@vue/shared': 3.5.32
     optionalDependencies:
       typescript: 6.0.3
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Laravel-tier pass on the docs: interactive, discoverable, auto-maintained.

### What's new

1. **`<Playground>`** — Sandpack-based, runs in-browser via mock-adapter presets (replaces cold-start iframes).
2. **Cmd+K grouped search** — Guides / API / Examples / Packages via per-page tag index (`createFromSource` `buildIndex`).
3. **`<FrameworkTabs>`** — sticky framework picker, persists across every page via `localStorage` + custom event.
4. **`<RunCode>`** — "Run ▶" button on any fenced block swaps the snippet for a live `<Playground>`.
5. **Auto-gen API reference** — typedoc → fumadocs MDX for 8 `@agentskit/*` packages. MDX-safe escaping.
6. **`<ArchDiagram>`** — interactive SVG of the package graph. Click to pin, hover to highlight deps.
7. **Aggregated changelog** — generated from root + per-package `CHANGELOG.md`. New `<Since>` version badge.
8. **Callouts** — `<Tip>`, `<Warning>`, `<Pitfall>`, `<Performance>`, `<Security>`, `<Info>`, `<Success>` + `<Compare>` for side-by-side do/don't.
9. **`/learn`** — 5-step interactive tutorial with Stepper, progress saved to `localStorage`, inline Playground per step.
10. **`/cookbook`** — 8 self-contained recipes: streaming, tools+memory, auth, rate-limit, error boundary, structured output, multi-agent, RAG.
11. **`/production/performance`** — auto-generated from `.size-limit.json` budgets, refreshed on every build.
12. **Brand polish** — Space Grotesk display font, `.ak-wordmark` gradient, gradient-border code blocks.

### Generation pipeline

`prebuild` wires three scripts so Vercel/CI regenerates on every deploy:

```bash
pnpm --filter @agentskit/docs-next gen:api
pnpm --filter @agentskit/docs-next gen:changelog
pnpm --filter @agentskit/docs-next gen:performance
```

Generated content is gitignored:

- `content/docs/api/`
- `content/docs/reference/changelog.mdx`
- `content/docs/production/performance.mdx`

### Numbers

- Docs build: **706 pages** generated (up from ~300) — the typedoc output is the bulk.
- New deps: `@codesandbox/sandpack-react` (prod), `typedoc` + `typedoc-plugin-markdown` (dev).

## Test plan

- [ ] `pnpm --filter @agentskit/docs-next lint` — passes locally
- [ ] `pnpm --filter @agentskit/docs-next build` — passes locally (707 routes)
- [ ] Open `/docs/reference/contribute/docs-components` — every new component renders
- [ ] Cmd+K → type `useChat` → verify tag filters work
- [ ] Pick a framework in `<FrameworkTabs>` on one page → navigate, confirm preference sticks
- [ ] `/learn/chat` → send a message → stream renders → click Mark done → reload, progress persists
- [ ] `/cookbook` index → every recipe opens without errors
- [ ] `/docs/production/performance` → budgets table populated from `.size-limit.json`
- [ ] `/docs/api/core` → generated typedoc content renders (MDX-safe escaping)
- [ ] `<ArchDiagram>` → click `cli` node → 8 deps highlight, others dim