### PR TITLE
feat(tools): slackTool (#305)

### DIFF
--- a/.changeset/slack-tool.md
+++ b/.changeset/slack-tool.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/tools': minor
+---
+
+feat(tools): add `slackTool` — outbound-only built-in that posts to a Slack Incoming Webhook. Schema `{ text, channel?, username? }`; returns `{ ok, status }`. Complements the Bearer-token-based `slack()` integration.

--- a/apps/docs-next/content/docs/agents/tools/builtins.mdx
+++ b/apps/docs-next/content/docs/agents/tools/builtins.mdx
@@ -10,6 +10,7 @@ description: Ship-ready tools — web, fetch, filesystem, shell.
 | `filesystem` | `@agentskit/tools` | read/write/list, scoped to a root |
 | `shell` | `@agentskit/tools` | exec commands, sandbox-friendly |
 | `sqliteQueryTool` | `@agentskit/tools` | read-only SQL against a local SQLite file |
+| `slackTool` | `@agentskit/tools` | post to a Slack Incoming Webhook |
 
 ## webSearch
 
@@ -69,6 +70,21 @@ npm install better-sqlite3
 > can produce data-exfiltration queries even though writes are blocked.
 > Treat the database as read-by-the-LLM data and avoid pointing this
 > tool at databases that hold secrets the agent shouldn't see.
+
+## slackTool
+
+```ts
+import { slackTool } from '@agentskit/tools'
+
+const tool = slackTool({ webhookUrl: process.env.SLACK_WEBHOOK_URL! })
+```
+
+Posts to a [Slack Incoming Webhook](https://api.slack.com/messaging/webhooks).
+Schema: `{ text, channel?, username? }`. Returns `{ ok, status }` —
+non-2xx replies surface as `ok: false` rather than throwing, so a chatty
+agent can keep going after a transient failure. For workspace-scoped
+features (search, channel listing, threading), use the
+[`slack()`](./integrations) integration which uses Bearer-token auth.
 
 ## Related
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -88,13 +88,14 @@ For tools without Zod, use `defineTool` from `@agentskit/core` with a JSON Schem
 
 ## Features
 
-### Built-ins (5)
+### Built-ins (6)
 
 - `webSearch()` — live web search with pluggable providers (Tavily, Brave, SerpAPI, custom).
 - `fetchUrl()` — safe HTTP GET with JSON / text handling, size cap, boilerplate stripping.
 - `filesystem({ basePath })` — sandboxed read, write, list, delete, stat, exists.
 - `shell({ allowed })` — shell execution with command allow-list + timeout.
 - `sqliteQueryTool({ path })` — read-only SQL against a local SQLite file. Optional peer dep on `better-sqlite3`. **Note:** never feed unvalidated user prompts straight into the `sql` field — wrap with input filtering or use parameterized helpers if exposing it to untrusted input.
+- `slackTool({ webhookUrl })` — post to a Slack Incoming Webhook. For Bearer-token features (search, channel listing), use the `slack()` integration.
 
 ### Integrations (20+)
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -17,3 +17,6 @@ export type { DefineZodToolConfig } from './zod'
 
 export { sqliteQueryTool } from './sqlite-query'
 export type { SqliteQueryConfig } from './sqlite-query'
+
+export { slackTool } from './slack'
+export type { SlackToolConfig } from './slack'

--- a/packages/tools/src/slack.ts
+++ b/packages/tools/src/slack.ts
@@ -1,0 +1,42 @@
+import type { ToolDefinition } from '@agentskit/core'
+
+export interface SlackToolConfig {
+  webhookUrl: string
+  /** Override fetch (mainly for tests). Defaults to the global `fetch`. */
+  fetch?: typeof fetch
+}
+
+export function slackTool(config: SlackToolConfig): ToolDefinition {
+  if (!config.webhookUrl) throw new Error('slackTool: webhookUrl is required')
+  const doFetch = config.fetch ?? fetch
+
+  return {
+    name: 'slack_send',
+    description: 'Send a message to a Slack channel via an Incoming Webhook.',
+    tags: ['slack', 'notify', 'webhook'],
+    category: 'notification',
+    schema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Message text. Slack mrkdwn is supported.' },
+        channel: { type: 'string', description: 'Channel override (only honored if your webhook allows it).' },
+        username: { type: 'string', description: 'Username override (only honored if your webhook allows it).' },
+      },
+      required: ['text'],
+    },
+    execute: async (args) => {
+      const text = String(args.text ?? '').trim()
+      if (!text) throw new Error('slack_send: missing text')
+      const payload: Record<string, string> = { text }
+      if (typeof args.channel === 'string' && args.channel) payload.channel = args.channel
+      if (typeof args.username === 'string' && args.username) payload.username = args.username
+
+      const response = await doFetch(config.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      return { ok: response.ok, status: response.status }
+    },
+  }
+}

--- a/packages/tools/tests/slack.test.ts
+++ b/packages/tools/tests/slack.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { slackTool } from '../src/slack'
+
+const WEBHOOK = 'https://hooks.slack.com/services/T/B/XYZ'
+
+function fakeFetch(impl: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    return impl(String(input), init ?? {})
+  }) as unknown as typeof fetch
+}
+
+describe('slackTool', () => {
+  it('satisfies ToolDefinition contract', () => {
+    const tool = slackTool({ webhookUrl: WEBHOOK })
+    expect(tool.name).toBe('slack_send')
+    expect(tool.description).toBeTruthy()
+    expect(tool.schema).toBeDefined()
+    expect(tool.category).toBe('notification')
+    expect(tool.execute).toBeTypeOf('function')
+  })
+
+  it('POSTs to the webhook with JSON body', async () => {
+    const fetchMock = fakeFetch(() => new Response(null, { status: 200 }))
+    const tool = slackTool({ webhookUrl: WEBHOOK, fetch: fetchMock })
+    const result = await tool.execute({ text: 'hello' })
+    expect(result).toEqual({ ok: true, status: 200 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = (fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    expect(url).toBe(WEBHOOK)
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(JSON.parse(String(init.body))).toEqual({ text: 'hello' })
+  })
+
+  it('forwards channel and username when present', async () => {
+    let captured: Record<string, unknown> = {}
+    const fetchMock = fakeFetch((_url, init) => {
+      captured = JSON.parse(String(init.body))
+      return new Response(null, { status: 200 })
+    })
+    const tool = slackTool({ webhookUrl: WEBHOOK, fetch: fetchMock })
+    await tool.execute({ text: 'hi', channel: '#alerts', username: 'bot' })
+    expect(captured).toEqual({ text: 'hi', channel: '#alerts', username: 'bot' })
+  })
+
+  it('reports non-2xx as ok=false with status', async () => {
+    const fetchMock = fakeFetch(() => new Response('rate limited', { status: 429 }))
+    const tool = slackTool({ webhookUrl: WEBHOOK, fetch: fetchMock })
+    const result = await tool.execute({ text: 'hi' }) as { ok: boolean; status: number }
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(429)
+  })
+
+  it('rejects missing text', async () => {
+    const tool = slackTool({ webhookUrl: WEBHOOK, fetch: fakeFetch(() => new Response()) })
+    await expect(tool.execute({ text: '' })).rejects.toThrow(/missing text/)
+  })
+
+  it('rejects missing webhookUrl at construction time', () => {
+    expect(() => slackTool({ webhookUrl: '' })).toThrow(/webhookUrl is required/)
+  })
+})


### PR DESCRIPTION
## Summary
- New built-in \`slackTool({ webhookUrl, fetch? })\` in \`@agentskit/tools\` for outbound notifications via a Slack Incoming Webhook.
- Schema: \`{ text, channel?, username? }\`. Returns \`{ ok, status }\` — non-2xx surfaces as \`ok: false\` instead of throwing.
- Complements the existing Bearer-token-based \`slack()\` integration (search / threading).

Closes #305.

## Test plan
- [x] \`pnpm --filter @agentskit/tools test\` — 6 new tests pass (139 total)
- [x] \`pnpm --filter @agentskit/tools lint\` (tsc --noEmit) passes
- [x] \`pnpm --filter @agentskit/tools build\` succeeds
- [x] \`pnpm --filter @agentskit/docs-next build\` succeeds
- [ ] Manual: point at a real Slack Incoming Webhook and verify the message lands