### PR TITLE
feat(templates): memory adapter blueprint — closes K/P1

### DIFF
--- a/.changeset/sprint-c-templates-memory-blueprint.md
+++ b/.changeset/sprint-c-templates-memory-blueprint.md
@@ -1,0 +1,25 @@
+---
+'@agentskit/templates': minor
+---
+
+feat(templates): memory adapter blueprint — closes K/P1.
+
+Adds `memory-vector` and `memory-chat` to `ScaffoldType`, with
+matching blueprint generators in `blueprints/memory.ts`:
+
+- `generateVectorMemorySource(name)` — emits a `VectorMemory`
+  skeleton wired to a generic HTTP backend, with the `store` /
+  `search` / `delete` triple stubbed and `MemoryError` / `ErrorCodes`
+  imports already wired (so first-error path is correct from day one).
+- `generateChatMemorySource(name)` — emits a `ChatMemory` skeleton
+  with `load` / `save` / `clear`, `serializeMessages` /
+  `deserializeMessages` import, and typed errors on the failure
+  branches.
+- `generateVectorMemoryTest(name)` — minimal test asserting upsert
+  endpoint hit + `MemoryError` raised on non-2xx.
+
+`scaffold({ type: 'memory-vector' | 'memory-chat', name, dir })`
+emits a complete package skeleton — package.json, tsconfig,
+tsup.config, src/index.ts, tests/index.test.ts, README.md.
+
+Templates package: 21 → 23 tests.

--- a/packages/templates/src/blueprints/index.ts
+++ b/packages/templates/src/blueprints/index.ts
@@ -3,5 +3,10 @@ export { generateTsConfig, generateTsupConfig } from './config-files'
 export { generateToolSource, generateToolTest } from './tool'
 export { generateSkillSource, generateSkillTest } from './skill'
 export { generateAdapterSource, generateAdapterTest } from './adapter'
+export {
+  generateVectorMemorySource,
+  generateVectorMemoryTest,
+  generateChatMemorySource,
+} from './memory'
 export { generateReadme } from './readme'
 export { camelCase, pascalCase, packageName } from './utils'

