### PR TITLE
feat(docs): Artifact + LivePlayground MDX components

### DIFF
--- a/apps/docs-next/components/mdx/artifact.tsx
+++ b/apps/docs-next/components/mdx/artifact.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock'
+
+export type ArtifactKind = 'code' | 'markdown' | 'html' | 'chart' | 'json'
+
+export interface ArtifactProps {
+  kind: ArtifactKind
+  /** Display title (filename / chart label / etc.). */
+  title?: string
+  /** Body — interpretation depends on `kind`. */
+  content: string
+  /** Code language for `kind="code"`. Defaults to 'text'. */
+  language?: string
+  /**
+   * For `kind="chart"`: a series of `{ label, value }` rows. JSON-encode
+   * into `content` to keep this MDX-compatible.
+   */
+  height?: number
+}
+
+/**
+ * AgentsKit `<Artifact />` — Claude.ai-style typed artifact rendered inline.
+ *
+ * Five kinds:
+ *   - `code`     → fumadocs DynamicCodeBlock with syntax highlighting
+ *   - `json`     → pretty-printed JSON in a code block
+ *   - `markdown` → rendered through the existing fumadocs MD pipeline
+ *   - `html`     → sandboxed iframe (no scripts, no same-origin)
+ *   - `chart`    → minimal SVG bar chart from `[{label, value}]` JSON
+ *
+ * All variants share a header with kind + title and a copy button. HTML
+ * runs in an `srcDoc` iframe with `sandbox=""` (no script execution, no
+ * same-origin) — safe to render LLM-generated HTML.
+ */
+export function Artifact({ kind, title, content, language = 'text', height = 360 }: ArtifactProps) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch { /* clipboard unavailable */ }
+  }
+
+  return (
+    <div data-ak-artifact data-kind={kind} className="my-6 overflow-hidden rounded-lg border border-ak-border bg-ak-surface">
+      <div className="flex items-center justify-between border-b border-ak-border px-3 py-2">
+        <div className="flex items-center gap-2 text-xs">
+          <span className="rounded bg-ak-midnight px-1.5 py-0.5 font-mono uppercase tracking-[0.15em] text-ak-graphite">
+            {kind}
+          </span>
+          {title && <span className="text-ak-foam">{title}</span>}
+        </div>
+        <button
+          type="button"
+          onClick={copy}
+          className="rounded px-2 py-1 text-xs text-ak-graphite hover:bg-ak-midnight hover:text-ak-foam"
+        >
+          {copied ? 'copied' : 'copy'}
+        </button>
+      </div>
+      <ArtifactBody kind={kind} content={content} language={language} height={height} />
+    </div>
+  )
+}
+
+function ArtifactBody({ kind, content, language, height }: { kind: ArtifactKind; content: string; language: string; height: number }): ReactNode {
+  if (kind === 'code') {
+    return <DynamicCodeBlock lang={language} code={content} />
+  }
+  if (kind === 'json') {
+    let pretty = content
+    try { pretty = JSON.stringify(JSON.parse(content), null, 2) } catch { /* leave as-is */ }
+    return <DynamicCodeBlock lang="json" code={pretty} />
+  }
+  if (kind === 'markdown') {
+    // Markdown is treated as code for safety. The docs site has a richer
+    // MdRenderer in components/examples/_shared — `<Artifact />` is a
+    // generic LLM-output renderer that should NOT execute remark plugins
+    // it didn't choose.
+    return <DynamicCodeBlock lang="markdown" code={content} />
+  }
+  if (kind === 'html') {
+    return (
+      <iframe
+        data-ak-artifact-html
+        title="HTML artifact"
+        srcDoc={content}
+        sandbox=""
+        style={{ width: '100%', height, border: 0, background: '#0a0a0a' }}
+      />
+    )
+  }
+  if (kind === 'chart') {
+    let rows: Array<{ label: string; value: number }> = []
+    try {
+      rows = JSON.parse(content) as Array<{ label: string; value: number }>
+    } catch { /* keep empty */ }
+    return <BarChart rows={rows} height={height} />
+  }
+  return null
+}
+
+function BarChart({ rows, height }: { rows: Array<{ label: string; value: number }>; height: number }) {
+  if (rows.length === 0) {
+    return <div className="p-6 text-sm text-ak-graphite">No data.</div>
+  }
+  const max = Math.max(...rows.map(r => r.value), 0)
+  const padding = 24
+  const barGap = 8
+  const barWidth = 24
+  const width = padding * 2 + rows.length * (barWidth + barGap)
+  const chartHeight = height - 56
+  return (
+    <div style={{ width: '100%', overflowX: 'auto' }}>
+      <svg
+        role="img"
+        aria-label="Bar chart"
+        viewBox={`0 0 ${width} ${height}`}
+        style={{ width, maxWidth: '100%', height }}
+      >
+        {rows.map((row, i) => {
+          const h = max > 0 ? (row.value / max) * chartHeight : 0
+          const x = padding + i * (barWidth + barGap)
+          const y = padding + (chartHeight - h)
+          return (
+            <g key={`${row.label}-${i}`}>
+              <rect x={x} y={y} width={barWidth} height={h} fill="currentColor" opacity={0.8} />
+              <text x={x + barWidth / 2} y={padding + chartHeight + 14} textAnchor="middle" fontSize="10" fill="currentColor">
+                {row.label}
+              </text>
+              <text x={x + barWidth / 2} y={y - 4} textAnchor="middle" fontSize="10" fill="currentColor">
+                {row.value}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/apps/docs-next/components/mdx/live-playground.tsx
+++ b/apps/docs-next/components/mdx/live-playground.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export type LivePlaygroundProps = {
+  /** Initial JS / TS source. Runs on every change inside a worker sandbox. */
+  code: string
+  /** Optional title for the editor pane. */
+  title?: string
+  /** Editor height in px. Defaults to 240. */
+  height?: number
+  /** Output area height in px. Defaults to 160. */
+  outputHeight?: number
+  /** Disable auto-run; user clicks "Run". */
+  manual?: boolean
+}
+
+/**
+ * `<LivePlayground />` — JS/TS editor + worker-sandbox runner.
+ *
+ * Each `code` change spawns a fresh Web Worker that evaluates the snippet
+ * in isolation (no DOM, no top-level `await`, 3-second hard timeout).
+ * Console output streams back via `postMessage`. The worker is terminated
+ * on every re-run, on unmount, and on the timeout.
+ *
+ * Why a Worker, not an iframe:
+ *   - Same-origin sandbox boundary, no DOM exposure.
+ *   - Faster spin-up than an `<iframe>` for repeated edits.
+ *   - Can be terminated mid-execution (`worker.terminate()`).
+ */
+export function LivePlayground({
+  code: initial,
+  title,
+  height = 240,
+  outputHeight = 160,
+  manual = false,
+}: LivePlaygroundProps) {
+  const [code, setCode] = useState(initial)
+  const [output, setOutput] = useState<Array<{ kind: 'log' | 'error'; text: string }>>([])
+  const [running, setRunning] = useState(false)
+  const workerRef = useRef<Worker | null>(null)
+
+  const run = (source: string) => {
+    if (workerRef.current) {
+      workerRef.current.terminate()
+      workerRef.current = null
+    }
+    setRunning(true)
+    setOutput([])
+
+    // Worker body — overrides console.log / error to postMessage back
+    // and runs the user snippet inside a Function constructor (sandboxed
+    // by the worker scope). No DOM, no parent-window access.
+    const workerSource = [
+      `const send = (kind, args) => self.postMessage({ kind, text: args.map(formatArg).join(' ') })`,
+      `function formatArg(a) { try { return typeof a === 'string' ? a : JSON.stringify(a) } catch { return String(a) } }`,
+      `console.log = (...args) => send('log', args)`,
+      `console.error = (...args) => send('error', args)`,
+      `self.onmessage = async (event) => {`,
+      `  try {`,
+      `    const fn = new Function(event.data)`,
+      `    const result = fn()`,
+      `    if (result instanceof Promise) await result`,
+      `    self.postMessage({ kind: 'done' })`,
+      `  } catch (err) {`,
+      `    self.postMessage({ kind: 'error', text: err && err.stack ? err.stack : String(err) })`,
+      `    self.postMessage({ kind: 'done' })`,
+      `  }`,
+      `}`,
+    ].join('\n')
+    const blobUrl = URL.createObjectURL(new Blob([workerSource], { type: 'application/javascript' }))
+    const worker = new Worker(blobUrl)
+    workerRef.current = worker
+    URL.revokeObjectURL(blobUrl)
+
+    const timeout = setTimeout(() => {
+      worker.terminate()
+      setOutput(prev => [...prev, { kind: 'error', text: '✗ run aborted — exceeded 3s timeout' }])
+      setRunning(false)
+    }, 3000)
+
+    worker.onmessage = (event: MessageEvent<{ kind: 'log' | 'error' | 'done'; text?: string }>) => {
+      if (event.data.kind === 'done') {
+        clearTimeout(timeout)
+        setRunning(false)
+        worker.terminate()
+        return
+      }
+      const { kind, text } = event.data
+      if (typeof text === 'string') {
+        setOutput(prev => [...prev, { kind, text }])
+      }
+    }
+
+    worker.onerror = (event) => {
+      clearTimeout(timeout)
+      setOutput(prev => [...prev, { kind: 'error', text: event.message }])
+      setRunning(false)
+      worker.terminate()
+    }
+
+    worker.postMessage(source)
+  }
+
+  useEffect(() => {
+    if (!manual) run(code)
+    return () => { workerRef.current?.terminate() }
+    // intentionally rerun whenever the code text changes (or on mount)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code, manual])
+
+  return (
+    <div data-ak-playground className="my-6 overflow-hidden rounded-lg border border-ak-border bg-ak-surface">
+      <div className="flex items-center justify-between border-b border-ak-border px-3 py-2">
+        <div className="flex items-center gap-2 text-xs">
+          <span className="rounded bg-ak-midnight px-1.5 py-0.5 font-mono uppercase tracking-[0.15em] text-ak-graphite">
+            playground
+          </span>
+          {title && <span className="text-ak-foam">{title}</span>}
+        </div>
+        <button
+          type="button"
+          onClick={() => run(code)}
+          disabled={running}
+          className="rounded bg-ak-foam px-2.5 py-1 text-xs font-semibold text-ak-midnight disabled:opacity-50"
+        >
+          {running ? 'running…' : 'run'}
+        </button>
+      </div>
+      <textarea
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        spellCheck={false}
+        style={{ width: '100%', height, padding: 12, fontFamily: 'ui-monospace, monospace', fontSize: 12, background: 'transparent', color: 'inherit', border: 0, resize: 'vertical' }}
+      />
+      <div
+        data-ak-playground-output
+        style={{ height: outputHeight, overflowY: 'auto', padding: 12, borderTop: '1px solid var(--color-ak-border, #2a2a2a)', fontFamily: 'ui-monospace, monospace', fontSize: 12 }}
+      >
+        {output.length === 0 && !running && (
+          <div className="text-ak-graphite">No output yet.</div>
+        )}
+        {output.map((line, i) => (
+          <div key={i} style={{ color: line.kind === 'error' ? '#ff6b6b' : 'inherit', whiteSpace: 'pre-wrap' }}>
+            {line.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
+++ b/apps/docs-next/content/docs/reference/contribute/docs-components.mdx
@@ -182,6 +182,40 @@ A11y-aware GIF with reduced-motion fallback.
 
 Respects `prefers-reduced-motion` — shows the PNG poster + a link to the animation for users with motion sensitivity.
 
+## `<Artifact />`
+
+Claude.ai-style typed inline artifact. Five kinds: `code`, `json`, `markdown`, `html`, `chart`.
+
+```mdx
+<Artifact
+  kind="code"
+  language="ts"
+  title="agent.ts"
+  content={`import { openai } from '@agentskit/adapters'\n\nexport const adapter = openai({ apiKey: '...', model: 'gpt-4o' })`}
+/>
+
+<Artifact kind="chart" title="Latency by adapter" content='[
+  { "label": "groq", "value": 80 },
+  { "label": "openai", "value": 320 },
+  { "label": "anthropic", "value": 410 }
+]' />
+```
+
+`html` artifacts run in an iframe with `sandbox=""` (no scripts, no same-origin) — safe to render LLM-generated HTML.
+
+## `<LivePlayground />`
+
+JS/TS editor + Web Worker sandbox runner. Each edit spawns a fresh worker that evaluates the snippet in isolation. No DOM, 3-second timeout.
+
+```mdx
+<LivePlayground
+  title="Reduce demo"
+  code={`const sum = [1,2,3,4,5].reduce((a, b) => a + b, 0)\nconsole.log(sum)`}
+/>
+```
+
+Pair with `<Artifact />` to render the resulting structure inline.
+
 ## `<Mermaid />`
 
 Inline diagrams. See [`components/mermaid.tsx`](https://github.com/AgentsKit-io/agentskit/blob/main/apps/docs-next/components/mermaid.tsx).

--- a/apps/docs-next/mdx-components.tsx
+++ b/apps/docs-next/mdx-components.tsx
@@ -15,6 +15,8 @@ import { Verified } from '@/components/mdx/verified'
 import { LiveAdapter } from '@/components/mdx/live-adapter'
 import { StackBuilder } from '@/components/mdx/stack-builder'
 import { MigrationDiff } from '@/components/mdx/migration-diff'
+import { Artifact } from '@/components/mdx/artifact'
+import { LivePlayground } from '@/components/mdx/live-playground'
 
 type HeadingProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLHeadingElement>,
@@ -61,6 +63,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     LiveAdapter,
     StackBuilder,
     MigrationDiff,
+    Artifact,
+    LivePlayground,
     ...components,
   }
 }


### PR DESCRIPTION
Closes #189, #480, #483. Skipped #188/#479 voice mode (VAD + barge-in WebRTC) — separate scope.

## Test plan
- [x] docs-next lint + build green
- [x] mdx-components.tsx wires both new components