### PR TITLE
feat(observability): datadog, axiom, newRelic sinks

### DIFF
--- a/.changeset/observability-sinks.md
+++ b/.changeset/observability-sinks.md
@@ -1,0 +1,11 @@
+---
+'@agentskit/observability': minor
+---
+
+feat(observability): three SaaS sinks built on the trace tracker:
+
+- `datadogSink` (#475) — Datadog Logs HTTP intake. Configurable `site` (datadoghq.com / datadoghq.eu / us5...), `service`, `env` tag.
+- `axiomSink` (#476) — Axiom dataset ingest with Bearer token. Configurable `endpoint` for EU region.
+- `newRelicSink` (#477) — New Relic Logs API. Region-aware (`US` default, `EU` flag).
+
+All three swallow network errors so observability never breaks the main loop. Each emits one event per span start and one per span end with `service`, `phase`, span ids, timestamps, status, and the full attribute bag.

--- a/apps/docs-next/content/docs/production/observability/loggers.mdx
+++ b/apps/docs-next/content/docs/production/observability/loggers.mdx
@@ -27,7 +27,27 @@ const runtime = createRuntime({
 | `consoleLogger()` | dev | — |
 | `langsmith({ apiKey, project })` | traces UI | `LANGSMITH_API_KEY` |
 | `opentelemetry({ serviceName })` | OTel pipeline | OTLP endpoint |
+| `datadogSink({ apiKey, site?, env? })` | Datadog Logs HTTP intake | `DD_API_KEY` |
+| `axiomSink({ token, dataset, endpoint? })` | Axiom dataset ingest | `AXIOM_TOKEN` |
+| `newRelicSink({ apiKey, region? })` | New Relic Logs API (`US` / `EU`) | `NEW_RELIC_LICENSE_KEY` |
 | `createTraceTracker()` | BYO span lifecycle | — |
+
+## SaaS sinks — failure-safe
+
+`datadogSink`, `axiomSink`, and `newRelicSink` follow the same observer contract: every span start / end is forwarded as a JSON event to the upstream HTTP intake. **All three swallow network errors** — observability never breaks the main agent loop. Configure region (`site` / `endpoint` / `region`) and service tags per provider.
+
+```ts
+import { datadogSink, axiomSink, newRelicSink } from '@agentskit/observability'
+
+createRuntime({
+  adapter,
+  observers: [
+    datadogSink({ apiKey: process.env.DD_API_KEY!, env: 'prod', site: 'datadoghq.eu' }),
+    axiomSink({ token: process.env.AXIOM_TOKEN!, dataset: 'agentskit' }),
+    newRelicSink({ apiKey: process.env.NEW_RELIC_LICENSE_KEY!, region: 'US' }),
+  ],
+})
+```
 
 ## Related
 

--- a/packages/observability/src/axiom.ts
+++ b/packages/observability/src/axiom.ts
@@ -1,0 +1,69 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from './trace-tracker'
+
+export interface AxiomSinkConfig {
+  /** Axiom API token. */
+  token: string
+  /** Dataset name to write into. */
+  dataset: string
+  /** Override the ingest endpoint (e.g. EU region: `https://api.eu.axiom.co`). */
+  endpoint?: string
+  /** Service name attached to every event. */
+  service?: string
+  fetch?: typeof globalThis.fetch
+}
+
+function endpointFor(config: AxiomSinkConfig): string {
+  const base = config.endpoint ?? 'https://api.axiom.co'
+  return `${base}/v1/datasets/${encodeURIComponent(config.dataset)}/ingest`
+}
+
+function spanToEvent(span: TraceSpan, config: AxiomSinkConfig, isEnd: boolean): Record<string, unknown> {
+  return {
+    _time: new Date(isEnd && span.endTime ? span.endTime : span.startTime).toISOString(),
+    service: config.service ?? 'agentskit',
+    phase: isEnd ? 'end' : 'start',
+    span_id: span.id,
+    parent_id: span.parentId,
+    name: span.name,
+    start_time: span.startTime,
+    end_time: span.endTime,
+    duration_ms: span.endTime ? span.endTime - span.startTime : null,
+    status: span.status,
+    attributes: span.attributes,
+  }
+}
+
+/**
+ * Axiom sink. POSTs each span start/end as one event to a dataset's ingest
+ * endpoint. Errors are swallowed.
+ */
+export function axiomSink(config: AxiomSinkConfig): Observer {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const url = endpointFor(config)
+
+  const send = async (span: TraceSpan, isEnd: boolean) => {
+    try {
+      await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${config.token}`,
+        },
+        body: JSON.stringify([spanToEvent(span, config, isEnd)]),
+      })
+    } catch {
+      // observability errors must not break the main loop
+    }
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) { void send(span, false) },
+    onSpanEnd(span) { void send(span, true) },
+  })
+
+  return {
+    name: 'axiom',
+    on(event) { tracker.handle(event) },
+  }
+}

--- a/packages/observability/src/datadog.ts
+++ b/packages/observability/src/datadog.ts
@@ -1,0 +1,71 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from './trace-tracker'
+
+export interface DatadogSinkConfig {
+  apiKey: string
+  /** Datadog site, defaults to `datadoghq.com` (US1). Use `datadoghq.eu`, `us5.datadoghq.com`, etc. */
+  site?: string
+  /** Service name attached to every event. */
+  service?: string
+  /** Environment tag (`prod`, `staging`, ...). */
+  env?: string
+  fetch?: typeof globalThis.fetch
+}
+
+function siteEndpoint(site = 'datadoghq.com'): string {
+  return `https://http-intake.logs.${site}/api/v2/logs`
+}
+
+function spanToLog(span: TraceSpan, config: DatadogSinkConfig, isEnd: boolean): Record<string, unknown> {
+  return {
+    ddsource: 'agentskit',
+    service: config.service ?? 'agentskit',
+    ddtags: [config.env ? `env:${config.env}` : null, `phase:${isEnd ? 'end' : 'start'}`].filter(Boolean).join(','),
+    message: `${span.name} ${isEnd ? 'ended' : 'started'}`,
+    span: {
+      id: span.id,
+      parent_id: span.parentId,
+      name: span.name,
+      start_time: span.startTime,
+      end_time: span.endTime,
+      duration_ms: span.endTime ? span.endTime - span.startTime : undefined,
+      status: span.status,
+      attributes: span.attributes,
+    },
+  }
+}
+
+/**
+ * Datadog Logs sink. Forwards every TraceSpan start/end as a JSON log entry
+ * to Datadog's HTTP intake. Failures are swallowed — observability never
+ * breaks the main loop.
+ */
+export function datadogSink(config: DatadogSinkConfig): Observer {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const url = siteEndpoint(config.site)
+
+  const send = async (span: TraceSpan, isEnd: boolean) => {
+    try {
+      await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'dd-api-key': config.apiKey,
+        },
+        body: JSON.stringify([spanToLog(span, config, isEnd)]),
+      })
+    } catch {
+      // observability errors must not break the main loop
+    }
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) { void send(span, false) },
+    onSpanEnd(span) { void send(span, true) },
+  })
+
+  return {
+    name: 'datadog',
+    on(event) { tracker.handle(event) },
+  }
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -4,6 +4,15 @@ export type { ConsoleLoggerConfig } from './console-logger'
 export { langsmith } from './langsmith'
 export type { LangSmithConfig } from './langsmith'
 
+export { datadogSink } from './datadog'
+export type { DatadogSinkConfig } from './datadog'
+
+export { axiomSink } from './axiom'
+export type { AxiomSinkConfig } from './axiom'
+
+export { newRelicSink } from './new-relic'
+export type { NewRelicSinkConfig } from './new-relic'
+
 export { opentelemetry } from './opentelemetry'
 export type { OpenTelemetryConfig } from './opentelemetry'
 

--- a/packages/observability/src/new-relic.ts
+++ b/packages/observability/src/new-relic.ts
@@ -1,0 +1,69 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from './trace-tracker'
+
+export interface NewRelicSinkConfig {
+  /** New Relic license / API key (NRAK-... or license key). */
+  apiKey: string
+  /** Region. `'US'` (default) → log-api.newrelic.com, `'EU'` → log-api.eu.newrelic.com. */
+  region?: 'US' | 'EU'
+  /** Service name attached to every event. */
+  service?: string
+  fetch?: typeof globalThis.fetch
+}
+
+function endpointFor(region: 'US' | 'EU' = 'US'): string {
+  return region === 'EU'
+    ? 'https://log-api.eu.newrelic.com/log/v1'
+    : 'https://log-api.newrelic.com/log/v1'
+}
+
+function spanToLog(span: TraceSpan, config: NewRelicSinkConfig, isEnd: boolean): Record<string, unknown> {
+  return {
+    timestamp: isEnd && span.endTime ? span.endTime : span.startTime,
+    message: `${span.name} ${isEnd ? 'ended' : 'started'}`,
+    service: config.service ?? 'agentskit',
+    phase: isEnd ? 'end' : 'start',
+    'span.id': span.id,
+    'span.parent_id': span.parentId,
+    'span.name': span.name,
+    'span.start_time': span.startTime,
+    'span.end_time': span.endTime,
+    'span.duration_ms': span.endTime ? span.endTime - span.startTime : undefined,
+    'span.status': span.status,
+    attributes: span.attributes,
+  }
+}
+
+/**
+ * New Relic Logs sink. Forwards span start/end events to New Relic's Log API.
+ * Errors are swallowed — observability never breaks the main loop.
+ */
+export function newRelicSink(config: NewRelicSinkConfig): Observer {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const url = endpointFor(config.region)
+
+  const send = async (span: TraceSpan, isEnd: boolean) => {
+    try {
+      await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': config.apiKey,
+        },
+        body: JSON.stringify([spanToLog(span, config, isEnd)]),
+      })
+    } catch {
+      // observability errors must not break the main loop
+    }
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) { void send(span, false) },
+    onSpanEnd(span) { void send(span, true) },
+  })
+
+  return {
+    name: 'new-relic',
+    on(event) { tracker.handle(event) },
+  }
+}

