### PR TITLE
fix(docs): left-align hero-demo assistant bubble

### DIFF
--- a/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
+++ b/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
@@ -226,8 +226,8 @@ export function HeroDemo() {
 
               {frame.assistant && (
                 <div
-                  className="w-fit max-w-full rounded-2xl rounded-bl-md bg-ak-surface px-3.5 py-2 text-ak-foam"
-                  style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}
+                  className="w-fit max-w-full rounded-2xl rounded-bl-md bg-ak-surface px-3.5 py-2 text-left text-ak-foam"
+                  style={{ wordBreak: 'break-word', overflowWrap: 'anywhere', textAlign: 'left' }}
                 >
                   {frame.assistant}
                   <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-ak-blue" />

--- a/apps/docs-next/content/docs/agents/skills/data-analyst.mdx
+++ b/apps/docs-next/content/docs/agents/skills/data-analyst.mdx
@@ -28,7 +28,7 @@ const runtime = createRuntime({
 - **Inspect schema before writing SQL.** Lists relevant tables / columns / types up-front; never guesses column names.
 - **Distributions over means.** Median + p95 by default for revenue / latency / session-length.
 - **Explicit time windows.** "Last 30 days", "Q3 2026" — never "recent".
-- **Group sizes.** Buckets with <30 observations are labeled low-N or folded into "Other".
+- **Group sizes.** Buckets with `<30` observations are labeled low-N or folded into "Other".
 - **Survivorship + selection bias.** Filters that exclude rows are called out, not silent.
 - **Units on every number.** No bare integers — `ms`, `$`, `%`, `count`.
 


### PR DESCRIPTION
Hero demo assistant text rendered as justified two-line. Pin text-align: left.