### PR TITLE
feat(templates): embedder + browser-adapter + conditional deps (K/P2)

### DIFF
--- a/.changeset/templates-extra-blueprints.md
+++ b/.changeset/templates-extra-blueprints.md
@@ -1,0 +1,26 @@
+---
+'@agentskit/templates': minor
+---
+
+feat(templates): embedder + browser-adapter scaffolds + conditional package.json deps.
+
+Closes K/P2 #631 + #632 + #633.
+
+Two new `ScaffoldType`s:
+
+- `embedder` — emits an `EmbedFn` factory (OpenAI-compatible HTTP
+  shape by default), pair with any vector memory backend.
+- `browser-adapter` — emits an `AdapterFactory` skeleton matching
+  the `webllm` shape (lazy `loadEngine`, OpenAI-style chunk
+  iteration, `capabilities: { tools: false }`).
+
+`generatePackageJson` now picks dependencies per scaffold type:
+
+| Type | Adds (alongside `@agentskit/core`) |
+|---|---|
+| `tool` / `skill` | — |
+| `adapter` / `embedder` / `browser-adapter` | `@agentskit/adapters` |
+| `memory-vector` / `memory-chat` | `@agentskit/memory` |
+| `flow` | `@agentskit/runtime` |
+
+Templates package: 24 → 29 tests. lint clean. Both CI gates green.

--- a/packages/templates/src/blueprints/embedder.ts
+++ b/packages/templates/src/blueprints/embedder.ts
@@ -1,0 +1,144 @@
+import { camelCase, pascalCase } from './utils'
+
+/**
+ * Embedder blueprint — produces an `EmbedFn` factory matching the
+ * @agentskit/core contract. Pair with a vector memory backend
+ * (createRAG, fileVectorMemory, pgvector, etc.).
+ */
+export function generateEmbedderSource(name: string): string {
+  return `import type { EmbedFn } from '@agentskit/core'
+
+export interface ${pascalCase(name)}EmbedderConfig {
+  apiKey: string
+  model?: string
+  baseUrl?: string
+}
+
+export function ${camelCase(name)}Embedder(config: ${pascalCase(name)}EmbedderConfig): EmbedFn {
+  const model = config.model ?? 'text-embedding-3-small'
+  const baseUrl = (config.baseUrl ?? 'https://api.example.com').replace(/\\/$/, '')
+
+  return async (text: string): Promise<number[]> => {
+    const url = \`\${baseUrl}/v1/embeddings\`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: \`Bearer \${config.apiKey}\`,
+      },
+      body: JSON.stringify({ model, input: text }),
+    })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(\`embedder \${model} HTTP \${response.status}: \${body.slice(0, 200)}\`)
+    }
+    const json = (await response.json()) as { data?: Array<{ embedding: number[] }> }
+    const first = json.data?.[0]?.embedding
+    if (!first) throw new Error(\`embedder \${model}: response missing data[0].embedding\`)
+    return first
+  }
+}
+`
+}
+
+export function generateEmbedderTest(name: string): string {
+  return `import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ${camelCase(name)}Embedder } from '../src/index'
+
+const realFetch = globalThis.fetch
+afterEach(() => { globalThis.fetch = realFetch })
+
+describe('${name}Embedder', () => {
+  it('returns embedding vector on success', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), { status: 200 }),
+    ) as unknown as typeof fetch
+    const embed = ${camelCase(name)}Embedder({ apiKey: 'k' })
+    expect(await embed('hi')).toEqual([0.1, 0.2])
+  })
+
+  it('throws on non-2xx', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as unknown as typeof fetch
+    const embed = ${camelCase(name)}Embedder({ apiKey: 'k' })
+    await expect(embed('hi')).rejects.toThrow(/HTTP 500/)
+  })
+})
+`
+}
+
+/**
+ * Browser-only / WebGPU adapter blueprint — same shape as the
+ * `webllm` adapter that ships in @agentskit/adapters. Caller
+ * provides an async `getEngine()` that resolves a model engine
+ * lazily (model download + WASM compile happen on first stream).
+ */
+export function generateBrowserAdapterSource(name: string): string {
+  return `import type { AdapterFactory, StreamChunk } from '@agentskit/core'
+
+export interface ${pascalCase(name)}EngineLike {
+  reload(model: string): Promise<void>
+  chat: {
+    completions: {
+      create(params: {
+        messages: Array<{ role: string; content: string }>
+        stream: true
+      }): AsyncIterable<{ choices: Array<{ delta?: { content?: string } }> }>
+    }
+  }
+}
+
+export interface ${pascalCase(name)}Config {
+  /** Browser-side model id. */
+  model: string
+  /** Pre-loaded engine. If omitted, the adapter dynamically imports. */
+  engine?: ${pascalCase(name)}EngineLike
+  /** Progress callback while the engine loads. */
+  onProgress?: (info: { progress: number; text: string }) => void
+}
+
+let cached: Promise<${pascalCase(name)}EngineLike> | null = null
+
+async function loadEngine(config: ${pascalCase(name)}Config): Promise<${pascalCase(name)}EngineLike> {
+  if (config.engine) return config.engine
+  if (cached) return cached
+  cached = (async () => {
+    // TODO: replace this dynamic import with the real engine loader,
+    // e.g. \`await import('@mlc-ai/web-llm')\` for MLC.
+    throw new Error('${name} engine loader not implemented')
+  })()
+  return cached
+}
+
+export function ${camelCase(name)}(config: ${pascalCase(name)}Config): AdapterFactory {
+  return {
+    capabilities: { tools: false },
+    createSource: (request) => {
+      let aborted = false
+      return {
+        stream: async function* (): AsyncIterableIterator<StreamChunk> {
+          try {
+            const engine = await loadEngine(config)
+            const messages = request.messages.map(m => ({
+              role: String(m.role),
+              content: typeof m.content === 'string' ? m.content : '',
+            }))
+            const iter = engine.chat.completions.create({ messages, stream: true })
+            for await (const chunk of iter) {
+              if (aborted) return
+              const delta = chunk.choices?.[0]?.delta?.content
+              if (delta) yield { type: 'text', content: delta }
+            }
+            yield { type: 'done' }
+          } catch (err) {
+            yield { type: 'error', content: err instanceof Error ? err.message : String(err) }
+          }
+        },
+        abort: () => {
+          aborted = true
+        },
+      }
+    },
+  }
+}
+`
+}

