### PR TITLE
feat(examples): apps/example-flow demonstrates compileFlow — closes J/P0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,7 @@
     "@agentskit/example-react",
     "@agentskit/example-ink",
     "@agentskit/example-runtime",
-    "@agentskit/example-multi-agent"
+    "@agentskit/example-multi-agent",
+    "@agentskit/example-flow"
   ]
 }

--- a/apps/example-flow/.gitignore
+++ b/apps/example-flow/.gitignore
@@ -1,0 +1,3 @@
+.agentskit/
+dist/
+node_modules/

--- a/apps/example-flow/README.md
+++ b/apps/example-flow/README.md
@@ -1,0 +1,73 @@
+# @agentskit/example-flow
+
+Live demo of `compileFlow` from `@agentskit/runtime`: a YAML
+`FlowDefinition` is compiled into a durable DAG, executed with a
+JSONL step log, and prints a rendered markdown summary.
+
+The flow pulls stargazer counts for two GitHub repos in parallel,
+sums them, and renders a digest:
+
+```
+▸ flow=octo-stars-digest runId=demo-run
+  order=fetch-react → fetch-vue → total → render
+▸ fetch-react start
+  ★ facebook/react → 235,492
+✓ fetch-react done
+▸ fetch-vue start
+  ★ vuejs/core → 50,876
+✓ fetch-vue done
+▸ total start
+✓ total done
+▸ render start
+✓ render done
+
+— done in 412ms —
+
+# Stargazers digest
+
+- **facebook/react** — 235,492 ★ (node `fetch-react`)
+- **vuejs/core** — 50,876 ★ (node `fetch-vue`)
+
+_Total across the listed repos: **286,368** ★_
+```
+
+## Run
+
+```bash
+pnpm --filter @agentskit/example-flow dev
+```
+
+Re-running with the same `RUN_ID` short-circuits any node already
+recorded as successful in `.agentskit/flow.jsonl` — try killing the
+process mid-run and re-launching:
+
+```bash
+RUN_ID=resume-test pnpm --filter @agentskit/example-flow dev
+# Ctrl-C during one of the github.stars nodes, then:
+RUN_ID=resume-test pnpm --filter @agentskit/example-flow dev
+```
+
+The replayed steps print no `start` / `done` events; only the
+unfinished node and downstream nodes execute.
+
+## Reset the durable log
+
+```bash
+pnpm --filter @agentskit/example-flow dev -- --reset
+```
+
+## Auth
+
+GitHub's anonymous API has a strict rate limit. Set `GITHUB_TOKEN`
+to a personal access token with `public_repo` (or any scope) to
+raise the cap:
+
+```bash
+GITHUB_TOKEN=ghp_xxx pnpm --filter @agentskit/example-flow dev
+```
+
+## See also
+
+- [`/docs/agents/flow`](https://www.agentskit.io/docs/agents/flow) — the user-facing guide.
+- [`/docs/agents/durable`](https://www.agentskit.io/docs/agents/durable) — durable runner internals.
+- `apps/example-runtime` — same runtime, plain ReAct loop.

--- a/apps/example-flow/flow.yaml
+++ b/apps/example-flow/flow.yaml
@@ -1,0 +1,31 @@
+name: octo-stars-digest
+version: 1
+description: |
+  Example DAG: pull two GitHub repo stargazer counts, sum them, and
+  format a markdown summary. Demonstrates compileFlow's needs:
+  threading + the durable runner short-circuiting on resume.
+
+nodes:
+  - id: fetch-react
+    name: Fetch React stargazers
+    run: github.stars
+    with:
+      owner: facebook
+      repo: react
+
+  - id: fetch-vue
+    name: Fetch Vue stargazers
+    run: github.stars
+    with:
+      owner: vuejs
+      repo: core
+
+  - id: total
+    name: Sum totals
+    run: math.sum
+    needs: [fetch-react, fetch-vue]
+
+  - id: render
+    name: Render markdown
+    run: render.markdown
+    needs: [fetch-react, fetch-vue, total]

--- a/apps/example-flow/package.json
+++ b/apps/example-flow/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@agentskit/example-flow",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*",
+    "@agentskit/runtime": "workspace:*",
+    "yaml": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/example-flow/src/index.ts
+++ b/apps/example-flow/src/index.ts
@@ -1,0 +1,116 @@
+/**
+ * apps/example-flow — demonstrates `compileFlow` from `@agentskit/runtime`.
+ *
+ * Reads `flow.yaml`, compiles it against a `FlowRegistry`, runs the
+ * resulting DAG with a JSONL durable step log, and prints the rendered
+ * markdown. Stop the process mid-run, re-run, and the durable log
+ * short-circuits the work that already finished.
+ *
+ * Usage:
+ *   pnpm --filter @agentskit/example-flow dev
+ *   pnpm --filter @agentskit/example-flow dev -- --reset   # drop log
+ */
+
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { parse } from 'yaml'
+import {
+  compileFlow,
+  createFileStepLog,
+  type FlowDefinition,
+  type FlowRegistry,
+} from '@agentskit/runtime'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+const FLOW_PATH = resolve(repoRoot, 'flow.yaml')
+const STORE_PATH = resolve(repoRoot, '.agentskit/flow.jsonl')
+
+type StarsArgs = { owner: string; repo: string }
+type StarsResult = { owner: string; repo: string; stars: number }
+
+const registry: FlowRegistry = {
+  'github.stars': async ({ with: w }) => {
+    const args = w as StarsArgs
+    const url = `https://api.github.com/repos/${args.owner}/${args.repo}`
+    const response = await fetch(url, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        'user-agent': 'agentskit-example-flow',
+        ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+      },
+    })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(`github ${response.status} for ${url}: ${body.slice(0, 200)}`)
+    }
+    const json = (await response.json()) as { stargazers_count?: number }
+    const result: StarsResult = {
+      owner: args.owner,
+      repo: args.repo,
+      stars: typeof json.stargazers_count === 'number' ? json.stargazers_count : 0,
+    }
+    process.stderr.write(`  ★ ${args.owner}/${args.repo} → ${result.stars.toLocaleString()}\n`)
+    return result
+  },
+
+  'math.sum': ({ deps }) => {
+    let total = 0
+    for (const value of Object.values(deps)) {
+      if (value && typeof value === 'object' && 'stars' in value) {
+        total += (value as { stars: number }).stars
+      }
+    }
+    return total
+  },
+
+  'render.markdown': ({ deps }) => {
+    const lines: string[] = ['# Stargazers digest', '']
+    for (const [id, value] of Object.entries(deps)) {
+      if (!value || typeof value !== 'object' || !('stars' in value)) continue
+      const r = value as StarsResult
+      lines.push(`- **${r.owner}/${r.repo}** — ${r.stars.toLocaleString()} ★ (node \`${id}\`)`)
+    }
+    const total = Object.values(deps).find(v => typeof v === 'number') as number | undefined
+    if (typeof total === 'number') {
+      lines.push('', `_Total across the listed repos: **${total.toLocaleString()}** ★_`)
+    }
+    return lines.join('\n')
+  },
+}
+
+async function main(): Promise<void> {
+  const reset = process.argv.includes('--reset')
+  const yamlSource = await readFile(FLOW_PATH, 'utf8')
+  const definition = parse(yamlSource) as FlowDefinition
+
+  const store = await createFileStepLog(STORE_PATH)
+  const compiled = compileFlow({ definition, registry })
+
+  const runId = process.env.RUN_ID ?? 'demo-run'
+  if (reset) await store.clear?.(runId)
+
+  process.stderr.write(`▸ flow=${definition.name} runId=${runId} order=${compiled.order.join(' → ')}\n`)
+  process.stderr.write(`  store=${STORE_PATH}${reset ? ' (cleared)' : ''}\n\n`)
+
+  const t0 = Date.now()
+  const outputs = await compiled.run(undefined, {
+    runId,
+    store,
+    onEvent: event => {
+      if (event.type === 'node:start') process.stderr.write(`▸ ${event.nodeId} start\n`)
+      if (event.type === 'node:success') process.stderr.write(`✓ ${event.nodeId} done\n`)
+      if (event.type === 'node:failure') process.stderr.write(`✗ ${event.nodeId}: ${event.error}\n`)
+    },
+  })
+  const elapsed = Date.now() - t0
+
+  process.stderr.write(`\n— done in ${elapsed}ms —\n\n`)
+  process.stdout.write(`${outputs['render'] as string}\n`)
+}
+
+main().catch(err => {
+  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/apps/example-flow/tsconfig.json
+++ b/apps/example-flow/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/example-flow:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      yaml:
+        specifier: ^2.6.0
+        version: 2.8.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/example-ink:
     dependencies:
       '@agentskit/core':


### PR DESCRIPTION
## Summary

Closes J/P0 #622 — runnable example app that exercises \`compileFlow\` end-to-end.

## What it does

\`flow.yaml\` describes a 4-node DAG:

\`\`\`
fetch-react ──┐
              ├── total ──┐
fetch-vue ────┘           ├── render
                          │
fetch-react, fetch-vue ───┘
\`\`\`

\`src/index.ts\` registers three handlers (\`github.stars\`, \`math.sum\`, \`render.markdown\`), compiles the YAML, runs against a JSONL durable step log, and prints a rendered markdown summary.

\`\`\`
▸ flow=octo-stars-digest runId=demo-run order=fetch-react → fetch-vue → total → render
▸ fetch-react start
  ★ facebook/react → 244,800
✓ fetch-react done
...

# Stargazers digest

- **facebook/react** — 244,800 ★ (node \`fetch-react\`)
- **vuejs/core** — 53,583 ★ (node \`fetch-vue\`)

_Total across the listed repos: **298,383** ★_
\`\`\`

Re-running with the same \`RUN_ID\` skips replayed nodes — Ctrl-C mid-run + re-launch demonstrates durable resume.

## Files

- \`apps/example-flow/flow.yaml\` — visual DAG.
- \`apps/example-flow/src/index.ts\` — registry + driver.
- \`apps/example-flow/README.md\` — usage + auth (\`GITHUB_TOKEN\`) + reset.
- \`apps/example-flow/package.json\` + \`tsconfig.json\` + \`.gitignore\`.
- \`.changeset/config.json\` — added to ignore list (private app).

## Test plan

- [x] \`pnpm --filter @agentskit/example-flow lint\` — clean
- [x] \`pnpm --filter @agentskit/example-flow dev\` — first run executes 4 nodes
- [x] Second run with same \`RUN_ID\` short-circuits (no \`★\` lines printed; replayed events fire only)
- [x] \`node scripts/check-no-bare-throw.mjs\` + \`node scripts/check-for-agents-coverage.mjs\` — both clean

## Companion

PR #738 added the K/P1 \`flow\` scaffold type that emits the same shape as this app (the scaffolded \`FlowRegistry\` is a subset of what \`apps/example-flow\` ships).

Refs: epic #562.