### PR TITLE
chore(ci): bump actions/github-script v7 → v9

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post Lighthouse summary
         if: always() && steps.preview.outputs.url != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           LH_MANIFEST: ${{ steps.lhci.outputs.manifest }}
         with:


### PR DESCRIPTION
Closes #506. Script doesn't hit any v9 breaking changes.