--- a/packages/templates/src/blueprints/index.ts
+++ b/packages/templates/src/blueprints/index.ts
@@ -14,5 +14,10 @@ export {
   generateFlowYaml,
   generateFlowReadme,
 } from './flow'
+export {
+  generateEmbedderSource,
+  generateEmbedderTest,
+  generateBrowserAdapterSource,
+} from './embedder'
 export { generateReadme } from './readme'
 export { camelCase, pascalCase, packageName } from './utils'

--- a/packages/templates/src/blueprints/package-json.ts
+++ b/packages/templates/src/blueprints/package-json.ts
@@ -1,7 +1,25 @@
-import type { ScaffoldConfig } from '../scaffold'
+import type { ScaffoldConfig, ScaffoldType } from '../scaffold'
 import { packageName } from './utils'
 
+/**
+ * Per-scaffold-type runtime dependency set. Every package depends on
+ * `@agentskit/core`; tool/skill scaffolds need only that.
+ * Adapter / embedder / browser-adapter pull in the adapters package.
+ * Memory / flow / runtime-adjacent scaffolds pull the runtime.
+ */
+const EXTRA_DEPS: Partial<Record<ScaffoldType, Record<string, string>>> = {
+  adapter: { '@agentskit/adapters': '*' },
+  embedder: { '@agentskit/adapters': '*' },
+  'browser-adapter': { '@agentskit/adapters': '*' },
+  'memory-vector': { '@agentskit/memory': '*' },
+  'memory-chat': { '@agentskit/memory': '*' },
+  flow: { '@agentskit/runtime': '*' },
+}
+
 export function generatePackageJson(config: ScaffoldConfig): string {
+  const baseDeps: Record<string, string> = { '@agentskit/core': '*' }
+  const extra = EXTRA_DEPS[config.type] ?? {}
+
   return JSON.stringify({
     name: packageName(config.name),
     version: '0.1.0',
@@ -25,7 +43,8 @@ export function generatePackageJson(config: ScaffoldConfig): string {
       lint: 'tsc --noEmit',
     },
     dependencies: {
-      '@agentskit/core': '*',
+      ...baseDeps,
+      ...extra,
     },
     devDependencies: {
       tsup: '^8.5.0',

--- a/packages/templates/src/scaffold.ts
+++ b/packages/templates/src/scaffold.ts
@@ -17,6 +17,9 @@ import {
   generateFlowTest,
   generateFlowYaml,
   generateFlowReadme,
+  generateEmbedderSource,
+  generateEmbedderTest,
+  generateBrowserAdapterSource,
   generateReadme,
 } from './blueprints'
 
@@ -27,6 +30,8 @@ export type ScaffoldType =
   | 'memory-vector'
   | 'memory-chat'
   | 'flow'
+  | 'embedder'
+  | 'browser-adapter'
 
 export interface ScaffoldConfig {
   type: ScaffoldType
@@ -54,6 +59,8 @@ const sourceGenerators: Record<ScaffoldType, (name: string) => string> = {
   'memory-vector': generateVectorMemorySource,
   'memory-chat': generateChatMemorySource,
   flow: generateFlowSource,
+  embedder: generateEmbedderSource,
+  'browser-adapter': generateBrowserAdapterSource,
 }
 
 const testGenerators: Record<ScaffoldType, (name: string) => string> = {
@@ -63,6 +70,8 @@ const testGenerators: Record<ScaffoldType, (name: string) => string> = {
   'memory-vector': generateVectorMemoryTest,
   'memory-chat': placeholderTest,
   flow: generateFlowTest,
+  embedder: generateEmbedderTest,
+  'browser-adapter': placeholderTest,
 }
 
 export async function scaffold(config: ScaffoldConfig): Promise<string[]> {

--- a/packages/templates/tests/scaffold.test.ts
+++ b/packages/templates/tests/scaffold.test.ts
@@ -118,4 +118,43 @@ describe('scaffold', () => {
     expect(test).toContain('compileFlow')
     expect(test).toContain('@agentskit/runtime')
   })
+
+  it('scaffolds an embedder package', async () => {
+    await scaffold({ type: 'embedder', name: 'voyage-mini', dir })
+    const src = await readFile(join(dir, 'voyage-mini', 'src', 'index.ts'), 'utf8')
+    expect(src).toContain('EmbedFn')
+    expect(src).toContain('VoyageMiniEmbedderConfig')
+    expect(src).toContain('voyageMiniEmbedder')
+
+    const pkg = JSON.parse(await readFile(join(dir, 'voyage-mini', 'package.json'), 'utf8'))
+    expect(pkg.dependencies['@agentskit/adapters']).toBe('*')
+  })
+
+  it('scaffolds a browser-adapter package', async () => {
+    await scaffold({ type: 'browser-adapter', name: 'mlc-mini', dir })
+    const src = await readFile(join(dir, 'mlc-mini', 'src', 'index.ts'), 'utf8')
+    expect(src).toContain('AdapterFactory')
+    expect(src).toContain('MlcMiniConfig')
+    expect(src).toContain("capabilities: { tools: false }")
+    expect(src).toContain('chat.completions.create')
+  })
+
+  it('memory-vector scaffold gets @agentskit/memory dependency', async () => {
+    await scaffold({ type: 'memory-vector', name: 'fast-store', dir })
+    const pkg = JSON.parse(await readFile(join(dir, 'fast-store', 'package.json'), 'utf8'))
+    expect(pkg.dependencies['@agentskit/memory']).toBe('*')
+    expect(pkg.dependencies['@agentskit/core']).toBe('*')
+  })
+
+  it('flow scaffold gets @agentskit/runtime dependency', async () => {
+    await scaffold({ type: 'flow', name: 'nightly-2', dir })
+    const pkg = JSON.parse(await readFile(join(dir, 'nightly-2', 'package.json'), 'utf8'))
+    expect(pkg.dependencies['@agentskit/runtime']).toBe('*')
+  })
+
+  it('plain tool scaffold gets only @agentskit/core', async () => {
+    await scaffold({ type: 'tool', name: 'plain-tool', dir })
+    const pkg = JSON.parse(await readFile(join(dir, 'plain-tool', 'package.json'), 'utf8'))
+    expect(Object.keys(pkg.dependencies)).toEqual(['@agentskit/core'])
+  })
 })


### PR DESCRIPTION
Closes K/P2 #631 + #632 + #633. Two new scaffold types (embedder, browser-adapter); package.json deps now picked per type. Templates: 24 → 29 tests. Refs epic #562.