### PR TITLE
chore(audit): Sprint C — skills cross-link + for-agents drift gate

### DIFF
--- a/.changeset/sprint-c-skills-crosslink.md
+++ b/.changeset/sprint-c-skills-crosslink.md
@@ -1,0 +1,16 @@
+---
+---
+
+chore(docs): cross-link extra + vertical skills from `agents/skills/index`.
+
+Adds inline links to every per-skill page (prReviewer, sqlAnalyst,
+technicalWriter, securityAuditor, customerSupport) and a dedicated
+"Vertical (regulated domains)" section listing healthcareAssistant,
+clinicalNoteSummarizer, financialAdvisor, transactionTriage. Closes
+G/P1 of the enterprise-readiness audit (#562).
+
+Also adds `scripts/check-for-agents-coverage.mjs` — a CI helper that
+asserts every value export in `packages/<name>/src/index.ts` is
+mentioned in the corresponding `for-agents/<name>.mdx` page. Not yet
+wired into ci.yml; lands in a follow-up once existing for-agents
+drift PRs (#718, #721, #722, #723) merge to main.

--- a/apps/docs-next/content/docs/agents/skills/index.mdx
+++ b/apps/docs-next/content/docs/agents/skills/index.mdx
@@ -5,7 +5,16 @@ description: Personas as packages — system prompt + behavior, versioned and co
 
 ## Ready-made
 
-`researcher` · `coder` · `planner` · `critic` · `summarizer` · `codeReviewer` · `sqlGen` · `dataAnalyst` · `translator`
+`researcher` · `coder` · `planner` · `critic` · `summarizer` · `codeReviewer` · `sqlGen` · `dataAnalyst` · `translator` · [`prReviewer`](./pr-reviewer) · [`sqlAnalyst`](./sql-analyst) · [`technicalWriter`](./technical-writer) · [`securityAuditor`](./security-auditor) · [`customerSupport`](./customer-support)
+
+## Vertical (regulated domains)
+
+Skills with built-in refusal contracts for high-stakes use cases:
+
+- [`healthcareAssistant`](./healthcare-assistant) — refuses diagnosis / dosage / triage.
+- [`clinicalNoteSummarizer`](./clinical-note-summarizer) — SOAP-format summarization, never interprets.
+- [`financialAdvisor`](./financial-advisor) — refuses tickers / "should you" / payment decisions.
+- [`transactionTriage`](./transaction-triage) — bookkeeping triage with fixed output.
 
 ## Composition
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# scripts/
+
+Repo-level CI helpers. Each script is dependency-free Node ESM, runnable
+from the repo root.
+
+## `check-for-agents-coverage.mjs`
+
+Asserts that every value export from `packages/<name>/src/index.ts`
+appears at least once in
+`apps/docs-next/content/docs/for-agents/<name>.mdx`. Catches drift
+between code and the agent-discoverable reference page.
+
+```bash
+node scripts/check-for-agents-coverage.mjs
+```
+
+Exits non-zero on drift, listing each missing symbol per package.
+Type-only exports are skipped (the for-agents pages document the
+runtime surface, not every supporting type). Per-package exclusions
+live in the `IGNORE_EXPORTS` table at the top of the script.
+
+**Wiring into CI:** ready to drop into `.github/workflows/ci.yml` once
+the for-agents pages catch up with current main. PRs #718, #721, #722,
+#723 add the missing entries; once those land we add this step to
+`ci.yml` so the gate blocks future drift.

--- a/scripts/check-for-agents-coverage.mjs
+++ b/scripts/check-for-agents-coverage.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * CI gate: every public export from packages/<name>/src/index.ts must
+ * appear at least once in apps/docs-next/content/docs/for-agents/<name>.mdx.
+ * Catches drift between code and the agent-discoverable reference.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const docsDir = join(root, 'apps/docs-next/content/docs/for-agents')
+const packagesDir = join(root, 'packages')
+
+const SKIP_PAGES = new Set(['index', 'angular', 'react-native'])
+const SKIP_PACKAGES = new Set(['framework-adapters', 'templates'])
+
+const IGNORE_EXPORTS = {
+  core: new Set(['normalizeChunk', 'flushPending', 'mergeStreamChunks']),
+  adapters: new Set(['createOpenAICompatibleAdapter', 'cohereAdapter', 'groqAdapter']),
+}
+
+/**
+ * Public *value* exports only. Type-only exports (interface, type alias,
+ * `export type {...}` blocks, `export { type Foo }`) are intentionally
+ * skipped — for-agents pages document the runtime surface, not every
+ * supporting type.
+ */
+function listExports(srcIndex) {
+  const text = readFileSync(srcIndex, 'utf8')
+  const names = new Set()
+
+  const blockRe = /export\s*(type)?\s*\{([^}]+)\}/g
+  let m
+  while ((m = blockRe.exec(text))) {
+    if (m[1]) continue // entire block is type-only
+    for (const piece of m[2].split(',')) {
+      const trimmed = piece.trim()
+      if (!trimmed) continue
+      if (trimmed.startsWith('type ') || trimmed.startsWith('type\t')) continue
+      const asMatch = trimmed.match(/\bas\s+([A-Za-z0-9_$]+)/)
+      const name = asMatch ? asMatch[1] : trimmed.split(/\s+/)[0]
+      if (name) names.add(name)
+    }
+  }
+
+  const declRe = /export\s+(?:declare\s+)?(const|function|class|enum)\s+([A-Za-z0-9_$]+)/g
+  while ((m = declRe.exec(text))) names.add(m[2])
+
+  return names
+}
+
+function readDocBody(slug) {
+  const file = join(docsDir, `${slug}.mdx`)
+  try {
+    return readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+const violations = []
+const checked = []
+
+for (const pkg of readdirSync(packagesDir)) {
+  if (SKIP_PACKAGES.has(pkg)) continue
+  const srcIndex = join(packagesDir, pkg, 'src/index.ts')
+  let stat
+  try {
+    stat = statSync(srcIndex)
+  } catch {
+    continue
+  }
+  if (!stat.isFile()) continue
+
+  const slug = pkg
+  if (SKIP_PAGES.has(slug)) continue
+
+  const doc = readDocBody(slug)
+  if (doc === null) {
+    violations.push(`packages/${pkg}: no for-agents/${slug}.mdx`)
+    continue
+  }
+
+  const items = listExports(srcIndex)
+  const ignore = IGNORE_EXPORTS[pkg] ?? new Set()
+  const missing = []
+  for (const name of items) {
+    if (ignore.has(name)) continue
+    const re = new RegExp(`(?:^|[^A-Za-z0-9_])${name.replace(/[$]/g, '\\$')}(?:[^A-Za-z0-9_]|$)`)
+    if (!re.test(doc)) missing.push(name)
+  }
+
+  checked.push({ pkg, total: items.size, missing: missing.length })
+  if (missing.length > 0) {
+    violations.push(
+      `packages/${pkg}: ${missing.length} export(s) not mentioned in for-agents/${slug}.mdx:\n    ${missing.join(', ')}`,
+    )
+  }
+}
+
+if (violations.length > 0) {
+  console.error('for-agents documentation drift detected.')
+  console.error('')
+  for (const v of violations) console.error('  - ' + v)
+  console.error('')
+  console.error(`${violations.length} package(s) with drift.`)
+  console.error('Add the missing entries to the for-agents page, or extend')
+  console.error('IGNORE_EXPORTS in scripts/check-for-agents-coverage.mjs.')
+  process.exit(1)
+}
+
+console.log(`for-agents coverage clean across ${checked.length} packages.`)


### PR DESCRIPTION
## Summary

Sprint C polish: closes G/P1 (vertical + extra skills cross-link) and lands a dormant for-agents drift CI helper script.

Refs: epic #562. Independent of all open PRs (#561, #718–#725).

## Changes

### G/P1 — `agents/skills/index.mdx` cross-link

The index previously listed only the 9 \"original\" ready-made skills. Adds inline links to:

- 5 extra skills: `prReviewer`, `sqlAnalyst`, `technicalWriter`, `securityAuditor`, `customerSupport`.
- 4 vertical skills under a dedicated **Vertical (regulated domains)** section: `healthcareAssistant`, `clinicalNoteSummarizer`, `financialAdvisor`, `transactionTriage`.

### P/P1 — `scripts/check-for-agents-coverage.mjs`

Dependency-free Node ESM script. Asserts every value export from `packages/<name>/src/index.ts` is mentioned in `for-agents/<name>.mdx`. Type-only exports skipped. Per-package opt-outs in an `IGNORE_EXPORTS` table.

```bash
node scripts/check-for-agents-coverage.mjs
```

**Not yet wired into `ci.yml`.** Wiring deferred until existing for-agents drift PRs (#718 / #721 / #722 / #723) merge to main, otherwise the gate would fail on existing drift. Plan in `scripts/README.md`.

### G/P1 — `api/meta.json` index entry (deferred / N/A)

The audit asked for an `index` entry in `apps/docs-next/content/docs/api/meta.json`. That whole directory is `.gitignore`'d (typedoc-generated at build time), so the change has no source-of-truth file to land in. Closing the audit issue with this note.

## Test plan

- [x] `node scripts/check-for-agents-coverage.mjs` runs on a clean checkout (currently reports the existing drift the other PRs fix; will be green once they land).
- [x] Markdown lint clean.

## Out of scope (next sub-PRs)

- P/P1 forbid bare throw new Error — script ready; wire after #721 + #722 + #723 merge (clears 158 current violations on main).
- M/P2 link-check workflow.
- N/P2 migration guides (from-langgraph, from-llamaindex, from-openai-assistants).
- K/P1 templates `flow` scaffold (waits on #561).
- L — phase-gate verifications (read-only audit work).