### PR TITLE
feat(observability): multiTenantCostGuard (#478)

### DIFF
--- a/.changeset/multi-tenant-cost-guard.md
+++ b/.changeset/multi-tenant-cost-guard.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/observability': minor
+---
+
+feat(observability): `multiTenantCostGuard` — same accounting as `costGuard` partitioned by tenant id, with per-tenant budgets, optional `defaultBudgetUsd` for unlisted tenants, and a no-auto-abort default (SaaS deployments enforce at the gateway). Tenant resolution via `tenantOf()` (AsyncLocalStorage-friendly) or imperative `setTenant(...)`.

--- a/apps/docs-next/content/docs/production/observability/cost-guard.mdx
+++ b/apps/docs-next/content/docs/production/observability/cost-guard.mdx
@@ -18,6 +18,31 @@ const runtime = createRuntime({
 
 `onExceed`: `'throw' | 'stop' | 'warn'`.
 
+## multiTenantCostGuard
+
+Same accounting partitioned by tenant for SaaS deployments.
+
+```ts
+import { multiTenantCostGuard } from '@agentskit/observability'
+
+const guard = multiTenantCostGuard({
+  budgets: { 'acme-co': 5, 'startup-co': 1 },
+  defaultBudgetUsd: 0.10,         // unlisted tenants
+  onExceeded: ({ tenant, costUsd, budgetUsd }) => {
+    metrics.increment('agent.budget.exceeded', { tenant })
+    // Reject the next request at the gateway, log+drop, etc.
+  },
+})
+
+createRuntime({ adapter, observers: [guard] })
+
+// Wire your request scope: AsyncLocalStorage or set-before-call
+guard.setTenant(req.tenant)
+await runtime.run(task)
+```
+
+**Why no auto-abort.** SaaS multi-tenant deployments typically reject the inbound request at the gateway, not mid-run. Wire the abort to the controller you already track per request.
+
 ## Token counters
 
 ```ts

--- a/packages/observability/src/cost-guard-multi-tenant.ts
+++ b/packages/observability/src/cost-guard-multi-tenant.ts
@@ -1,0 +1,143 @@
+import type { AgentEvent, Observer } from '@agentskit/core'
+import { DEFAULT_PRICES, priceFor, computeCost, type TokenPrice } from './cost-guard'
+
+export interface MultiTenantCostGuardOptions {
+  /**
+   * Per-tenant USD budgets. Tenants not listed here either inherit
+   * `defaultBudgetUsd` (if set) or are unmetered (no enforcement).
+   */
+  budgets: Record<string, number>
+  /**
+   * Fallback budget for tenants not explicitly listed in `budgets`.
+   * Omit to make unlisted tenants unmetered.
+   */
+  defaultBudgetUsd?: number
+  /**
+   * Resolver called on every event. Returns the active tenant id, or
+   * `undefined` to skip metering for this event entirely. The runtime
+   * does not propagate tenant ids natively; wire this up with
+   * AsyncLocalStorage or by calling `setTenant(...)` from the returned
+   * observer immediately before invoking `runtime.run`.
+   */
+  tenantOf?: () => string | undefined
+  /** Optional price table override. */
+  prices?: Record<string, TokenPrice>
+  /**
+   * Called when a tenant exceeds its budget. The runtime is NOT aborted
+   * automatically — multi-tenant deployments typically reject the
+   * inbound request at the gateway instead. Wire your own enforcement
+   * here (`controllers[tenant].abort()`, log+drop, send 402, etc.).
+   */
+  onExceeded?: (info: { tenant: string; costUsd: number; budgetUsd: number }) => void
+  /** Called whenever a tenant's running total changes. */
+  onCost?: (info: {
+    tenant: string
+    costUsd: number
+    promptTokens: number
+    completionTokens: number
+    budgetUsd: number | undefined
+    budgetRemainingUsd: number | undefined
+  }) => void
+  modelOverride?: string
+  name?: string
+}
+
+interface TenantState {
+  prompt: number
+  completion: number
+  cost: number
+  model: string | undefined
+  exceeded: boolean
+}
+
+function freshState(modelOverride?: string): TenantState {
+  return { prompt: 0, completion: 0, cost: 0, model: modelOverride, exceeded: false }
+}
+
+/**
+ * Per-tenant cost-guard. Same accounting as `costGuard`, partitioned by
+ * tenant id, with separate budgets per tenant and a no-abort default
+ * (the SaaS gateway typically enforces).
+ */
+export function multiTenantCostGuard(options: MultiTenantCostGuardOptions): Observer & {
+  /** Active tenant. The observer ignores events while this is unset. */
+  setTenant: (tenant: string | undefined) => void
+  costUsd: (tenant: string) => number
+  promptTokens: (tenant: string) => number
+  completionTokens: (tenant: string) => number
+  exceeded: (tenant: string) => boolean
+  budgetFor: (tenant: string) => number | undefined
+  reset: (tenant?: string) => void
+  tenants: () => string[]
+} {
+  const mergedPrices = options.prices ? { ...DEFAULT_PRICES, ...options.prices } : DEFAULT_PRICES
+  const tenants = new Map<string, TenantState>()
+  let activeTenant: string | undefined
+
+  const resolve = (): string | undefined => {
+    return options.tenantOf?.() ?? activeTenant
+  }
+
+  const budgetOf = (tenant: string): number | undefined => {
+    return options.budgets[tenant] ?? options.defaultBudgetUsd
+  }
+
+  const stateOf = (tenant: string): TenantState => {
+    let s = tenants.get(tenant)
+    if (!s) {
+      s = freshState(options.modelOverride)
+      tenants.set(tenant, s)
+    }
+    return s
+  }
+
+  const update = (tenant: string, s: TenantState) => {
+    const price = priceFor(s.model, mergedPrices)
+    s.cost = computeCost({ promptTokens: s.prompt, completionTokens: s.completion }, price)
+    const budget = budgetOf(tenant)
+    options.onCost?.({
+      tenant,
+      costUsd: s.cost,
+      promptTokens: s.prompt,
+      completionTokens: s.completion,
+      budgetUsd: budget,
+      budgetRemainingUsd: budget !== undefined ? Math.max(0, budget - s.cost) : undefined,
+    })
+    if (budget !== undefined && s.cost > budget && !s.exceeded) {
+      s.exceeded = true
+      options.onExceeded?.({ tenant, costUsd: s.cost, budgetUsd: budget })
+    }
+  }
+
+  return {
+    name: options.name ?? 'cost-guard-multi-tenant',
+    on(event: AgentEvent) {
+      const tenant = resolve()
+      if (!tenant) return
+      const s = stateOf(tenant)
+      switch (event.type) {
+        case 'llm:start':
+          if (event.model && !options.modelOverride) s.model = event.model
+          break
+        case 'llm:end':
+          if (event.usage) {
+            s.prompt += event.usage.promptTokens
+            s.completion += event.usage.completionTokens
+            update(tenant, s)
+          }
+          break
+      }
+    },
+    setTenant(tenant) { activeTenant = tenant },
+    costUsd: (tenant) => stateOf(tenant).cost,
+    promptTokens: (tenant) => stateOf(tenant).prompt,
+    completionTokens: (tenant) => stateOf(tenant).completion,
+    exceeded: (tenant) => stateOf(tenant).exceeded,
+    budgetFor: (tenant) => budgetOf(tenant),
+    reset(tenant) {
+      if (tenant) tenants.set(tenant, freshState(options.modelOverride))
+      else tenants.clear()
+    },
+    tenants: () => Array.from(tenants.keys()),
+  }
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -22,6 +22,9 @@ export type { TraceSpan, TraceTrackerCallbacks } from './trace-tracker'
 export { costGuard, priceFor, computeCost, DEFAULT_PRICES } from './cost-guard'
 export type { CostGuardOptions, TokenPrice } from './cost-guard'
 
+export { multiTenantCostGuard } from './cost-guard-multi-tenant'
+export type { MultiTenantCostGuardOptions } from './cost-guard-multi-tenant'
+
 export { approximateCounter, countTokens, countTokensDetailed, createProviderCounter } from './token-counter'
 export type { ProviderTokenCounterOptions } from './token-counter'
 

--- a/packages/observability/tests/cost-guard-multi-tenant.test.ts
+++ b/packages/observability/tests/cost-guard-multi-tenant.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { multiTenantCostGuard } from '../src/cost-guard-multi-tenant'
+
+function make(opts: Partial<Parameters<typeof multiTenantCostGuard>[0]> = {}) {
+  return multiTenantCostGuard({
+    budgets: { 'tenant-a': 0.01, 'tenant-b': 1 },
+    ...opts,
+  })
+}
+
+const start = (model: string) => ({
+  type: 'llm:start' as const,
+  spanId: 's1',
+  parentSpanId: undefined,
+  model,
+  attributes: {},
+  startTime: 0,
+})
+
+const end = (promptTokens: number, completionTokens: number) => ({
+  type: 'llm:end' as const,
+  spanId: 's1',
+  content: 'x',
+  usage: { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens },
+  attributes: {},
+  startTime: 0,
+  endTime: 1,
+})
+
+describe('multiTenantCostGuard', () => {
+  it('partitions usage by tenant', () => {
+    const guard = make()
+    guard.setTenant('tenant-a')
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    guard.setTenant('tenant-b')
+    guard.on(start('gpt-4o'))
+    guard.on(end(2000, 1000))
+    expect(guard.promptTokens('tenant-a')).toBe(1000)
+    expect(guard.promptTokens('tenant-b')).toBe(2000)
+    expect(guard.tenants().sort()).toEqual(['tenant-a', 'tenant-b'])
+  })
+
+  it('fires onExceeded once per tenant when its budget is breached', () => {
+    const onExceeded = vi.fn()
+    const guard = make({ onExceeded })
+    guard.setTenant('tenant-a')
+    guard.on(start('gpt-4o'))
+    guard.on(end(10_000, 5_000))   // 0.025 + 0.05 = 0.075 USD > 0.01
+    expect(guard.exceeded('tenant-a')).toBe(true)
+    expect(onExceeded).toHaveBeenCalledTimes(1)
+    // additional events do not re-fire
+    guard.on(start('gpt-4o'))
+    guard.on(end(1, 1))
+    expect(onExceeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not abort the runtime — emission is up to the caller', () => {
+    const guard = make()
+    guard.setTenant('tenant-a')
+    guard.on(start('gpt-4o'))
+    guard.on(end(10_000, 10_000))
+    expect(guard.exceeded('tenant-a')).toBe(true)
+  })
+
+  it('uses defaultBudgetUsd when tenant is unlisted', () => {
+    const onExceeded = vi.fn()
+    const guard = multiTenantCostGuard({
+      budgets: {},
+      defaultBudgetUsd: 0.001,
+      onExceeded,
+    })
+    guard.setTenant('walk-in')
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    expect(onExceeded).toHaveBeenCalledTimes(1)
+    expect(guard.budgetFor('walk-in')).toBe(0.001)
+  })
+
+  it('skips metering entirely when no tenant is set', () => {
+    const guard = make()
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    expect(guard.tenants()).toEqual([])
+  })
+
+  it('reset(tenant) clears one bucket, reset() clears all', () => {
+    const guard = make()
+    guard.setTenant('tenant-a')
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    guard.setTenant('tenant-b')
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    guard.reset('tenant-a')
+    expect(guard.costUsd('tenant-a')).toBe(0)
+    expect(guard.costUsd('tenant-b')).toBeGreaterThan(0)
+    guard.reset()
+    expect(guard.costUsd('tenant-b')).toBe(0)
+  })
+
+  it('tenantOf resolver overrides setTenant', () => {
+    let externalTenant: string | undefined = 'tenant-b'
+    const guard = multiTenantCostGuard({
+      budgets: { 'tenant-b': 1 },
+      tenantOf: () => externalTenant,
+    })
+    guard.setTenant('ignored')
+    guard.on(start('gpt-4o'))
+    guard.on(end(1000, 500))
+    expect(guard.promptTokens('tenant-b')).toBe(1000)
+    expect(guard.tenants()).toEqual(['tenant-b'])
+    externalTenant = undefined
+    guard.on(start('gpt-4o'))
+    guard.on(end(99, 99))   // skipped
+    expect(guard.promptTokens('tenant-b')).toBe(1000)
+  })
+})


### PR DESCRIPTION
Per-tenant cost-guard for SaaS deployments. Closes #478.

## Test plan
- [x] observability tests pass (99 total, +7 new)
- [x] observability lint + build green
- [x] docs build green; cost-guard page documents the multi-tenant section