### PR TITLE
feat(templates): flow scaffold type — closes K/P1

### DIFF
--- a/.changeset/templates-flow-scaffold.md
+++ b/.changeset/templates-flow-scaffold.md
@@ -1,0 +1,22 @@
+---
+'@agentskit/templates': minor
+---
+
+feat(templates): `flow` scaffold type — closes K/P1.
+
+`scaffold({ type: 'flow', name, dir })` now emits:
+
+- `flow.yaml` — starter `FlowDefinition` with two demo nodes
+  (`fetch` → `parse`) showing the `name`, `version`, `nodes`,
+  `needs` shape.
+- `src/index.ts` — `FlowRegistry` skeleton with `http.get` +
+  `json.parse` handler stubs typed against the runtime contract.
+- `tests/index.test.ts` — minimal smoke test that imports the
+  registry and runs `compileFlow` to assert the shape.
+- `README.md` — `agentskit flow validate / render / run` quick
+  reference + the programmatic `compileFlow` snippet, deep-linked
+  to `/docs/agents/flow`.
+
+Companion to the memory blueprint added in #734. `ScaffoldType` now
+covers `tool` | `skill` | `adapter` | `memory-vector` |
+`memory-chat` | `flow`.

--- a/packages/templates/src/blueprints/flow.ts
+++ b/packages/templates/src/blueprints/flow.ts
@@ -1,0 +1,127 @@
+import { camelCase, pascalCase } from './utils'
+
+/**
+ * Scaffold for a flow handler registry. The author writes a YAML
+ * `FlowDefinition` (see `/docs/agents/flow`) and pairs it with a
+ * registry module that this skeleton produces. `compileFlow` consumes
+ * both and returns a durable runner.
+ */
+export function generateFlowSource(name: string): string {
+  return `import type { FlowRegistry } from '@agentskit/runtime'
+
+/**
+ * Handler registry for the \`${name}\` flow. Each key matches the
+ * \`run:\` field on a node in the flow's YAML / object definition.
+ *
+ * Each handler receives \`{ node, input, deps, with }\`:
+ * - \`node\`   the FlowNode metadata (id, name, run, with, needs).
+ * - \`input\`  the value passed to compiled.run(input).
+ * - \`deps\`   outputs of upstream nodes, keyed by node id.
+ * - \`with\`   static inputs from the YAML \`with:\` block.
+ */
+export const ${camelCase(name)}Registry: FlowRegistry = {
+  // TODO: replace these stubs with real handlers.
+  'http.get': async ({ with: w }) => {
+    const url = String(w.url ?? '')
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(\`http.get \${response.status}: \${url}\`)
+    return await response.text()
+  },
+
+  'json.parse': ({ deps }) => {
+    const raw = String(deps[Object.keys(deps)[0] ?? ''] ?? '')
+    return JSON.parse(raw)
+  },
+
+  // Add more handlers as your flow's nodes need them.
+}
+
+export default ${camelCase(name)}Registry
+`
+}
+
+export function generateFlowYaml(name: string): string {
+  return `# ${pascalCase(name)} — visual flow.
+# Documented at https://www.agentskit.io/docs/agents/flow
+
+name: ${name}
+version: 1
+description: TODO — what does this flow do?
+
+nodes:
+  - id: fetch
+    name: Fetch the source
+    run: http.get
+    with:
+      url: https://example.com/data.json
+
+  - id: parse
+    name: Parse JSON
+    run: json.parse
+    needs: [fetch]
+`
+}
+
+export function generateFlowReadme(name: string): string {
+  return `# ${name}
+
+A visual flow + handler registry for AgentsKit.
+
+## Run
+
+\`\`\`bash
+agentskit flow validate flow.yaml --registry ./dist/index.js
+agentskit flow render   flow.yaml > flow.mmd
+agentskit flow run      flow.yaml --registry ./dist/index.js \\\\
+  --store .agentskit/flow.jsonl --run-id $(date +%s)
+\`\`\`
+
+## Layout
+
+- \`flow.yaml\` — the visual graph.
+- \`src/index.ts\` — handler registry. Each key matches the \`run:\`
+  field on a node.
+
+## Programmatic use
+
+\`\`\`ts
+import { compileFlow } from '@agentskit/runtime'
+import { parse } from 'yaml'
+import registry from './src/index'
+
+const definition = parse(await readFile('./flow.yaml', 'utf8'))
+const compiled = compileFlow({ definition, registry })
+const outputs = await compiled.run()
+\`\`\`
+
+See [Visual flows](https://www.agentskit.io/docs/agents/flow).
+`
+}
+
+export function generateFlowTest(name: string): string {
+  return `import { describe, expect, it } from 'vitest'
+import { compileFlow } from '@agentskit/runtime'
+import registry from '../src/index'
+
+describe('${name} registry', () => {
+  it('exposes a handler for every node referenced in flow.yaml', () => {
+    expect(typeof registry).toBe('object')
+    // The registry is consumed by compileFlow at run time. This test
+    // just guards against accidental "{}" exports during refactors.
+    expect(Object.keys(registry).length).toBeGreaterThan(0)
+  })
+
+  it('compiles a minimal flow against the registry', () => {
+    expect(() =>
+      compileFlow({
+        definition: {
+          name: 'smoke',
+          nodes: Object.keys(registry).slice(0, 1).map(run => ({ id: 'a', run })),
+        },
+        registry,
+      }),
+    ).not.toThrow()
+  })
+})
+`
+}

