### PR TITLE
feat(examples): apps/example-embedded — VS Code task + Raycast script (closes J/P2 #627)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
     "@agentskit/example-multi-agent",
     "@agentskit/example-flow",
     "@agentskit/example-edge",
-    "@agentskit/example-webllm"
+    "@agentskit/example-webllm",
+    "@agentskit/example-embedded"
   ]
 }

--- a/apps/example-embedded/README.md
+++ b/apps/example-embedded/README.md
@@ -1,0 +1,79 @@
+# @agentskit/example-embedded
+
+Same agent runs from anywhere. Three host integrations of the
+*identical* runtime:
+
+| Host | Wrapper | Try it |
+|---|---|---|
+| Node CLI | `src/index.ts` | `pnpm --filter @agentskit/example-embedded dev "Why is the sky blue?"` |
+| Raycast Script Command | `raycast/agentskit-ask.ts` | Copy into `~/.config/raycast/scripts/agentskit/`, install, type "Ask AgentsKit" in Raycast. |
+| VS Code Task | `vscode/tasks.json` | Copy into `.vscode/tasks.json` (or merge), then `Cmd+Shift+P → Tasks: Run Task → AgentsKit · Ask`. |
+
+All three wrap the same `createRuntime({ adapter: openai({...}) })`
+shape — the difference is just how the host invokes it.
+
+## Run from Node
+
+```bash
+# Demo fallback (no key required):
+pnpm --filter @agentskit/example-embedded dev "Hello"
+
+# Real provider:
+OPENAI_API_KEY=sk-... pnpm --filter @agentskit/example-embedded dev "Explain JIT compilation in 50 words."
+
+# From stdin:
+echo "Summarise this commit message" | pnpm --filter @agentskit/example-embedded dev
+```
+
+## Install as a Raycast Script Command
+
+```bash
+mkdir -p ~/.config/raycast/scripts/agentskit
+cp raycast/agentskit-ask.ts ~/.config/raycast/scripts/agentskit/
+cp package.json ~/.config/raycast/scripts/agentskit/
+cd ~/.config/raycast/scripts/agentskit
+pnpm install
+```
+
+Open Raycast preferences → Extensions → Script Commands → Add the
+folder. Set `OPENAI_API_KEY` in the script's environment variables
+panel. Trigger from Raycast with the prompt argument.
+
+## Wire as a VS Code Task
+
+Copy `vscode/tasks.json` into your project's `.vscode/tasks.json`
+(or merge the `tasks` array). The default keybinding for "Run Task"
+is `Ctrl+Shift+P → Tasks: Run Task` — bind your favourite shortcut
+to it via `keybindings.json`:
+
+```json
+{
+  "key": "cmd+k cmd+a",
+  "command": "workbench.action.tasks.runTask",
+  "args": "AgentsKit · Ask"
+}
+```
+
+Two tasks ship in this template:
+
+- **AgentsKit · Ask** — VS Code prompts for input, the agent
+  answers in a dedicated panel.
+- **AgentsKit · Ask about selection** — pipes the current editor
+  selection to the agent (great for "explain this snippet").
+
+## What's not in scope
+
+- A full VS Code extension. Possible (open a `WebviewPanel`, render
+  the React chat from `@agentskit/react`); see
+  [`/docs/production/embedded`](https://www.agentskit.io/docs/production/embedded)
+  for the pattern.
+- LSP server. Same — pattern is documented; building one is a
+  weekend project per LSP feature.
+
+## See also
+
+- [`/docs/production/embedded`](https://www.agentskit.io/docs/production/embedded) — full pattern guide.
+- [`apps/example-edge`](../example-edge) — same runtime in the opposite
+  direction (server-side, no host integration).
+- [`apps/example-runtime`](../example-runtime) — speculate / durable /
+  topology demos using the same `createRuntime` factory.

--- a/apps/example-embedded/package.json
+++ b/apps/example-embedded/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agentskit/example-embedded",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "raycast": "tsx raycast/agentskit-ask.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/example-embedded/raycast/agentskit-ask.ts
+++ b/apps/example-embedded/raycast/agentskit-ask.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Required Raycast metadata. The header is parsed by Raycast on
+// install — do not move the comments. See:
+// https://developers.raycast.com/basics/script-commands
+
+// @raycast.schemaVersion 1
+// @raycast.title Ask AgentsKit
+// @raycast.mode fullOutput
+// @raycast.icon 🤖
+// @raycast.packageName AgentsKit
+// @raycast.argument1 { "type": "text", "placeholder": "Question for the agent" }
+// @raycast.author AgentsKit
+// @raycast.authorURL https://www.agentskit.io
+// @raycast.description Ask the AgentsKit demo agent a question. Streams the answer to Raycast's full-output pane.
+
+/**
+ * Raycast Script Command. Reads the user's argument, runs an
+ * AgentsKit runtime against `OPENAI_API_KEY` (or a demo fallback),
+ * and prints the answer. Identical core to apps/example-embedded/
+ * src/index.ts — different host wrapper.
+ *
+ * Install: copy this file (and its sibling `package.json`) into
+ *   ~/.config/raycast/scripts/agentskit/
+ * then run `pnpm install` in that folder. Raycast picks it up
+ * automatically.
+ */
+
+import { createRuntime } from '@agentskit/runtime'
+import { openai } from '@agentskit/adapters'
+import type { AdapterFactory } from '@agentskit/core'
+
+function pickAdapter(): AdapterFactory {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    return {
+      createSource: () => ({
+        stream: async function* () {
+          yield { type: 'text' as const, content: '[demo] set OPENAI_API_KEY in Raycast → Extensions → AgentsKit to get real replies.' }
+          yield { type: 'done' as const }
+        },
+        abort: () => {},
+      }),
+    }
+  }
+  return openai({ apiKey, model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' })
+}
+
+const prompt = process.argv.slice(2).join(' ').trim()
+if (!prompt) {
+  process.stderr.write('Usage: agentskit-ask "<prompt>"\n')
+  process.exit(2)
+}
+
+const runtime = createRuntime({
+  adapter: pickAdapter(),
+  systemPrompt: 'You are a concise coding assistant. Reply in plain text — no markdown headings.',
+})
+
+runtime.run(prompt).then(
+  result => process.stdout.write(result.content + '\n'),
+  err => {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+    process.exit(1)
+  },
+)

--- a/apps/example-embedded/src/index.ts
+++ b/apps/example-embedded/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * apps/example-embedded — same agent runs from anywhere.
+ *
+ * `dev` (this file) is the canonical Node CLI invocation. Reads the
+ * prompt from argv or stdin, runs a runtime, prints the result. The
+ * Raycast Script Command at `raycast/agentskit-ask.ts` and the
+ * VS Code task at `vscode/tasks.json` both call this same shape —
+ * just packaged for those hosts.
+ */
+
+import { createRuntime } from '@agentskit/runtime'
+import { openai } from '@agentskit/adapters'
+import type { AdapterFactory } from '@agentskit/core'
+
+function readStdin(): Promise<string> {
+  return new Promise(resolve => {
+    if (process.stdin.isTTY) return resolve('')
+    let buf = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', chunk => (buf += chunk))
+    process.stdin.on('end', () => resolve(buf))
+  })
+}
+
+async function resolvePrompt(): Promise<string> {
+  const arg = process.argv.slice(2).join(' ').trim()
+  if (arg) return arg
+  const piped = (await readStdin()).trim()
+  return piped
+}
+
+function pickAdapter(): AdapterFactory {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    process.stderr.write('OPENAI_API_KEY not set; falling back to demo adapter.\n')
+    return {
+      createSource: () => ({
+        stream: async function* () {
+          yield { type: 'text' as const, content: '[demo] set OPENAI_API_KEY for a real reply.' }
+          yield { type: 'done' as const }
+        },
+        abort: () => {},
+      }),
+    }
+  }
+  return openai({ apiKey, model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' })
+}
+
+async function main() {
+  const prompt = await resolvePrompt()
+  if (!prompt) {
+    process.stderr.write('Usage: agentskit-ask <prompt>\n   or: echo "..." | agentskit-ask\n')
+    process.exit(2)
+  }
+
+  const runtime = createRuntime({
+    adapter: pickAdapter(),
+    systemPrompt: 'You are a concise coding assistant. Reply in plain text — no markdown headings.',
+  })
+
+  const result = await runtime.run(prompt)
+  process.stdout.write(result.content + '\n')
+}
+
+main().catch(err => {
+  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/apps/example-embedded/tsconfig.json
+++ b/apps/example-embedded/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "raycast"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/example-embedded/vscode/tasks.json
+++ b/apps/example-embedded/vscode/tasks.json
@@ -1,0 +1,64 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "AgentsKit · Ask",
+      "type": "shell",
+      "command": "tsx",
+      "args": [
+        "${workspaceFolder}/apps/example-embedded/src/index.ts",
+        "${input:agentskitPrompt}"
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "AgentsKit · Ask about selection",
+      "type": "shell",
+      "command": "tsx",
+      "args": [
+        "${workspaceFolder}/apps/example-embedded/src/index.ts"
+      ],
+      "options": {
+        "env": {
+          "AGENTSKIT_PIPED_INPUT": "true"
+        }
+      },
+      "windows": {
+        "command": "powershell",
+        "args": ["-Command", "echo '${selectedText}' | tsx ${workspaceFolder}/apps/example-embedded/src/index.ts"]
+      },
+      "linux": {
+        "command": "sh",
+        "args": ["-c", "echo \"${selectedText}\" | tsx ${workspaceFolder}/apps/example-embedded/src/index.ts"]
+      },
+      "osx": {
+        "command": "sh",
+        "args": ["-c", "echo \"${selectedText}\" | tsx ${workspaceFolder}/apps/example-embedded/src/index.ts"]
+      },
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "id": "agentskitPrompt",
+      "type": "promptString",
+      "description": "Ask the agent…"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/example-embedded:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/example-flow:
     dependencies:
       '@agentskit/core':


### PR DESCRIPTION
Closes J/P2 #627. Same runtime wrapped three ways: Node CLI, Raycast Script Command, VS Code Task. Validates /docs/production/embedded. Refs epic #562.