--- a/packages/templates/src/blueprints/memory.ts
+++ b/packages/templates/src/blueprints/memory.ts
@@ -1,0 +1,166 @@
+import { camelCase, pascalCase } from './utils'
+
+/**
+ * Skeleton for a vector-memory backend that follows the
+ * `@agentskit/core` `VectorMemory` contract. Author fills in the three
+ * methods (`store`, `search`, `delete`) and any backend-specific
+ * client wiring.
+ */
+export function generateVectorMemorySource(name: string): string {
+  return `import { ErrorCodes, MemoryError } from '@agentskit/core'
+import type { RetrievedDocument, VectorDocument, VectorMemory } from '@agentskit/core'
+
+export interface ${pascalCase(name)}Config {
+  /** Backend URL — use whatever your provider exposes. */
+  url: string
+  /** Auth token. Optional for self-hosted setups. */
+  apiKey?: string
+  /** Default topK for \`search\`. */
+  topK?: number
+  /** Override fetch (mainly for tests). */
+  fetch?: typeof globalThis.fetch
+}
+
+async function call<T>(config: ${pascalCase(name)}Config, path: string, body: unknown): Promise<T> {
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const response = await fetchImpl(\`\${config.url}\${path}\`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(config.apiKey ? { authorization: \`Bearer \${config.apiKey}\` } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new MemoryError({
+      code: ErrorCodes.AK_MEMORY_REMOTE_HTTP,
+      message: \`${name} \${response.status}: \${text.slice(0, 200)}\`,
+      hint: \`URL \${config.url}\${path}.\`,
+    })
+  }
+  return (text.length > 0 ? JSON.parse(text) : {}) as T
+}
+
+export function ${camelCase(name)}(config: ${pascalCase(name)}Config): VectorMemory {
+  const defaultTopK = Math.max(1, config.topK ?? 10)
+
+  return {
+    async store(docs: VectorDocument[]) {
+      // TODO: translate docs → backend's upsert payload + call.
+      await call<unknown>(config, '/v1/upsert', { docs })
+    },
+    async search(embedding: number[], options) {
+      const topK = options?.topK ?? defaultTopK
+      const result = await call<{ matches: Array<{ id: string; score: number; metadata?: Record<string, unknown>; content?: string }> }>(
+        config,
+        '/v1/query',
+        { vector: embedding, topK, filter: options?.filter },
+      )
+      return result.matches.map((m): RetrievedDocument => ({
+        id: m.id,
+        content: m.content ?? '',
+        score: m.score,
+        metadata: m.metadata,
+      }))
+    },
+    async delete(ids: string[]) {
+      await call<unknown>(config, '/v1/delete', { ids })
+    },
+  }
+}
+`
+}
+
+export function generateVectorMemoryTest(name: string): string {
+  return `import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ${camelCase(name)} } from '../src/index'
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('${name}', () => {
+  it('stores documents via the upsert endpoint', async () => {
+    const calls: Array<{ url: string; body: string }> = []
+    globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), body: init?.body as string })
+      return new Response('{}', { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    const memory = ${camelCase(name)}({ url: 'https://example/v1' })
+    await memory.store([{ id: '1', content: 'hi', embedding: [0.1, 0.2] }])
+    expect(calls[0]!.url).toContain('/v1/upsert')
+  })
+
+  it('throws MemoryError on non-2xx', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as unknown as typeof globalThis.fetch
+    const memory = ${camelCase(name)}({ url: 'https://example/v1' })
+    await expect(memory.store([{ id: '1', content: '', embedding: [0] }])).rejects.toThrow(/${name}/)
+  })
+})
+`
+}
+
+/**
+ * Chat-memory backend skeleton. Implements load + save against any
+ * persistent store. Pair with \`generateVectorMemorySource\` for a
+ * combined backend, or ship one without the other.
+ */
+export function generateChatMemorySource(name: string): string {
+  return `import {
+  ErrorCodes,
+  MemoryError,
+  deserializeMessages,
+  serializeMessages,
+} from '@agentskit/core'
+import type { ChatMemory, Message, MemoryRecord } from '@agentskit/core'
+
+export interface ${pascalCase(name)}Config {
+  /** Connection URL or driver-specific config. */
+  url: string
+  /** Logical conversation id. Defaults to 'default'. */
+  conversationId?: string
+}
+
+export function ${camelCase(name)}(config: ${pascalCase(name)}Config): ChatMemory {
+  const conversationId = config.conversationId ?? 'default'
+
+  // TODO: wire your backend client here (open connection, prepare statements, etc.)
+
+  return {
+    async load(): Promise<Message[]> {
+      try {
+        // TODO: read serialised JSON for conversationId from your store.
+        const raw = '[]'
+        return deserializeMessages(JSON.parse(raw) as MemoryRecord[])
+      } catch (err) {
+        throw new MemoryError({
+          code: ErrorCodes.AK_MEMORY_LOAD_FAILED,
+          message: \`${name}: load failed for conversation \${conversationId}\`,
+          cause: err,
+        })
+      }
+    },
+    async save(messages: Message[]): Promise<void> {
+      try {
+        const encoded = JSON.stringify(serializeMessages(messages))
+        // TODO: write \`encoded\` against \`conversationId\` in your store.
+        void encoded
+      } catch (err) {
+        throw new MemoryError({
+          code: ErrorCodes.AK_MEMORY_SAVE_FAILED,
+          message: \`${name}: save failed for conversation \${conversationId}\`,
+          cause: err,
+        })
+      }
+    },
+    async clear(): Promise<void> {
+      // TODO: delete \`conversationId\` row(s) in your store.
+    },
+  }
+}
+`
+}

--- a/packages/templates/src/scaffold.ts
+++ b/packages/templates/src/scaffold.ts
@@ -10,10 +10,13 @@ import {
   generateSkillTest,
   generateAdapterSource,
   generateAdapterTest,
+  generateChatMemorySource,
+  generateVectorMemorySource,
+  generateVectorMemoryTest,
   generateReadme,
 } from './blueprints'
 
