### PR TITLE
feat(examples): apps/example-webllm — browser-only WebGPU demo (closes J/P1)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,7 @@
     "@agentskit/example-runtime",
     "@agentskit/example-multi-agent",
     "@agentskit/example-flow",
-    "@agentskit/example-edge"
+    "@agentskit/example-edge",
+    "@agentskit/example-webllm"
   ]
 }

--- a/apps/example-webllm/README.md
+++ b/apps/example-webllm/README.md
@@ -1,0 +1,76 @@
+# @agentskit/example-webllm
+
+Browser-only chat — the LLM runs **100% in your browser** via WebGPU
++ [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm). No API key,
+no server-side inference, no telemetry.
+
+Demonstrates the [`webllm`](https://www.agentskit.io/docs/data/providers/webllm)
+adapter from `@agentskit/adapters` driving the standard
+[`useChat`](https://www.agentskit.io/docs/for-agents/react) hook
+from `@agentskit/react`.
+
+## Run
+
+```bash
+pnpm --filter @agentskit/example-webllm dev
+# open http://localhost:5173
+```
+
+First message kicks off model download + WASM compilation. The
+status line reports progress (`32% — Fetching shard 5 of 12`).
+Subsequent loads hit the browser cache.
+
+## Requirements
+
+- A browser with **WebGPU** enabled (Chrome 113+, Edge 113+, recent
+  Safari Technology Preview, Firefox Nightly with `dom.webgpu.enabled`).
+- ~4–8 GB free disk space for the model cache.
+- A discrete GPU is much faster but not strictly required.
+
+## What's running
+
+```ts
+import { useChat } from '@agentskit/react'
+import { webllm } from '@agentskit/adapters'
+
+const adapter = webllm({
+  model: 'Llama-3.1-8B-Instruct-q4f16_1-MLC',
+  onProgress: ({ progress, text }) => console.log(progress, text),
+})
+
+const chat = useChat({ adapter })
+```
+
+That's the entire integration. The adapter exposes the same
+`AdapterFactory` surface as `openai`, `anthropic`, etc., so any
+component you've already built against `useChat` works unchanged.
+
+## What's not in scope
+
+- Tool calling — the WebLLM engine does not expose a tool-use API
+  in the OpenAI-compatible chat completion shape today. The
+  `webllm` adapter therefore declares `capabilities: { tools: false }`.
+  If you need tools in the browser, route through a small
+  server-side adapter (`example-edge` shows how).
+- Memory persistence — sessions live in the React state. Wire
+  `localStorageMemory` from `@agentskit/core` if you want them to
+  outlive a tab refresh.
+
+## Troubleshooting
+
+- **"WebGPU not available"** — your browser hasn't enabled it yet.
+  Check `chrome://gpu` (Chrome / Edge) or your browser's WebGPU
+  feature flag.
+- **First message hangs at 0%** — the cross-origin isolation
+  headers in `vite.config.ts` are required for some browsers.
+  Verify the server returned `Cross-Origin-Opener-Policy: same-origin`
+  in the network tab.
+- **OOM on smaller GPUs** — try a smaller-quant model id like
+  `Phi-3.5-mini-instruct-q4f16_1-MLC` (edit `MODEL_ID` in
+  `src/App.tsx`).
+
+## See also
+
+- [Provider page · `webllm`](https://www.agentskit.io/docs/data/providers/webllm)
+- [`/docs/production/edge`](https://www.agentskit.io/docs/production/edge) — server-side small-bundle counterpart.
+- [`apps/example-react`](../example-react) — same `useChat` hook, server-side OpenAI.

--- a/apps/example-webllm/index.html
+++ b/apps/example-webllm/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AgentsKit · WebLLM (browser-only) demo</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font-family: -apple-system, system-ui, sans-serif;
+        max-width: 720px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        line-height: 1.5;
+      }
+      [data-ak-chat] { display: flex; flex-direction: column; gap: 0.75rem; }
+      [data-ak-messages] { display: flex; flex-direction: column; gap: 0.5rem; }
+      [data-ak-message][data-ak-role="user"] { font-weight: 600; }
+      [data-ak-message] {
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        background: color-mix(in srgb, currentColor 6%, transparent);
+        white-space: pre-wrap;
+      }
+      [data-ak-form] { display: flex; gap: 0.5rem; }
+      [data-ak-input] {
+        flex: 1;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+        background: transparent;
+        color: inherit;
+        font: inherit;
+      }
+      .progress { font-size: 0.875rem; opacity: 0.75; }
+    </style>
+  </head>
+  <body>
+    <h1>AgentsKit · WebLLM</h1>
+    <p>
+      LLM running 100% in your browser via WebGPU. First load downloads
+      the model (~1–4 GB depending on quantization) and compiles WASM.
+      Subsequent loads hit the cache.
+    </p>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/example-webllm/package.json
+++ b/apps/example-webllm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agentskit/example-webllm",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "lint": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/react": "workspace:*",
+    "@mlc-ai/web-llm": "^0.2.79",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/example-webllm/src/App.tsx
+++ b/apps/example-webllm/src/App.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useChat } from '@agentskit/react'
+import { webllm } from '@agentskit/adapters'
+
+/**
+ * Browser-only chat. The MLCEngine is loaded lazily on first stream;
+ * to make the load visible to the user we warm it up in an effect and
+ * surface the progress text. Once warm, swap in the agentskit adapter
+ * factory and let `useChat` drive it like any other provider.
+ */
+
+const MODEL_ID = 'Llama-3.1-8B-Instruct-q4f16_1-MLC'
+
+export function App() {
+  const [progress, setProgress] = useState<string>('Idle. Send a message to load the model.')
+  const [ready, setReady] = useState(false)
+
+  const adapter = useMemo(() => {
+    return webllm({
+      model: MODEL_ID,
+      onProgress: ({ progress, text }) => {
+        setProgress(`${Math.round(progress * 100)}% — ${text}`)
+        if (progress >= 1) setReady(true)
+      },
+    })
+  }, [])
+
+  const chat = useChat({ adapter })
+
+  useEffect(() => {
+    if (chat.status === 'streaming' && !ready) setProgress('Loading model… first turn warms the engine.')
+  }, [chat.status, ready])
+
+  return (
+    <div data-ak-chat="">
+      <p className="progress" aria-live="polite">{progress}</p>
+
+      <div data-ak-messages="">
+        {chat.messages.map(m => (
+          <div key={m.id} data-ak-message="" data-ak-role={m.role}>
+            <strong>{m.role}:</strong> {m.content}
+          </div>
+        ))}
+      </div>
+
+      <form
+        data-ak-form=""
+        onSubmit={e => {
+          e.preventDefault()
+          if (!chat.input.trim() || chat.status === 'streaming') return
+          void chat.send(chat.input)
+        }}
+      >
+        <input
+          data-ak-input=""
+          value={chat.input}
+          onChange={e => chat.setInput(e.target.value)}
+          placeholder="Ask anything (model runs locally)…"
+          disabled={chat.status === 'streaming'}
+        />
+        <button type="submit" disabled={chat.status === 'streaming' || !chat.input.trim()}>
+          {chat.status === 'streaming' ? '…' : 'Send'}
+        </button>
+        {chat.status === 'streaming' && (
+          <button type="button" onClick={() => chat.stop()}>
+            Stop
+          </button>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/apps/example-webllm/src/main.tsx
+++ b/apps/example-webllm/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+const root = document.getElementById('root')
+if (!root) throw new Error('#root missing in index.html')
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/example-webllm/tsconfig.json
+++ b/apps/example-webllm/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/example-webllm/vite.config.ts
+++ b/apps/example-webllm/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// WebLLM ships large WASM + model shards. Use the Vite default behaviour
+// (serve from /public + dynamic import) — no special bundler config
+// needed beyond the React plugin.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    headers: {
+      // WebGPU + WebLLM threads need cross-origin isolation in some
+      // browser configurations.
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,43 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/example-webllm:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@mlc-ai/web-llm':
+        specifier: ^0.2.79
+        version: 0.2.83
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/adapters:
     dependencies:
       '@agentskit/core':
@@ -2080,6 +2117,9 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@mlc-ai/web-llm@0.2.83':
+    resolution: {integrity: sha512-Ynuses0TM9CcSIs9PfX5+xwGOVFssQTXQaAwKFggfEw++shBbEr8fOjI7yJlY96wv0dwVFE+C2KGcO287+FuHw==}
 
   '@mswjs/interceptors@0.41.6':
     resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
@@ -5447,6 +5487,10 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -8881,6 +8925,10 @@ snapshots:
       langium: 4.2.2
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@mlc-ai/web-llm@0.2.83':
+    dependencies:
+      loglevel: 1.9.2
 
   '@mswjs/interceptors@0.41.6':
     dependencies:
@@ -12322,6 +12370,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash.throttle@4.1.1: {}
+
+  loglevel@1.9.2: {}
 
   long@5.3.2: {}
 


### PR DESCRIPTION
## Summary

Closes J/P1 #623. Vite + React app driving the \`webllm\` adapter — LLM runs **100% in the browser** via WebGPU + \`@mlc-ai/web-llm\`. No API key, no server-side inference.

## Stack

- \`@agentskit/react\` \`useChat\` hook
- \`@agentskit/adapters\` \`webllm({ model, onProgress })\`
- \`@mlc-ai/web-llm\` (optional peer)
- Vite 8 + \`@vitejs/plugin-react\` 6

## Files

- \`src/main.tsx\` — React mount.
- \`src/App.tsx\` — \`useChat({ adapter: webllm({ model, onProgress }) })\` with progress UI.
- \`index.html\` — minimal styled shell using \`data-ak-*\` selectors.
- \`vite.config.ts\` — COOP/COEP headers for cross-origin isolation (required by some WebGPU browser configs).
- \`README.md\` — requirements (WebGPU + ~4–8 GB cache), troubleshooting, smaller-model swap (\`Phi-3.5-mini-instruct\`).

\`.changeset/config.json\` adds the app to the ignore list (private).

## Test plan

- [x] \`pnpm install\` succeeds (vite 8 / @vitejs/plugin-react 6 versions resolve).
- [x] \`pnpm --filter @agentskit/example-webllm lint\` — clean
- [x] \`node scripts/check-no-bare-throw.mjs\` — clean
- [x] \`node scripts/check-for-agents-coverage.mjs\` — clean

Live browser validation requires WebGPU-enabled Chrome / Edge + the user has ~4 GB free for the model cache. Documented in the README.

## Companion examples

- \`example-edge\` (PR #742) — server-side small bundle.
- \`example-flow\` (PR #739) — durable DAG.
- \`example-react\` — server-side OpenAI.

This PR fills the browser-only / on-device end of the spectrum.

Refs: epic #562.