--- a/packages/observability/tests/sinks-batch.test.ts
+++ b/packages/observability/tests/sinks-batch.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { datadogSink, axiomSink, newRelicSink } from '../src/index'
+
+interface Capture { url: string; init: RequestInit }
+
+function fakeFetch(): { fetch: typeof fetch; calls: Capture[] } {
+  const calls: Capture[] = []
+  const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return new Response('{}', { status: 202 })
+  }) as unknown as typeof globalThis.fetch
+  return { fetch, calls }
+}
+
+const llmStartEvent = {
+  type: 'llm:start' as const,
+  spanId: 'span-1',
+  parentSpanId: undefined,
+  attributes: { 'gen_ai.system': 'openai', 'gen_ai.model': 'gpt-4o' },
+  startTime: 1_700_000_000_000,
+}
+
+const llmEndEvent = {
+  type: 'llm:end' as const,
+  spanId: 'span-1',
+  content: 'hello',
+  usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+  attributes: { 'gen_ai.usage.total_tokens': 15 },
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_000_500,
+}
+
+async function flush() { await new Promise(r => setTimeout(r, 5)) }
+
+describe('datadogSink', () => {
+  it('POSTs span start + end to the Datadog logs intake', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = datadogSink({ apiKey: 'dd-test', service: 'svc', env: 'prod', fetch })
+    sink.on(llmStartEvent)
+    sink.on(llmEndEvent)
+    await flush()
+    expect(calls.length).toBe(2)
+    expect(calls[0].url).toContain('http-intake.logs.datadoghq.com')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers['dd-api-key']).toBe('dd-test')
+    const body = JSON.parse(String(calls[0].init.body)) as Array<Record<string, unknown>>
+    expect(body[0].service).toBe('svc')
+    expect(String(body[0].ddtags)).toContain('env:prod')
+  })
+
+  it('honors the site option for non-US regions', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = datadogSink({ apiKey: 'k', site: 'datadoghq.eu', fetch })
+    sink.on(llmStartEvent)
+    await flush()
+    expect(calls[0].url).toContain('http-intake.logs.datadoghq.eu')
+  })
+})
+
+describe('axiomSink', () => {
+  it('POSTs to the dataset ingest URL with Bearer auth', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = axiomSink({ token: 'xaat-test', dataset: 'agentskit', service: 'svc', fetch })
+    sink.on(llmStartEvent)
+    await flush()
+    expect(calls[0].url).toBe('https://api.axiom.co/v1/datasets/agentskit/ingest')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.authorization).toBe('Bearer xaat-test')
+    const body = JSON.parse(String(calls[0].init.body)) as Array<Record<string, unknown>>
+    expect(body[0].service).toBe('svc')
+    expect(body[0].phase).toBe('start')
+  })
+
+  it('honors a custom endpoint (EU region)', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = axiomSink({ token: 't', dataset: 'd', endpoint: 'https://api.eu.axiom.co', fetch })
+    sink.on(llmStartEvent)
+    await flush()
+    expect(calls[0].url).toBe('https://api.eu.axiom.co/v1/datasets/d/ingest')
+  })
+})
+
+describe('newRelicSink', () => {
+  it('POSTs to log-api.newrelic.com by default', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = newRelicSink({ apiKey: 'nrak-test', service: 'svc', fetch })
+    sink.on(llmStartEvent)
+    await flush()
+    expect(calls[0].url).toBe('https://log-api.newrelic.com/log/v1')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers['api-key']).toBe('nrak-test')
+  })
+
+  it('routes EU region to log-api.eu.newrelic.com', async () => {
+    const { fetch, calls } = fakeFetch()
+    const sink = newRelicSink({ apiKey: 'k', region: 'EU', fetch })
+    sink.on(llmStartEvent)
+    await flush()
+    expect(calls[0].url).toBe('https://log-api.eu.newrelic.com/log/v1')
+  })
+})


### PR DESCRIPTION
Three SaaS observability sinks. Closes #475, #476, #477.

## Test plan
- [x] observability tests pass (92 total, +6 new)
- [x] observability lint + build green
- [x] docs build green; loggers page lists all three