-export type ScaffoldType = 'tool' | 'skill' | 'adapter'
+export type ScaffoldType = 'tool' | 'skill' | 'adapter' | 'memory-vector' | 'memory-chat'
 
 export interface ScaffoldConfig {
   type: ScaffoldType
@@ -22,16 +25,32 @@ export interface ScaffoldConfig {
   description?: string
 }
 
+function placeholderTest(name: string): string {
+  return `import { describe, expect, it } from 'vitest'
+import * as mod from '../src/index'
+
+describe('${name}', () => {
+  it('exports the factory', () => {
+    expect(typeof mod).toBe('object')
+  })
+})
+`
+}
+
 const sourceGenerators: Record<ScaffoldType, (name: string) => string> = {
   tool: generateToolSource,
   skill: generateSkillSource,
   adapter: generateAdapterSource,
+  'memory-vector': generateVectorMemorySource,
+  'memory-chat': generateChatMemorySource,
 }
 
 const testGenerators: Record<ScaffoldType, (name: string) => string> = {
   tool: generateToolTest,
   skill: generateSkillTest,
   adapter: generateAdapterTest,
+  'memory-vector': generateVectorMemoryTest,
+  'memory-chat': placeholderTest,
 }
 
 export async function scaffold(config: ScaffoldConfig): Promise<string[]> {

--- a/packages/templates/tests/scaffold.test.ts
+++ b/packages/templates/tests/scaffold.test.ts
@@ -74,4 +74,25 @@ describe('scaffold', () => {
     const pkg = JSON.parse(await readFile(join(dir, 'slack', 'package.json'), 'utf8'))
     expect(pkg.description).toBe('Send Slack messages from agents')
   })
+
+  it('scaffolds a vector-memory package', async () => {
+    await scaffold({ type: 'memory-vector', name: 'pinedrop', dir })
+    const src = await readFile(join(dir, 'pinedrop', 'src', 'index.ts'), 'utf8')
+    expect(src).toContain('VectorMemory')
+    expect(src).toContain('PinedropConfig')
+    expect(src).toContain('AK_MEMORY_REMOTE_HTTP')
+    expect(src).toContain('async store')
+    expect(src).toContain('async search')
+    expect(src).toContain('async delete')
+  })
+
+  it('scaffolds a chat-memory package', async () => {
+    await scaffold({ type: 'memory-chat', name: 'turso-lite', dir })
+    const src = await readFile(join(dir, 'turso-lite', 'src', 'index.ts'), 'utf8')
+    expect(src).toContain('ChatMemory')
+    expect(src).toContain('TursoLiteConfig')
+    expect(src).toContain('serializeMessages')
+    expect(src).toContain('AK_MEMORY_LOAD_FAILED')
+    expect(src).toContain('AK_MEMORY_SAVE_FAILED')
+  })
 })


### PR DESCRIPTION
## Summary

Closes K/P1 (templates: memory adapter blueprint) of [epic #562](https://github.com/AgentsKit-io/agentskit/issues/562).

## Changes

### `packages/templates/src/blueprints/memory.ts` (new)

- `generateVectorMemorySource(name)` — `VectorMemory` skeleton wired to a generic HTTP backend. `store` / `search` / `delete` stubbed, `MemoryError` + `ErrorCodes` already imported so the first-error path is right from day one.
- `generateChatMemorySource(name)` — `ChatMemory` skeleton with `load` / `save` / `clear`, `serializeMessages` + `deserializeMessages` wired, typed errors on failure branches.
- `generateVectorMemoryTest(name)` — minimal test asserting upsert hit + `MemoryError` on non-2xx.

### `packages/templates/src/scaffold.ts`

- `ScaffoldType` extended: `'memory-vector'` + `'memory-chat'`.
- `sourceGenerators` + `testGenerators` records updated with the new entries.

### `packages/templates/src/blueprints/index.ts`

Re-exports the three new generators.

### `packages/templates/tests/scaffold.test.ts`

Two new tests verifying the scaffolded source contains the expected contract symbols (`VectorMemory`, `ChatMemory`, error codes, action method signatures).

## Test plan

- [x] `pnpm --filter @agentskit/templates test` — 23/23 (was 21)
- [x] `pnpm --filter @agentskit/templates lint` — clean
- [x] Source generators emit valid TypeScript that imports from `@agentskit/core` (post-#723 typed-error API).

## Related

- Audit issue: #630 (closed by this PR)
- Templates package now scaffolds: `tool`, `skill`, `adapter`, `memory-vector`, `memory-chat`. `flow` scaffold still queued for #629 once #561 (flow runtime) merges.

Refs: epic #562. 13 PRs now stacked.