### PR TITLE
chore(audit): Sprint B/E-P1 — error message enrichments

### DIFF
--- a/.changeset/sprint-b-e1-enrichments.md
+++ b/.changeset/sprint-b-e1-enrichments.md
@@ -1,0 +1,23 @@
+---
+'@agentskit/adapters': patch
+'@agentskit/core': patch
+---
+
+chore(audit): Sprint B/E-P1 — error message enrichments.
+
+**Embedder HTTP errors now include URL + body context.** The internal
+`fetchAvailableModels` helpers in `openai`, `gemini`, `ollama`, and
+`openai-compatible` previously threw bare `HTTP ${status}`. They now
+include the full URL and the first 200 chars of the response body, so
+the rich-error wrap (`buildModelError`) ends up with diagnostic
+context instead of just a status code.
+
+**HITL approval errors now carry id + remediation hint.** The
+abort, not-found, and timeout throws in `core/src/hitl.ts:await` and
+`decide` are now `AgentsKitError` / `ConfigError` instances with
+hints that name the next action (open the approval first, extend
+`timeoutMs`, etc.). The approval `id` is included in the message so
+log grep finds it.
+
+No message-string regressions — all `toThrow(/regex/)` matchers stay
+green. Adapters 322/322, core 265/265.

--- a/packages/adapters/src/embedders/gemini.ts
+++ b/packages/adapters/src/embedders/gemini.ts
@@ -7,9 +7,11 @@ export interface GeminiEmbedderConfig {
 }
 
 async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
-  const response = await fetch(`${baseUrl}/v1beta/models?key=${apiKey}`)
+  const url = `${baseUrl}/v1beta/models?key=${apiKey}`
+  const response = await fetch(url)
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(`HTTP ${response.status} from gemini ${baseUrl}/v1beta/models: ${body.slice(0, 200)}`)
   }
   const data = (await response.json()) as {
     models: Array<{ name: string; supportedGenerationMethods: string[] }>

--- a/packages/adapters/src/embedders/ollama.ts
+++ b/packages/adapters/src/embedders/ollama.ts
@@ -6,9 +6,11 @@ export interface OllamaEmbedderConfig {
 }
 
 async function fetchAvailableModels(baseUrl: string): Promise<string[]> {
-  const response = await fetch(`${baseUrl}/api/tags`)
+  const url = `${baseUrl}/api/tags`
+  const response = await fetch(url)
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(`HTTP ${response.status} from ollama ${url}: ${body.slice(0, 200)}`)
   }
   const data = (await response.json()) as { models: Array<{ name: string }> }
   return data.models

--- a/packages/adapters/src/embedders/openai-compatible.ts
+++ b/packages/adapters/src/embedders/openai-compatible.ts
@@ -7,11 +7,13 @@ export interface OpenAICompatibleEmbedderConfig {
 }
 
 async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
-  const response = await fetch(`${baseUrl}/v1/models`, {
+  const url = `${baseUrl}/v1/models`
+  const response = await fetch(url, {
     headers: { 'Authorization': `Bearer ${apiKey}` },
   })
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(`HTTP ${response.status} from ${url}: ${body.slice(0, 200)}`)
   }
   const data = (await response.json()) as { data: Array<{ id: string }> }
   return data.data

--- a/packages/adapters/src/embedders/openai.ts
+++ b/packages/adapters/src/embedders/openai.ts
@@ -7,11 +7,13 @@ export interface OpenAIEmbedderConfig {
 }
 
 async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
-  const response = await fetch(`${baseUrl}/v1/models`, {
+  const url = `${baseUrl}/v1/models`
+  const response = await fetch(url, {
     headers: { 'Authorization': `Bearer ${apiKey}` },
   })
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(`HTTP ${response.status} from ${url}: ${body.slice(0, 200)}`)
   }
   const data = (await response.json()) as { data: Array<{ id: string }> }
   return data.data

--- a/packages/core/src/hitl.ts
+++ b/packages/core/src/hitl.ts
@@ -1,3 +1,5 @@
+import { AgentsKitError, ConfigError, ErrorCodes } from './errors'
+
 /**
  * Human-in-the-loop primitives. A gate pauses agent execution at a
  * named decision point and records an `Approval` in a user-supplied
@@ -98,12 +100,28 @@ export function createApprovalGate<TPayload = unknown>(
           ? Date.now() + options.timeoutMs
           : Infinity
       while (true) {
-        if (options.signal?.aborted) throw new Error('await approval aborted')
+        if (options.signal?.aborted) {
+          throw new AgentsKitError({
+            code: ErrorCodes.AK_CONFIG_INVALID,
+            message: `await approval aborted (id="${id}")`,
+            hint: 'Caller passed an AbortSignal that fired before the approval was decided.',
+          })
+        }
         const current = await store.get<TPayload>(id)
-        if (!current) throw new Error(`approval "${id}" not found`)
+        if (!current) {
+          throw new ConfigError({
+            code: ErrorCodes.AK_CONFIG_INVALID,
+            message: `approval "${id}" not found`,
+            hint: 'Open the approval with createApprovalGate.open() before awaiting it.',
+          })
+        }
         if (current.status !== 'pending') return current
         if (Date.now() >= deadline) {
-          throw new Error(`approval "${id}" timed out after ${options.timeoutMs}ms`)
+          throw new AgentsKitError({
+            code: ErrorCodes.AK_CONFIG_INVALID,
+            message: `approval "${id}" timed out after ${options.timeoutMs}ms`,
+            hint: 'Extend options.timeoutMs (default Infinity), or wire a faster decider.',
+          })
         }
         await new Promise(r => setTimeout(r, pollMs))
       }
@@ -115,7 +133,13 @@ export function createApprovalGate<TPayload = unknown>(
         decidedAt: new Date().toISOString(),
         decisionMetadata: metadata,
       })
-      if (!updated) throw new Error(`approval "${id}" not found`)
+      if (!updated) {
+        throw new ConfigError({
+          code: ErrorCodes.AK_CONFIG_INVALID,
+          message: `approval "${id}" not found`,
+          hint: 'The approval id was never opened, or it was cleared from the store.',
+        })
+      }
       return updated
     },
 


### PR DESCRIPTION
## Summary

E/P1 — embedder HTTP error enrichment + HITL approval id/remediation.

Companion to #721 / #722 / #723 (typed error hierarchy). No runtime behaviour change.

## Changes

### E/P1 — embedder HTTP errors

`fetchAvailableModels` helpers in `openai`, `gemini`, `ollama`, and `openai-compatible` previously threw bare `HTTP ${status}`. They now include the full URL and first 200 chars of the response body. The rich-error wrap (`buildModelError`) inherits that context.

### E/P1 — HITL approval errors

`core/src/hitl.ts:await` and `decide` previously threw bare `Error`. They now throw `AgentsKitError` / `ConfigError` with:

- abort: `await approval aborted (id="...")` + hint about the AbortSignal
- not-found: hint about opening the approval first
- timeout: hint about extending `timeoutMs`

Approval id is included in every message — log grep finds it.

## Issues closed

- E/P1 embedder HTTP enrichment
- E/P1 hitl approval id + remediation

## Deferred

- E/P1 flow registry-key listing on missing handler — `flow.ts` lands in PR #561; will follow up after merge.

## Test plan

- [x] core 265/265
- [x] adapters 322/322
- [x] core / adapters lint clean
- [x] No `toThrow(/regex/)` regressions

Refs: epic #562. Independent of #721 / #722 / #723.