### PR TITLE
feat(tools): sqliteQueryTool (#306)

### DIFF
--- a/.changeset/sqlite-query-tool.md
+++ b/.changeset/sqlite-query-tool.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/tools': minor
+---
+
+feat(tools): add `sqliteQueryTool` — read-only SQL against a local SQLite file. `better-sqlite3` is an optional peer dependency. Returns up to 100 rows with a `truncated` flag; rejects writes (`INSERT`, `UPDATE`, `DELETE`, `DROP`, etc.).

--- a/apps/docs-next/content/docs/agents/tools/builtins.mdx
+++ b/apps/docs-next/content/docs/agents/tools/builtins.mdx
@@ -9,6 +9,7 @@ description: Ship-ready tools — web, fetch, filesystem, shell.
 | `fetchUrl` | `@agentskit/tools` | HTTP GET + content extraction |
 | `filesystem` | `@agentskit/tools` | read/write/list, scoped to a root |
 | `shell` | `@agentskit/tools` | exec commands, sandbox-friendly |
+| `sqliteQueryTool` | `@agentskit/tools` | read-only SQL against a local SQLite file |
 
 ## webSearch
 
@@ -44,6 +45,30 @@ const tool = createMandatorySandbox(shell({ cwd: '/tmp/agent-work' }), {
   requireSandbox: true,
 })
 ```
+
+## sqliteQueryTool
+
+```ts
+import { sqliteQueryTool } from '@agentskit/tools'
+
+const tool = sqliteQueryTool({ path: './data/app.db' })
+```
+
+Read-only by design — `INSERT`, `UPDATE`, `DELETE`, `DROP`, etc. are
+rejected. Returns up to 100 rows by default with a `truncated` flag;
+override with `maxRows`.
+
+`better-sqlite3` is an **optional peer dependency** — install it
+alongside this package:
+
+```bash
+npm install better-sqlite3
+```
+
+> **Safety note.** SQL is the agent's input here, so prompt injection
+> can produce data-exfiltration queries even though writes are blocked.
+> Treat the database as read-by-the-LLM data and avoid pointing this
+> tool at databases that hold secrets the agent shouldn't see.
 
 ## Related
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -88,12 +88,13 @@ For tools without Zod, use `defineTool` from `@agentskit/core` with a JSON Schem
 
 ## Features
 
-### Built-ins (4)
+### Built-ins (5)
 
 - `webSearch()` — live web search with pluggable providers (Tavily, Brave, SerpAPI, custom).
 - `fetchUrl()` — safe HTTP GET with JSON / text handling, size cap, boilerplate stripping.
 - `filesystem({ basePath })` — sandboxed read, write, list, delete, stat, exists.
 - `shell({ allowed })` — shell execution with command allow-list + timeout.
+- `sqliteQueryTool({ path })` — read-only SQL against a local SQLite file. Optional peer dep on `better-sqlite3`. **Note:** never feed unvalidated user prompts straight into the `sql` field — wrap with input filtering or use parameterized helpers if exposing it to untrusted input.
 
 ### Integrations (20+)
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -61,11 +61,21 @@
     "@agentskit/core": "workspace:*"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^25.6.0",
+    "better-sqlite3": "^12.9.0",
     "tsup": "^8.5.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "better-sqlite3": "^11.0.0 || ^12.0.0"
+  },
+  "peerDependenciesMeta": {
+    "better-sqlite3": {
+      "optional": true
+    }
   },
   "agentskit": {
     "stability": "stable",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -14,3 +14,6 @@ export { listTools } from './discovery'
 
 export { defineZodTool } from './zod'
 export type { DefineZodToolConfig } from './zod'
+
+export { sqliteQueryTool } from './sqlite-query'
+export type { SqliteQueryConfig } from './sqlite-query'

--- a/packages/tools/src/sqlite-query.ts
+++ b/packages/tools/src/sqlite-query.ts
@@ -1,0 +1,78 @@
+import type { ToolDefinition } from '@agentskit/core'
+
+export interface SqliteQueryConfig {
+  path: string
+  /** Reserved for v2; only `true` is accepted today. */
+  readOnly?: true
+  /** Max rows returned. Defaults to 100. */
+  maxRows?: number
+}
+
+interface SqliteDb {
+  prepare(sql: string): {
+    all(...args: unknown[]): Record<string, unknown>[]
+    readonly?: boolean
+  }
+  pragma(source: string): unknown
+  close(): void
+}
+
+interface SqliteCtor {
+  new (path: string, options?: { readonly?: boolean; fileMustExist?: boolean }): SqliteDb
+}
+
+async function openDatabase(path: string): Promise<SqliteDb> {
+  try {
+    const mod = await import('better-sqlite3')
+    const Database = (mod.default ?? mod) as unknown as SqliteCtor
+    const db = new Database(path, { readonly: true })
+    db.pragma('query_only = ON')
+    return db
+  } catch {
+    throw new Error('Install better-sqlite3 to use sqliteQueryTool: npm install better-sqlite3')
+  }
+}
+
+const WRITE_KEYWORDS = /\b(?:insert|update|delete|drop|create|alter|attach|detach|replace|reindex|vacuum|pragma)\b/i
+
+export function sqliteQueryTool(config: SqliteQueryConfig): ToolDefinition {
+  if (config.readOnly !== undefined && config.readOnly !== true) {
+    throw new Error('sqliteQueryTool: writes are not supported in v1 (readOnly must be true).')
+  }
+  const maxRows = config.maxRows ?? 100
+  let dbPromise: Promise<SqliteDb> | null = null
+  const getDb = (): Promise<SqliteDb> => {
+    if (!dbPromise) dbPromise = openDatabase(config.path)
+    return dbPromise
+  }
+
+  return {
+    name: 'sqlite_query',
+    description: 'Run a read-only SQL query against a local SQLite database. Returns up to 100 rows.',
+    tags: ['sqlite', 'sql', 'database', 'read'],
+    category: 'database',
+    schema: {
+      type: 'object',
+      properties: {
+        sql: { type: 'string', description: 'A single SELECT-style SQL statement.' },
+      },
+      required: ['sql'],
+    },
+    execute: async (args) => {
+      const sql = String(args.sql ?? '').trim()
+      if (!sql) throw new Error('sqlite_query: missing sql argument')
+      if (WRITE_KEYWORDS.test(sql)) {
+        throw new Error('sqlite_query: only read-only SELECT-style statements are allowed')
+      }
+      const db = await getDb()
+      const stmt = db.prepare(sql)
+      const rows = stmt.all() as Record<string, unknown>[]
+      const truncated = rows.length > maxRows
+      return {
+        rows: truncated ? rows.slice(0, maxRows) : rows,
+        rowCount: rows.length,
+        truncated,
+      }
+    },
+  }
+}

--- a/packages/tools/tests/sqlite-query.test.ts
+++ b/packages/tools/tests/sqlite-query.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { sqliteQueryTool } from '../src/sqlite-query'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { unlink } from 'node:fs/promises'
+
+interface SeedDb {
+  exec(sql: string): void
+  prepare(sql: string): { run(...args: unknown[]): void }
+  close(): void
+}
+
+async function seedDb(path: string, rows: number): Promise<void> {
+  const mod = await import('better-sqlite3')
+  const Database = (mod.default ?? mod) as unknown as new (p: string) => SeedDb
+  const db = new Database(path)
+  db.exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)')
+  const insert = db.prepare('INSERT INTO items (id, name) VALUES (?, ?)')
+  for (let i = 1; i <= rows; i++) insert.run(i, `item-${i}`)
+  db.close()
+}
+
+describe('sqliteQueryTool', () => {
+  let dbPath: string
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `agentskit-sqlite-query-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+    await seedDb(dbPath, 5)
+  })
+
+  afterEach(async () => {
+    try { await unlink(dbPath) } catch {}
+  })
+
+  it('satisfies ToolDefinition contract', () => {
+    const tool = sqliteQueryTool({ path: dbPath })
+    expect(tool.name).toBe('sqlite_query')
+    expect(tool.description).toBeTruthy()
+    expect(tool.schema).toBeDefined()
+    expect(tool.category).toBe('database')
+    expect(tool.execute).toBeTypeOf('function')
+  })
+
+  it('returns rows from a SELECT', async () => {
+    const tool = sqliteQueryTool({ path: dbPath })
+    const result = await tool.execute({ sql: 'SELECT id, name FROM items ORDER BY id' }) as {
+      rows: Array<{ id: number; name: string }>
+      rowCount: number
+      truncated: boolean
+    }
+    expect(result.rows).toHaveLength(5)
+    expect(result.rows[0]).toEqual({ id: 1, name: 'item-1' })
+    expect(result.rowCount).toBe(5)
+    expect(result.truncated).toBe(false)
+  })
+
+  it('truncates when row count exceeds maxRows', async () => {
+    const big = join(tmpdir(), `agentskit-sqlite-query-big-${Date.now()}.db`)
+    await seedDb(big, 150)
+    try {
+      const tool = sqliteQueryTool({ path: big })
+      const result = await tool.execute({ sql: 'SELECT * FROM items' }) as {
+        rows: unknown[]
+        rowCount: number
+        truncated: boolean
+      }
+      expect(result.rows.length).toBe(100)
+      expect(result.rowCount).toBe(150)
+      expect(result.truncated).toBe(true)
+    } finally {
+      await unlink(big).catch(() => {})
+    }
+  })
+
+  it('respects custom maxRows', async () => {
+    const tool = sqliteQueryTool({ path: dbPath, maxRows: 2 })
+    const result = await tool.execute({ sql: 'SELECT * FROM items' }) as {
+      rows: unknown[]
+      truncated: boolean
+    }
+    expect(result.rows).toHaveLength(2)
+    expect(result.truncated).toBe(true)
+  })
+
+  it('rejects writes', async () => {
+    const tool = sqliteQueryTool({ path: dbPath })
+    await expect(tool.execute({ sql: "INSERT INTO items (id, name) VALUES (99, 'x')" }))
+      .rejects.toThrow(/read-only/)
+    await expect(tool.execute({ sql: 'DROP TABLE items' })).rejects.toThrow(/read-only/)
+    await expect(tool.execute({ sql: 'UPDATE items SET name = ?' })).rejects.toThrow(/read-only/)
+  })
+
+  it('rejects empty sql', async () => {
+    const tool = sqliteQueryTool({ path: dbPath })
+    await expect(tool.execute({ sql: '' })).rejects.toThrow(/missing sql/)
+  })
+
+  it('rejects readOnly: false in config', () => {
+    expect(() => sqliteQueryTool({ path: dbPath, readOnly: false as unknown as true }))
+      .toThrow(/v1/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,12 +732,18 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- New built-in tool \`sqliteQueryTool({ path, maxRows? })\` in \`@agentskit/tools\` for read-only SQL against a local SQLite file.
- \`better-sqlite3\` is an **optional peer dependency** — loaded lazily via dynamic import; throws a clear install hint if absent.
- Returns \`{ rows, rowCount, truncated }\`; default cap 100 rows.
- Writes are blocked two ways: keyword-level rejection (\`INSERT/UPDATE/DELETE/DROP/CREATE/ALTER/...\`) AND \`pragma query_only = ON\` + \`readonly: true\` on the connection.

Closes #306.

## Test plan
- [x] \`pnpm --filter @agentskit/tools test\` — 7 new tests pass (140 total)
- [x] \`pnpm --filter @agentskit/tools lint\` (tsc --noEmit) passes
- [x] \`pnpm --filter @agentskit/tools build\` succeeds (tsup ESM + CJS + DTS)
- [x] \`pnpm --filter @agentskit/docs-next build\` succeeds with the new builtins page entry
- [ ] Manual: point at a real \`.db\` file and verify a SELECT returns rows