### PR TITLE
chore(audit): Sprint B/D-P1 — RuntimeError / SandboxError / SkillError

### DIFF
--- a/.changeset/sprint-b-d1-runtime-sandbox-skills.md
+++ b/.changeset/sprint-b-d1-runtime-sandbox-skills.md
@@ -1,0 +1,49 @@
+---
+'@agentskit/core': patch
+'@agentskit/runtime': patch
+'@agentskit/sandbox': patch
+'@agentskit/skills': patch
+---
+
+chore(audit): Sprint B/D-P1 — RuntimeError / SandboxError / SkillError.
+
+Adds three new typed error subclasses to `@agentskit/core/errors` and
+converts the bare `throw new Error(...)` sites in their respective
+packages.
+
+**`@agentskit/core`** — new classes + codes:
+
+- `RuntimeError` (`AK_RUNTIME_INVALID_INPUT`,
+  `AK_RUNTIME_STEP_FAILED`, `AK_RUNTIME_DELEGATE_FAILED`).
+- `SandboxError` (`AK_SANDBOX_DENIED`, `AK_SANDBOX_INVALID_TOOL`,
+  `AK_SANDBOX_PEER_MISSING`, `AK_SANDBOX_BACKEND_FAILED`).
+- `SkillError` (`AK_SKILL_INVALID`, `AK_SKILL_DUPLICATE`).
+
+**`@agentskit/runtime`** — converts:
+
+- `speculate.ts` — empty candidates → `ConfigError`; unknown picker id
+  → `RuntimeError(AK_RUNTIME_INVALID_INPUT)`.
+- `durable.ts` — replaying a previously-failed step →
+  `RuntimeError(AK_RUNTIME_STEP_FAILED)` with hint to drop log.
+- `topologies.ts` — empty supervisor / swarm / blackboard members →
+  `ConfigError`; "every swarm member failed" →
+  `RuntimeError(AK_RUNTIME_DELEGATE_FAILED)`.
+- `background.ts` — invalid `every:` / cron schedule → `ConfigError`.
+
+**`@agentskit/sandbox`** — converts:
+
+- `sandbox.ts` — missing apiKey + backend → `ConfigError`.
+- `e2b-backend.ts` — peer dep missing → `SandboxError(AK_SANDBOX_PEER_MISSING)`;
+  Sandbox class missing → `SandboxError(AK_SANDBOX_BACKEND_FAILED)`.
+- `policy.ts` — denied tool → `SandboxError(AK_SANDBOX_DENIED)`;
+  no execute fn → `SandboxError(AK_SANDBOX_INVALID_TOOL)`.
+
+**`@agentskit/skills`** — converts:
+
+- `marketplace.ts` — invalid semver → `SkillError(AK_SKILL_INVALID)`;
+  duplicate publish → `SkillError(AK_SKILL_DUPLICATE)`.
+- `compose.ts` — empty composeSkills → `ConfigError`.
+
+No message-string regressions — every existing `toThrow(/regex/)` still
+matches. Test results: core 265/265, runtime 96/96, sandbox 25/25,
+skills 83/83. Lints clean.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,13 +2,13 @@
   {
     "name": "@agentskit/core (ESM)",
     "path": "packages/core/dist/index.js",
-    "limit": "9.8 KB",
+    "limit": "10 KB",
     "gzip": true
   },
   {
     "name": "@agentskit/core (CJS)",
     "path": "packages/core/dist/index.cjs",
-    "limit": "9.8 KB",
+    "limit": "10 KB",
     "gzip": true
   },
   {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -108,6 +108,45 @@ export class ConfigError extends AgentsKitError {
   }
 }
 