--- a/packages/templates/src/blueprints/index.ts
+++ b/packages/templates/src/blueprints/index.ts
@@ -8,5 +8,11 @@ export {
   generateVectorMemoryTest,
   generateChatMemorySource,
 } from './memory'
+export {
+  generateFlowSource,
+  generateFlowTest,
+  generateFlowYaml,
+  generateFlowReadme,
+} from './flow'
 export { generateReadme } from './readme'
 export { camelCase, pascalCase, packageName } from './utils'

--- a/packages/templates/src/scaffold.ts
+++ b/packages/templates/src/scaffold.ts
@@ -13,10 +13,20 @@ import {
   generateChatMemorySource,
   generateVectorMemorySource,
   generateVectorMemoryTest,
+  generateFlowSource,
+  generateFlowTest,
+  generateFlowYaml,
+  generateFlowReadme,
   generateReadme,
 } from './blueprints'
 
-export type ScaffoldType = 'tool' | 'skill' | 'adapter' | 'memory-vector' | 'memory-chat'
+export type ScaffoldType =
+  | 'tool'
+  | 'skill'
+  | 'adapter'
+  | 'memory-vector'
+  | 'memory-chat'
+  | 'flow'
 
 export interface ScaffoldConfig {
   type: ScaffoldType
@@ -43,6 +53,7 @@ const sourceGenerators: Record<ScaffoldType, (name: string) => string> = {
   adapter: generateAdapterSource,
   'memory-vector': generateVectorMemorySource,
   'memory-chat': generateChatMemorySource,
+  flow: generateFlowSource,
 }
 
 const testGenerators: Record<ScaffoldType, (name: string) => string> = {
@@ -51,6 +62,7 @@ const testGenerators: Record<ScaffoldType, (name: string) => string> = {
   adapter: generateAdapterTest,
   'memory-vector': generateVectorMemoryTest,
   'memory-chat': placeholderTest,
+  flow: generateFlowTest,
 }
 
 export async function scaffold(config: ScaffoldConfig): Promise<string[]> {
@@ -69,7 +81,13 @@ export async function scaffold(config: ScaffoldConfig): Promise<string[]> {
   await write('tsup.config.ts', generateTsupConfig())
   await write('src/index.ts', sourceGenerators[config.type](config.name))
   await write('tests/index.test.ts', testGenerators[config.type](config.name))
-  await write('README.md', generateReadme(config))
+
+  if (config.type === 'flow') {
+    await write('flow.yaml', generateFlowYaml(config.name))
+    await write('README.md', generateFlowReadme(config.name))
+  } else {
+    await write('README.md', generateReadme(config))
+  }
 
   return created
 }

--- a/packages/templates/tests/scaffold.test.ts
+++ b/packages/templates/tests/scaffold.test.ts
@@ -95,4 +95,27 @@ describe('scaffold', () => {
     expect(src).toContain('AK_MEMORY_LOAD_FAILED')
     expect(src).toContain('AK_MEMORY_SAVE_FAILED')
   })
+
+  it('scaffolds a flow package with yaml + registry + README', async () => {
+    await scaffold({ type: 'flow', name: 'nightly-refresh', dir })
+    const src = await readFile(join(dir, 'nightly-refresh', 'src', 'index.ts'), 'utf8')
+    expect(src).toContain('FlowRegistry')
+    expect(src).toContain('nightlyRefreshRegistry')
+    expect(src).toContain("'http.get'")
+    expect(src).toContain("'json.parse'")
+
+    const yaml = await readFile(join(dir, 'nightly-refresh', 'flow.yaml'), 'utf8')
+    expect(yaml).toContain('name: nightly-refresh')
+    expect(yaml).toContain('nodes:')
+    expect(yaml).toContain('run: http.get')
+    expect(yaml).toContain('needs: [fetch]')
+
+    const readme = await readFile(join(dir, 'nightly-refresh', 'README.md'), 'utf8')
+    expect(readme).toContain('agentskit flow validate')
+    expect(readme).toContain('compileFlow')
+
+    const test = await readFile(join(dir, 'nightly-refresh', 'tests', 'index.test.ts'), 'utf8')
+    expect(test).toContain('compileFlow')
+    expect(test).toContain('@agentskit/runtime')
+  })
 })


### PR DESCRIPTION
## Summary

Closes K/P1 #629 — \`scaffold({ type: 'flow', name, dir })\` now emits a complete starter package for a visual YAML flow + handler registry.

## Changes

- \`packages/templates/src/blueprints/flow.ts\` (new) — generators for \`flow.yaml\`, \`src/index.ts\` (FlowRegistry stub), \`tests/index.test.ts\`, \`README.md\`.
- \`packages/templates/src/scaffold.ts\` — \`ScaffoldType\` extended to include \`'flow'\`; scaffold function writes the extra \`flow.yaml\` file and uses the flow-specific README.
- \`packages/templates/src/blueprints/index.ts\` — re-exports the four new generators.
- \`packages/templates/tests/scaffold.test.ts\` — verifies the scaffolded package contains \`FlowRegistry\`, \`compileFlow\`, \`http.get\`, \`json.parse\`, and the deep-linked CLI quick reference.

## Generated layout

\`\`\`
nightly-refresh/
├── flow.yaml          # FlowDefinition with fetch → parse demo
├── src/index.ts       # FlowRegistry { 'http.get', 'json.parse', ... }
├── tests/index.test.ts
├── README.md
├── package.json
├── tsconfig.json
└── tsup.config.ts
\`\`\`

## Test plan

- [x] \`pnpm --filter @agentskit/templates test\` — 24/24 (was 23)
- [x] \`pnpm --filter @agentskit/templates lint\` — clean
- [x] \`node scripts/check-no-bare-throw.mjs\` — clean (334 files)
- [x] \`node scripts/check-for-agents-coverage.mjs\` — clean (16 packages)

## Sprint follow-up

\`ScaffoldType\` now covers: \`tool\` | \`skill\` | \`adapter\` | \`memory-vector\` | \`memory-chat\` | \`flow\`. Audit K/P2 backlog (\`embedder\` helper, \`webllm\`/browser-only adapter pattern, conditional package.json deps) is the next templates work.

Refs: epic #562.