### PR TITLE
chore(ci): gate every example app's lint + build (closes J/P2 #628)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,12 @@ jobs:
 
       - run: pnpm --filter "./packages/*" build
 
+      - name: Lint every example app
+        run: pnpm --filter "./apps/example-*" lint
+
+      - name: Build every example app
+        run: pnpm --filter "./apps/example-*" build
+
       - run: pnpm exec playwright test
 
       - if: always()


### PR DESCRIPTION
Adds lint + build steps for every `apps/example-*` to e2e.yml after the package build step. Catches regressions on every PR. Existing Playwright run unchanged. Refs epic #562.