+export class RuntimeError extends AgentsKitError {
+  constructor(options: {
+    code: string
+    message: string
+    hint?: string
+    docsUrl?: string
+    cause?: unknown
+  }) {
+    super({ docsUrl: `${DOCS_BASE}/agents/runtime`, ...options })
+    this.name = 'RuntimeError'
+  }
+}
+
+export class SandboxError extends AgentsKitError {
+  constructor(options: {
+    code: string
+    message: string
+    hint?: string
+    docsUrl?: string
+    cause?: unknown
+  }) {
+    super({ docsUrl: `${DOCS_BASE}/production/security/mandatory-sandbox`, ...options })
+    this.name = 'SandboxError'
+  }
+}
+
+export class SkillError extends AgentsKitError {
+  constructor(options: {
+    code: string
+    message: string
+    hint?: string
+    docsUrl?: string
+    cause?: unknown
+  }) {
+    super({ docsUrl: `${DOCS_BASE}/agents/skills`, ...options })
+    this.name = 'SkillError'
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Error code constants
 // ---------------------------------------------------------------------------
@@ -132,4 +171,19 @@ export const ErrorCodes = {
 
   // Config errors
   AK_CONFIG_INVALID: 'AK_CONFIG_INVALID',
+
+  // Runtime errors
+  AK_RUNTIME_INVALID_INPUT: 'AK_RUNTIME_INVALID_INPUT',
+  AK_RUNTIME_STEP_FAILED: 'AK_RUNTIME_STEP_FAILED',
+  AK_RUNTIME_DELEGATE_FAILED: 'AK_RUNTIME_DELEGATE_FAILED',
+
+  // Sandbox errors
+  AK_SANDBOX_DENIED: 'AK_SANDBOX_DENIED',
+  AK_SANDBOX_INVALID_TOOL: 'AK_SANDBOX_INVALID_TOOL',
+  AK_SANDBOX_PEER_MISSING: 'AK_SANDBOX_PEER_MISSING',
+  AK_SANDBOX_BACKEND_FAILED: 'AK_SANDBOX_BACKEND_FAILED',
+
+  // Skill errors
+  AK_SKILL_INVALID: 'AK_SKILL_INVALID',
+  AK_SKILL_DUPLICATE: 'AK_SKILL_DUPLICATE',
 } as const

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,9 @@ export {
   ToolError,
   MemoryError,
   ConfigError,
+  RuntimeError,
+  SandboxError,
+  SkillError,
   ErrorCodes,
 } from './errors'
 export { createInMemoryMemory, createLocalStorageMemory, serializeMessages, deserializeMessages } from './memory'

--- a/packages/runtime/src/background.ts
+++ b/packages/runtime/src/background.ts
@@ -4,6 +4,7 @@
  * natively and return framework-agnostic HTTP handlers.
  */
 
+import { ConfigError, ErrorCodes } from '@agentskit/core'
 import type { AgentHandle } from './topologies'
 
 // ---------------------------------------------------------------------------
@@ -84,11 +85,23 @@ export function parseSchedule(schedule: string): ParsedSchedule {
   const trimmed = schedule.trim()
   if (trimmed.startsWith('every:')) {
     const ms = Number(trimmed.slice('every:'.length))
-    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid every: schedule: "${schedule}"`)
+    if (!Number.isFinite(ms) || ms <= 0) {
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: `invalid every: schedule: "${schedule}"`,
+        hint: 'Use every:<positiveMilliseconds>, e.g. every:60000.',
+      })
+    }
     return { type: 'every', intervalMs: ms }
   }
   const parts = trimmed.split(/\s+/)
-  if (parts.length !== 5) throw new Error(`cron must have 5 fields: "${schedule}"`)
+  if (parts.length !== 5) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `cron must have 5 fields: "${schedule}"`,
+      hint: 'Use a 5-field cron (minute hour dom month dow) or every:<ms>.',
+    })
+  }
   return {
     type: 'cron',
     minute: expandField(parts[0]!, 0, 59),

--- a/packages/runtime/src/durable.ts
+++ b/packages/runtime/src/durable.ts
@@ -1,3 +1,5 @@
+import { ErrorCodes, RuntimeError } from '@agentskit/core'
+
 /**
  * Temporal-style durable execution primitive. Wraps any side-effectful
  * step in a `runner.step(name, fn)` call; the result is appended to a
@@ -77,7 +79,11 @@ export function createDurableRunner(options: DurableRunnerOptions): DurableRunne
     if (existing) {
       options.onEvent?.({ type: 'step:replay', stepId, name, runId })
       if (existing.status === 'success') return existing.result as TResult
-      throw new Error(`step "${stepId}" previously failed: ${existing.error}`)
+      throw new RuntimeError({
+        code: ErrorCodes.AK_RUNTIME_STEP_FAILED,
+        message: `step "${stepId}" previously failed: ${existing.error}`,
+        hint: 'Drop the run log to retry, or fix the underlying cause and use a new runId.',
+      })
     }
 
     let attempt = 0

--- a/packages/runtime/src/speculate.ts
+++ b/packages/runtime/src/speculate.ts
@@ -1,3 +1,4 @@
+import { ConfigError, ErrorCodes, RuntimeError } from '@agentskit/core'
 import type { AdapterFactory, AdapterRequest, StreamChunk, StreamSource } from '@agentskit/core'
 
 export interface SpeculativeCandidate {
@@ -84,7 +85,11 @@ async function drain({ source, timeoutMs, abortSignal }: DrainInput): Promise<{ 
  */
 export async function speculate(input: SpeculateInput): Promise<SpeculateOutput> {
   if (input.candidates.length === 0) {
-    throw new Error('speculate requires at least one candidate')
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'speculate requires at least one candidate',
+      hint: 'Pass at least one candidate, e.g. speculate({ candidates: [{ id, adapter }] }).',
+    })
   }
 
   const pickMode = input.pick ?? 'first'
@@ -150,6 +155,12 @@ export async function speculate(input: SpeculateInput): Promise<SpeculateOutput>
     winnerId = await pickMode(all)
   }
   const winner = all.find(r => r.id === winnerId)
-  if (!winner) throw new Error(`picker returned unknown id: ${winnerId}`)
+  if (!winner) {
+    throw new RuntimeError({
+      code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+      message: `picker returned unknown id: ${winnerId}`,
+      hint: 'Custom pickers must return one of the candidate ids.',
+    })
+  }
   return { winner, losers: all.filter(r => r.id !== winnerId), all }
 }

--- a/packages/runtime/src/topologies.ts
+++ b/packages/runtime/src/topologies.ts
@@ -1,3 +1,5 @@
+import { ConfigError, ErrorCodes, RuntimeError } from '@agentskit/core'
+
 /**
  * Ready-made multi-agent topologies. Each builder takes a set of
  * `AgentHandle`s + config and returns a single `AgentHandle` that
@@ -42,7 +44,12 @@ export interface SupervisorConfig<TContext = unknown> {
 export function supervisor<TContext = unknown>(
   config: SupervisorConfig<TContext>,
 ): AgentHandle<TContext> {
-  if (config.workers.length === 0) throw new Error('supervisor requires ≥ 1 worker')
+  if (config.workers.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'supervisor requires ≥ 1 worker',
+    })
+  }
   const maxRounds = Math.max(1, config.maxRounds ?? 1)
   let rr = 0
   const route =
@@ -106,7 +113,12 @@ function withTimeout<T>(p: Promise<T>, timeoutMs: number | undefined, label: str
 }
 
 export function swarm<TContext = unknown>(config: SwarmConfig<TContext>): AgentHandle<TContext> {
-  if (config.members.length === 0) throw new Error('swarm requires ≥ 1 member')
+  if (config.members.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'swarm requires ≥ 1 member',
+    })
+  }
   const merge =
     config.merge ??
     ((results: Array<{ agent: string; output: string }>): string =>
@@ -125,7 +137,13 @@ export function swarm<TContext = unknown>(config: SwarmConfig<TContext>): AgentH
         }),
       )
       const results = settled.flatMap(s => (s.status === 'fulfilled' ? [s.value] : []))
-      if (results.length === 0) throw new Error('every swarm member failed')
+      if (results.length === 0) {
+        throw new RuntimeError({
+          code: ErrorCodes.AK_RUNTIME_DELEGATE_FAILED,
+          message: 'every swarm member failed',
+          hint: 'Add a TopologyObserver via config.onEvent to capture per-member errors.',
+        })
+      }
       const merged = await merge(results)
       config.onEvent?.({ topology: 'swarm', phase: 'done', result: merged })
       return merged
@@ -201,7 +219,12 @@ export interface BlackboardConfig<TContext = unknown> {
 export function blackboard<TContext = unknown>(
   config: BlackboardConfig<TContext>,
 ): AgentHandle<TContext> {
-  if (config.agents.length === 0) throw new Error('blackboard requires ≥ 1 agent')
+  if (config.agents.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'blackboard requires ≥ 1 agent',
+    })
+  }
   const maxIterations = Math.max(1, config.maxIterations ?? 5)
 
   return {

--- a/packages/sandbox/src/e2b-backend.ts
+++ b/packages/sandbox/src/e2b-backend.ts
@@ -1,3 +1,4 @@
+import { ErrorCodes, SandboxError } from '@agentskit/core'
 import type { SandboxBackend, ExecuteOptions, ExecuteResult } from './types'
 
 export interface E2BConfig {
@@ -22,7 +23,13 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
       try {
         const mod = await import('@e2b/code-interpreter')
         const Sandbox = mod.Sandbox ?? (mod as unknown as { default: { Sandbox: unknown } }).default?.Sandbox
-        if (!Sandbox) throw new Error('Sandbox class not found in @e2b/code-interpreter')
+        if (!Sandbox) {
+          throw new SandboxError({
+            code: ErrorCodes.AK_SANDBOX_BACKEND_FAILED,
+            message: 'Sandbox class not found in @e2b/code-interpreter',
+            hint: 'The installed @e2b/code-interpreter does not export Sandbox; check version compatibility.',
+          })
+        }
 
         const sb = await (Sandbox as unknown as {
           create(opts: { apiKey: string; timeout?: number }): Promise<E2BSandboxInstance>
@@ -37,7 +44,11 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
         instancePromise = null
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('Cannot find module') || msg.includes('@e2b')) {
-          throw new Error('Install @e2b/code-interpreter to use E2B sandbox: npm install @e2b/code-interpreter')
+          throw new SandboxError({
+            code: ErrorCodes.AK_SANDBOX_PEER_MISSING,
+            message: 'Install @e2b/code-interpreter to use E2B sandbox: npm install @e2b/code-interpreter',
+            hint: 'E2B is the default backend; install the optional peer or pass a custom backend.',
+          })
         }
         throw err
       }

--- a/packages/sandbox/src/policy.ts
+++ b/packages/sandbox/src/policy.ts
@@ -1,3 +1,4 @@
+import { ErrorCodes, SandboxError } from '@agentskit/core'
 import type { ToolDefinition } from '@agentskit/core'
 
 export interface SandboxPolicy {
@@ -76,7 +77,11 @@ export function createMandatorySandbox(options: {
         return {
           ...tool,
           execute: async () => {
-            throw new Error(`Tool "${tool.name}" is ${decision.reason} by sandbox policy`)
+            throw new SandboxError({
+              code: ErrorCodes.AK_SANDBOX_DENIED,
+              message: `Tool "${tool.name}" is ${decision.reason} by sandbox policy`,
+              hint: 'Adjust SandboxPolicy allow / deny lists to permit this tool.',
+            })
           },
         }
       }
@@ -106,7 +111,11 @@ export function createMandatorySandbox(options: {
             }
           }
           if (!baseExecute) {
-            throw new Error(`Tool "${tool.name}" has no execute function`)
+            throw new SandboxError({
+              code: ErrorCodes.AK_SANDBOX_INVALID_TOOL,
+              message: `Tool "${tool.name}" has no execute function`,
+              hint: 'Tool definitions wired through the sandbox must export an execute function.',
+            })
           }
           return baseExecute(args, context)
         },

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,3 +1,4 @@
+import { ConfigError, ErrorCodes } from '@agentskit/core'
 import type { SandboxBackend, ExecuteOptions, ExecuteResult } from './types'
 import { createE2BBackend, type E2BConfig } from './e2b-backend'
 
@@ -29,10 +30,12 @@ export function createSandbox(config: SandboxConfig = {}): Sandbox {
     if (backend) return backend
 
     if (!config.apiKey) {
-      throw new Error(
-        'Sandbox requires either an apiKey (for E2B) or a custom backend. ' +
-        'Provide apiKey or pass a SandboxBackend via the backend option.'
-      )
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message:
+          'Sandbox requires either an apiKey (for E2B) or a custom backend. ' +
+          'Provide apiKey or pass a SandboxBackend via the backend option.',
+      })
     }
 
     backend = createE2BBackend({

--- a/packages/skills/src/compose.ts
+++ b/packages/skills/src/compose.ts
@@ -1,8 +1,12 @@
+import { ConfigError, ErrorCodes } from '@agentskit/core'
 import type { SkillDefinition } from '@agentskit/core'
 
 export function composeSkills(...skills: SkillDefinition[]): SkillDefinition {
   if (skills.length === 0) {
-    throw new Error('composeSkills requires at least one skill')
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'composeSkills requires at least one skill',
+    })
   }
 
   if (skills.length === 1) {

--- a/packages/skills/src/marketplace.ts
+++ b/packages/skills/src/marketplace.ts
@@ -1,3 +1,4 @@
+import { ErrorCodes, SkillError } from '@agentskit/core'
 import type { SkillDefinition } from '@agentskit/core'
 
 /**
@@ -40,7 +41,13 @@ const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-[\w.-]+)?$/
 
 export function parseSemver(version: string): [number, number, number] {
   const match = version.match(SEMVER)
-  if (!match) throw new Error(`invalid semver: "${version}"`)
+  if (!match) {
+    throw new SkillError({
+      code: ErrorCodes.AK_SKILL_INVALID,
+      message: `invalid semver: "${version}"`,
+      hint: 'Use the X.Y.Z form, optionally suffixed with -<prerelease>.',
+    })
+  }
   return [Number(match[1]), Number(match[2]), Number(match[3])]
 }
 
@@ -94,7 +101,11 @@ export function createSkillRegistry(initial: SkillPackage[] = []): SkillRegistry
     const entry = { ...pkg, publishedAt: pkg.publishedAt ?? new Date().toISOString() }
     const bucket = packages.get(pkg.skill.name) ?? []
     if (bucket.some(p => p.version === pkg.version)) {
-      throw new Error(`already published: ${pkg.skill.name}@${pkg.version}`)
+      throw new SkillError({
+        code: ErrorCodes.AK_SKILL_DUPLICATE,
+        message: `already published: ${pkg.skill.name}@${pkg.version}`,
+        hint: 'Bump the version or unpublish the existing entry first.',
+      })
     }
     bucket.push(entry)
     bucket.sort((a, b) => compareSemver(b.version, a.version))


### PR DESCRIPTION
## Summary

Closes Sprint B's D/P1 — introduces three new error subclasses and converts the runtime, sandbox, and skills throws.

Companion to #721 (adapters + memory) and #722 (tools). No runtime behaviour change.

## Changes

### Core — new classes

| Class | Codes |
|---|---|
| `RuntimeError` | `AK_RUNTIME_INVALID_INPUT`, `AK_RUNTIME_STEP_FAILED`, `AK_RUNTIME_DELEGATE_FAILED` |
| `SandboxError` | `AK_SANDBOX_DENIED`, `AK_SANDBOX_INVALID_TOOL`, `AK_SANDBOX_PEER_MISSING`, `AK_SANDBOX_BACKEND_FAILED` |
| `SkillError` | `AK_SKILL_INVALID`, `AK_SKILL_DUPLICATE` |

### Runtime conversions

| File | Throws | Class | Code |
|---|---|---|---|
| `speculate.ts` | empty candidates | ConfigError | AK_CONFIG_INVALID |
| `speculate.ts` | unknown picker id | RuntimeError | AK_RUNTIME_INVALID_INPUT |
| `durable.ts` | replay of failed step | RuntimeError | AK_RUNTIME_STEP_FAILED |
| `topologies.ts` | empty supervisor / swarm / blackboard | ConfigError | AK_CONFIG_INVALID |
| `topologies.ts` | every swarm member failed | RuntimeError | AK_RUNTIME_DELEGATE_FAILED |
| `background.ts` | invalid `every:` / cron schedule | ConfigError | AK_CONFIG_INVALID |

### Sandbox conversions

| File | Throws | Class | Code |
|---|---|---|---|
| `sandbox.ts` | no apiKey + no backend | ConfigError | AK_CONFIG_INVALID |
| `e2b-backend.ts` | peer dep missing | SandboxError | AK_SANDBOX_PEER_MISSING |
| `e2b-backend.ts` | Sandbox class missing | SandboxError | AK_SANDBOX_BACKEND_FAILED |
| `policy.ts` | denied tool | SandboxError | AK_SANDBOX_DENIED |
| `policy.ts` | no execute fn | SandboxError | AK_SANDBOX_INVALID_TOOL |

### Skills conversions

| File | Throws | Class | Code |
|---|---|---|---|
| `marketplace.ts` | invalid semver | SkillError | AK_SKILL_INVALID |
| `marketplace.ts` | duplicate publish | SkillError | AK_SKILL_DUPLICATE |
| `compose.ts` | empty composeSkills | ConfigError | AK_CONFIG_INVALID |

## Test plan

- [x] core 265/265, runtime 96/96, sandbox 25/25, skills 83/83 — all green
- [x] core / runtime / sandbox / skills lint clean
- [x] No `toThrow(/regex/)` regressions

## Sprint B status

- D/P0 ✅ (adapters + memory + tools — #721, #722)
- D/P1 ✅ (runtime + sandbox + skills — this PR)
- E/P1 next sub-PR (embedder enrichment, hitl approval id, flow registry-key)
- H/P0 next sub-PR (adapter + skill test gaps)
- J/P0 next sub-PR (example-flow)

Refs: epic #562. Independent of #721 / #722 (different packages on the conversion side; core errors.ts overlaps in code-list ordering only).