### PR TITLE
feat(rag): four loaders + two rerankers (S3 / GCS / Dropbox / OneDrive + voyage / jina)

### DIFF
--- a/.changeset/rag-batch-462-466.md
+++ b/.changeset/rag-batch-462-466.md
@@ -1,0 +1,14 @@
+---
+'@agentskit/rag': minor
+---
+
+feat(rag): four new loaders and two new rerankers:
+
+- `loadS3` (#462) — S3 (and S3-compatible: R2, MinIO) bucket walk with prefix + filter + maxFiles. `@aws-sdk/client-s3` resolved lazily; commands can be passed in to skip the dynamic-import path.
+- `loadGcs` (#464) — Google Cloud Storage bucket walk via Storage REST + OAuth2 access token (string or `() => Promise<string>`).
+- `loadDropbox` (#463) — recursive folder walk via `files/list_folder` + `files/download`.
+- `loadOneDrive` (#465) — Microsoft Graph drive children walk + `@microsoft.graph.downloadUrl`.
+- `voyageReranker` (#466) — Voyage AI cross-encoder reranker. Default `rerank-2`.
+- `jinaReranker` (#466) — Jina AI cross-encoder reranker. Default `jina-reranker-v2-base-multilingual`.
+
+All four loaders return `InputDocument[]` ready to pipe into `RAG.ingest`. Both rerankers are drop-in `RerankFn` for `createRerankedRetriever`.

--- a/apps/docs-next/content/docs/data/rag/loaders.mdx
+++ b/apps/docs-next/content/docs/data/rag/loaders.mdx
@@ -1,6 +1,6 @@
 ---
 title: Document loaders
-description: Fetch + normalize documents from URLs, GitHub, Notion, Confluence, Google Drive, PDFs.
+description: Fetch + normalize documents from URLs, GitHub, Notion, Confluence, Google Drive, S3, GCS, Dropbox, OneDrive, PDFs.
 ---
 
 All loaders return `LoadedDocument[]` ready for `rag.ingest`.
@@ -45,6 +45,68 @@ const docs = await loadConfluencePage({ baseUrl, auth, pageId })
 import { loadGoogleDriveFile } from '@agentskit/rag'
 const docs = await loadGoogleDriveFile({ fileId, accessToken })
 ```
+
+## S3 (and S3-compatible: R2, MinIO)
+
+```ts
+import { S3Client, ListObjectsV2Command, GetObjectCommand } from '@aws-sdk/client-s3'
+import { loadS3 } from '@agentskit/rag'
+
+const client = new S3Client({ region: 'us-east-1' })
+const docs = await loadS3({
+  client,
+  bucket: 'my-bucket',
+  prefix: 'docs/',
+  filter: key => key.endsWith('.md'),
+  // Optional — pass commands to skip the dynamic import path:
+  commands: { ListObjectsV2Command, GetObjectCommand },
+})
+```
+
+`@aws-sdk/client-s3` is an optional peer dep. For Cloudflare R2 / MinIO, configure the client's `endpoint` to the compatible host.
+
+## Google Cloud Storage
+
+```ts
+import { loadGcs } from '@agentskit/rag'
+
+const docs = await loadGcs({
+  bucket: 'my-bucket',
+  prefix: 'docs/',
+  accessToken: process.env.GCP_ACCESS_TOKEN!,   // string or () => Promise<string>
+  filter: name => name.endsWith('.md'),
+})
+```
+
+OAuth2 token bring-your-own — mint via `google-auth-library`, Workload Identity, or `gcloud auth print-access-token`.
+
+## Dropbox
+
+```ts
+import { loadDropbox } from '@agentskit/rag'
+
+const docs = await loadDropbox({
+  accessToken: process.env.DROPBOX_TOKEN!,
+  path: '/team-docs',
+  filter: p => p.endsWith('.md'),
+})
+```
+
+Walks a folder recursively via `files/list_folder` and downloads each file via `files/download`.
+
+## OneDrive (Microsoft Graph)
+
+```ts
+import { loadOneDrive } from '@agentskit/rag'
+
+const docs = await loadOneDrive({
+  accessToken: msalToken,         // string or () => Promise<string>
+  driveId: 'b!...',               // omit for the signed-in user's drive
+  folderItemId: '01ABC...',       // omit for root
+})
+```
+
+Walks the drive children recursively, follows `@microsoft.graph.downloadUrl` for each file.
 
 ## PDF
 

--- a/apps/docs-next/content/docs/data/rag/rerank.mdx
+++ b/apps/docs-next/content/docs/data/rag/rerank.mdx
@@ -15,9 +15,13 @@ const retriever = createRerankedRetriever({
 
 ## Rerankers
 
-- `cohereReranker({ apiKey, model? })`
-- `bgeReranker({ url, model? })` — self-hosted.
-- `bm25Reranker()` — zero-dep fallback.
+- `cohereReranker({ apiKey, model? })` — Cohere Rerank.
+- `bgeReranker({ url, model? })` — self-hosted BGE cross-encoder.
+- `voyageReranker({ apiKey, model? })` — Voyage AI; defaults to `rerank-2`. Pass `rerank-2-lite` for cheaper / faster runs.
+- `jinaReranker({ apiKey, model? })` — Jina AI; defaults to `jina-reranker-v2-base-multilingual`.
+- `bm25Rerank` — zero-dep fallback.
+
+All rerankers are drop-in `RerankFn` values — they share the same `createRerankedRetriever` API so you can swap them without changing call sites.
 
 ## Related
 

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -11,6 +11,10 @@ export {
   loadConfluencePage,
   loadGoogleDriveFile,
   loadPdf,
+  loadS3,
+  loadGcs,
+  loadDropbox,
+  loadOneDrive,
 } from './loaders'
 export type {
   LoaderOptions,
@@ -21,7 +25,15 @@ export type {
   ConfluenceLoaderOptions,
   DriveLoaderOptions,
   PdfLoaderOptions,
+  S3LoaderOptions,
+  S3LikeClient,
+  GcsLoaderOptions,
+  DropboxLoaderOptions,
+  OneDriveLoaderOptions,
 } from './loaders'
+
+export { voyageReranker, jinaReranker } from './rerankers'
+export type { VoyageRerankerOptions, JinaRerankerOptions } from './rerankers'
 
 export {
   createRerankedRetriever,

--- a/packages/rag/src/loaders.ts
+++ b/packages/rag/src/loaders.ts
@@ -160,6 +160,267 @@ export async function loadGoogleDriveFile(
   return [{ content, source: `gdrive://${fileId}`, metadata: { fileId } }]
 }
 
+// ---------------------------------------------------------------------------
+// S3 — Cloudflare R2 / MinIO / any S3-compatible bucket
+// ---------------------------------------------------------------------------
+
+export interface S3LikeClient {
+  send(command: { input: Record<string, unknown> }): Promise<unknown>
+}
+
+export interface S3LoaderOptions extends LoaderOptions {
+  /**
+   * AWS SDK v3 \`S3Client\`-shaped client. Bring your own to keep the bundle
+   * lean. Works with R2 / MinIO / etc. by configuring the client's endpoint.
+   */
+  client: S3LikeClient
+  bucket: string
+  /**
+   * AWS SDK v3 commands. Pass them in to skip the dynamic import:
+   * \`{ ListObjectsV2Command, GetObjectCommand }\` from \`@aws-sdk/client-s3\`.
+   * Optional — when omitted the loader resolves them lazily.
+   */
+  commands?: {
+    ListObjectsV2Command: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
+    GetObjectCommand: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
+  }
+  /** Limit to keys under this prefix. */
+  prefix?: string
+  /** Include only keys matching this predicate after listing. */
+  filter?: (key: string) => boolean
+  /** Cap on number of objects to load. Default 100. */
+  maxFiles?: number
+}
+
+interface S3SdkLike {
+  ListObjectsV2Command: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
+  GetObjectCommand: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
+}
+
+let cachedS3Sdk: Promise<S3SdkLike> | null = null
+async function loadS3Sdk(): Promise<S3SdkLike> {
+  if (!cachedS3Sdk) {
+    cachedS3Sdk = (async () => {
+      try {
+        const moduleId = '@aws-sdk/client-s3'
+        return (await import(/* @vite-ignore */ moduleId)) as unknown as S3SdkLike
+      } catch {
+        throw new Error('Install @aws-sdk/client-s3 to use loadS3: npm install @aws-sdk/client-s3')
+      }
+    })()
+  }
+  return cachedS3Sdk
+}
+
+export async function loadS3(options: S3LoaderOptions): Promise<InputDocument[]> {
+  const { ListObjectsV2Command, GetObjectCommand } = options.commands ?? await loadS3Sdk()
+  const docs: InputDocument[] = []
+  let continuationToken: string | undefined
+  const maxFiles = options.maxFiles ?? 100
+  outer: while (true) {
+    const list = await options.client.send(new ListObjectsV2Command({
+      Bucket: options.bucket,
+      Prefix: options.prefix,
+      ContinuationToken: continuationToken,
+    })) as {
+      Contents?: Array<{ Key?: string }>
+      NextContinuationToken?: string
+      IsTruncated?: boolean
+    }
+    for (const obj of list.Contents ?? []) {
+      const key = obj.Key
+      if (!key) continue
+      if (options.filter && !options.filter(key)) continue
+      const get = await options.client.send(new GetObjectCommand({
+        Bucket: options.bucket,
+        Key: key,
+      })) as { Body?: { transformToString(): Promise<string> } }
+      const content = await get.Body?.transformToString() ?? ''
+      docs.push({
+        content,
+        source: `s3://${options.bucket}/${key}`,
+        metadata: { bucket: options.bucket, key },
+      })
+      if (docs.length >= maxFiles) break outer
+    }
+    if (!list.IsTruncated) break
+    continuationToken = list.NextContinuationToken
+  }
+  return docs
+}
+
+// ---------------------------------------------------------------------------
+// GCS — Google Cloud Storage
+// ---------------------------------------------------------------------------
+
+export interface GcsLoaderOptions extends LoaderOptions {
+  bucket: string
+  prefix?: string
+  /** OAuth2 access token. Mint via google-auth-library or workload identity. */
+  accessToken: string | (() => string | Promise<string>)
+  filter?: (name: string) => boolean
+  maxFiles?: number
+}
+
+export async function loadGcs(options: GcsLoaderOptions): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const docs: InputDocument[] = []
+  const maxFiles = options.maxFiles ?? 100
+  const getToken = async () =>
+    typeof options.accessToken === 'string' ? options.accessToken : await options.accessToken()
+
+  let pageToken: string | undefined
+  outer: while (true) {
+    const params = new URLSearchParams()
+    if (options.prefix) params.set('prefix', options.prefix)
+    if (pageToken) params.set('pageToken', pageToken)
+    const url = `https://storage.googleapis.com/storage/v1/b/${options.bucket}/o?${params.toString()}`
+    const response = await fetchImpl(url, {
+      headers: { authorization: `Bearer ${await getToken()}` },
+    })
+    if (!response.ok) throw new Error(`loadGcs ${response.status}: ${url}`)
+    const data = await response.json() as {
+      items?: Array<{ name: string }>
+      nextPageToken?: string
+    }
+    for (const item of data.items ?? []) {
+      if (options.filter && !options.filter(item.name)) continue
+      const objUrl = `https://storage.googleapis.com/storage/v1/b/${options.bucket}/o/${encodeURIComponent(item.name)}?alt=media`
+      const objResponse = await fetchImpl(objUrl, {
+        headers: { authorization: `Bearer ${await getToken()}` },
+      })
+      if (!objResponse.ok) continue
+      docs.push({
+        content: await objResponse.text(),
+        source: `gs://${options.bucket}/${item.name}`,
+        metadata: { bucket: options.bucket, name: item.name },
+      })
+      if (docs.length >= maxFiles) break outer
+    }
+    if (!data.nextPageToken) break
+    pageToken = data.nextPageToken
+  }
+  return docs
+}
+
+// ---------------------------------------------------------------------------
+// Dropbox
+// ---------------------------------------------------------------------------
+
+export interface DropboxLoaderOptions extends LoaderOptions {
+  /** Dropbox OAuth2 access token. */
+  accessToken: string
+  /** Folder path, e.g. `/team-docs`. Empty string = root. */
+  path?: string
+  filter?: (path: string) => boolean
+  maxFiles?: number
+}
+
+export async function loadDropbox(options: DropboxLoaderOptions): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const docs: InputDocument[] = []
+  const maxFiles = options.maxFiles ?? 100
+  const headers = { authorization: `Bearer ${options.accessToken}`, 'content-type': 'application/json' }
+
+  let cursor: string | undefined
+  outer: while (true) {
+    const url = cursor
+      ? 'https://api.dropboxapi.com/2/files/list_folder/continue'
+      : 'https://api.dropboxapi.com/2/files/list_folder'
+    const body = cursor ? { cursor } : { path: options.path ?? '', recursive: true }
+    const response = await fetchImpl(url, { method: 'POST', headers, body: JSON.stringify(body) })
+    if (!response.ok) throw new Error(`loadDropbox ${response.status}: ${url}`)
+    const data = await response.json() as {
+      entries?: Array<{ '.tag': string; path_lower?: string; path_display?: string }>
+      cursor?: string
+      has_more?: boolean
+    }
+    for (const entry of data.entries ?? []) {
+      if (entry['.tag'] !== 'file') continue
+      const path = entry.path_display ?? entry.path_lower
+      if (!path) continue
+      if (options.filter && !options.filter(path)) continue
+      const downloadResponse = await fetchImpl('https://content.dropboxapi.com/2/files/download', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${options.accessToken}`,
+          'Dropbox-API-Arg': JSON.stringify({ path }),
+        },
+      })
+      if (!downloadResponse.ok) continue
+      docs.push({
+        content: await downloadResponse.text(),
+        source: `dropbox:${path}`,
+        metadata: { path },
+      })
+      if (docs.length >= maxFiles) break outer
+    }
+    if (!data.has_more) break
+    cursor = data.cursor
+  }
+  return docs
+}
+
+// ---------------------------------------------------------------------------
+// OneDrive — Microsoft Graph
+// ---------------------------------------------------------------------------
+
+export interface OneDriveLoaderOptions extends LoaderOptions {
+  /** Microsoft Graph access token (mint via MSAL). */
+  accessToken: string | (() => string | Promise<string>)
+  /** Drive id. Defaults to `me/drive` (the signed-in user's OneDrive). */
+  driveId?: string
+  /** Item id (folder) to walk. Defaults to root. */
+  folderItemId?: string
+  filter?: (name: string) => boolean
+  maxFiles?: number
+}
+
+export async function loadOneDrive(options: OneDriveLoaderOptions): Promise<InputDocument[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const docs: InputDocument[] = []
+  const maxFiles = options.maxFiles ?? 100
+  const driveBase = options.driveId
+    ? `https://graph.microsoft.com/v1.0/drives/${options.driveId}`
+    : `https://graph.microsoft.com/v1.0/me/drive`
+  const folder = options.folderItemId ? `items/${options.folderItemId}` : 'root'
+
+  const getToken = async () =>
+    typeof options.accessToken === 'string' ? options.accessToken : await options.accessToken()
+
+  async function walk(prefix: string): Promise<void> {
+    const url = `${driveBase}/${prefix}/children`
+    const response = await fetchImpl(url, {
+      headers: { authorization: `Bearer ${await getToken()}` },
+    })
+    if (!response.ok) throw new Error(`loadOneDrive ${response.status}: ${url}`)
+    const data = await response.json() as {
+      value?: Array<{ id: string; name: string; folder?: object; file?: { mimeType: string }; '@microsoft.graph.downloadUrl'?: string }>
+    }
+    for (const item of data.value ?? []) {
+      if (docs.length >= maxFiles) return
+      if (item.folder) {
+        await walk(`items/${item.id}`)
+        continue
+      }
+      if (!item.file) continue
+      if (options.filter && !options.filter(item.name)) continue
+      const downloadUrl = item['@microsoft.graph.downloadUrl']
+      if (!downloadUrl) continue
+      const fileResponse = await fetchImpl(downloadUrl)
+      if (!fileResponse.ok) continue
+      docs.push({
+        content: await fileResponse.text(),
+        source: `onedrive:${item.id}`,
+        metadata: { id: item.id, name: item.name, mimeType: item.file.mimeType },
+      })
+    }
+  }
+
+  await walk(folder)
+  return docs
+}
+
 export interface PdfLoaderOptions extends LoaderOptions {
   parsePdf: (bytes: Uint8Array) => Promise<{ text: string; pages?: number }> | { text: string; pages?: number }
 }

--- a/packages/rag/src/rerankers/index.ts
+++ b/packages/rag/src/rerankers/index.ts
@@ -1,0 +1,5 @@
+export { voyageReranker } from './voyage'
+export type { VoyageRerankerOptions } from './voyage'
+
+export { jinaReranker } from './jina'
+export type { JinaRerankerOptions } from './jina'

--- a/packages/rag/src/rerankers/jina.ts
+++ b/packages/rag/src/rerankers/jina.ts
@@ -1,0 +1,50 @@
+import type { RetrievedDocument } from '@agentskit/core'
+import type { RerankFn } from '../rerank'
+
+export interface JinaRerankerOptions {
+  apiKey: string
+  /** Default `jina-reranker-v2-base-multilingual`. */
+  model?: string
+  fetch?: typeof globalThis.fetch
+}
+
+interface JinaRerankResponse {
+  results?: Array<{ index: number; relevance_score: number }>
+  detail?: string
+}
+
+/**
+ * Jina AI cross-encoder reranker. Drop-in `RerankFn` for
+ * `createRerankedRetriever`.
+ */
+export function jinaReranker(options: JinaRerankerOptions): RerankFn {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const model = options.model ?? 'jina-reranker-v2-base-multilingual'
+  return async ({ query, documents }) => {
+    if (documents.length === 0) return documents
+    const response = await fetchImpl('https://api.jina.ai/v1/rerank', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${options.apiKey}`,
+      },
+      body: JSON.stringify({
+        query,
+        documents: documents.map(d => d.content),
+        model,
+      }),
+    })
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`jina rerank: ${response.status} ${text.slice(0, 200)}`)
+    }
+    const data = await response.json() as JinaRerankResponse
+    const ranked: RetrievedDocument[] = (data.results ?? [])
+      .sort((a, b) => b.relevance_score - a.relevance_score)
+      .map(r => {
+        const doc = documents[r.index]!
+        return { ...doc, score: r.relevance_score }
+      })
+    return ranked
+  }
+}

--- a/packages/rag/src/rerankers/voyage.ts
+++ b/packages/rag/src/rerankers/voyage.ts
@@ -1,0 +1,51 @@
+import type { RetrievedDocument } from '@agentskit/core'
+import type { RerankFn } from '../rerank'
+
+export interface VoyageRerankerOptions {
+  apiKey: string
+  /** Default `rerank-2`. Pass `rerank-2-lite` for cheaper / faster runs. */
+  model?: string
+  /** Override fetch (mainly for tests). */
+  fetch?: typeof globalThis.fetch
+}
+
+interface VoyageRerankResponse {
+  data?: Array<{ index: number; relevance_score: number }>
+  detail?: string
+}
+
+/**
+ * Voyage AI cross-encoder reranker. Drop-in `RerankFn` for
+ * `createRerankedRetriever`.
+ */
+export function voyageReranker(options: VoyageRerankerOptions): RerankFn {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const model = options.model ?? 'rerank-2'
+  return async ({ query, documents }) => {
+    if (documents.length === 0) return documents
+    const response = await fetchImpl('https://api.voyageai.com/v1/rerank', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${options.apiKey}`,
+      },
+      body: JSON.stringify({
+        query,
+        documents: documents.map(d => d.content),
+        model,
+      }),
+    })
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`voyage rerank: ${response.status} ${text.slice(0, 200)}`)
+    }
+    const data = await response.json() as VoyageRerankResponse
+    const ranked: RetrievedDocument[] = (data.data ?? [])
+      .sort((a, b) => b.relevance_score - a.relevance_score)
+      .map(r => {
+        const doc = documents[r.index]!
+        return { ...doc, score: r.relevance_score }
+      })
+    return ranked
+  }
+}

--- a/packages/rag/tests/rag-batch-462-466.test.ts
+++ b/packages/rag/tests/rag-batch-462-466.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  loadS3,
+  loadGcs,
+  loadDropbox,
+  loadOneDrive,
+  voyageReranker,
+  jinaReranker,
+} from '../src/index'
+
+function fakeFetch(impl: (url: string, init: RequestInit) => Response | Promise<Response>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+    impl(String(input), init ?? {})
+  ) as unknown as typeof fetch
+}
+
+// Mock the SDK command classes so tests don't pull @aws-sdk/client-s3.
+const FakeCommands = {
+  ListObjectsV2Command: class { input: Record<string, unknown>; constructor(input: Record<string, unknown>) { this.input = input } },
+  GetObjectCommand: class { input: Record<string, unknown>; constructor(input: Record<string, unknown>) { this.input = input } },
+}
+
+describe('loadS3', () => {
+  it('lists + fetches objects via the injected client', async () => {
+    const client = {
+      send: vi.fn()
+        .mockResolvedValueOnce({ Contents: [{ Key: 'a.txt' }, { Key: 'b.txt' }], IsTruncated: false })
+        .mockResolvedValueOnce({ Body: { transformToString: async () => 'hello A' } })
+        .mockResolvedValueOnce({ Body: { transformToString: async () => 'hello B' } }),
+    }
+    const docs = await loadS3({ client, bucket: 'b1', commands: FakeCommands })
+    expect(docs).toHaveLength(2)
+    expect(docs[0].source).toBe('s3://b1/a.txt')
+    expect(docs[0].content).toBe('hello A')
+  })
+
+  it('honours filter and maxFiles', async () => {
+    const client = {
+      send: vi.fn()
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'keep.txt' }, { Key: 'skip.bin' }, { Key: 'keep2.txt' }],
+          IsTruncated: false,
+        })
+        .mockResolvedValue({ Body: { transformToString: async () => 'x' } }),
+    }
+    const docs = await loadS3({
+      client,
+      bucket: 'b1',
+      commands: FakeCommands,
+      filter: k => k.endsWith('.txt'),
+      maxFiles: 1,
+    })
+    expect(docs).toHaveLength(1)
+    expect(docs[0].source).toBe('s3://b1/keep.txt')
+  })
+})
+
+describe('loadGcs', () => {
+  it('walks bucket pages and downloads with the access token', async () => {
+    let listed = 0
+    const fetchMock = fakeFetch((url) => {
+      if (url.includes('?prefix') || url.endsWith('/o') || url.includes('/o?')) {
+        listed++
+        if (listed === 1) {
+          return new Response(JSON.stringify({
+            items: [{ name: 'doc.txt' }],
+            nextPageToken: undefined,
+          }))
+        }
+      }
+      return new Response('content')
+    })
+    const docs = await loadGcs({
+      bucket: 'b1',
+      accessToken: 'ya29.token',
+      fetch: fetchMock,
+    })
+    expect(docs).toHaveLength(1)
+    expect(docs[0].source).toBe('gs://b1/doc.txt')
+    expect(docs[0].content).toBe('content')
+  })
+
+  it('accepts an async accessToken', async () => {
+    let captured: string | undefined
+    const fetchMock = fakeFetch((_url, init) => {
+      captured = (init.headers as Record<string, string>)?.authorization
+      return new Response(JSON.stringify({ items: [] }))
+    })
+    await loadGcs({
+      bucket: 'b1',
+      accessToken: async () => 'dynamic',
+      fetch: fetchMock,
+    })
+    expect(captured).toBe('Bearer dynamic')
+  })
+})
+
+describe('loadDropbox', () => {
+  it('lists folder + downloads each file', async () => {
+    const fetchMock = fakeFetch((url) => {
+      if (url.endsWith('/list_folder')) {
+        return new Response(JSON.stringify({
+          entries: [
+            { '.tag': 'file', path_display: '/docs/a.md' },
+            { '.tag': 'folder', path_display: '/docs/sub' },
+          ],
+          has_more: false,
+        }))
+      }
+      if (url.endsWith('/download')) {
+        return new Response('# Hello')
+      }
+      return new Response('', { status: 404 })
+    })
+    const docs = await loadDropbox({ accessToken: 'sl.token', path: '/docs', fetch: fetchMock })
+    expect(docs).toHaveLength(1)
+    expect(docs[0].source).toBe('dropbox:/docs/a.md')
+    expect(docs[0].content).toBe('# Hello')
+  })
+})
+
+describe('loadOneDrive', () => {
+  it('walks children + downloads files', async () => {
+    const fetchMock = fakeFetch((url) => {
+      if (url.endsWith('/root/children')) {
+        return new Response(JSON.stringify({
+          value: [
+            { id: 'f1', name: 'a.txt', file: { mimeType: 'text/plain' }, '@microsoft.graph.downloadUrl': 'https://dl.example/a' },
+          ],
+        }))
+      }
+      if (url.startsWith('https://dl.example/')) return new Response('A')
+      return new Response('', { status: 404 })
+    })
+    const docs = await loadOneDrive({ accessToken: 'msal.token', fetch: fetchMock })
+    expect(docs).toHaveLength(1)
+    expect(docs[0].metadata?.name).toBe('a.txt')
+    expect(docs[0].content).toBe('A')
+  })
+})
+
+describe('voyageReranker', () => {
+  it('returns documents in voyage-supplied order with new scores', async () => {
+    const fetchMock = fakeFetch(() => new Response(JSON.stringify({
+      data: [
+        { index: 1, relevance_score: 0.9 },
+        { index: 0, relevance_score: 0.4 },
+      ],
+    })))
+    const fn = voyageReranker({ apiKey: 'pa-test', fetch: fetchMock })
+    const docs = [
+      { id: 'a', content: 'doc A', score: 0.5 },
+      { id: 'b', content: 'doc B', score: 0.5 },
+    ]
+    const out = await fn({ query: 'q', documents: docs })
+    expect(out.map(d => d.id)).toEqual(['b', 'a'])
+    expect(out[0].score).toBe(0.9)
+  })
+
+  it('throws on non-2xx', async () => {
+    const fetchMock = fakeFetch(() => new Response('rate limited', { status: 429 }))
+    const fn = voyageReranker({ apiKey: 'k', fetch: fetchMock })
+    await expect(fn({ query: 'q', documents: [{ id: 'a', content: 'x' }] })).rejects.toThrow(/voyage rerank/)
+  })
+})
+
+describe('jinaReranker', () => {
+  it('returns documents in jina-supplied order', async () => {
+    const fetchMock = fakeFetch(() => new Response(JSON.stringify({
+      results: [
+        { index: 0, relevance_score: 0.95 },
+        { index: 1, relevance_score: 0.30 },
+      ],
+    })))
+    const fn = jinaReranker({ apiKey: 'jina-test', fetch: fetchMock })
+    const out = await fn({
+      query: 'q',
+      documents: [
+        { id: 'a', content: 'doc A' },
+        { id: 'b', content: 'doc B' },
+      ],
+    })
+    expect(out.map(d => d.id)).toEqual(['a', 'b'])
+    expect(out[0].score).toBe(0.95)
+  })
+})


### PR DESCRIPTION
Five RAG additions. Closes #462, #463, #464, #465, #466.

## Test plan
- [x] @agentskit/rag tests pass (52 total, +9 new)
- [x] @agentskit/rag lint + build green
- [x] docs build green; loaders + rerank pages updated