### PR TITLE
chore(audit): Sprint C — migration guides for LangGraph / LlamaIndex / OpenAI Assistants

### DIFF
--- a/.changeset/sprint-c-migration-guides.md
+++ b/.changeset/sprint-c-migration-guides.md
@@ -1,0 +1,19 @@
+---
+---
+
+chore(docs): three new migration guides — LangGraph, LlamaIndex, OpenAI Assistants.
+
+Closes N/P2 of the enterprise-readiness audit (#562). Each guide
+follows the existing structure: when to migrate, when to stay,
+quick-reference mapping table, side-by-side code samples for the
+common patterns, and honest "where the other still wins" callouts.
+
+- `from-langgraph.mdx` — graph nodes/edges → runtime loop +
+  topologies + `compileFlow` for declarative DAGs.
+- `from-llamaindex.mdx` — `VectorStoreIndex` + `ReActAgent` →
+  `createRAG` + `createRuntime`. Vector backend mapping table.
+- `from-openai-assistants.mdx` — assistants/threads/runs →
+  runtime + `ChatMemory`, including the deprecation-window
+  mitigation argument.
+
+Migrating index page + meta.json updated to list the new entries.

--- a/apps/docs-next/content/docs/get-started/migrating/from-langgraph.mdx
+++ b/apps/docs-next/content/docs/get-started/migrating/from-langgraph.mdx
@@ -1,0 +1,219 @@
+---
+title: From LangGraph
+description: Side-by-side migration guide. Map LangGraph stateful graphs to AgentsKit runtime + topologies.
+---
+import { ContributeCallout } from '@/components/contribute/contribute-callout'
+
+LangGraph encodes agent control flow as an explicit state machine — nodes,
+edges, conditionals. AgentsKit reaches the same problem from the opposite
+direction: a runtime that already knows how to loop, with composable
+`topologies` (supervisor / swarm / hierarchical / blackboard) and
+`compileFlow` for declarative DAGs. Migrate when:
+
+- You want **less ceremony** for the common ReAct case — no nodes, no edges, just `runtime.run(task)`.
+- You need **first-class durability** for long workflows (`createDurableRunner`) without spinning up a separate orchestrator.
+- You want **the same adapter** across every surface (terminal, CLI, runtime, React, Ink) instead of a graph wrapper around one model.
+- You'd rather author a flow as **YAML the team can review** than as code (`agentskit flow`).
+
+Stay with LangGraph when:
+
+- You depend on **LangSmith's graph debugger** and your team thinks visually in nodes/edges.
+- You have **dozens of conditional transitions** that map naturally onto a state-machine view.
+- You're already deep in the LangChain ecosystem and the integration cost outweighs the runtime simplification.
+
+## Quick reference
+
+| LangGraph | AgentsKit | Notes |
+|---|---|---|
+| `StateGraph(stateType)` | `createRuntime({ adapter, tools, memory })` | Most ReAct loops don't need an explicit graph. |
+| `graph.add_node(name, fn)` | A `ToolDefinition` or a `SkillDefinition` delegate | Nodes that wrap an LLM call become a delegate; nodes that wrap I/O become a tool. |
+| `graph.add_edge('a', 'b')` | Implicit in the runtime loop | The runtime already moves from "model thinks" → "tool runs" → "model continues". |
+| `add_conditional_edges(...)` | Custom delegate router or `compileFlow` `needs:` | Branching belongs in code, not in YAML; conditionals stay in a handler. |
+| `graph.compile()` | `compileFlow({ definition, registry })` for DAGs | YAML or JSON object → durable runner. See [Visual flows](/docs/agents/flow). |
+| `Checkpointer` | `createDurableRunner({ store, runId })` | File or in-memory step log; reuse `runId` to resume. |
+| `Send(...)` (parallel fan-out) | `swarm({ members })` or `compileFlow` parallel `needs` | Topologies wrap N agents into one. |
+| Multi-agent (supervisor + workers) | `supervisor({ supervisor, workers })` | Built-in. See [Topologies](/docs/agents/topologies). |
+| Tool node | `ToolDefinition` registered on the runtime | Same JSON Schema 7 inputs. |
+| `interrupt()` | `createApprovalGate` (HITL) | Pause + resume on a human decision. |
+
+## 1. Basic ReAct loop
+
+### Before — LangGraph
+
+```python
+from langgraph.graph import StateGraph, END
+from langgraph.prebuilt import ToolNode
+
+graph = StateGraph(AgentState)
+graph.add_node("agent", call_model)
+graph.add_node("tools", ToolNode(tools))
+graph.add_edge("tools", "agent")
+graph.add_conditional_edges("agent", should_continue, {"continue": "tools", "end": END})
+graph.set_entry_point("agent")
+app = graph.compile()
+```
+
+### After — AgentsKit
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { openai } from '@agentskit/adapters'
+import { webSearch } from '@agentskit/tools'
+
+const runtime = createRuntime({
+  adapter: openai({ apiKey: KEY, model: 'gpt-4o-mini' }),
+  tools: [webSearch()],
+  maxSteps: 10,
+})
+
+await runtime.run('Find the top 3 results for "agent frameworks 2026"')
+```
+
+The agent / tool alternation, "should continue" decision, and entry point are all the runtime's job. You configure capacity (`maxSteps`) and content (`tools`, `memory`, `skill`).
+
+## 2. Stateful graph → durable runner
+
+### Before — LangGraph
+
+```python
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+memory = SqliteSaver.from_conn_string("checkpoints.db")
+app = graph.compile(checkpointer=memory)
+config = {"configurable": {"thread_id": "user-42"}}
+result = await app.ainvoke({"messages": [...]}, config)
+```
+
+### After — AgentsKit
+
+```ts
+import { createDurableRunner, createFileStepLog } from '@agentskit/runtime'
+
+const store = await createFileStepLog('.agentskit/runs.jsonl')
+const runner = createDurableRunner({ store, runId: 'user-42' })
+
+await runner.step('plan', () => runtime.run(task))
+await runner.step('act',  () => runtime.run(followUp))
+```
+
+Each `runner.step(id, fn)` is recorded; replays short-circuit on resume. Crash, deploy, or retry — the same `runId` picks up where it stopped. See [Durable execution](/docs/agents/durable).
+
+## 3. Conditional graphs → flow YAML
+
+LangGraph excels at "if state.x then go to node Y" chains. When that's the actual shape, AgentsKit ships `compileFlow`:
+
+```yaml
+name: nightly-refresh
+nodes:
+  - id: fetch
+    run: http.get
+    with: { url: https://api.example.com/items }
+  - id: parse
+    run: json.parse
+    needs: [fetch]
+  - id: write
+    run: cache.write
+    needs: [parse]
+```
+
+```ts
+import { compileFlow } from '@agentskit/runtime'
+
+const compiled = compileFlow({
+  definition,
+  registry: {
+    'http.get':    ({ with: w }) => fetch(w.url as string).then(r => r.text()),
+    'json.parse':  ({ deps })   => JSON.parse(deps.fetch as string),
+    'cache.write': ({ deps })   => cache.set('items', deps.parse),
+  },
+})
+
+await compiled.run(input, { runId: 'nightly', store })
+```
+
+Branching inside a node stays in code — flow YAML stays linear (no `if`, no expressions) so it's reviewable. See [Visual flows](/docs/agents/flow).
+
+## 4. Multi-agent — supervisor / swarm
+
+### LangGraph supervisor pattern
+
+```python
+graph = StateGraph(...)
+graph.add_node("supervisor", supervisor_fn)
+graph.add_node("researcher", researcher_node)
+graph.add_node("coder", coder_node)
+graph.add_conditional_edges("supervisor", route_to_worker, {...})
+```
+
+### AgentsKit
+
+```ts
+import { supervisor } from '@agentskit/runtime'
+import { researcher, coder } from '@agentskit/skills'
+
+const research = createRuntime({ adapter, skill: researcher, tools: [...] })
+const code     = createRuntime({ adapter, skill: coder, tools: [...] })
+
+const ensemble = supervisor({
+  supervisor: { name: 'lead',     run: task => leadRuntime.run(task).then(r => r.content) },
+  workers: [
+    { name: 'research', run: task => research.run(task).then(r => r.content) },
+    { name: 'code',     run: task => code.run(task).then(r => r.content) },
+  ],
+  maxRounds: 3,
+})
+
+await ensemble.run('Build a landing page about quantum computing')
+```
+
+`swarm`, `hierarchical`, and `blackboard` topologies are interchangeable — they all return an `AgentHandle`. See [Topologies](/docs/agents/topologies).
+
+## 5. Human-in-the-loop
+
+LangGraph: `interrupt()` + a separate channel to deliver the answer.
+
+AgentsKit:
+
+```ts
+import { createApprovalGate, createInMemoryApprovalStore } from '@agentskit/core/hitl'
+
+const gate = createApprovalGate({ store: createInMemoryApprovalStore() })
+await gate.open({ id: 'approve-spend', payload: { amountUsd: 42 } })
+// somewhere else: await gate.decide('approve-spend', 'approved')
+const decision = await gate.await('approve-spend', { timeoutMs: 5 * 60_000 })
+```
+
+See [HITL approvals](/docs/reference/recipes/hitl-approvals).
+
+## 6. Streaming
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({
+  adapter,
+  observers: [
+    { name: 'log', on: e => e.type === 'text' && process.stdout.write((e as { content: string }).content) },
+  ],
+})
+```
+
+Same observer plugs into LangSmith / OpenTelemetry sinks if you want to keep your existing dashboards.
+
+## Incremental migration
+
+You don't have to port the whole graph at once:
+
+1. **Keep your LangGraph app** for the critical path.
+2. **Wrap one node as an AgentsKit runtime** — point it at the same provider, see how the loop simplifies.
+3. **Port a parallel fan-out** to `swarm` or `compileFlow` — easy win since LangGraph's `Send` is verbose.
+4. **Move durable runs** to `createDurableRunner` when the checkpointer story stops being enough.
+
+## Related
+
+- [Visual flows](/docs/agents/flow) — the YAML DAG counterpart.
+- [Topologies](/docs/agents/topologies) — supervisor / swarm / hierarchical / blackboard.
+- [Durable execution](/docs/agents/durable) — Temporal-style step logs.
+- [From LangChain](./from-langchain) — companion guide for the LangChain runtime layer.
+
+<ContributeCallout title="Migrated from LangGraph?" body="Tell us what tripped you up — every real-world migration makes the next one smoother." />

--- a/apps/docs-next/content/docs/get-started/migrating/from-llamaindex.mdx
+++ b/apps/docs-next/content/docs/get-started/migrating/from-llamaindex.mdx
@@ -1,0 +1,230 @@
+---
+title: From LlamaIndex
+description: Side-by-side migration guide. Map LlamaIndex retrieval and agent abstractions to AgentsKit RAG + runtime.
+---
+import { ContributeCallout } from '@/components/contribute/contribute-callout'
+
+LlamaIndex is the king of "RAG over your documents". AgentsKit treats RAG
+as one piece of a larger agent runtime — adapters, tools, memory,
+skills, observability all share the same contracts. Migrate when:
+
+- You want **one runtime** for "agent that uses RAG" instead of two libraries (LlamaIndex + your own loop).
+- You need **swappable providers** in one line — adapters are the seam.
+- You want **TypeScript-first** ergonomics. AgentsKit is TS, not Python.
+- You want **first-class tool calling, durable execution, and topologies** alongside RAG.
+
+Stay with LlamaIndex when:
+
+- You're 100% Python and don't want a TS dependency.
+- You depend on the LlamaIndex agent recipes (`OpenAIAssistantAgent`, `ReActAgent` with very specific prompt structures).
+- You need exotic indexers (TreeIndex, ListIndex, KeywordTableIndex) AgentsKit doesn't have.
+
+## Quick reference
+
+| LlamaIndex | AgentsKit | Notes |
+|---|---|---|
+| `VectorStoreIndex.from_documents(docs)` | `createRAG({ embed, store }).ingest(docs)` | One factory; pluggable embedder + vector store. |
+| `index.as_retriever()` | The `RAG` instance itself implements `Retriever` | Use it as `retriever:` on the runtime. |
+| `index.as_query_engine()` | `runtime.run(query)` with `retriever` set | Retrieval per-turn is automatic. |
+| `Document(text, metadata)` | `{ content, metadata }` | Same shape, plain object. |
+| `SimpleNodeParser`, `SentenceSplitter` | `chunkText({ chunkSize, chunkOverlap })` | Lower-level helper if you want to chunk yourself. |
+| `OpenAIEmbedding` | `openaiEmbedder({ apiKey, model })` | Embedders are first-class adapters. |
+| `Chroma`, `Pinecone`, `Qdrant`, `Weaviate` | `chroma`, `pinecone`, `qdrant`, `weaviateVectorStore` | All in `@agentskit/memory`. |
+| `OpenAIAgent.from_tools(tools)` | `createRuntime({ adapter, tools })` | Same idea; one runtime for every model. |
+| `ReActAgent` | `createRuntime` (the loop is ReAct by default) | No separate class. |
+| `Workflow` (LlamaIndex 0.10+) | `compileFlow` for DAGs, `topologies` for multi-agent | YAML DAG vs explicit code; pick per use case. |
+
+## 1. Basic RAG over local files
+
+### Before — LlamaIndex (Python)
+
+```python
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+from llama_index.embeddings.openai import OpenAIEmbedding
+
+documents = SimpleDirectoryReader("./docs").load_data()
+index = VectorStoreIndex.from_documents(
+    documents,
+    embed_model=OpenAIEmbedding(model="text-embedding-3-small"),
+)
+query_engine = index.as_query_engine()
+print(query_engine.query("How do I deploy?"))
+```
+
+### After — AgentsKit
+
+```ts
+import { createRAG } from '@agentskit/rag'
+import { fileVectorMemory } from '@agentskit/memory'
+import { openaiEmbedder, openai } from '@agentskit/adapters'
+import { createRuntime } from '@agentskit/runtime'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  store: fileVectorMemory({ path: './embeddings.json' }),
+})
+
+const docs = await Promise.all(
+  (await readdir('./docs')).map(async f => ({
+    content: await readFile(join('./docs', f), 'utf8'),
+    source: f,
+  })),
+)
+await rag.ingest(docs)
+
+const runtime = createRuntime({
+  adapter: openai({ apiKey: KEY, model: 'gpt-4o-mini' }),
+  retriever: rag,
+})
+
+console.log(await runtime.run('How do I deploy?'))
+```
+
+The shape is the same: ingest → retrieve → answer. `runtime.run()` calls the retriever per turn automatically.
+
+## 2. Reranking
+
+LlamaIndex has `LLMRerank` and `SentenceTransformerRerank`. AgentsKit ships pluggable rerankers:
+
+```ts
+import { createRerankedRetriever, voyageReranker } from '@agentskit/rag'
+
+const reranked = createRerankedRetriever(rag, {
+  candidatePool: 30,
+  topK: 5,
+  rerank: voyageReranker({ apiKey: VOYAGE_KEY, model: 'rerank-2' }),
+})
+
+createRuntime({ adapter, retriever: reranked })
+```
+
+Built-in: BM25 (default), `voyageReranker`, `jinaReranker`. Custom: pass any `RerankFn`. See [RAG reranking](/docs/reference/recipes/rag-reranking).
+
+## 3. Hybrid retrieval
+
+LlamaIndex 0.10+ has `QueryFusionRetriever` for vector + keyword. AgentsKit:
+
+```ts
+import { createHybridRetriever } from '@agentskit/rag'
+
+const hybrid = createHybridRetriever(rag, {
+  vectorWeight: 0.7,
+  bm25Weight: 0.3,
+})
+```
+
+## 4. Document loaders
+
+LlamaIndex has hundreds of `LlamaHub` loaders. AgentsKit ships the
+common ones in `@agentskit/rag`:
+
+```ts
+import {
+  loadUrl, loadGitHubFile, loadGitHubTree,
+  loadNotionPage, loadConfluencePage, loadGoogleDriveFile,
+  loadPdf, loadS3, loadGcs, loadDropbox, loadOneDrive,
+} from '@agentskit/rag'
+
+await rag.ingest(await loadGitHubTree('agentskit-io', 'agentskit', { token }))
+await rag.ingest(await loadNotionPage('PAGE_ID', { token: NOTION_KEY }))
+```
+
+For everything else, the loader contract is `() => Promise<Array<{ content, source?, metadata? }>>` — write your own in 10 lines.
+
+## 5. Tool-using agent
+
+### Before — LlamaIndex
+
+```python
+from llama_index.core.agent import ReActAgent
+from llama_index.core.tools import FunctionTool
+
+def get_weather(city: str) -> str:
+    ...
+
+agent = ReActAgent.from_tools(
+    [FunctionTool.from_defaults(fn=get_weather)],
+    llm=OpenAI(model="gpt-4o"),
+)
+agent.chat("What's the weather in Lisbon?")
+```
+
+### After — AgentsKit
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { openai } from '@agentskit/adapters'
+import type { ToolDefinition } from '@agentskit/core'
+
+const weather: ToolDefinition = {
+  name: 'weather',
+  description: 'Get the weather for a city',
+  schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+  execute: async ({ city }) => fetch(`https://wttr.in/${city}?format=j1`).then(r => r.json()),
+}
+
+const runtime = createRuntime({
+  adapter: openai({ apiKey: KEY, model: 'gpt-4o' }),
+  tools: [weather],
+})
+
+await runtime.run("What's the weather in Lisbon?")
+```
+
+JSON Schema 7 is the input format. Convert from Zod with `zod-to-json-schema` if you want Zod as your source of truth.
+
+## 6. Combining RAG + tools + memory
+
+```ts
+import { sqliteChatMemory } from '@agentskit/memory'
+
+const runtime = createRuntime({
+  adapter,
+  tools: [weather, ...filesystem({ basePath: './workspace' })],
+  retriever: rag,
+  memory: sqliteChatMemory({ path: './sessions/user-42.db' }),
+  maxSteps: 10,
+})
+```
+
+Memory load + save, retrieval per turn, tool resolution — all handled. The runtime contract is locked in [ADR 0006](https://github.com/AgentsKit-io/agentskit/blob/main/docs/architecture/adrs/0006-runtime-contract.md).
+
+## 7. Vector store choice
+
+| Backend | Import | Notes |
+|---|---|---|
+| In-memory | `createInMemoryMemory` (core) | Tests, demos. |
+| File JSON | `fileVectorMemory({ path })` | Vectra-backed; one process. |
+| Postgres | `pgvector(...)` | Bring your own client (`pg` Pool, Neon, Supabase RPC). |
+| Pinecone | `pinecone({ indexUrl, apiKey })` | HTTP only; no SDK dep. |
+| Qdrant | `qdrant({ url, apiKey?, collection })` | HTTP only. |
+| Chroma | `chroma({ url, collection })` | HTTP only. |
+| Upstash | `upstashVector({ url, token })` | HTTP only. |
+| Weaviate | `weaviateVectorStore({ url, apiKey?, className })` | HTTP only. |
+| Milvus / Zilliz | `milvusVectorStore({ url, token, collection })` | HTTP only. |
+| MongoDB Atlas | `mongoAtlasVectorStore({ collection, ... })` | BYO client. |
+| Supabase | `supabaseVectorStore({ url, serviceRoleKey, table? })` | Wraps pgvector via RPC. |
+
+## Where LlamaIndex still wins
+
+- **Python ecosystem.** If your team and your data tooling are 100% Python, the migration cost might not be worth it.
+- **Tree / list / keyword indices** for non-embedding retrieval shapes.
+- **Document loaders.** LlamaHub has hundreds; AgentsKit ships ~10. If you need an exotic source (Slack archive, Salesforce object), you'd write it.
+- **Multimodal indices** (image / video). AgentsKit's RAG is text-first today.
+
+## Incremental migration
+
+1. **Embed once with LlamaIndex; retrieve with AgentsKit** — vector backends are wire-compatible. Point AgentsKit at your existing Pinecone / Qdrant index.
+2. **Move the agent loop to AgentsKit's runtime** — keep your LlamaIndex retriever wrapped via the `Retriever` contract.
+3. **Port loaders incrementally** as you re-ingest.
+
+## Related
+
+- [Recipe: Chat with RAG](/docs/reference/recipes/rag-chat) — end-to-end.
+- [RAG reranking](/docs/reference/recipes/rag-reranking) — voyage / jina / BM25.
+- [Vector adapters](/docs/reference/recipes/vector-adapters) — backend-by-backend.
+- [Concepts: Retriever](../concepts/retriever) — the contract LlamaIndex retrievers can implement.
+
+<ContributeCallout title="Coming from LlamaIndex?" body="Spot a missing equivalent? Open a discussion or send a PR — we want the mapping table to be exhaustive." />

--- a/apps/docs-next/content/docs/get-started/migrating/from-openai-assistants.mdx
+++ b/apps/docs-next/content/docs/get-started/migrating/from-openai-assistants.mdx
@@ -1,0 +1,214 @@
+---
+title: From OpenAI Assistants
+description: Side-by-side migration guide. Map OpenAI's Assistants API (and the deprecation path) to AgentsKit runtime + memory.
+---
+import { ContributeCallout } from '@/components/contribute/contribute-callout'
+
+OpenAI announced the Assistants API will be **deprecated** (with the
+target sunset window already on the roadmap). Migrate to AgentsKit when:
+
+- You want a runtime that **keeps working** when OpenAI deprecates the
+  endpoint — the runtime is provider-agnostic.
+- You need **multi-provider** support — Anthropic, Gemini, Bedrock,
+  Vertex, local (Ollama, vLLM, llama.cpp, WebLLM), etc.
+- You want **first-class durability** (`createDurableRunner`) instead
+  of leaning on OpenAI-managed thread state.
+- You want the **same tools / memory / skills** to work in terminal,
+  CLI, headless, React, Ink, every framework.
+
+Stay with the Assistants API while:
+
+- You're **prototyping** and want OpenAI to host the thread + files for you.
+- Your project ends before the deprecation window matters.
+- You depend specifically on **Code Interpreter** running in OpenAI's
+  managed sandbox (AgentsKit ships `@agentskit/sandbox` with E2B as the
+  recommended backend; comparable but not the same).
+
+## Quick reference
+
+| OpenAI Assistants | AgentsKit | Notes |
+|---|---|---|
+| `client.beta.assistants.create({ model, instructions, tools })` | `createRuntime({ adapter, systemPrompt, tools })` | One factory; configuration is plain data. |
+| `client.beta.threads.create()` | `sqliteChatMemory({ path })` (or `fileChatMemory`, `redisChatMemory`, `tursoChatMemory`) | The thread is your `ChatMemory`. |
+| `client.beta.threads.messages.create({ thread_id, content })` | `runtime.run(content)` with `memory:` set | Memory load + save is automatic. |
+| `client.beta.threads.runs.create({ thread_id, assistant_id })` | Same `runtime.run(...)` | No separate "run" entity — the runtime executes inline. |
+| `tool_outputs.submit({...})` | Tool `execute(args)` returns the result directly | The runtime resolves tool calls in the loop. |
+| `file_search` (built-in retrieval) | `createRAG({ embed, store })` + `retriever:` | Bring your own embedder + vector store. |
+| `code_interpreter` | `@agentskit/sandbox` (E2B by default) | Sandbox runs JS or Python with policy controls. |
+| Vision (image input) | `imagePart({ url })` in message content | Multi-modal content parts in `@agentskit/core`. |
+| `client.beta.threads.runs.stream(...)` | Built-in — every adapter streams | `for await (const chunk of source.stream())`. |
+| Function calling | `ToolDefinition` with JSON Schema 7 | Same shape; explicit `name` + `schema`. |
+| Polling status | Not needed | The runtime returns when the loop ends. |
+| `additional_instructions` | `runtime.run(task, { systemPrompt })` | Per-call override. |
+
+## 1. Basic assistant → runtime
+
+### Before — Assistants API
+
+```ts
+import OpenAI from 'openai'
+const client = new OpenAI()
+
+const assistant = await client.beta.assistants.create({
+  model: 'gpt-4o',
+  instructions: 'You are a helpful coding assistant.',
+  tools: [{ type: 'code_interpreter' }],
+})
+
+const thread = await client.beta.threads.create()
+await client.beta.threads.messages.create(thread.id, {
+  role: 'user',
+  content: 'Sort this list and explain Big-O',
+})
+const run = await client.beta.threads.runs.createAndPoll(thread.id, {
+  assistant_id: assistant.id,
+})
+```
+
+### After — AgentsKit
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { openai } from '@agentskit/adapters'
+import { sqliteChatMemory } from '@agentskit/memory'
+import { createSandbox, sandboxedShell } from '@agentskit/sandbox'
+
+const sandbox = createSandbox({ apiKey: process.env.E2B_API_KEY! })
+
+const runtime = createRuntime({
+  adapter: openai({ apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o' }),
+  systemPrompt: 'You are a helpful coding assistant.',
+  tools: [sandboxedShell({ sandbox })],
+  memory: sqliteChatMemory({ path: './threads/user-42.db' }),
+})
+
+await runtime.run('Sort this list and explain Big-O')
+```
+
+The thread + assistant + run + poll cycle collapses into one `runtime.run(...)`. Memory is yours to keep (file, SQLite, Redis, Turso, etc.) — no managed-thread lock-in.
+
+## 2. File search → RAG
+
+```ts
+import { createRAG, loadGitHubTree, loadPdf } from '@agentskit/rag'
+import { fileVectorMemory } from '@agentskit/memory'
+import { openaiEmbedder } from '@agentskit/adapters'
+
+const rag = createRAG({
+  embed: openaiEmbedder({ apiKey: KEY, model: 'text-embedding-3-small' }),
+  store: fileVectorMemory({ path: './kb.json' }),
+})
+
+await rag.ingest([
+  ...await loadGitHubTree('myorg', 'docs', { token }),
+  ...await loadPdf('/path/to/manual.pdf', { parsePdf }),
+])
+
+createRuntime({ adapter, retriever: rag })
+```
+
+You own the embedding model, vector store, and reranker. Swap any of them without rewriting the assistant logic.
+
+## 3. Code interpreter → sandbox
+
+```ts
+import { createSandbox } from '@agentskit/sandbox'
+import { runWithMandatorySandbox } from '@agentskit/sandbox'
+
+const sandbox = createSandbox({ apiKey: process.env.E2B_API_KEY! })
+
+const runtime = createRuntime({
+  adapter,
+  tools: runWithMandatorySandbox({
+    tools: [shellTool, pythonTool],
+    sandbox,
+    policy: { requireSandbox: '*' },
+  }),
+})
+```
+
+Policies, allow/deny lists, and per-tool validators are first-class. See [Mandatory sandbox](/docs/production/security/mandatory-sandbox).
+
+## 4. Vision
+
+```ts
+import { imagePart, textPart } from '@agentskit/core'
+
+await runtime.run({
+  role: 'user',
+  content: [
+    textPart('What does this chart show?'),
+    imagePart({ url: 'https://example.com/chart.png' }),
+  ],
+})
+```
+
+The same content-part helpers work across providers that support vision (`openai`, `anthropic`, `gemini`).
+
+## 5. Streaming
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+
+const runtime = createRuntime({
+  adapter,
+  observers: [{
+    name: 'stdout',
+    on: e => e.type === 'text' && process.stdout.write((e as { content: string }).content),
+  }],
+})
+```
+
+Every adapter streams. No "polling" mental model.
+
+## 6. Multi-provider in one place
+
+```ts
+import { createRouter } from '@agentskit/adapters'
+import { openai, anthropic } from '@agentskit/adapters'
+
+const router = createRouter({
+  candidates: [
+    { id: 'oai',  adapter: openai({ apiKey: O, model: 'gpt-4o' }),       cost: 5,  capabilities: { tools: true } },
+    { id: 'anth', adapter: anthropic({ apiKey: A, model: 'claude-sonnet-4-6' }), cost: 6, capabilities: { tools: true } },
+  ],
+  policy: 'cheapest',
+})
+
+createRuntime({ adapter: router })
+```
+
+When OpenAI deprecates Assistants and ships a successor, you swap one line. Provider risk is contained at the adapter seam.
+
+## 7. Durable runs
+
+OpenAI manages thread state for you. AgentsKit makes it explicit and portable:
+
+```ts
+import { createDurableRunner, createFileStepLog } from '@agentskit/runtime'
+
+const store = await createFileStepLog('.agentskit/runs.jsonl')
+const runner = createDurableRunner({ store, runId: 'order-1234' })
+
+const draft = await runner.step('draft',  () => runtime.run('Draft refund email'))
+const sent  = await runner.step('send',   () => sendEmail(draft.content))
+```
+
+Crash mid-step? Resume with the same `runId`. See [Durable execution](/docs/agents/durable).
+
+## Incremental migration
+
+1. **Keep Assistants for legacy threads.** Read-only, until the deprecation window.
+2. **New surfaces use AgentsKit.** Same model, but provider-agnostic adapter.
+3. **Port active threads** when you can — `ChatMemory.save(messages)` accepts the same role/content shape OpenAI returns.
+4. **Cut over** by the time the deprecation window closes. The runtime + memory stack is the durable part.
+
+## Related
+
+- [Build your first agent](/docs/get-started/getting-started/build-your-first-agent)
+- [Architecture at a glance](/docs/get-started/architecture-at-a-glance)
+- [Mandatory sandbox](/docs/production/security/mandatory-sandbox)
+- [Recipe: Chat with RAG](/docs/reference/recipes/rag-chat)
+- [Concepts: Adapter](../concepts/adapter)
+
+<ContributeCallout title="Migrating off Assistants?" body="Tell us what's blocking you — the more concrete the example, the better the next iteration of this guide." />

--- a/apps/docs-next/content/docs/get-started/migrating/index.mdx
+++ b/apps/docs-next/content/docs/get-started/migrating/index.mdx
@@ -9,6 +9,9 @@ AgentsKit isn't in conflict with the libraries you're already using — but if y
 |---|---|
 | Vercel AI SDK | [`from-vercel-ai-sdk`](/docs/get-started/migrating/from-vercel-ai-sdk) |
 | LangChain.js | [`from-langchain`](/docs/get-started/migrating/from-langchain) |
+| LangGraph | [`from-langgraph`](/docs/get-started/migrating/from-langgraph) |
+| LlamaIndex | [`from-llamaindex`](/docs/get-started/migrating/from-llamaindex) |
+| OpenAI Assistants | [`from-openai-assistants`](/docs/get-started/migrating/from-openai-assistants) |
 | Mastra | [`from-mastra`](/docs/get-started/migrating/from-mastra) |
 
 ## Choose your migration path

--- a/apps/docs-next/content/docs/get-started/migrating/meta.json
+++ b/apps/docs-next/content/docs/get-started/migrating/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Migrating",
   "description": "Moving from another framework to AgentsKit.",
-  "pages": ["index", "from-vercel-ai-sdk", "from-langchain", "from-mastra"]
+  "pages": ["index", "from-vercel-ai-sdk", "from-langchain", "from-langgraph", "from-llamaindex", "from-openai-assistants", "from-mastra"]
 }


### PR DESCRIPTION
## Summary

Closes N/P2 of [epic #562](https://github.com/AgentsKit-io/agentskit/issues/562). Three new migration guides under `apps/docs-next/content/docs/get-started/migrating/`.

Independent of all open PRs — pure docs.

## Files

- `from-langgraph.mdx` — graph nodes/edges → runtime loop + topologies + `compileFlow` + `createDurableRunner`. Maps `StateGraph`, `Checkpointer`, `Send`, `interrupt()`, conditional edges.
- `from-llamaindex.mdx` — `VectorStoreIndex`, retrievers, agent classes, every vector backend. Includes a backend-by-backend mapping table.
- `from-openai-assistants.mdx` — assistants/threads/runs/file_search/code_interpreter → runtime + `ChatMemory` + RAG + sandbox. Frames the deprecation-window argument up front.

Each guide follows the existing voice + structure (see `from-vercel-ai-sdk.mdx` for the template):

1. When to migrate / when to stay
2. Quick-reference mapping table
3. Side-by-side code samples for common patterns
4. Honest "where the other still wins" callouts
5. Incremental migration path
6. Related links + ContributeCallout

`migrating/index.mdx` and `meta.json` updated to list the three new entries.

## Test plan

- [x] Markdown lint clean (visual)
- [x] All internal links land on existing routes (`/docs/agents/flow`, `/docs/agents/topologies`, `/docs/agents/durable`, `/docs/reference/recipes/*`, etc.)

## Out of scope (next sub-PRs)

- M/P2 link-check workflow (next polish PR)
- P/P1 forbid bare throw — wires after #721 / #722 / #723 merge
- L — phase-gate verifications (read-only audit)
- K/P1 templates `flow` scaffold — waits on #561

Refs: epic #562. 10 PRs now stacked.