### PR TITLE
feat(examples): example-runtime extension — speculate + durable + topologies (J/P1)

### DIFF
--- a/apps/example-runtime/.gitignore
+++ b/apps/example-runtime/.gitignore
@@ -1,0 +1,1 @@
+.agentskit/

--- a/apps/example-runtime/README.md
+++ b/apps/example-runtime/README.md
@@ -1,0 +1,52 @@
+# @agentskit/example-runtime
+
+Headless runtime demos. No UI, no provider keys — every adapter is
+mocked so the scripts run anywhere.
+
+| Script | What it shows | Source |
+|---|---|---|
+| `pnpm dev` | Basic ReAct loop with one tool call | [`src/index.ts`](./src/index.ts) |
+| `pnpm dev:speculate` | Race two adapters; loser is aborted as soon as the winner settles | [`src/speculate.ts`](./src/speculate.ts) |
+| `pnpm dev:durable` | Step log: re-running short-circuits successful prior steps | [`src/durable.ts`](./src/durable.ts) |
+| `pnpm dev:topology` | Supervisor + swarm + blackboard topologies, three shapes back to back | [`src/topology.ts`](./src/topology.ts) |
+
+Run any of them via the workspace filter:
+
+```bash
+pnpm --filter @agentskit/example-runtime dev
+pnpm --filter @agentskit/example-runtime dev:speculate
+pnpm --filter @agentskit/example-runtime dev:durable
+pnpm --filter @agentskit/example-runtime dev:topology
+```
+
+## Durable demo: try the resume
+
+```bash
+# First run: each step takes ~800ms.
+pnpm --filter @agentskit/example-runtime dev:durable
+
+# Second run: every step replays instantly from the JSONL log.
+pnpm --filter @agentskit/example-runtime dev:durable
+
+# Wipe the log and start over:
+pnpm --filter @agentskit/example-runtime dev:durable -- --reset
+```
+
+The log lives at `apps/example-runtime/.agentskit/durable.jsonl` and
+is gitignored.
+
+## Wiring real adapters
+
+Every demo accepts the `AdapterFactory` shape. Swap the mocks for
+`openai`, `anthropic`, `vercelAI`, etc., from `@agentskit/adapters`
+and the rest of the code is unchanged. Topologies operate on
+`AgentHandle`s, which `createRuntime({ adapter, … }).run` produces
+when you adapt the result into one.
+
+## See also
+
+- [`/docs/agents/runtime`](https://www.agentskit.io/docs/agents/runtime)
+- [`/docs/agents/topologies`](https://www.agentskit.io/docs/agents/topologies)
+- [`/docs/agents/durable`](https://www.agentskit.io/docs/agents/durable)
+- [`/docs/agents/speculate`](https://www.agentskit.io/docs/agents/speculate)
+- [`apps/example-flow`](../example-flow) — the flow + durable runner counterpart.

--- a/apps/example-runtime/package.json
+++ b/apps/example-runtime/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
+    "dev:speculate": "tsx src/speculate.ts",
+    "dev:durable": "tsx src/durable.ts",
+    "dev:topology": "tsx src/topology.ts",
     "build": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },

--- a/apps/example-runtime/src/durable.ts
+++ b/apps/example-runtime/src/durable.ts
@@ -1,0 +1,55 @@
+/**
+ * durable.ts — Temporal-style step log. Each side-effect step records
+ * its result. On retry, recorded steps short-circuit; only the unfinished
+ * tail re-executes.
+ *
+ * Run once:        pnpm --filter @agentskit/example-runtime dev:durable
+ * Run again:       same command — second run replays.
+ * Wipe + retry:    pnpm --filter @agentskit/example-runtime dev:durable -- --reset
+ */
+
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createDurableRunner, createFileStepLog } from '@agentskit/runtime'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const STORE_PATH = resolve(__dirname, '../.agentskit/durable.jsonl')
+
+const reset = process.argv.includes('--reset')
+const store = await createFileStepLog(STORE_PATH)
+
+const runId = 'demo-run'
+if (reset) await store.clear?.(runId)
+
+const runner = createDurableRunner({
+  store,
+  runId,
+  onEvent: event => {
+    if (event.type === 'step:replay') process.stderr.write(`▸ ${event.stepId} replayed (cached)\n`)
+    if (event.type === 'step:start')   process.stderr.write(`▸ ${event.stepId} start\n`)
+    if (event.type === 'step:success') process.stderr.write(`✓ ${event.stepId} (${event.durationMs}ms)\n`)
+  },
+})
+
+process.stderr.write(`store=${STORE_PATH}${reset ? ' (cleared)' : ''}\n\n`)
+
+// Each call is N seconds of "work". Re-running the script re-uses
+// any successful prior step from the JSONL log.
+const research = await runner.step('research', async () => {
+  await new Promise(r => setTimeout(r, 800))
+  return { topic: 'AI safety', sources: 3 }
+})
+
+const summary = await runner.step('summarize', async () => {
+  await new Promise(r => setTimeout(r, 600))
+  return `Summary based on ${research.sources} sources about ${research.topic}.`
+})
+
+const sent = await runner.step('email', async () => {
+  await new Promise(r => setTimeout(r, 400))
+  return { to: 'team@example.com', length: summary.length }
+})
+
+process.stdout.write(`\n${summary}\n`)
+process.stderr.write(`\nemail: ${JSON.stringify(sent)}\n`)
+process.stderr.write(`Re-run the script — the three steps replay instantly from the log.\n`)

--- a/apps/example-runtime/src/speculate.ts
+++ b/apps/example-runtime/src/speculate.ts
@@ -1,0 +1,49 @@
+/**
+ * speculate.ts — race two adapters, take whichever finishes first.
+ *
+ * Run:  pnpm --filter @agentskit/example-runtime dev:speculate
+ *
+ * Mocks two adapters with deliberately different latencies + outputs.
+ * The default 'first' picker takes whatever streams to completion
+ * first; loser is aborted as soon as the winner settles.
+ */
+
+import { speculate } from '@agentskit/runtime'
+import type { AdapterFactory } from '@agentskit/core'
+
+function fakeAdapter(name: string, delayMs: number, text: string): AdapterFactory {
+  return {
+    createSource: () => {
+      let aborted = false
+      return {
+        stream: async function* () {
+          for (const word of text.split(' ')) {
+            if (aborted) return
+            await new Promise(r => setTimeout(r, delayMs))
+            yield { type: 'text' as const, content: word + ' ' }
+          }
+          yield { type: 'done' as const }
+        },
+        abort: () => {
+          aborted = true
+          process.stderr.write(`  ✗ ${name} aborted (lost the race)\n`)
+        },
+      }
+    },
+  }
+}
+
+const result = await speculate({
+  candidates: [
+    { id: 'fast-cheap', adapter: fakeAdapter('fast-cheap', 30, 'Fast model output landed first.') },
+    { id: 'slow-deep',  adapter: fakeAdapter('slow-deep',  70, 'Slower more thoughtful response that loses the race.') },
+  ],
+  request: { messages: [], context: undefined } as never,
+})
+
+process.stderr.write(`\n— winner: ${result.winner.id} (${result.winner.latencyMs}ms) —\n`)
+process.stdout.write(`${result.winner.text.trim()}\n`)
+process.stderr.write(`\nLoser results:\n`)
+for (const loser of result.losers) {
+  process.stderr.write(`  ${loser.id}: ${loser.aborted ? 'aborted' : 'finished'} after ${loser.latencyMs}ms\n`)
+}

--- a/apps/example-runtime/src/topology.ts
+++ b/apps/example-runtime/src/topology.ts
@@ -1,0 +1,71 @@
+/**
+ * topology.ts — supervisor + workers + swarm + blackboard.
+ *
+ * Run:  pnpm --filter @agentskit/example-runtime dev:topology
+ *
+ * Three multi-agent shapes, each driven by mock AgentHandles so the
+ * example runs without API keys. Same topology factories accept any
+ * runtime — wrap createRuntime({ adapter, ... }) handles for the real
+ * thing.
+ */
+
+import { blackboard, supervisor, swarm } from '@agentskit/runtime'
+import type { AgentHandle } from '@agentskit/runtime'
+
+function mock(name: string, reply: (task: string) => string): AgentHandle {
+  return {
+    name,
+    async run(task) {
+      await new Promise(r => setTimeout(r, 50))
+      return reply(task)
+    },
+  }
+}
+
+// --- supervisor: planner delegates to workers, then synthesises ----
+const supervisorAgent = supervisor({
+  supervisor: mock('lead', t => `Synthesised answer from worker outputs:\n${t}`),
+  workers: [
+    mock('research', t => `Research note: ${t.slice(0, 40)}…`),
+    mock('write',    t => `Drafted summary for: ${t.slice(0, 40)}…`),
+  ],
+  maxRounds: 1,
+  onEvent: e => process.stderr.write(`  [supervisor:${e.phase}] ${e.agent ?? '-'}\n`),
+})
+
+process.stderr.write('▸ supervisor topology\n')
+const supRes = await supervisorAgent.run('Quantum computing in 100 words')
+process.stdout.write(`\n${supRes}\n`)
+
+// --- swarm: every member runs in parallel, merger picks output -----
+const swarmAgent = swarm({
+  members: [
+    mock('claude', () => 'Long thoughtful answer with three points.'),
+    mock('gpt',    () => 'Short answer.'),
+    mock('local',  () => 'Medium-length local answer.'),
+  ],
+  merge: results => {
+    // Take the longest response.
+    return results.reduce((best, r) => (r.output.length > best.length ? r.output : best), '')
+  },
+  onEvent: e => process.stderr.write(`  [swarm:${e.phase}] ${e.agent ?? '-'}\n`),
+})
+
+process.stderr.write('\n▸ swarm topology\n')
+const swarmRes = await swarmAgent.run('What is quantum computing?')
+process.stdout.write(`\n${swarmRes}\n`)
+
+// --- blackboard: agents iterate on a shared scratchpad -------------
+const blackboardAgent = blackboard({
+  agents: [
+    mock('outline', () => '# Outline\n- intro\n- mechanics\n- applications'),
+    mock('drafter', t => t.includes('mechanics') ? '## Mechanics\nQubits use superposition…' : 'pending'),
+    mock('editor',  () => 'Editor pass: tightened mechanics paragraph.'),
+  ],
+  maxIterations: 2,
+  onEvent: e => process.stderr.write(`  [blackboard:${e.phase}] ${e.agent ?? '-'}\n`),
+})
+
+process.stderr.write('\n▸ blackboard topology\n')
+const bbRes = await blackboardAgent.run('Write a blog post about quantum computing')
+process.stdout.write(`\n${bbRes}\n`)


### PR DESCRIPTION
## Summary

Closes J/P1 #625. Extends the existing \`example-runtime\` with three new headless demo scripts covering the runtime primitives that previously only had docs coverage.

## New scripts

| Command | Source | What it demonstrates |
|---|---|---|
| \`dev:speculate\` | \`src/speculate.ts\` | Two mock adapters race; loser aborts when winner settles. \`pick: 'first'\`. |
| \`dev:durable\` | \`src/durable.ts\` | \`createDurableRunner\` + JSONL \`createFileStepLog\`. Three side-effecting steps; re-runs replay from log. \`--reset\` wipes. |
| \`dev:topology\` | \`src/topology.ts\` | \`supervisor\` + \`swarm\` + \`blackboard\` back-to-back, all driven by mock \`AgentHandle\`s. |

## Test plan

- [x] \`pnpm --filter @agentskit/example-runtime lint\` — clean
- [x] \`dev:speculate\` — winner reported with abort log for loser
- [x] \`dev:durable\` first run executes ~1.8s; second run replays instantly
- [x] \`dev:topology\` — three topologies print their event traces + final synthesis
- [x] CI gates clean

## Wiring real adapters

Every demo uses the same \`AdapterFactory\` / \`AgentHandle\` shape — swap the inline mocks for \`openai\`, \`anthropic\`, \`vercelAI\`, etc. from \`@agentskit/adapters\` and the rest is unchanged. Documented in the rewritten \`README.md\`.

## J section status after this PR

- ✅ J/P0 #622 example-flow
- ✅ J/P1 #623 example-webllm
- ✅ J/P1 #624 example-edge
- ✅ J/P1 #625 example-runtime (this PR)
- 🔵 J/P2 #626 #627 #628 — refresh-runtime/ink, embedded-pattern, e2e gate

Refs: epic #562.