### PR TITLE
chore(audit): E enrichments — flow registry-key listing + http JSON guard

### DIFF
--- a/.changeset/flow-error-enrichments.md
+++ b/.changeset/flow-error-enrichments.md
@@ -1,0 +1,22 @@
+---
+'@agentskit/runtime': patch
+'@agentskit/tools': patch
+---
+
+chore(audit): E enrichments — flow registry-key listing + http JSON-content-type guard.
+
+- **E/P1 #586** `compileFlow` now lists every registered handler key
+  in the error message + hint when a node references a missing one.
+  Previously: `"handler 'x' missing for node 'y'"`. Now: that same
+  message plus `Available handlers: a, b, c. Add "x" …`. Same change
+  applies to the `validateFlow` failure path — bare `Error` →
+  `RuntimeError(AK_RUNTIME_INVALID_INPUT)` with the per-issue list
+  inline.
+- **E/P2 #589** `httpJson` no longer silently coerces non-JSON to
+  string when the server advertised `application/json`. If the
+  server says JSON but the body fails to parse, raise
+  `ToolError(AK_TOOL_EXEC_FAILED)` with the body preview + cause.
+  Other content-types fall back to the raw text body (historical
+  behaviour preserved).
+- Bare-throw gate allowlist: `packages/runtime/src/flow.ts` removed
+  (entire file is now typed).

--- a/packages/runtime/src/flow.ts
+++ b/packages/runtime/src/flow.ts
@@ -12,6 +12,7 @@
  * a handler, not in YAML.
  */
 
+import { ErrorCodes, RuntimeError } from '@agentskit/core'
 import { createDurableRunner, createInMemoryStepLog, type DurableRunner, type StepLogStore } from './durable'
 
 export interface FlowNode {
@@ -178,9 +179,11 @@ export function compileFlow<TInput = unknown>(
   const { definition, registry } = options
   const result = validateFlow(definition, registry as FlowRegistry)
   if (!result.ok) {
-    throw new Error(
-      `invalid flow "${definition.name}":\n${result.issues.map(i => `  - ${i.message}`).join('\n')}`,
-    )
+    throw new RuntimeError({
+      code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+      message: `invalid flow "${definition.name}":\n${result.issues.map(i => `  - ${i.message}`).join('\n')}`,
+      hint: 'validateFlow returned issues; fix each one (duplicate ids, missing handlers, unknown deps, cycles).',
+    })
   }
   const byId = new Map(definition.nodes.map(n => [n.id, n] as const))
 
@@ -202,7 +205,15 @@ export function compileFlow<TInput = unknown>(
     for (const id of result.order) {
       const node = byId.get(id)!
       const handler = registry[node.run]
-      if (!handler) throw new Error(`handler "${node.run}" missing for node "${id}"`)
+      if (!handler) {
+        const available = Object.keys(registry).sort()
+        const list = available.length > 0 ? available.join(', ') : '(empty registry)'
+        throw new RuntimeError({
+          code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+          message: `handler "${node.run}" missing for node "${id}"`,
+          hint: `Available handlers: ${list}. Add "${node.run}" to the FlowRegistry, or rename the node's run: field.`,
+        })
+      }
       const stepId = `node:${id}`
       runOptions.onEvent?.({ type: 'node:start', flow: definition.name, runId, nodeId: id })
       try {

--- a/packages/tools/src/integrations/http.ts
+++ b/packages/tools/src/integrations/http.ts
@@ -65,7 +65,8 @@ export async function httpJson<TResult = unknown>(
       signal: controller.signal,
     })
     const text = await response.text()
-    const parsed = text.length > 0 ? safeParse(text) : undefined
+    const contentType = response.headers.get('content-type') ?? ''
+    const parsed = text.length > 0 ? safeParse(text, contentType, url.toString()) : undefined
     if (!response.ok) {
       throw new ToolError({
         code: ErrorCodes.AK_TOOL_EXEC_FAILED,
@@ -79,10 +80,22 @@ export async function httpJson<TResult = unknown>(
   }
 }
 
-function safeParse(text: string): unknown {
+function safeParse(text: string, contentType: string, url: string): unknown {
   try {
     return JSON.parse(text) as unknown
-  } catch {
+  } catch (err) {
+    // If the server advertised JSON but we couldn't parse it, that's a
+    // contract violation — surface it as a typed error instead of
+    // silently coercing to a string. Any other content-type falls
+    // back to the raw text body (the historical behaviour).
+    if (/\bjson\b/i.test(contentType)) {
+      throw new ToolError({
+        code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+        message: `Invalid JSON from ${url} (content-type: ${contentType})`,
+        hint: `Body preview: ${text.slice(0, 200)}`,
+        cause: err,
+      })
+    }
     return text
   }
 }

--- a/scripts/check-no-bare-throw.mjs
+++ b/scripts/check-no-bare-throw.mjs
@@ -42,10 +42,6 @@ const ALLOW_FILES = new Set([
   'packages/rag/src/loaders.ts',
   'packages/rag/src/rerankers/jina.ts',
   'packages/rag/src/rerankers/voyage.ts',
-  // Flow throws live in the F3 PR landing line; primary errors are
-  // already typed (compileFlow), the remaining bare throws are
-  // internal step-replay signals.
-  'packages/runtime/src/flow.ts',
 ])
 
 /**


### PR DESCRIPTION
Closes E/P1 #586 + E/P2 #589. compileFlow missing-handler hint now lists registered keys; httpJson refuses silent JSON parse fallback when server advertised JSON. Bare-throw gate allowlist drops flow.ts (typed). Refs epic #562.