### PR TITLE
chore(ci): add link-check workflow (lychee) — closes M/P2

### DIFF
--- a/.changeset/sprint-c-link-check.md
+++ b/.changeset/sprint-c-link-check.md
@@ -1,0 +1,13 @@
+---
+---
+
+chore(ci): add link-check workflow (lychee).
+
+Closes M/P2 of the enterprise-readiness audit (#562). New
+`.github/workflows/link-check.yml` runs `lycheeverse/lychee-action@v2`
+on every PR (and push to main) that touches the docs tree or the
+top-level `*.md` files. Caches results for 7 days.
+
+`.lycheeignore` skips localhost, well-known placeholder hosts, and
+typedoc-generated `/docs/api/*` paths (those are built at site-build
+time, not committed).

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,6 +38,5 @@ jobs:
             --cache
             --max-cache-age 7d
             --accept 200,206,301,302,403,429
-            --exclude-mail
             'apps/docs-next/content/docs/**/*.mdx'
             '*.md'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,43 @@
+name: Link check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/docs-next/content/docs/**'
+      - '*.md'
+      - '.github/workflows/link-check.yml'
+      - '.lycheeignore'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/docs-next/content/docs/**'
+      - '*.md'
+
+jobs:
+  lychee:
+    name: Lychee
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-cache-${{ runner.os }}
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: >-
+            --no-progress
+            --cache
+            --max-cache-age 7d
+            --accept 200,206,301,302,403,429
+            --exclude-mail
+            'apps/docs-next/content/docs/**/*.mdx'
+            '*.md'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,16 @@
+# Local dev URLs — never resolvable from CI
+^http://localhost
+^http://127\.0\.0\.1
+^http://0\.0\.0\.0
+
+# Internal-only / placeholder hosts referenced in examples
+^https?://internal\.
+^https?://example\.com
+^https?://example\.invalid
+^https?://api\.example\.com
+
+# Typedoc-generated API pages — present at build time, not in repo
+^/docs/api/
+
+# Anchored fragments that mdx-lint can't resolve cleanly (per-page, fine in browser)
+#strikes-known


### PR DESCRIPTION
## Summary

Closes M/P2 of [epic #562](https://github.com/AgentsKit-io/agentskit/issues/562). Adds a `lychee` link-check workflow gating PRs and pushes that touch the docs tree.

## Changes

- `.github/workflows/link-check.yml` — uses `lycheeverse/lychee-action@v2`. Triggers only on docs/markdown changes (path filters keep it cheap). 7-day result cache.
- `.lycheeignore` — skips localhost / well-known placeholder hosts / typedoc-generated `/docs/api/*` (those are built at site-build time, not committed).

Accepted statuses: 200, 206, 301, 302, 403, 429 (last two cover providers that block CI scans like Cloudflare / GitHub anonymous rate-limit).

## Test plan

- [x] Workflow YAML lints visually (no `${{ ... }}` expressions consume untrusted input).
- [x] On dry-run reasoning, `--cache --max-cache-age 7d` keeps repeat scans cheap; `paths:` filter avoids running on every PR.

First run on this PR is the smoke test — it'll surface any latent dead links across the existing docs (which is the point).

## Out of scope

- Wiring `check-for-agents-coverage.mjs` (script lives in #730).
- Wiring `check-no-bare-throw.mjs` — waits on D-conversion PRs (#721 / #722 / #723) merging to clear current main violations.

Refs: epic #562. Independent of all open PRs.