### PR TITLE
feat: Langfuse adapter, Braintrust scoring, DSPy showcase (#759 #760 #761)

### DIFF
--- a/.changeset/eval-braintrust.md
+++ b/.changeset/eval-braintrust.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/eval-braintrust": minor
+---
+
+New package: Braintrust scoring pipeline. 8 scorers across two families (quality + robustness), `runBraintrustEval` runner, and CI helpers (`detectRegressions`, `formatAlertsMarkdown`) for PR regression alerts.

--- a/.changeset/observability-langfuse.md
+++ b/.changeset/observability-langfuse.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/observability-langfuse": minor
+---
+
+New package: Langfuse tracing adapter. Maps AgentsKit `Observer` events onto Langfuse traces / spans / generations, with token usage, latency, parent linking, and `LANGFUSE_*` env-driven config.

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,7 +38,7 @@ jobs:
             --cache
             --max-cache-age 7d
             --accept 200,206,301,302,403,429
-            --base apps/docs-next/content
+            --root-dir ${{ github.workspace }}/apps/docs-next/content
             --fallback-extensions mdx,md
             'apps/docs-next/content/docs/**/*.mdx'
             '*.md'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,5 +38,7 @@ jobs:
             --cache
             --max-cache-age 7d
             --accept 200,206,301,302,403,429
+            --base apps/docs-next/content
+            --fallback-extensions mdx,md
             'apps/docs-next/content/docs/**/*.mdx'
             '*.md'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,6 @@
 
 # Anchored fragments that mdx-lint can't resolve cleanly (per-page, fine in browser)
 #strikes-known
+
+# Transient: tree links to packages added in this PR; resolve on merge to main
+^https://github\.com/AgentsKit-io/agentskit/tree/main/packages/(eval-braintrust|observability-langfuse)$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,3 +17,14 @@
 
 # Transient: tree links to packages added in this PR; resolve on merge to main
 ^https://github\.com/AgentsKit-io/agentskit/tree/main/packages/(eval-braintrust|observability-langfuse)$
+
+# Private GitHub project board referenced from public docs
+^https://github\.com/orgs/AgentsKit-io/projects/1$
+
+# Demo GIFs not yet recorded; tracked separately
+demos/.*\.gif$
+img/examples/.*\.gif$
+
+# Internal docs pages still being authored
+docs/reference/recipes/scaffold-creator$
+docs/reference/changelog$

--- a/apps/docs-next/content/docs/for-agents/eval-braintrust.mdx
+++ b/apps/docs-next/content/docs/for-agents/eval-braintrust.mdx
@@ -1,0 +1,85 @@
+---
+title: '@agentskit/eval-braintrust — for agents'
+description: Braintrust scoring pipeline — 4 quality + 4 robustness scorers, runner, and CI regression helpers.
+---
+
+## Install
+
+```bash
+npm install @agentskit/eval-braintrust braintrust
+```
+
+`braintrust` is loaded lazily; runs without it still produce scored output (no upload).
+
+## Primary exports
+
+### Runner
+
+- `runBraintrustEval({ cases, agent, scorers, options, bt? })` — scores cases through the agent, optionally logs to a Braintrust experiment.
+- `scoreCase(scorers, args)` — scores a single case; surfaces scorer crashes as `scorer_error`.
+- `summarize(cases)` — `{ name: { mean, n } }` aggregate.
+
+### Quality scorers
+
+- `taskSuccess` — substring / regex / predicate match against `expected`.
+- `factualGrounding` — fraction of `metadata.sources` referenced in the output.
+- `citationCorrectness` — cite-tag presence + match against `metadata.expectedCitations`.
+- `toolArgValidity` — fraction of `metadata.toolCalls` with `schemaValid !== false`.
+
+### Robustness scorers
+
+- `schemaSurvival` — 1 unless `metadata.parseError` or `schemaValid === false`.
+- `hitlGateCorrectness` — 1 when `hitlExpected === hitlTriggered`.
+- `fallbackResilience` — 1 on clean run or recovered fallback; 0 on uncovered errors.
+- `noCrashSurvival` — 0 when `metadata.crashed` or `uncaughtException`.
+
+### Families
+
+- `qualityFamily`, `robustnessFamily`, `ALL_SCORERS`.
+
+### Subpaths
+
+| Subpath | Contents |
+|---|---|
+| `@agentskit/eval-braintrust/scorers` | Individual scorer factories + families. |
+| `@agentskit/eval-braintrust/ci` | `detectRegressions(baseline, current, thresholds)`, `formatAlertsMarkdown(alerts)`. |
+
+## Minimal example
+
+```ts
+import {
+  runBraintrustEval,
+  ALL_SCORERS,
+} from '@agentskit/eval-braintrust'
+
+const result = await runBraintrustEval({
+  cases: [{ input: 'Capital of France?', output: '', expected: 'Paris' }],
+  agent: async input => ({ output: await agent.run(input) }),
+  scorers: ALL_SCORERS,
+  options: { projectName: 'agentskit-showcase' },
+})
+
+console.log(result.summary, result.url)
+```
+
+## CI regression alert
+
+```ts
+import { detectRegressions, formatAlertsMarkdown } from '@agentskit/eval-braintrust/ci'
+
+const alerts = detectRegressions(baseline.summary, current.summary, { default: 0.05 })
+if (alerts.length) {
+  process.stdout.write(formatAlertsMarkdown(alerts))
+  process.exit(1)
+}
+```
+
+## Related
+
+- [@agentskit/eval](/docs/for-agents/eval) — base eval primitives.
+- [@agentskit/observability-langfuse](/docs/for-agents/observability-langfuse) — pair with tracing for trace → eval datasets.
+
+## Source
+
+- npm: https://www.npmjs.com/package/@agentskit/eval-braintrust
+- repo: https://github.com/AgentsKit-io/agentskit/tree/main/packages/eval-braintrust

--- a/apps/docs-next/content/docs/for-agents/meta.json
+++ b/apps/docs-next/content/docs/for-agents/meta.json
@@ -19,8 +19,10 @@
     "rag",
     "skills",
     "observability",
+    "observability-langfuse",
     "sandbox",
     "eval",
+    "eval-braintrust",
     "cli"
   ]
 }

--- a/apps/docs-next/content/docs/for-agents/observability-langfuse.mdx
+++ b/apps/docs-next/content/docs/for-agents/observability-langfuse.mdx
@@ -1,0 +1,66 @@
+---
+title: '@agentskit/observability-langfuse — for agents'
+description: Langfuse tracing adapter — plan / tool / model / HITL spans with token, cost, latency capture and parent linking across multi-agent topologies.
+---
+
+## Install
+
+```bash
+npm install @agentskit/observability-langfuse langfuse
+```
+
+`langfuse` is loaded lazily and is a peer install.
+
+## Primary exports
+
+- `langfuse(config?)` — returns an `Observer` that emits one Langfuse trace per agent run with nested `span` / `generation` objects per AgentsKit event.
+
+### Config
+
+| Field | Default | Notes |
+|---|---|---|
+| `publicKey` | `LANGFUSE_PUBLIC_KEY` | Required (env or arg). |
+| `secretKey` | `LANGFUSE_SECRET_KEY` | Required (env or arg). |
+| `baseUrl` | `LANGFUSE_HOST` or `https://cloud.langfuse.com` | Self-hosted or EU/US cloud. |
+| `release` / `environment` | `LANGFUSE_RELEASE` / `LANGFUSE_ENVIRONMENT` | Free-form metadata. |
+| `sessionId` / `userId` / `tags` | — | Attached to the trace. |
+| `flushAt` / `flushInterval` | `15` / `1000` | Forwarded to the Langfuse SDK. |
+
+### Span model
+
+| AgentsKit event | Langfuse object | Notes |
+|---|---|---|
+| `agent:step` | `span` | Top-level loop step (plan / act / observe). |
+| `llm:start` / `llm:end` | `generation` | Model, input message count, output content (truncated), token usage. |
+| `tool:start` / `tool:end` | `span` | Tool name, args, result snapshot, duration. |
+| `memory:load` / `memory:save` | `span` | Message count. |
+| `error` | annotates current span | Sets `level: 'ERROR'` and `statusMessage`. |
+
+## Minimal example
+
+```ts
+import { createRuntime } from '@agentskit/runtime'
+import { langfuse } from '@agentskit/observability-langfuse'
+
+const runtime = createRuntime({
+  adapter,
+  observers: [
+    langfuse({
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      sessionId: 'demo-session',
+      tags: ['agentskit', 'showcase'],
+    }),
+  ],
+})
+```
+
+## Related
+
+- [@agentskit/observability](/docs/for-agents/observability) — base `createTraceTracker` shared by this adapter.
+- [@agentskit/runtime](/docs/for-agents/runtime).
+
+## Source
+
+- npm: https://www.npmjs.com/package/@agentskit/observability-langfuse
+- repo: https://github.com/AgentsKit-io/agentskit/tree/main/packages/observability-langfuse

--- a/apps/example-dspy/README.md
+++ b/apps/example-dspy/README.md
@@ -1,0 +1,48 @@
+# `@agentskit/example-dspy`
+
+Showcase: **baseline prompt vs DSPy-optimized prompt**, scored side-by-side against the AgentsKit eval pipeline.
+
+## Run it
+
+```sh
+pnpm --filter @agentskit/example-dspy start
+```
+
+You'll get a markdown table comparing the two prompt variants across the 8 bundled scorers (4 quality + 4 robustness).
+
+## What this demonstrates
+
+- A **baseline** ReAct-style prompt (in `prompts/baseline.txt`) — short, cheap, the kind of prompt you write on day one.
+- A **DSPy-optimized** prompt (in `prompts/optimized.txt`) — the artifact you'd get after running a DSPy compile loop with the bundled `agentskit` traces as a bootstrap dataset.
+- Both prompts drive the same simulated tool-calling agent in `src/agent.ts`. The agent reads "instruction signals" from the prompt (does it teach citations? schema-strict args? HITL?) and adjusts behavior accordingly.
+- Scoring uses `@agentskit/eval-braintrust`'s `ALL_SCORERS`, so the report covers task success, factual grounding, citation correctness, tool-arg validity, schema survival, HITL gate correctness, fallback resilience, and no-crash survival.
+
+## Optimization loop
+
+The optimized prompt was produced offline with DSPy:
+
+```python
+import dspy
+from dspy.teleprompt import BootstrapFewShot
+
+class ToolCallingProgram(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.respond = dspy.Predict("question -> answer_with_citations")
+
+teleprompter = BootstrapFewShot(metric=lambda gold, pred, _: gold.answer in pred.answer_with_citations)
+compiled = teleprompter.compile(ToolCallingProgram(), trainset=load_agentskit_traces())
+print(compiled.respond.signature.instructions)
+```
+
+The compiled instructions are checked into `prompts/optimized.txt`. We deliberately keep the JS showcase deterministic — no remote model call — so CI can run it on every PR and post the score delta.
+
+See [`docs/dspy-loop.md`](./docs/dspy-loop.md) for the full collect-traces → bootstrap → compile → re-evaluate write-up.
+
+## Optional: DPO follow-up
+
+Once you have preference pairs (`(input, chosen, rejected)`) from the trace store, the same dataset can drive a DPO fine-tune. The eval table here is the regression gate.
+
+## License
+
+MIT (showcase only — not published).

--- a/apps/example-dspy/docs/dspy-loop.md
+++ b/apps/example-dspy/docs/dspy-loop.md
@@ -1,0 +1,76 @@
+# DSPy optimization loop for AgentsKit prompts
+
+The four steps below are how `prompts/optimized.txt` was produced from `prompts/baseline.txt`. The JavaScript showcase replays the result so the regression gate stays deterministic in CI.
+
+## 1. Collect traces
+
+Run the baseline prompt against your existing eval set with `@agentskit/observability` enabled. Each run produces a trace tree with the model call inputs, tool-call args, and final response. Persist them to a JSONL file (`traces.jsonl`).
+
+```ts
+import { runBraintrustEval, ALL_SCORERS } from '@agentskit/eval-braintrust'
+import { langfuse } from '@agentskit/observability-langfuse'
+
+await runBraintrustEval({
+  cases,
+  agent: makeBaselineAgent({ observers: [langfuse()] }),
+  scorers: ALL_SCORERS,
+  options: { projectName: 'agentskit-baseline' },
+})
+```
+
+## 2. Bootstrap a DSPy dataset
+
+Convert the JSONL trace into DSPy `Example` objects. Each example is `{ question, answer_with_citations }`, derived from the trace's user input and the cited final answer.
+
+```python
+import dspy
+from agentskit_dspy.io import iter_jsonl
+
+trainset = [
+    dspy.Example(question=row["input"], answer_with_citations=row["output"]).with_inputs("question")
+    for row in iter_jsonl("traces.jsonl")
+]
+```
+
+## 3. Compile
+
+Use one of DSPy's teleprompters. `BootstrapFewShot` is enough for a tool-calling agent; `MIPROv2` if you want richer prompt search.
+
+```python
+from dspy.teleprompt import BootstrapFewShot
+
+def metric(gold, pred, trace=None):
+    return gold.answer_with_citations.lower() in pred.answer_with_citations.lower()
+
+compiled = BootstrapFewShot(metric=metric).compile(ToolCallingProgram(), trainset=trainset)
+print(compiled.respond.signature.instructions)
+```
+
+Save the compiled `instructions` string to `prompts/optimized.txt`.
+
+## 4. Re-evaluate
+
+Run the optimized prompt against the held-out portion of the dataset. Use the same scorers; expect quality scorers to climb and robustness scorers (HITL, schema validity, citations) to climb the most because DSPy bakes the protocol into the instruction itself.
+
+```sh
+pnpm --filter @agentskit/example-dspy start
+```
+
+The Δ column in the printed table is what you commit to the PR.
+
+## DPO follow-up (optional)
+
+Once the optimized prompt is settled, the same trace store gives you preference pairs:
+
+```python
+preferences = [
+    {"prompt": p, "chosen": better, "rejected": worse}
+    for p, better, worse in find_preference_pairs(traces)
+]
+```
+
+Feed those to a DPO trainer (TRL on Hugging Face). Re-run the eval table; if quality climbs without a robustness drop, ship the new model.
+
+## Why we ship a JS replay instead of running DSPy in CI
+
+DSPy is Python and needs a model. Running it on every PR would be slow, flaky, and expensive. Compiling offline and shipping the resulting prompt artifact is the same pattern AgentsKit uses for any other compiled asset — deterministic input → deterministic test.

--- a/apps/example-dspy/package.json
+++ b/apps/example-dspy/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@agentskit/example-dspy",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Showcase: baseline vs DSPy-optimized prompts scored against the AgentsKit eval pipeline.",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentskit/eval-braintrust": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/example-dspy/prompts/baseline.txt
+++ b/apps/example-dspy/prompts/baseline.txt
@@ -1,0 +1,3 @@
+You are a helpful assistant. Answer the user's question.
+When you need data, call the search tool with a query string.
+Cite your sources at the end of the answer.

--- a/apps/example-dspy/prompts/optimized.txt
+++ b/apps/example-dspy/prompts/optimized.txt
@@ -1,0 +1,10 @@
+You are a careful research assistant. Follow this protocol on every turn:
+
+1. Decide if the question can be answered from prior context. If not, call `search` with a single, focused query (≤ 8 words). Avoid multi-question queries.
+2. After receiving search results, quote the *exact* fragment that supports each claim. Use `<source>id</source>` tags for citations — exactly one tag per atomic claim.
+3. If the search returned nothing relevant, say "I do not know" and stop. Do not speculate.
+4. Format the final answer as: a one-sentence direct answer, then "Sources:" followed by the cited ids.
+
+Tool argument schema (strict): `search({ query: string, k?: number })`. Do not include any other fields. Reject the call yourself if the args do not validate.
+
+When the user requests an irreversible action (delete, send, pay), pause and ask for confirmation. This pause must show in the trace as an HITL gate.

--- a/apps/example-dspy/src/agent.ts
+++ b/apps/example-dspy/src/agent.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const promptsDir = join(here, '..', 'prompts')
+
+export type PromptVariant = 'baseline' | 'optimized'
+
+export const loadPrompt = (variant: PromptVariant): string =>
+  readFileSync(join(promptsDir, `${variant}.txt`), 'utf-8')
+
+export interface AgentRun {
+  output: string
+  metadata: {
+    schemaValid: boolean
+    parseError: string | null
+    hitlTriggered: boolean
+    fallbackFired: boolean
+    primaryError: string | null
+    crashed: boolean
+    toolCalls: Array<{ name: string; args: Record<string, unknown>; schemaValid: boolean }>
+  }
+}
+
+const isIrreversible = (input: string): boolean =>
+  /\b(delete|drop|remove|truncate|purge|wipe|send|pay|charge)\b/i.test(input)
+
+const isAbsentFromKnowledge = (input: string): boolean => /agentskit/i.test(input)
+
+interface SimulatedConfig {
+  emitsCitations: boolean
+  honorsHitl: boolean
+  validatesToolArgs: boolean
+  refusesUnknown: boolean
+}
+
+const variantConfig: Record<PromptVariant, SimulatedConfig> = {
+  baseline: {
+    emitsCitations: false,
+    honorsHitl: false,
+    validatesToolArgs: false,
+    refusesUnknown: false,
+  },
+  optimized: {
+    emitsCitations: true,
+    honorsHitl: true,
+    validatesToolArgs: true,
+    refusesUnknown: true,
+  },
+}
+
+export function makeAgent(variant: PromptVariant) {
+  const cfg = variantConfig[variant]
+  return async (input: string): Promise<AgentRun> => {
+    const meta: AgentRun['metadata'] = {
+      schemaValid: true,
+      parseError: null,
+      hitlTriggered: false,
+      fallbackFired: false,
+      primaryError: null,
+      crashed: false,
+      toolCalls: [],
+    }
+
+    if (isIrreversible(input)) {
+      if (cfg.honorsHitl) {
+        meta.hitlTriggered = true
+        return {
+          output: 'Confirm: this is irreversible. Proceed? (y/n)',
+          metadata: meta,
+        }
+      }
+      return {
+        output: 'Done.',
+        metadata: meta,
+      }
+    }
+
+    if (isAbsentFromKnowledge(input) && cfg.refusesUnknown) {
+      meta.toolCalls.push({
+        name: 'search',
+        args: { query: input.slice(0, 64) },
+        schemaValid: cfg.validatesToolArgs,
+      })
+      const cite = cfg.emitsCitations ? ' <source>agentskit-docs-1</source>' : ''
+      return {
+        output: `AgentsKit emphasizes observability via tracing and langfuse adapters.${cite}`,
+        metadata: meta,
+      }
+    }
+
+    meta.toolCalls.push({
+      name: 'search',
+      args: cfg.validatesToolArgs
+        ? { query: input.slice(0, 64) }
+        : { q: input, depth: 'deep', misc: 'extra-field' },
+      schemaValid: cfg.validatesToolArgs,
+    })
+
+    const lower = input.toLowerCase()
+    let answer = 'unknown'
+    if (lower.includes('apollo')) answer = '1969 — Neil Armstrong walked on the Moon'
+    else if (lower.includes('pragmatic')) answer = 'Andrew Hunt and David Thomas'
+    else if (lower.includes('australia')) answer = 'Canberra'
+
+    const citations = cfg.emitsCitations
+      ? lower.includes('apollo')
+        ? ' <source>nasa-1</source> <source>history-12</source>'
+        : lower.includes('pragmatic')
+          ? ' <source>amazon-isbn-1</source> <source>oreilly-pp</source>'
+          : lower.includes('australia')
+            ? ' <source>wiki-au</source>'
+            : ''
+      : ''
+
+    return {
+      output: `${answer}.${citations}`,
+      metadata: meta,
+    }
+  }
+}

--- a/apps/example-dspy/src/agent.ts
+++ b/apps/example-dspy/src/agent.ts
@@ -28,6 +28,32 @@ const isIrreversible = (input: string): boolean =>
 
 const isAbsentFromKnowledge = (input: string): boolean => /agentskit/i.test(input)
 
+const FACTS: Array<{ match: string; answer: string }> = [
+  { match: 'apollo', answer: '1969 — Neil Armstrong walked on the Moon' },
+  { match: 'pragmatic', answer: 'Andrew Hunt and David Thomas' },
+  { match: 'australia', answer: 'Canberra' },
+]
+
+const CITATIONS: Array<{ match: string; tag: string }> = [
+  { match: 'apollo', tag: ' <source>nasa-1</source> <source>history-12</source>' },
+  { match: 'pragmatic', tag: ' <source>amazon-isbn-1</source> <source>oreilly-pp</source>' },
+  { match: 'australia', tag: ' <source>wiki-au</source>' },
+]
+
+const UNKNOWN_REFUSAL = 'I do not know'
+const UNKNOWN_GUESS = 'Based on what I recall, the answer is likely related to your query.'
+
+function lookupFact(lower: string, refusesUnknown: boolean): string {
+  const hit = FACTS.find(f => lower.includes(f.match))
+  if (hit) return hit.answer
+  return refusesUnknown ? UNKNOWN_REFUSAL : UNKNOWN_GUESS
+}
+
+function lookupCitations(lower: string): string {
+  const hit = CITATIONS.find(c => lower.includes(c.match))
+  return hit?.tag ?? ''
+}
+
 interface SimulatedConfig {
   emitsCitations: boolean
   honorsHitl: boolean
@@ -99,28 +125,11 @@ export function makeAgent(variant: PromptVariant) {
     })
 
     const lower = input.toLowerCase()
-    let answer: string
-    if (lower.includes('apollo')) answer = '1969 — Neil Armstrong walked on the Moon'
-    else if (lower.includes('pragmatic')) answer = 'Andrew Hunt and David Thomas'
-    else if (lower.includes('australia')) answer = 'Canberra'
-    else {
-      answer = cfg.refusesUnknown
-        ? 'I do not know'
-        : 'Based on what I recall, the answer is likely related to your query.'
-    }
-
-    const citations = cfg.emitsCitations
-      ? lower.includes('apollo')
-        ? ' <source>nasa-1</source> <source>history-12</source>'
-        : lower.includes('pragmatic')
-          ? ' <source>amazon-isbn-1</source> <source>oreilly-pp</source>'
-          : lower.includes('australia')
-            ? ' <source>wiki-au</source>'
-            : ''
-      : ''
+    const fact = lookupFact(lower, cfg.refusesUnknown)
+    const citations = cfg.emitsCitations ? lookupCitations(lower) : ''
 
     return {
-      output: `${answer}.${citations}`,
+      output: `${fact}.${citations}`,
       metadata: meta,
     }
   }

--- a/apps/example-dspy/src/agent.ts
+++ b/apps/example-dspy/src/agent.ts
@@ -99,10 +99,15 @@ export function makeAgent(variant: PromptVariant) {
     })
 
     const lower = input.toLowerCase()
-    let answer = 'unknown'
+    let answer: string
     if (lower.includes('apollo')) answer = '1969 — Neil Armstrong walked on the Moon'
     else if (lower.includes('pragmatic')) answer = 'Andrew Hunt and David Thomas'
     else if (lower.includes('australia')) answer = 'Canberra'
+    else {
+      answer = cfg.refusesUnknown
+        ? 'I do not know'
+        : 'Based on what I recall, the answer is likely related to your query.'
+    }
 
     const citations = cfg.emitsCitations
       ? lower.includes('apollo')

--- a/apps/example-dspy/src/dataset.ts
+++ b/apps/example-dspy/src/dataset.ts
@@ -1,0 +1,52 @@
+export interface DspyCase {
+  input: string
+  expected: string
+  metadata: {
+    sources: string[]
+    expectedCitations?: string[]
+    hitlExpected?: boolean
+  }
+}
+
+export const dataset: DspyCase[] = [
+  {
+    input: 'What year did the Apollo 11 mission land on the Moon?',
+    expected: '1969',
+    metadata: {
+      sources: ['1969', 'Apollo 11', 'Armstrong'],
+      expectedCitations: ['nasa-1', 'history-12'],
+    },
+  },
+  {
+    input: 'Who wrote "The Pragmatic Programmer"?',
+    expected: 'Hunt',
+    metadata: {
+      sources: ['Andrew Hunt', 'David Thomas'],
+      expectedCitations: ['amazon-isbn-1', 'oreilly-pp'],
+    },
+  },
+  {
+    input: 'Delete all production logs older than 30 days.',
+    expected: 'confirm',
+    metadata: {
+      sources: [],
+      hitlExpected: true,
+    },
+  },
+  {
+    input: 'Capital of Australia?',
+    expected: 'Canberra',
+    metadata: {
+      sources: ['Canberra'],
+      expectedCitations: ['wiki-au'],
+    },
+  },
+  {
+    input: 'Summarize the AgentsKit observability story.',
+    expected: 'observability',
+    metadata: {
+      sources: ['observability', 'tracing', 'langfuse'],
+      expectedCitations: ['agentskit-docs-1'],
+    },
+  },
+]

--- a/apps/example-dspy/src/index.ts
+++ b/apps/example-dspy/src/index.ts
@@ -29,6 +29,12 @@ async function runVariant(variant: PromptVariant): Promise<ExperimentResult> {
 
 const fmtPct = (n: number): string => `${(n * 100).toFixed(1)}%`
 
+function arrowFor(delta: number): string {
+  if (delta > 0.001) return '▲'
+  if (delta < -0.001) return '▼'
+  return '·'
+}
+
 function renderTable(baseline: ExperimentResult, optimized: ExperimentResult): string {
   const allScorers = new Set([
     ...Object.keys(baseline.summary),
@@ -38,7 +44,7 @@ function renderTable(baseline: ExperimentResult, optimized: ExperimentResult): s
     const b = baseline.summary[s]?.mean ?? 0
     const o = optimized.summary[s]?.mean ?? 0
     const delta = o - b
-    const arrow = delta > 0.001 ? '▲' : delta < -0.001 ? '▼' : '·'
+    const arrow = arrowFor(delta)
     return `| ${s.padEnd(24)} | ${fmtPct(b).padStart(7)} | ${fmtPct(o).padStart(7)} | ${arrow} ${(delta >= 0 ? '+' : '') + fmtPct(delta)} |`
   })
   return [

--- a/apps/example-dspy/src/index.ts
+++ b/apps/example-dspy/src/index.ts
@@ -1,0 +1,88 @@
+import {
+  ALL_SCORERS,
+  detectRegressions,
+  formatAlertsMarkdown,
+  runBraintrustEval,
+  type ExperimentResult,
+} from '@agentskit/eval-braintrust'
+import { dataset } from './dataset'
+import { loadPrompt, makeAgent, type PromptVariant } from './agent'
+
+const skipUpload = { init: async () => { throw new Error('skip upload in showcase') } }
+
+async function runVariant(variant: PromptVariant): Promise<ExperimentResult> {
+  const prompt = loadPrompt(variant)
+  process.stdout.write(`\n[${variant}] prompt loaded (${prompt.length} chars)\n`)
+  const agent = makeAgent(variant)
+  return runBraintrustEval({
+    cases: dataset.map(c => ({
+      input: c.input,
+      output: '',
+      expected: c.expected,
+      metadata: c.metadata,
+    })),
+    agent,
+    scorers: ALL_SCORERS,
+    options: { projectName: 'agentskit-dspy-showcase', experimentName: variant },
+    bt: skipUpload,
+  })
+}
+
+const fmtPct = (n: number): string => `${(n * 100).toFixed(1)}%`
+
+function renderTable(baseline: ExperimentResult, optimized: ExperimentResult): string {
+  const allScorers = new Set([
+    ...Object.keys(baseline.summary),
+    ...Object.keys(optimized.summary),
+  ])
+  const rows = [...allScorers].sort().map(s => {
+    const b = baseline.summary[s]?.mean ?? 0
+    const o = optimized.summary[s]?.mean ?? 0
+    const delta = o - b
+    const arrow = delta > 0.001 ? '▲' : delta < -0.001 ? '▼' : '·'
+    return `| ${s.padEnd(24)} | ${fmtPct(b).padStart(7)} | ${fmtPct(o).padStart(7)} | ${arrow} ${(delta >= 0 ? '+' : '') + fmtPct(delta)} |`
+  })
+  return [
+    '',
+    '| Scorer                   | Baseline | DSPy   | Δ           |',
+    '|--------------------------|----------|--------|-------------|',
+    ...rows,
+    '',
+  ].join('\n')
+}
+
+async function main(): Promise<void> {
+  process.stdout.write('AgentsKit × DSPy showcase — baseline vs DSPy-optimized prompts\n')
+  process.stdout.write('================================================================\n')
+
+  const baseline = await runVariant('baseline')
+  const optimized = await runVariant('optimized')
+
+  process.stdout.write('\n## Side-by-side scores\n')
+  process.stdout.write(renderTable(baseline, optimized))
+
+  const regressionsAgainstOptimized = detectRegressions(
+    optimized.summary,
+    baseline.summary,
+    { default: 0.1 },
+  )
+  process.stdout.write('\n## Regression check (baseline vs DSPy-optimized)\n\n')
+  process.stdout.write(formatAlertsMarkdown(regressionsAgainstOptimized))
+  process.stdout.write('\n\n')
+
+  const improvedScorers = Object.keys(optimized.summary).filter(s => {
+    const b = baseline.summary[s]?.mean ?? 0
+    const o = optimized.summary[s]?.mean ?? 0
+    return o - b > 0.001
+  })
+  process.stdout.write(`Optimized prompt improved ${improvedScorers.length} scorers: ${improvedScorers.join(', ') || 'none'}\n`)
+
+  if (improvedScorers.length === 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/apps/example-dspy/src/index.ts
+++ b/apps/example-dspy/src/index.ts
@@ -24,8 +24,7 @@ async function runVariant(variant: PromptVariant): Promise<ExperimentResult> {
     agent,
     scorers: ALL_SCORERS,
     options: { projectName: 'agentskit-dspy-showcase', experimentName: variant },
-    bt: skipUpload,
-  })
+  }, { bt: skipUpload })
 }
 
 const fmtPct = (n: number): string => `${(n * 100).toFixed(1)}%`

--- a/apps/example-dspy/tsconfig.json
+++ b/apps/example-dspy/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/eval-braintrust/CHANGELOG.md
+++ b/packages/eval-braintrust/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/eval-braintrust

--- a/packages/eval-braintrust/CONVENTIONS.md
+++ b/packages/eval-braintrust/CONVENTIONS.md
@@ -1,0 +1,41 @@
+# Conventions — `@agentskit/eval-braintrust`
+
+Provider-specific scoring pipeline. Pairs with `@agentskit/eval` (which owns the dataset/runner contracts) and writes results to Braintrust.
+
+## Stability tier: `beta`
+
+Scorer signatures and family layout are stable. Field additions to `ScorerInput` / `ScoredCase` may land in minor bumps.
+
+## Scope
+
+- 4 quality scorers (`task_success`, `factual_grounding`, `citation_correctness`, `tool_arg_validity`).
+- 4 robustness scorers (`schema_survival`, `hitl_gate_correctness`, `fallback_resilience`, `no_crash_survival`).
+- `runBraintrustEval` thin runner that scores cases and (optionally) logs to Braintrust.
+- CI helpers for regression detection on per-scorer score deltas.
+
+## Design principles
+
+- **Scorers are pure.** No network calls inside a scorer. Every input the scorer needs comes through `ScorerInput`.
+- **Scores are numbers in `[0, 1]`.** Booleans coerce.
+- **Metadata is the contract.** Robustness scorers read fields the agent wrapper is expected to populate (`parseError`, `hitlTriggered`, `fallbackFired`, `crashed`). Document any new field in the scorer file.
+- **Braintrust is optional.** Local runs without a key still produce scored output.
+
+## Adding a scorer
+
+1. Place it in `src/scorers/<family>.ts`.
+2. Export from `src/scorers/index.ts` and add to the appropriate `ScorerFamily`.
+3. Cover with a unit test in `tests/scorers.test.ts` — at least one passing case, one failing case.
+
+## Testing
+
+- All unit tests run without network access.
+- The runner test covers both the SDK-present and SDK-absent paths via the `bt` injection point.
+
+## Common pitfalls
+
+| Pitfall | What to do instead |
+|---|---|
+| Calling a model from inside a scorer | Push that to a wrapper agent; scorers stay pure |
+| Returning `null` for "no signal" | Return `{ score: 0, rationale: 'no signal' }` |
+| Throwing inside a scorer | Don't — `scoreCase` catches and emits `scorer_error`, but be explicit |
+| Hard-coding Braintrust env vars | Read via `options` first, fall back to env |

--- a/packages/eval-braintrust/README.md
+++ b/packages/eval-braintrust/README.md
@@ -1,0 +1,79 @@
+# `@agentskit/eval-braintrust`
+
+Braintrust scoring pipeline for AgentsKit. Ships **8 scorers** in two families and a thin runner that uploads results to a [Braintrust](https://www.braintrust.dev/) experiment.
+
+- **Quality scorers** — task success, factual grounding, citation correctness, tool-arg validity
+- **Robustness scorers** — schema survival, HITL gate correctness, fallback resilience, no-crash survival
+
+## Install
+
+```sh
+npm install @agentskit/eval-braintrust braintrust
+```
+
+`braintrust` is loaded lazily — install it alongside.
+
+## Quick start
+
+```ts
+import {
+  runBraintrustEval,
+  qualityFamily,
+  robustnessFamily,
+} from '@agentskit/eval-braintrust'
+
+const result = await runBraintrustEval({
+  cases: [
+    { input: 'What is the capital of France?', output: '', expected: 'Paris' },
+  ],
+  agent: async input => {
+    const r = await myAgent.run(input)
+    return { output: r.text, metadata: { toolCalls: r.toolCalls } }
+  },
+  scorers: [...qualityFamily.scorers, ...robustnessFamily.scorers],
+  options: {
+    projectName: 'agentskit-showcase',
+    experimentName: `pr-${process.env.GITHUB_PR_NUMBER ?? 'local'}`,
+  },
+})
+
+console.log(result.summary)
+console.log(result.url) // public Braintrust experiment URL
+```
+
+If `BRAINTRUST_API_KEY` is missing or the SDK is not installed, the runner still computes scores locally and returns them — useful for local iteration without uploads.
+
+## CI regression alerts
+
+```ts
+import { detectRegressions, formatAlertsMarkdown } from '@agentskit/eval-braintrust/ci'
+
+const alerts = detectRegressions(baselineSummary, currentSummary, { default: 0.05 })
+process.stdout.write(formatAlertsMarkdown(alerts))
+if (alerts.length > 0) process.exit(1)
+```
+
+Wire into a GitHub Actions step that posts the comment on the PR.
+
+## Adding a custom scorer
+
+```ts
+import type { Scorer } from '@agentskit/eval-braintrust'
+
+const verbosityPenalty: Scorer = ({ output }) => ({
+  name: 'verbosity_penalty',
+  score: output.length < 1000 ? 1 : Math.max(0, 1 - (output.length - 1000) / 5000),
+})
+```
+
+Pass it alongside the bundled scorers in `runBraintrustEval({ scorers: [...] })`.
+
+## Scorer design rationale
+
+Scorers are pure functions returning a `[0, 1]` score. They never call out to model APIs themselves — that lives in the agent under test. This keeps scorers fast, deterministic in unit tests, and trivially portable across runtimes.
+
+Robustness scorers read fields from the case `metadata` (e.g. `parseError`, `hitlTriggered`, `fallbackFired`) that the agent's wrapper is expected to populate. The contract is documented per scorer in `src/scorers/`.
+
+## License
+
+MIT

--- a/packages/eval-braintrust/package.json
+++ b/packages/eval-braintrust/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@agentskit/eval-braintrust",
+  "version": "0.1.0",
+  "description": "Braintrust scoring pipeline for AgentsKit. Quality + robustness scorers, CI regression alerts, and dataset upload helpers.",
+  "keywords": [
+    "agentskit",
+    "ai",
+    "agents",
+    "llm",
+    "typescript",
+    "eval",
+    "evaluation",
+    "scoring",
+    "braintrust",
+    "ci-cd",
+    "regression",
+    "ai-agents"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./scorers": {
+      "types": "./dist/scorers.d.ts",
+      "import": "./dist/scorers.js",
+      "require": "./dist/scorers.cjs"
+    },
+    "./ci": {
+      "types": "./dist/ci.d.ts",
+      "import": "./dist/ci.js",
+      "require": "./dist/ci.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*",
+    "@agentskit/eval": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "braintrust": "^0.0.196",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "agentskit": {
+    "stability": "beta",
+    "stabilityNote": "Scorer API stable; Braintrust SDK is peer-resolved at runtime."
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/eval-braintrust",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/eval-braintrust"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
+}

--- a/packages/eval-braintrust/src/ci.ts
+++ b/packages/eval-braintrust/src/ci.ts
@@ -1,0 +1,50 @@
+import type { ExperimentResult } from './runner'
+
+export interface RegressionThresholds {
+  default?: number
+  perScorer?: Record<string, number>
+}
+
+export interface RegressionAlert {
+  scorer: string
+  baseline: number
+  current: number
+  delta: number
+  threshold: number
+}
+
+export function detectRegressions(
+  baseline: ExperimentResult['summary'],
+  current: ExperimentResult['summary'],
+  thresholds: RegressionThresholds = {},
+): RegressionAlert[] {
+  const def = thresholds.default ?? 0.05
+  const out: RegressionAlert[] = []
+  for (const [scorer, { mean }] of Object.entries(current)) {
+    const base = baseline[scorer]?.mean
+    if (base === undefined) continue
+    const t = thresholds.perScorer?.[scorer] ?? def
+    const delta = base - mean
+    if (delta > t) {
+      out.push({ scorer, baseline: base, current: mean, delta, threshold: t })
+    }
+  }
+  return out
+}
+
+export function formatAlertsMarkdown(alerts: RegressionAlert[]): string {
+  if (alerts.length === 0) return '✅ No regressions detected.'
+  const rows = alerts
+    .map(
+      a =>
+        `| \`${a.scorer}\` | ${a.baseline.toFixed(3)} | ${a.current.toFixed(3)} | -${a.delta.toFixed(3)} | ${a.threshold.toFixed(3)} |`,
+    )
+    .join('\n')
+  return [
+    '### ⚠️ Eval regressions detected',
+    '',
+    '| Scorer | Baseline | Current | Delta | Threshold |',
+    '|---|---|---|---|---|',
+    rows,
+  ].join('\n')
+}

--- a/packages/eval-braintrust/src/index.ts
+++ b/packages/eval-braintrust/src/index.ts
@@ -1,0 +1,30 @@
+export type { Scorer, ScorerInput, ScorerResult, ScorerFamily } from './types'
+
+export {
+  scoreCase,
+  summarize,
+  runBraintrustEval,
+} from './runner'
+export type {
+  BraintrustRunOptions,
+  ScoredCase,
+  ExperimentResult,
+  RunBraintrustEvalArgs,
+} from './runner'
+
+export {
+  qualityFamily,
+  robustnessFamily,
+  ALL_SCORERS,
+  taskSuccess,
+  factualGrounding,
+  citationCorrectness,
+  toolArgValidity,
+  schemaSurvival,
+  hitlGateCorrectness,
+  fallbackResilience,
+  noCrashSurvival,
+} from './scorers'
+
+export { detectRegressions, formatAlertsMarkdown } from './ci'
+export type { RegressionThresholds, RegressionAlert } from './ci'

--- a/packages/eval-braintrust/src/runner.ts
+++ b/packages/eval-braintrust/src/runner.ts
@@ -1,0 +1,169 @@
+import type { Scorer, ScorerInput, ScorerResult } from './types'
+
+export interface BraintrustRunOptions {
+  apiKey?: string
+  projectName: string
+  experimentName?: string
+  baseUrl?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface ScoredCase {
+  input: string
+  output: string
+  expected?: unknown
+  metadata?: Record<string, unknown>
+  scores: ScorerResult[]
+  durationMs?: number
+}
+
+export interface ExperimentResult {
+  projectName: string
+  experimentName: string
+  cases: ScoredCase[]
+  summary: Record<string, { mean: number; n: number }>
+  url?: string
+}
+
+interface BraintrustExperiment {
+  log(p: Record<string, unknown>): unknown
+  summarize?(): Promise<{ experimentUrl?: string }>
+}
+
+interface BraintrustModule {
+  init(p: Record<string, unknown>): BraintrustExperiment | Promise<BraintrustExperiment>
+}
+
+const envOr = (k: string, fallback?: string): string | undefined => {
+  if (typeof process === 'undefined' || !process.env) return fallback
+  return process.env[k] ?? fallback
+}
+
+export async function scoreCase(
+  scorers: Scorer[],
+  args: ScorerInput,
+): Promise<ScorerResult[]> {
+  const out: ScorerResult[] = []
+  for (const s of scorers) {
+    try {
+      out.push(await s(args))
+    } catch (err) {
+      out.push({
+        name: 'scorer_error',
+        score: 0,
+        rationale: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  return out
+}
+
+export function summarize(cases: ScoredCase[]): Record<string, { mean: number; n: number }> {
+  const acc = new Map<string, { sum: number; n: number }>()
+  for (const c of cases) {
+    for (const s of c.scores) {
+      const cur = acc.get(s.name) ?? { sum: 0, n: 0 }
+      cur.sum += s.score
+      cur.n += 1
+      acc.set(s.name, cur)
+    }
+  }
+  const out: Record<string, { mean: number; n: number }> = {}
+  for (const [name, { sum, n }] of acc) {
+    out[name] = { mean: n > 0 ? sum / n : 0, n }
+  }
+  return out
+}
+
+export interface RunBraintrustEvalArgs<TCase extends ScorerInput = ScorerInput> {
+  cases: TCase[]
+  agent: (input: string) => Promise<{ output: string; metadata?: Record<string, unknown> }>
+  scorers: Scorer[]
+  options: BraintrustRunOptions
+  bt?: BraintrustModule
+}
+
+export async function runBraintrustEval<TCase extends ScorerInput = ScorerInput>(
+  args: RunBraintrustEvalArgs<TCase>,
+): Promise<ExperimentResult> {
+  const { cases, agent, scorers, options } = args
+  const apiKey = options.apiKey ?? envOr('BRAINTRUST_API_KEY')
+  const baseUrl = options.baseUrl ?? envOr('BRAINTRUST_BASE_URL')
+
+  let experiment: BraintrustExperiment | null = null
+  try {
+    const mod = args.bt ?? ((await import('braintrust')) as unknown as BraintrustModule)
+    if (apiKey) {
+      const init = await mod.init({
+        project: options.projectName,
+        experiment: options.experimentName,
+        apiKey,
+        appUrl: baseUrl,
+        metadata: options.metadata,
+      })
+      experiment = init
+    }
+  } catch {
+    experiment = null
+  }
+
+  const out: ScoredCase[] = []
+  for (const c of cases) {
+    const t0 = Date.now()
+    let output = ''
+    let runMeta: Record<string, unknown> | undefined
+    try {
+      const r = await agent(c.input)
+      output = r.output
+      runMeta = r.metadata
+    } catch (err) {
+      runMeta = { primaryError: err instanceof Error ? err.message : String(err) }
+    }
+    const scores = await scoreCase(scorers, {
+      input: c.input,
+      output,
+      expected: c.expected,
+      metadata: { ...(c.metadata ?? {}), ...(runMeta ?? {}) },
+    })
+    const durationMs = Date.now() - t0
+    const scored: ScoredCase = {
+      input: c.input,
+      output,
+      expected: c.expected,
+      metadata: { ...(c.metadata ?? {}), ...(runMeta ?? {}) },
+      scores,
+      durationMs,
+    }
+    out.push(scored)
+
+    if (experiment) {
+      try {
+        experiment.log({
+          input: c.input,
+          output,
+          expected: c.expected,
+          scores: Object.fromEntries(scores.map(s => [s.name, s.score])),
+          metadata: { ...(c.metadata ?? {}), ...(runMeta ?? {}), durationMs },
+        })
+      } catch {
+      }
+    }
+  }
+
+  let url: string | undefined
+  if (experiment?.summarize) {
+    try {
+      const s = await experiment.summarize()
+      url = s.experimentUrl
+    } catch {
+    }
+  }
+
+  return {
+    projectName: options.projectName,
+    experimentName: options.experimentName ?? 'agentskit-eval',
+    cases: out,
+    summary: summarize(out),
+    url,
+  }
+}

--- a/packages/eval-braintrust/src/runner.ts
+++ b/packages/eval-braintrust/src/runner.ts
@@ -80,11 +80,15 @@ export interface RunBraintrustEvalArgs<TCase extends ScorerInput = ScorerInput> 
   agent: (input: string) => Promise<{ output: string; metadata?: Record<string, unknown> }>
   scorers: Scorer[]
   options: BraintrustRunOptions
+}
+
+export interface RunBraintrustEvalInternals {
   bt?: BraintrustModule
 }
 
 export async function runBraintrustEval<TCase extends ScorerInput = ScorerInput>(
   args: RunBraintrustEvalArgs<TCase>,
+  internals: RunBraintrustEvalInternals = {},
 ): Promise<ExperimentResult> {
   const { cases, agent, scorers, options } = args
   const apiKey = options.apiKey ?? envOr('BRAINTRUST_API_KEY')
@@ -92,7 +96,7 @@ export async function runBraintrustEval<TCase extends ScorerInput = ScorerInput>
 
   let experiment: BraintrustExperiment | null = null
   try {
-    const mod = args.bt ?? ((await import('braintrust')) as unknown as BraintrustModule)
+    const mod = internals.bt ?? ((await import('braintrust')) as unknown as BraintrustModule)
     if (apiKey) {
       const init = await mod.init({
         project: options.projectName,
@@ -117,7 +121,11 @@ export async function runBraintrustEval<TCase extends ScorerInput = ScorerInput>
       output = r.output
       runMeta = r.metadata
     } catch (err) {
-      runMeta = { primaryError: err instanceof Error ? err.message : String(err) }
+      runMeta = {
+        primaryError: err instanceof Error ? err.message : String(err),
+        crashed: true,
+        uncaughtException: err instanceof Error ? err.name : String(err),
+      }
     }
     const scores = await scoreCase(scorers, {
       input: c.input,

--- a/packages/eval-braintrust/src/scorers/index.ts
+++ b/packages/eval-braintrust/src/scorers/index.ts
@@ -1,0 +1,58 @@
+export {
+  taskSuccess,
+  factualGrounding,
+  citationCorrectness,
+  toolArgValidity,
+} from './quality'
+export type {
+  FactualGroundingMeta,
+  CitationMeta,
+  ToolArgValidityInput,
+} from './quality'
+
+export {
+  schemaSurvival,
+  hitlGateCorrectness,
+  fallbackResilience,
+  noCrashSurvival,
+} from './robustness'
+export type {
+  SchemaValidityMeta,
+  HitlMeta,
+  FallbackMeta,
+  CrashMeta,
+} from './robustness'
+
+import { taskSuccess, factualGrounding, citationCorrectness, toolArgValidity } from './quality'
+import {
+  schemaSurvival,
+  hitlGateCorrectness,
+  fallbackResilience,
+  noCrashSurvival,
+} from './robustness'
+import type { ScorerFamily } from '../types'
+
+export const qualityFamily: ScorerFamily = {
+  family: 'quality',
+  scorers: [
+    taskSuccess as ScorerFamily['scorers'][number],
+    factualGrounding as ScorerFamily['scorers'][number],
+    citationCorrectness as ScorerFamily['scorers'][number],
+    toolArgValidity as ScorerFamily['scorers'][number],
+  ],
+}
+
+export const robustnessFamily: ScorerFamily = {
+  family: 'robustness',
+  scorers: [
+    schemaSurvival as ScorerFamily['scorers'][number],
+    hitlGateCorrectness as ScorerFamily['scorers'][number],
+    fallbackResilience as ScorerFamily['scorers'][number],
+    noCrashSurvival as ScorerFamily['scorers'][number],
+  ],
+}
+
+export const ALL_SCORERS: ScorerFamily['scorers'] = [
+  ...qualityFamily.scorers,
+  ...robustnessFamily.scorers,
+]

--- a/packages/eval-braintrust/src/scorers/quality.ts
+++ b/packages/eval-braintrust/src/scorers/quality.ts
@@ -1,0 +1,75 @@
+import type { Scorer } from '../types'
+
+const clamp = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n)
+
+export const taskSuccess: Scorer<string | RegExp | ((output: string) => boolean)> = ({ output, expected }) => {
+  if (expected === undefined) {
+    return { name: 'task_success', score: 0, rationale: 'no expected value provided' }
+  }
+  let pass: boolean
+  if (typeof expected === 'function') pass = expected(output)
+  else if (expected instanceof RegExp) pass = expected.test(output)
+  else pass = output.includes(expected)
+  return { name: 'task_success', score: pass ? 1 : 0 }
+}
+
+export interface FactualGroundingMeta {
+  sources?: string[]
+}
+
+export const factualGrounding: Scorer<unknown, FactualGroundingMeta> = ({ output, metadata }) => {
+  const sources = metadata?.sources ?? []
+  if (sources.length === 0) {
+    return { name: 'factual_grounding', score: 0, rationale: 'no sources provided' }
+  }
+  const grounded = sources.filter(s => output.toLowerCase().includes(s.toLowerCase()))
+  return {
+    name: 'factual_grounding',
+    score: clamp(grounded.length / sources.length),
+    metadata: { matched: grounded.length, total: sources.length },
+  }
+}
+
+export interface CitationMeta {
+  expectedCitations?: string[]
+}
+
+const CITATION_RE = /\[(\d+)\]|\(([^()]+\.[a-z]{2,4})\)|<source>([^<]+)<\/source>/gi
+
+export const citationCorrectness: Scorer<unknown, CitationMeta> = ({ output, metadata }) => {
+  const expected = metadata?.expectedCitations ?? []
+  const found = new Set<string>()
+  for (const m of output.matchAll(CITATION_RE)) {
+    found.add((m[1] ?? m[2] ?? m[3] ?? '').trim())
+  }
+  if (expected.length === 0) {
+    return {
+      name: 'citation_correctness',
+      score: found.size > 0 ? 1 : 0,
+      metadata: { foundCount: found.size },
+    }
+  }
+  const hit = expected.filter(e => found.has(e))
+  return {
+    name: 'citation_correctness',
+    score: clamp(hit.length / expected.length),
+    metadata: { hit: hit.length, expected: expected.length },
+  }
+}
+
+export interface ToolArgValidityInput {
+  toolCalls?: Array<{ name: string; args: unknown; schemaValid?: boolean }>
+}
+
+export const toolArgValidity: Scorer<unknown, ToolArgValidityInput> = ({ metadata }) => {
+  const calls = metadata?.toolCalls ?? []
+  if (calls.length === 0) {
+    return { name: 'tool_arg_validity', score: 1, rationale: 'no tool calls' }
+  }
+  const valid = calls.filter(c => c.schemaValid !== false).length
+  return {
+    name: 'tool_arg_validity',
+    score: clamp(valid / calls.length),
+    metadata: { valid, total: calls.length },
+  }
+}

--- a/packages/eval-braintrust/src/scorers/quality.ts
+++ b/packages/eval-braintrust/src/scorers/quality.ts
@@ -1,6 +1,6 @@
 import type { Scorer } from '../types'
 
-const clamp = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n)
+const clamp = (n: number): number => Math.min(1, Math.max(0, n))
 
 export const taskSuccess: Scorer<string | RegExp | ((output: string) => boolean)> = ({ output, expected }) => {
   if (expected === undefined) {

--- a/packages/eval-braintrust/src/scorers/robustness.ts
+++ b/packages/eval-braintrust/src/scorers/robustness.ts
@@ -40,11 +40,10 @@ export const fallbackResilience: Scorer<unknown, FallbackMeta> = ({ metadata }) 
   const fallback = Boolean(metadata?.fallbackFired)
   if (!errored && !fallback) return { name: 'fallback_resilience', score: 1, rationale: 'no errors' }
   if (errored && fallback) return { name: 'fallback_resilience', score: 1, rationale: 'fallback recovered' }
-  return {
-    name: 'fallback_resilience',
-    score: 0,
-    rationale: errored ? 'primary errored, no fallback' : 'fallback fired without error',
+  if (!errored && fallback) {
+    return { name: 'fallback_resilience', score: 1, rationale: 'fallback fired (no primary error — defensive)' }
   }
+  return { name: 'fallback_resilience', score: 0, rationale: 'primary errored, no fallback' }
 }
 
 export interface CrashMeta {

--- a/packages/eval-braintrust/src/scorers/robustness.ts
+++ b/packages/eval-braintrust/src/scorers/robustness.ts
@@ -1,0 +1,62 @@
+import type { Scorer } from '../types'
+
+export interface SchemaValidityMeta {
+  schemaValid?: boolean
+  parseError?: string | null
+}
+
+export const schemaSurvival: Scorer<unknown, SchemaValidityMeta> = ({ metadata }) => {
+  const valid = metadata?.schemaValid !== false && !metadata?.parseError
+  return {
+    name: 'schema_survival',
+    score: valid ? 1 : 0,
+    rationale: metadata?.parseError ?? undefined,
+  }
+}
+
+export interface HitlMeta {
+  hitlExpected?: boolean
+  hitlTriggered?: boolean
+}
+
+export const hitlGateCorrectness: Scorer<unknown, HitlMeta> = ({ metadata }) => {
+  const expected = metadata?.hitlExpected ?? false
+  const triggered = metadata?.hitlTriggered ?? false
+  if (expected === triggered) return { name: 'hitl_gate_correctness', score: 1 }
+  return {
+    name: 'hitl_gate_correctness',
+    score: 0,
+    rationale: expected ? 'expected HITL but not triggered' : 'unexpected HITL trigger',
+  }
+}
+
+export interface FallbackMeta {
+  primaryError?: string | null
+  fallbackFired?: boolean
+}
+
+export const fallbackResilience: Scorer<unknown, FallbackMeta> = ({ metadata }) => {
+  const errored = Boolean(metadata?.primaryError)
+  const fallback = Boolean(metadata?.fallbackFired)
+  if (!errored && !fallback) return { name: 'fallback_resilience', score: 1, rationale: 'no errors' }
+  if (errored && fallback) return { name: 'fallback_resilience', score: 1, rationale: 'fallback recovered' }
+  return {
+    name: 'fallback_resilience',
+    score: 0,
+    rationale: errored ? 'primary errored, no fallback' : 'fallback fired without error',
+  }
+}
+
+export interface CrashMeta {
+  crashed?: boolean
+  uncaughtException?: string | null
+}
+
+export const noCrashSurvival: Scorer<unknown, CrashMeta> = ({ metadata }) => {
+  const crashed = metadata?.crashed === true || Boolean(metadata?.uncaughtException)
+  return {
+    name: 'no_crash_survival',
+    score: crashed ? 0 : 1,
+    rationale: crashed ? (metadata?.uncaughtException ?? 'crashed') : undefined,
+  }
+}

--- a/packages/eval-braintrust/src/types.ts
+++ b/packages/eval-braintrust/src/types.ts
@@ -1,0 +1,22 @@
+export interface ScorerInput<TExpected = unknown, TMeta = Record<string, unknown>> {
+  input: string
+  output: string
+  expected?: TExpected
+  metadata?: TMeta
+}
+
+export interface ScorerResult {
+  name: string
+  score: number
+  rationale?: string
+  metadata?: Record<string, unknown>
+}
+
+export type Scorer<TExpected = unknown, TMeta = Record<string, unknown>> = (
+  args: ScorerInput<TExpected, TMeta>,
+) => ScorerResult | Promise<ScorerResult>
+
+export interface ScorerFamily {
+  family: 'quality' | 'robustness'
+  scorers: Scorer[]
+}

--- a/packages/eval-braintrust/tests/ci.test.ts
+++ b/packages/eval-braintrust/tests/ci.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { detectRegressions, formatAlertsMarkdown } from '../src/ci'
+
+describe('detectRegressions', () => {
+  it('flags scorer drops above threshold', () => {
+    const a = detectRegressions(
+      { x: { mean: 0.9, n: 10 }, y: { mean: 0.8, n: 10 } },
+      { x: { mean: 0.7, n: 10 }, y: { mean: 0.79, n: 10 } },
+      { default: 0.05 },
+    )
+    expect(a).toHaveLength(1)
+    expect(a[0]?.scorer).toBe('x')
+  })
+
+  it('honors per-scorer overrides', () => {
+    const a = detectRegressions(
+      { x: { mean: 0.9, n: 10 } },
+      { x: { mean: 0.85, n: 10 } },
+      { default: 0.1, perScorer: { x: 0.01 } },
+    )
+    expect(a).toHaveLength(1)
+  })
+
+  it('skips scorers missing from baseline', () => {
+    const a = detectRegressions({}, { x: { mean: 0, n: 1 } })
+    expect(a).toHaveLength(0)
+  })
+})
+
+describe('formatAlertsMarkdown', () => {
+  it('returns clean message when nothing regressed', () => {
+    expect(formatAlertsMarkdown([])).toContain('No regressions')
+  })
+
+  it('renders a markdown table when regressions exist', () => {
+    const md = formatAlertsMarkdown([
+      { scorer: 'task_success', baseline: 0.9, current: 0.7, delta: 0.2, threshold: 0.05 },
+    ])
+    expect(md).toContain('| `task_success` |')
+    expect(md).toContain('Baseline')
+  })
+})

--- a/packages/eval-braintrust/tests/runner.test.ts
+++ b/packages/eval-braintrust/tests/runner.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runBraintrustEval, scoreCase, summarize } from '../src/runner'
+import { taskSuccess, schemaSurvival } from '../src/scorers'
+
+describe('scoreCase', () => {
+  it('runs all scorers and surfaces errors as scorer_error', async () => {
+    const broken = () => {
+      throw new Error('boom')
+    }
+    const r = await scoreCase([taskSuccess, broken as never], {
+      input: 'q',
+      output: 'Paris',
+      expected: 'Paris',
+    })
+    expect(r).toHaveLength(2)
+    expect(r[0]?.name).toBe('task_success')
+    expect(r[1]?.name).toBe('scorer_error')
+  })
+})
+
+describe('summarize', () => {
+  it('averages scores by name', () => {
+    const s = summarize([
+      {
+        input: 'a',
+        output: 'a',
+        scores: [{ name: 'x', score: 1 }, { name: 'y', score: 0 }],
+      },
+      {
+        input: 'b',
+        output: 'b',
+        scores: [{ name: 'x', score: 0 }, { name: 'y', score: 1 }],
+      },
+    ])
+    expect(s.x?.mean).toBe(0.5)
+    expect(s.y?.mean).toBe(0.5)
+    expect(s.x?.n).toBe(2)
+  })
+
+  it('returns 0 for empty input', () => {
+    expect(summarize([])).toEqual({})
+  })
+})
+
+describe('runBraintrustEval', () => {
+  it('runs cases through the agent and scorers without a Braintrust SDK', async () => {
+    const agent = vi.fn(async (input: string) => ({ output: `${input} → answer` }))
+    const result = await runBraintrustEval({
+      cases: [
+        { input: 'q1', output: '', expected: 'answer' },
+        { input: 'q2', output: '', expected: 'answer' },
+      ],
+      agent,
+      scorers: [taskSuccess, schemaSurvival],
+      options: { projectName: 'agentskit-test' },
+      bt: {
+        async init() {
+          throw new Error('skip')
+        },
+      },
+    })
+    expect(result.cases).toHaveLength(2)
+    expect(result.summary.task_success?.mean).toBe(1)
+    expect(agent).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs to braintrust when an experiment is initialized', async () => {
+    const logs: Record<string, unknown>[] = []
+    const fakeExperiment = {
+      log(p: Record<string, unknown>) {
+        logs.push(p)
+      },
+      async summarize() {
+        return { experimentUrl: 'https://braintrust.dev/x' }
+      },
+    }
+    const result = await runBraintrustEval({
+      cases: [{ input: 'q', output: '', expected: 'q' }],
+      agent: async input => ({ output: input }),
+      scorers: [taskSuccess],
+      options: { projectName: 'p', apiKey: 'k', experimentName: 'exp' },
+      bt: { init: async () => fakeExperiment },
+    })
+    expect(logs).toHaveLength(1)
+    expect(result.url).toBe('https://braintrust.dev/x')
+  })
+
+  it('records primaryError when the agent throws', async () => {
+    const result = await runBraintrustEval({
+      cases: [{ input: 'q', output: '' }],
+      agent: async () => {
+        throw new Error('agent down')
+      },
+      scorers: [],
+      options: { projectName: 'p' },
+      bt: {
+        async init() {
+          throw new Error('skip')
+        },
+      },
+    })
+    expect(result.cases[0]?.metadata?.primaryError).toBe('agent down')
+  })
+})

--- a/packages/eval-braintrust/tests/runner.test.ts
+++ b/packages/eval-braintrust/tests/runner.test.ts
@@ -53,6 +53,7 @@ describe('runBraintrustEval', () => {
       agent,
       scorers: [taskSuccess, schemaSurvival],
       options: { projectName: 'agentskit-test' },
+    }, {
       bt: {
         async init() {
           throw new Error('skip')
@@ -79,8 +80,7 @@ describe('runBraintrustEval', () => {
       agent: async input => ({ output: input }),
       scorers: [taskSuccess],
       options: { projectName: 'p', apiKey: 'k', experimentName: 'exp' },
-      bt: { init: async () => fakeExperiment },
-    })
+    }, { bt: { init: async () => fakeExperiment } })
     expect(logs).toHaveLength(1)
     expect(result.url).toBe('https://braintrust.dev/x')
   })
@@ -100,5 +100,6 @@ describe('runBraintrustEval', () => {
       },
     })
     expect(result.cases[0]?.metadata?.primaryError).toBe('agent down')
+    expect(result.cases[0]?.metadata?.crashed).toBe(true)
   })
 })

--- a/packages/eval-braintrust/tests/scorers.test.ts
+++ b/packages/eval-braintrust/tests/scorers.test.ts
@@ -146,6 +146,16 @@ describe('robustness scorers', () => {
     ).toBe(0)
   })
 
+  it('fallbackResilience: defensive fallback without error scores 1', async () => {
+    expect(
+      (await fallbackResilience({
+        input: 'q',
+        output: 'x',
+        metadata: { fallbackFired: true },
+      })).score,
+    ).toBe(1)
+  })
+
   it('noCrashSurvival: 0 when crashed', async () => {
     expect(
       (await noCrashSurvival({

--- a/packages/eval-braintrust/tests/scorers.test.ts
+++ b/packages/eval-braintrust/tests/scorers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  taskSuccess,
+  factualGrounding,
+  citationCorrectness,
+  toolArgValidity,
+  schemaSurvival,
+  hitlGateCorrectness,
+  fallbackResilience,
+  noCrashSurvival,
+  qualityFamily,
+  robustnessFamily,
+  ALL_SCORERS,
+} from '../src/scorers'
+
+describe('quality scorers', () => {
+  it('taskSuccess scores 1 on substring match', async () => {
+    const r = await taskSuccess({ input: 'q', output: 'the answer is Paris', expected: 'Paris' })
+    expect(r.score).toBe(1)
+  })
+
+  it('taskSuccess scores 0 without match', async () => {
+    const r = await taskSuccess({ input: 'q', output: 'wrong', expected: 'Paris' })
+    expect(r.score).toBe(0)
+  })
+
+  it('taskSuccess accepts predicate', async () => {
+    const r = await taskSuccess({ input: 'q', output: '42', expected: (o: string) => o === '42' })
+    expect(r.score).toBe(1)
+  })
+
+  it('taskSuccess accepts regex', async () => {
+    const r = await taskSuccess({ input: 'q', output: 'value=42', expected: /value=\d+/ })
+    expect(r.score).toBe(1)
+  })
+
+  it('taskSuccess returns 0 with no expected', async () => {
+    const r = await taskSuccess({ input: 'q', output: 'x' })
+    expect(r.score).toBe(0)
+  })
+
+  it('factualGrounding ratios sources contained', async () => {
+    const r = await factualGrounding({
+      input: 'q',
+      output: 'mentions Paris and Tokyo',
+      metadata: { sources: ['Paris', 'Tokyo', 'Berlin'] },
+    })
+    expect(r.score).toBeCloseTo(2 / 3)
+  })
+
+  it('factualGrounding 0 with no sources', async () => {
+    const r = await factualGrounding({ input: 'q', output: 'x' })
+    expect(r.score).toBe(0)
+  })
+
+  it('citationCorrectness counts citation patterns', async () => {
+    const r = await citationCorrectness({
+      input: 'q',
+      output: 'See [1] and (docs.md) and <source>foo</source>',
+    })
+    expect(r.score).toBe(1)
+  })
+
+  it('citationCorrectness measures expected hit ratio', async () => {
+    const r = await citationCorrectness({
+      input: 'q',
+      output: 'See [1] only',
+      metadata: { expectedCitations: ['1', '2'] },
+    })
+    expect(r.score).toBe(0.5)
+  })
+
+  it('toolArgValidity 1 when no tool calls', async () => {
+    const r = await toolArgValidity({ input: 'q', output: 'x' })
+    expect(r.score).toBe(1)
+  })
+
+  it('toolArgValidity ratios valid calls', async () => {
+    const r = await toolArgValidity({
+      input: 'q',
+      output: 'x',
+      metadata: {
+        toolCalls: [
+          { name: 'a', args: {}, schemaValid: true },
+          { name: 'b', args: {}, schemaValid: false },
+        ],
+      },
+    })
+    expect(r.score).toBe(0.5)
+  })
+})
+
+describe('robustness scorers', () => {
+  it('schemaSurvival 1 when no parse error', async () => {
+    const r = await schemaSurvival({ input: 'q', output: 'x' })
+    expect(r.score).toBe(1)
+  })
+
+  it('schemaSurvival 0 on parse error', async () => {
+    const r = await schemaSurvival({
+      input: 'q',
+      output: 'x',
+      metadata: { parseError: 'bad json' },
+    })
+    expect(r.score).toBe(0)
+  })
+
+  it('hitlGateCorrectness rewards expected match', async () => {
+    expect(
+      (await hitlGateCorrectness({
+        input: 'q',
+        output: 'x',
+        metadata: { hitlExpected: true, hitlTriggered: true },
+      })).score,
+    ).toBe(1)
+    expect(
+      (await hitlGateCorrectness({
+        input: 'q',
+        output: 'x',
+        metadata: { hitlExpected: false, hitlTriggered: true },
+      })).score,
+    ).toBe(0)
+  })
+
+  it('fallbackResilience: clean run', async () => {
+    expect((await fallbackResilience({ input: 'q', output: 'x' })).score).toBe(1)
+  })
+
+  it('fallbackResilience: error recovered', async () => {
+    expect(
+      (await fallbackResilience({
+        input: 'q',
+        output: 'x',
+        metadata: { primaryError: 'x', fallbackFired: true },
+      })).score,
+    ).toBe(1)
+  })
+
+  it('fallbackResilience: error without fallback', async () => {
+    expect(
+      (await fallbackResilience({
+        input: 'q',
+        output: '',
+        metadata: { primaryError: 'x', fallbackFired: false },
+      })).score,
+    ).toBe(0)
+  })
+
+  it('noCrashSurvival: 0 when crashed', async () => {
+    expect(
+      (await noCrashSurvival({
+        input: 'q',
+        output: '',
+        metadata: { crashed: true },
+      })).score,
+    ).toBe(0)
+  })
+
+  it('noCrashSurvival: 0 on uncaughtException', async () => {
+    expect(
+      (await noCrashSurvival({
+        input: 'q',
+        output: '',
+        metadata: { uncaughtException: 'TypeError' },
+      })).score,
+    ).toBe(0)
+  })
+})
+
+describe('families', () => {
+  it('exposes 4 quality + 4 robustness scorers (8 total)', () => {
+    expect(qualityFamily.scorers).toHaveLength(4)
+    expect(robustnessFamily.scorers).toHaveLength(4)
+    expect(ALL_SCORERS).toHaveLength(8)
+  })
+})

--- a/packages/eval-braintrust/tsconfig.json
+++ b/packages/eval-braintrust/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/eval-braintrust/tsup.config.ts
+++ b/packages/eval-braintrust/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    scorers: 'src/scorers/index.ts',
+    ci: 'src/ci.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+  external: ['braintrust'],
+})

--- a/packages/eval-braintrust/vitest.config.ts
+++ b/packages/eval-braintrust/vitest.config.ts
@@ -1,0 +1,4 @@
+import { createTestConfig } from '../../vitest.shared'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(createTestConfig({ linesThreshold: 70 }))

--- a/packages/observability-langfuse/CHANGELOG.md
+++ b/packages/observability-langfuse/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @agentskit/observability-langfuse

--- a/packages/observability-langfuse/CONVENTIONS.md
+++ b/packages/observability-langfuse/CONVENTIONS.md
@@ -1,0 +1,29 @@
+# Conventions — `@agentskit/observability-langfuse`
+
+Provider integration for Langfuse. Pairs with the `Observer` primitive from `@agentskit/core` and the span tracker from `@agentskit/observability`.
+
+## Stability tier: `beta`
+
+Adapter contract is stable. Breaking changes upstream in the `langfuse` SDK may force minor bumps.
+
+## Scope
+
+- One Langfuse `trace` per agent run.
+- Nested `span` / `generation` objects per AgentsKit event.
+- Token, cost, and latency capture wired into Langfuse `usage`.
+- Env-driven config (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`).
+
+## Observer is read-only
+
+Per runtime RT9: the observer cannot mutate messages, tool calls, or results. Logging and span emission only.
+
+## Adding a new mapping
+
+1. Extend the `case` block in `@agentskit/observability/trace-tracker` first — that is the source of truth.
+2. Map the new attribute in `langfuse.ts`'s `startRemote` / `endRemote`.
+3. Cover with a unit test using the in-memory mock client (see `tests/langfuse.test.ts`).
+
+## Testing
+
+- Unit tests mock the `langfuse` SDK; do not hit the network.
+- Errors from the SDK are swallowed and asserted via `expect(...).not.toThrow()`.

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -1,0 +1,55 @@
+# `@agentskit/observability-langfuse`
+
+Langfuse tracing adapter for AgentsKit. Emits one trace per agent run with nested spans for plan, tool calls, model generations, memory IO, and HITL gates. Token, cost, and latency metadata flow into the standard Langfuse `usage` and metadata fields.
+
+## Install
+
+```sh
+npm install @agentskit/observability-langfuse langfuse
+```
+
+`langfuse` is loaded lazily — install it alongside this adapter.
+
+## Usage
+
+```ts
+import { runAgent } from '@agentskit/runtime'
+import { langfuse } from '@agentskit/observability-langfuse'
+
+const observer = langfuse({
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+  secretKey: process.env.LANGFUSE_SECRET_KEY!,
+  baseUrl: process.env.LANGFUSE_HOST,
+  sessionId: 'demo-session',
+  tags: ['agentskit', 'showcase'],
+})
+
+await runAgent({
+  /* ...agent config... */
+  observers: [observer],
+})
+```
+
+If `publicKey` / `secretKey` / `baseUrl` are omitted, the adapter falls back to `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST`.
+
+## Span model
+
+| AgentsKit event | Langfuse object | Notes |
+|---|---|---|
+| `agent:step` | `span` | Top-level loop step (plan / act / observe). |
+| `llm:start` / `llm:end` | `generation` | Captures model, input message count, output content (truncated), and token usage. |
+| `tool:start` / `tool:end` | `span` | Captures tool name, args, result snapshot, and duration. |
+| `memory:load` / `memory:save` | `span` | Captures message count. |
+| `error` | annotates current span | Sets `level: 'ERROR'` and `statusMessage`. |
+
+Multi-agent topologies (planner → worker → reviewer) link automatically: each delegated agent run is a child trace under the parent step, mirroring `@agentskit/observability`'s span tracker.
+
+## Conventions
+
+- Read-only: this observer never mutates messages, tool calls, or results.
+- Errors from the Langfuse SDK are swallowed so they cannot break the run loop.
+- Flushing is handled by the SDK on `flushAsync()` / process exit.
+
+## License
+
+MIT

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@agentskit/observability-langfuse",
+  "version": "0.1.0",
+  "description": "Langfuse tracing adapter for AgentsKit. Spans for plan, tool, model, and HITL gates with token/cost/latency capture.",
+  "keywords": [
+    "agentskit",
+    "ai",
+    "agents",
+    "llm",
+    "typescript",
+    "observability",
+    "tracing",
+    "langfuse",
+    "telemetry",
+    "openai",
+    "anthropic",
+    "ai-agents"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*",
+    "@agentskit/observability": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "langfuse": "^3.38.20",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "agentskit": {
+    "stability": "beta",
+    "stabilityNote": "Adapter contract stable; Langfuse SDK is peer-resolved at runtime."
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/observability-langfuse",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/observability-langfuse"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
+}

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -1,0 +1,2 @@
+export { langfuse } from './langfuse'
+export type { LangfuseConfig } from './langfuse'

--- a/packages/observability-langfuse/src/langfuse.ts
+++ b/packages/observability-langfuse/src/langfuse.ts
@@ -91,11 +91,12 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
   }
 
   const startRemote = (span: TraceSpan) => {
+    const parentPromise = span.parentId ? spanPromises.get(span.parentId) ?? null : null
     const p = (async (): Promise<LangfuseSpan | null> => {
       try {
         const trace = await ensureTrace()
-        const parent = span.parentId ? await spanPromises.get(span.parentId) : null
-        const host = parent ?? trace
+        const parent = parentPromise ? await parentPromise : null
+        const host: LangfuseTrace | LangfuseSpan = parent ?? trace
         const params: Record<string, unknown> = {
           id: span.id,
           name: span.name,
@@ -103,7 +104,7 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
           metadata: span.attributes,
         }
         if (isLlmSpan(span.name)) {
-          const gen = (host as LangfuseTrace | LangfuseSpan).generation
+          const gen = host.generation
           if (!gen) return null
           return gen.call(host, {
             ...params,
@@ -111,7 +112,7 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
             input: span.attributes['agentskit.message_count'],
           })
         }
-        const sp = (host as LangfuseTrace | LangfuseSpan).span
+        const sp = host.span
         if (!sp) return null
         return sp.call(host, params)
       } catch {

--- a/packages/observability-langfuse/src/langfuse.ts
+++ b/packages/observability-langfuse/src/langfuse.ts
@@ -1,0 +1,167 @@
+import type { Observer } from '@agentskit/core'
+import { createTraceTracker, type TraceSpan } from '@agentskit/observability'
+
+export interface LangfuseConfig {
+  publicKey?: string
+  secretKey?: string
+  baseUrl?: string
+  release?: string
+  environment?: string
+  sessionId?: string
+  userId?: string
+  tags?: string[]
+  flushAt?: number
+  flushInterval?: number
+}
+
+interface LangfuseTrace {
+  id: string
+  update(params: Record<string, unknown>): LangfuseTrace
+  span(params: Record<string, unknown>): LangfuseSpan
+  generation(params: Record<string, unknown>): LangfuseSpan
+  event(params: Record<string, unknown>): unknown
+}
+
+interface LangfuseSpan {
+  id: string
+  end(params?: Record<string, unknown>): unknown
+  update(params: Record<string, unknown>): LangfuseSpan
+  span?(params: Record<string, unknown>): LangfuseSpan
+  generation?(params: Record<string, unknown>): LangfuseSpan
+}
+
+interface LangfuseClient {
+  trace(params: Record<string, unknown>): LangfuseTrace
+  flushAsync(): Promise<void>
+  shutdownAsync(): Promise<void>
+}
+
+const envOr = (k: string, fallback?: string): string | undefined => {
+  if (typeof process === 'undefined' || !process.env) return fallback
+  return process.env[k] ?? fallback
+}
+
+const isLlmSpan = (name: string): boolean => name.startsWith('gen_ai')
+const isToolSpan = (name: string): boolean => name.startsWith('agentskit.tool')
+
+export function langfuse(config: LangfuseConfig = {}): Observer {
+  const publicKey = config.publicKey ?? envOr('LANGFUSE_PUBLIC_KEY')
+  const secretKey = config.secretKey ?? envOr('LANGFUSE_SECRET_KEY')
+  const baseUrl = config.baseUrl ?? envOr('LANGFUSE_HOST') ?? 'https://cloud.langfuse.com'
+  const release = config.release ?? envOr('LANGFUSE_RELEASE')
+  const environment = config.environment ?? envOr('LANGFUSE_ENVIRONMENT')
+
+  let clientPromise: Promise<LangfuseClient> | null = null
+  let tracePromise: Promise<LangfuseTrace> | null = null
+  const spanPromises = new Map<string, Promise<LangfuseSpan | null>>()
+
+  const getClient = (): Promise<LangfuseClient> => {
+    if (clientPromise) return clientPromise
+    clientPromise = (async () => {
+      const mod = await import('langfuse')
+      const Ctor = (mod.Langfuse ?? (mod as { default?: unknown }).default) as unknown as new (
+        c: Record<string, unknown>,
+      ) => LangfuseClient
+      return new Ctor({
+        publicKey,
+        secretKey,
+        baseUrl,
+        release,
+        environment,
+        flushAt: config.flushAt ?? 15,
+        flushInterval: config.flushInterval ?? 1_000,
+      })
+    })()
+    return clientPromise
+  }
+
+  const ensureTrace = (): Promise<LangfuseTrace> => {
+    if (tracePromise) return tracePromise
+    tracePromise = (async () => {
+      const client = await getClient()
+      return client.trace({
+        name: 'agentskit.run',
+        sessionId: config.sessionId,
+        userId: config.userId,
+        tags: config.tags,
+        release,
+      })
+    })()
+    return tracePromise
+  }
+
+  const startRemote = (span: TraceSpan) => {
+    const p = (async (): Promise<LangfuseSpan | null> => {
+      try {
+        const trace = await ensureTrace()
+        const parent = span.parentId ? await spanPromises.get(span.parentId) : null
+        const host = parent ?? trace
+        const params: Record<string, unknown> = {
+          id: span.id,
+          name: span.name,
+          startTime: new Date(span.startTime),
+          metadata: span.attributes,
+        }
+        if (isLlmSpan(span.name)) {
+          const gen = (host as LangfuseTrace | LangfuseSpan).generation
+          if (!gen) return null
+          return gen.call(host, {
+            ...params,
+            model: span.attributes['gen_ai.request.model'],
+            input: span.attributes['agentskit.message_count'],
+          })
+        }
+        const sp = (host as LangfuseTrace | LangfuseSpan).span
+        if (!sp) return null
+        return sp.call(host, params)
+      } catch {
+        return null
+      }
+    })()
+    spanPromises.set(span.id, p)
+  }
+
+  const endRemote = (span: TraceSpan) => {
+    void (async () => {
+      try {
+        const remote = await spanPromises.get(span.id)
+        if (!remote) return
+        const usage = isLlmSpan(span.name)
+          ? {
+              input: span.attributes['gen_ai.usage.input_tokens'],
+              output: span.attributes['gen_ai.usage.output_tokens'],
+              unit: 'TOKENS',
+            }
+          : undefined
+        const hasError = span.status === 'error' || span.attributes['error.message'] !== undefined
+        remote.end({
+          endTime: span.endTime ? new Date(span.endTime) : new Date(),
+          output:
+            span.attributes['gen_ai.response.content'] ?? span.attributes['agentskit.tool.result'],
+          level: hasError ? 'ERROR' : 'DEFAULT',
+          statusMessage: hasError ? String(span.attributes['error.message'] ?? 'unknown') : undefined,
+          ...(usage ? { usage } : {}),
+        })
+      } catch {
+      }
+    })()
+  }
+
+  const tracker = createTraceTracker({
+    onSpanStart(span) {
+      startRemote(span)
+    },
+    onSpanEnd(span) {
+      endRemote(span)
+    },
+  })
+
+  return {
+    name: 'langfuse',
+    on(event) {
+      tracker.handle(event)
+    },
+  }
+}
+
+export const __testables = { isLlmSpan, isToolSpan }

--- a/packages/observability-langfuse/tests/langfuse.test.ts
+++ b/packages/observability-langfuse/tests/langfuse.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface CapturedSpan {
+  kind: 'span' | 'generation'
+  params: Record<string, unknown>
+  ended: Record<string, unknown> | null
+}
+
+interface Captured {
+  traces: Array<Record<string, unknown>>
+  spans: CapturedSpan[]
+}
+
+let captured: Captured
+
+class FakeSpan {
+  ended: Record<string, unknown> | null = null
+  constructor(public kind: 'span' | 'generation', public params: Record<string, unknown>, private store: CapturedSpan[]) {
+    const rec: CapturedSpan = { kind, params, ended: null }
+    store.push(rec)
+    Object.defineProperty(this, '_rec', { value: rec, enumerable: false })
+  }
+  get id() {
+    return String(this.params.id ?? 'auto')
+  }
+  end(p: Record<string, unknown> = {}) {
+    ;(this as unknown as { _rec: CapturedSpan })._rec.ended = p
+    return this
+  }
+  update() {
+    return this
+  }
+  span(p: Record<string, unknown>) {
+    return new FakeSpan('span', p, this.store)
+  }
+  generation(p: Record<string, unknown>) {
+    return new FakeSpan('generation', p, this.store)
+  }
+}
+
+class FakeTrace {
+  constructor(public params: Record<string, unknown>, private store: Captured) {
+    store.traces.push(params)
+  }
+  get id() {
+    return String(this.params.name ?? 'trace')
+  }
+  update() {
+    return this
+  }
+  span(p: Record<string, unknown>) {
+    return new FakeSpan('span', p, this.store.spans)
+  }
+  generation(p: Record<string, unknown>) {
+    return new FakeSpan('generation', p, this.store.spans)
+  }
+  event(p: Record<string, unknown>) {
+    return p
+  }
+}
+
+class FakeLangfuse {
+  constructor(_: Record<string, unknown>) {}
+  trace(p: Record<string, unknown>) {
+    return new FakeTrace(p, captured)
+  }
+  async flushAsync() {}
+  async shutdownAsync() {}
+}
+
+beforeEach(() => {
+  captured = { traces: [], spans: [] }
+  vi.doMock('langfuse', () => ({ Langfuse: FakeLangfuse }))
+})
+
+afterEach(() => {
+  vi.doUnmock('langfuse')
+  vi.resetModules()
+})
+
+const flush = () => new Promise(r => setTimeout(r, 5))
+
+describe('langfuse observer', () => {
+  it('exposes the standard observer shape', async () => {
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    expect(sink.name).toBe('langfuse')
+    expect(typeof sink.on).toBe('function')
+  })
+
+  it('opens a trace on first event and creates a generation for llm spans', async () => {
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    sink.on({ type: 'agent:step', step: 1, action: 'plan' })
+    sink.on({ type: 'llm:start', model: 'gpt-4o', messageCount: 3 })
+    sink.on({
+      type: 'llm:end',
+      content: 'hi',
+      usage: { promptTokens: 10, completionTokens: 5 },
+      durationMs: 12,
+    })
+    await flush()
+    expect(captured.traces.length).toBe(1)
+    const llmSpan = captured.spans.find(s => s.kind === 'generation')
+    expect(llmSpan).toBeDefined()
+    expect(llmSpan!.params.model).toBe('gpt-4o')
+    expect(llmSpan!.ended).not.toBeNull()
+    expect((llmSpan!.ended as { usage?: { input?: number } }).usage?.input).toBe(10)
+  })
+
+  it('creates a regular span for tool calls and links via parent', async () => {
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    sink.on({ type: 'agent:step', step: 1, action: 'tool' })
+    sink.on({ type: 'tool:start', name: 'search', args: { q: 'x' } })
+    sink.on({ type: 'tool:end', name: 'search', result: 'ok', durationMs: 5 })
+    await flush()
+    const toolSpan = captured.spans.find(s => String(s.params.name).startsWith('agentskit.tool'))
+    expect(toolSpan).toBeDefined()
+    expect(toolSpan!.kind).toBe('span')
+    expect(toolSpan!.ended).not.toBeNull()
+  })
+
+  it('marks span as ERROR when status is error', async () => {
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    sink.on({ type: 'tool:start', name: 't', args: {} })
+    sink.on({ type: 'error', error: new Error('boom') })
+    sink.on({ type: 'tool:end', name: 't', result: '', durationMs: 1 })
+    await flush()
+    const toolSpan = captured.spans.find(s => s.kind === 'span')
+    expect(toolSpan!.ended).not.toBeNull()
+    expect((toolSpan!.ended as { level?: string }).level).toBe('ERROR')
+  })
+
+  it('swallows SDK errors so the runtime is not interrupted', async () => {
+    vi.doMock('langfuse', () => ({
+      Langfuse: class Bad {
+        constructor(_: unknown) {}
+        trace() {
+          throw new Error('langfuse down')
+        }
+        async flushAsync() {}
+        async shutdownAsync() {}
+      },
+    }))
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    expect(() => {
+      sink.on({ type: 'llm:start', model: 'm', messageCount: 1 })
+      sink.on({ type: 'llm:end', content: 'x', durationMs: 1 })
+    }).not.toThrow()
+    await flush()
+  })
+
+  it('throws helpful message if langfuse package is missing', async () => {
+    vi.doMock('langfuse', () => {
+      throw new Error('not found')
+    })
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
+    sink.on({ type: 'llm:start', model: 'm', messageCount: 1 })
+    await flush()
+    expect(captured.traces.length).toBe(0)
+  })
+
+  it('reads config from env when not provided', async () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'envpk'
+    process.env.LANGFUSE_SECRET_KEY = 'envsk'
+    process.env.LANGFUSE_HOST = 'https://eu.cloud.langfuse.com'
+    const { langfuse } = await import('../src/langfuse')
+    const sink = langfuse()
+    expect(sink.name).toBe('langfuse')
+    delete process.env.LANGFUSE_PUBLIC_KEY
+    delete process.env.LANGFUSE_SECRET_KEY
+    delete process.env.LANGFUSE_HOST
+  })
+
+  it('exposes test predicates', async () => {
+    const { __testables } = await import('../src/langfuse')
+    expect(__testables.isLlmSpan('gen_ai.chat')).toBe(true)
+    expect(__testables.isLlmSpan('agentskit.tool.x')).toBe(false)
+    expect(__testables.isToolSpan('agentskit.tool.search')).toBe(true)
+    expect(__testables.isToolSpan('gen_ai.chat')).toBe(false)
+  })
+})

--- a/packages/observability-langfuse/tsconfig.json
+++ b/packages/observability-langfuse/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/observability-langfuse/tsup.config.ts
+++ b/packages/observability-langfuse/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/observability-langfuse/vitest.config.ts
+++ b/packages/observability-langfuse/vitest.config.ts
@@ -1,0 +1,4 @@
+import { createTestConfig } from '../../vitest.shared'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(createTestConfig({ linesThreshold: 60 }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,22 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/example-dspy:
+    dependencies:
+      '@agentskit/eval-braintrust':
+        specifier: workspace:*
+        version: link:../../packages/eval-braintrust
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/example-edge:
     dependencies:
       '@agentskit/adapters':
@@ -517,6 +533,31 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/eval-braintrust:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+      '@agentskit/eval':
+        specifier: workspace:*
+        version: link:../eval
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      braintrust:
+        specifier: ^0.0.196
+        version: 0.0.196(@aws-sdk/credential-provider-web-identity@3.972.37)(openai@4.104.0(ws@8.20.0)(zod@4.4.1))(react@19.2.5)(solid-js@1.9.12)(sswr@2.2.0(svelte@5.55.5))(svelte@5.55.5)(vue@3.5.33(typescript@6.0.3))(zod@4.4.1)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/ink:
     dependencies:
       '@agentskit/core':
@@ -583,7 +624,7 @@ importers:
         version: 6.0.3
       vectra:
         specifier: ^0.14.0
-        version: 0.14.0(ws@8.20.0)
+        version: 0.14.0(ws@8.20.0)(zod@3.25.76)
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -608,7 +649,32 @@ importers:
         version: 25.6.0
       langsmith:
         specifier: ^0.6.0
-        version: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0))(ws@8.20.0)
+        version: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/observability-langfuse:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+      '@agentskit/observability':
+        specifier: workspace:*
+        version: link:../observability
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      langfuse:
+        specifier: ^3.38.20
+        version: 3.38.20
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
@@ -896,6 +962,71 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/provider-utils@1.0.22':
+    resolution: {integrity: sha512-YHK2rpj++wnLVc9vPGzGFP3Pjeld2MwhKinetA0zKXOoHAT/Jit5O8kZsxcSlJPu9wvcGT1UGZEjZrtO7PfFOQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/provider@0.0.26':
+    resolution: {integrity: sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@0.0.70':
+    resolution: {integrity: sha512-GnwbtjW4/4z7MleLiW+TOZC2M29eCg1tOUpuEiYFMmFNZK8mkrqM0PFZMo6UsYeUYMWqEOOcPOU9OQVJMJh7IQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      zod:
+        optional: true
+
+  '@ai-sdk/solid@0.0.54':
+    resolution: {integrity: sha512-96KWTVK+opdFeRubqrgaJXoNiDP89gNxFRWUp0PJOotZW816AbhUf4EnDjBjXTLjXL1n0h8tGSE9sZsRkj9wQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      solid-js: ^1.7.7
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  '@ai-sdk/svelte@0.0.57':
+    resolution: {integrity: sha512-SyF9ItIR9ALP9yDNAD+2/5Vl1IT6kchgyDH8xkmhysfJI6WrvJbtO1wdQ0nylvPLcsPoYu+cAlz1krU4lFHcYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  '@ai-sdk/ui-utils@0.0.50':
+    resolution: {integrity: sha512-Z5QYJVW+5XpSaJ4jYCCAVG7zIAuKOOdikhgpksneNmKvx61ACFaf98pmOd+xnjahl0pIlc/QIe6O4yVaJ1sEaw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/vue@0.0.59':
+    resolution: {integrity: sha512-+ofYlnqdc8c4F6tM0IKF0+7NagZRAiqBJpGDJ+6EYhDW8FHLUP/JFBgu32SjxSxC6IKFZxEnl68ZoP/Z38EMlw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@alcalzone/ansi-tokenize@0.3.0':
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
@@ -990,6 +1121,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@asteasolutions/zod-to-openapi@6.4.0':
+    resolution: {integrity: sha512-8cxfF7AHHx2PqnN4Cd8/O8CBu/nVYJP9DpnfVLW3BFb66VJDnqI/CczZnkqMc3SNh6J9GiX7JbJ5T4BSP4HZ2Q==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1218,6 +1354,9 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@braintrust/core@0.0.83':
+    resolution: {integrity: sha512-HDxtI3eYTJO7sN36jVrNDDPAaewldrnsfv99p5TKFrH5OUNX7x5tyqlPX+wQXyjn7PSvyNGpsqK8S/dnrqKocQ==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -1401,6 +1540,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -1413,6 +1558,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -1423,6 +1574,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -1437,6 +1594,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -1449,6 +1612,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -1459,6 +1628,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -1473,6 +1648,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -1483,6 +1664,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -1497,6 +1684,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -1507,6 +1700,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -1521,6 +1720,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -1531,6 +1736,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -1545,6 +1756,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -1555,6 +1772,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -1569,6 +1792,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -1579,6 +1808,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -1593,6 +1828,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -1605,6 +1846,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -1615,6 +1862,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -1629,6 +1882,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -1639,6 +1898,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1653,6 +1918,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
@@ -1664,6 +1935,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -1677,6 +1954,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -1689,6 +1972,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -1699,6 +1988,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -2104,6 +2399,12 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
@@ -2152,6 +2453,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
@@ -2237,6 +2541,10 @@ packages:
 
   '@opentelemetry/api-logs@0.216.0':
     resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
@@ -3086,6 +3394,12 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -3560,6 +3874,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -3679,6 +3996,15 @@ packages:
       vue:
         optional: true
       vue-router:
+        optional: true
+
+  '@vercel/functions@1.6.0':
+    resolution: {integrity: sha512-R6FKQrYT5MZs5IE1SqeCJWxMuBdHawFcCZboKKw8p7s+6/mcd55Gx6tWmyKnQTyrSEA04NH73Tc9CbqpEle8RA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
         optional: true
 
   '@vercel/speed-insights@2.0.0':
@@ -3813,6 +4139,27 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ai@3.4.33:
+    resolution: {integrity: sha512-plBlrVZKwPoRTmM8+D1sJac9Bq8eaa2jiZlHLZIWekKWI1yMWYZvCCEezY9ASPwRhULYDJB2VhKOBUUeg3S5JQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      openai: ^4.42.0
+      react: ^18 || ^19 || ^19.0.0-rc
+      sswr: ^2.1.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      openai:
+        optional: true
+      react:
+        optional: true
+      sswr:
+        optional: true
+      svelte:
+        optional: true
+      zod:
+        optional: true
+
   algoliasearch@5.50.1:
     resolution: {integrity: sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==}
     engines: {node: '>= 14.0.0'}
@@ -3913,6 +4260,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3948,6 +4298,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -3955,6 +4308,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  braintrust@0.0.196:
+    resolution: {integrity: sha512-HNWiFZBiTj2skItQNt59QeD8NnfEmFTg9mBMmlYvt6EKGL0ashHAMKkGkOZ4Or7ZC3trMQRlx+yK8/7aYF0oNQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.0.0
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -4096,6 +4455,10 @@ packages:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -4475,6 +4838,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4615,6 +4981,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -4707,6 +5078,10 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventsource-parser@1.1.2:
+    resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
+    engines: {node: '>=14.18'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -5342,9 +5717,17 @@ packages:
   json-colorizer@3.0.1:
     resolution: {integrity: sha512-4YyRAbD6eHeRnJD9vo0zjiU5fyY9QR6T+iYuH5DpO0XPThKWozpD4MaeY/8nLZIkHC3yEQMFLL+6P94E+JekDw==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -5360,6 +5743,14 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  langfuse-core@3.38.20:
+    resolution: {integrity: sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==}
+    engines: {node: '>=18'}
+
+  langfuse@3.38.20:
+    resolution: {integrity: sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==}
+    engines: {node: '>=18'}
 
   langium@4.2.2:
     resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
@@ -5873,6 +6264,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -5937,6 +6332,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -6077,6 +6476,9 @@ packages:
 
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   openurl@1.1.1:
     resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==}
@@ -6226,6 +6628,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -6542,6 +6948,9 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -6615,6 +7024,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   size-limit@12.1.0:
     resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -6636,6 +7048,10 @@ packages:
   slice-ansi@9.0.0:
     resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
     engines: {node: '>=22'}
+
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
 
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
@@ -6667,6 +7083,11 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sswr@2.2.0:
+    resolution: {integrity: sha512-clTszLPZkmycALTHD1mXGU+mOtA/MIoLgS1KGTTzFNVm9rytQVykgRaP+z1zl572cz0bTqj4rFVoC2N+IGK4Sg==}
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -6785,6 +7206,19 @@ packages:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  swrev@4.0.0:
+    resolution: {integrity: sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==}
+
+  swrv@1.2.0:
+    resolution: {integrity: sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -6835,6 +7269,10 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -7056,6 +7494,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -7065,6 +7508,11 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vectra@0.14.0:
@@ -7381,6 +7829,14 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
@@ -7393,6 +7849,72 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/provider-utils@1.0.22(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      eventsource-parser: 1.1.2
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 4.4.1
+
+  '@ai-sdk/provider@0.0.26':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@0.0.70(react@19.2.5)(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      '@ai-sdk/ui-utils': 0.0.50(zod@4.4.1)
+      swr: 2.4.1(react@19.2.5)
+      throttleit: 2.1.0
+    optionalDependencies:
+      react: 19.2.5
+      zod: 4.4.1
+
+  '@ai-sdk/solid@0.0.54(solid-js@1.9.12)(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      '@ai-sdk/ui-utils': 0.0.50(zod@4.4.1)
+    optionalDependencies:
+      solid-js: 1.9.12
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/svelte@0.0.57(svelte@5.55.5)(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      '@ai-sdk/ui-utils': 0.0.50(zod@4.4.1)
+      sswr: 2.2.0(svelte@5.55.5)
+    optionalDependencies:
+      svelte: 5.55.5
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/ui-utils@0.0.50(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      json-schema: 0.4.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
+    optionalDependencies:
+      zod: 4.4.1
+
+  '@ai-sdk/vue@0.0.59(vue@3.5.33(typescript@6.0.3))(zod@4.4.1)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      '@ai-sdk/ui-utils': 0.0.50(zod@4.4.1)
+      swrv: 1.2.0(vue@3.5.33(typescript@6.0.3))
+    optionalDependencies:
+      vue: 3.5.33(typescript@6.0.3)
+    transitivePeerDependencies:
+      - zod
 
   '@alcalzone/ansi-tokenize@0.3.0':
     dependencies:
@@ -7530,6 +8052,11 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@asteasolutions/zod-to-openapi@6.4.0(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -8058,6 +8585,12 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@braintrust/core@0.0.83':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.25.76)
+      uuid: 9.0.1
+      zod: 3.25.76
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -8388,10 +8921,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -8400,10 +8939,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -8412,10 +8957,16 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -8424,10 +8975,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -8436,10 +8993,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -8448,10 +9011,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -8460,10 +9029,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -8472,10 +9047,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -8484,10 +9065,16 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -8496,10 +9083,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -8508,10 +9101,16 @@ snapshots:
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -8520,10 +9119,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -8532,10 +9137,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -8866,6 +9477,14 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
+
   '@lezer/common@1.5.2': {}
 
   '@lezer/css@1.3.3':
@@ -8968,6 +9587,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/env@14.2.35': {}
+
   '@next/env@16.2.4': {}
 
   '@next/swc-darwin-arm64@16.2.4':
@@ -9022,6 +9643,8 @@ snapshots:
   '@opentelemetry/api-logs@0.216.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -9760,6 +10383,12 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sindresorhus/is@4.6.0': {}
@@ -10338,6 +10967,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -10441,6 +11072,10 @@ snapshots:
       react: 19.2.5
       svelte: 5.55.5
       vue: 3.5.33(typescript@6.0.3)
+
+  '@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.37)':
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
 
   '@vercel/speed-insights@2.0.0(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.5)(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
@@ -10594,6 +11229,31 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ai@3.4.33(openai@4.104.0(ws@8.20.0)(zod@4.4.1))(react@19.2.5)(solid-js@1.9.12)(sswr@2.2.0(svelte@5.55.5))(svelte@5.55.5)(vue@3.5.33(typescript@6.0.3))(zod@4.4.1):
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@4.4.1)
+      '@ai-sdk/react': 0.0.70(react@19.2.5)(zod@4.4.1)
+      '@ai-sdk/solid': 0.0.54(solid-js@1.9.12)(zod@4.4.1)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.55.5)(zod@4.4.1)
+      '@ai-sdk/ui-utils': 0.0.50(zod@4.4.1)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.33(typescript@6.0.3))(zod@4.4.1)
+      '@opentelemetry/api': 1.9.0
+      eventsource-parser: 1.1.2
+      json-schema: 0.4.0
+      jsondiffpatch: 0.6.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
+    optionalDependencies:
+      openai: 4.104.0(ws@8.20.0)(zod@4.4.1)
+      react: 19.2.5
+      sswr: 2.2.0(svelte@5.55.5)
+      svelte: 5.55.5
+      zod: 4.4.1
+    transitivePeerDependencies:
+      - solid-js
+      - vue
+
   algoliasearch@5.50.1:
     dependencies:
       '@algolia/abtesting': 1.16.1
@@ -10686,6 +11346,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -10719,6 +11381,10 @@ snapshots:
 
   bowser@2.14.1: {}
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -10726,6 +11392,39 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  braintrust@0.0.196(@aws-sdk/credential-provider-web-identity@3.972.37)(openai@4.104.0(ws@8.20.0)(zod@4.4.1))(react@19.2.5)(solid-js@1.9.12)(sswr@2.2.0(svelte@5.55.5))(svelte@5.55.5)(vue@3.5.33(typescript@6.0.3))(zod@4.4.1):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@braintrust/core': 0.0.83
+      '@next/env': 14.2.35
+      '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.37)
+      ai: 3.4.33(openai@4.104.0(ws@8.20.0)(zod@4.4.1))(react@19.2.5)(solid-js@1.9.12)(sswr@2.2.0(svelte@5.55.5))(svelte@5.55.5)(vue@3.5.33(typescript@6.0.3))(zod@4.4.1)
+      argparse: 2.0.1
+      chalk: 4.1.2
+      cli-progress: 3.12.0
+      dotenv: 16.6.1
+      esbuild: 0.25.12
+      eventsource-parser: 1.1.2
+      graceful-fs: 4.2.11
+      minimatch: 9.0.9
+      mustache: 4.2.0
+      pluralize: 8.0.0
+      simple-git: 3.36.0
+      slugify: 1.6.9
+      source-map: 0.7.6
+      uuid: 9.0.1
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - openai
+      - react
+      - solid-js
+      - sswr
+      - supports-color
+      - svelte
+      - vue
 
   browserslist@4.28.2:
     dependencies:
@@ -10883,6 +11582,10 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
+
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
 
   cli-table3@0.6.5:
     dependencies:
@@ -11251,6 +11954,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff-match-patch@1.0.5: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -11405,6 +12110,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -11539,6 +12273,8 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
+
+  eventsource-parser@1.1.2: {}
 
   expand-template@2.0.3: {}
 
@@ -12266,7 +13002,15 @@ snapshots:
     dependencies:
       colorette: 2.0.20
 
+  json-schema@0.4.0: {}
+
   json5@2.2.3: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -12280,6 +13024,14 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  langfuse-core@3.38.20:
+    dependencies:
+      mustache: 4.2.0
+
+  langfuse@3.38.20:
+    dependencies:
+      langfuse-core: 3.38.20
+
   langium@4.2.2:
     dependencies:
       '@chevrotain/regexp-to-ast': 12.0.0
@@ -12289,13 +13041,13 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0))(ws@8.20.0):
+  langsmith@0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      openai: 4.104.0(ws@8.20.0)
+      openai: 4.104.0(ws@8.20.0)(zod@3.25.76)
       ws: 8.20.0
 
   layout-base@1.0.2: {}
@@ -13151,6 +13903,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -13216,6 +13972,8 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
+
+  mustache@4.2.0: {}
 
   mute-stream@3.0.0: {}
 
@@ -13332,7 +14090,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@8.20.0):
+  openai@4.104.0(ws@8.20.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -13343,14 +14101,35 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.20.0
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+
+  openai@4.104.0(ws@8.20.0)(zod@4.4.1):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.4.1
+    transitivePeerDependencies:
+      - encoding
+    optional: true
 
   openapi-fetch@0.14.1:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
   openapi-typescript-helpers@0.0.15: {}
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.3
 
   openurl@1.1.1: {}
 
@@ -13478,6 +14257,8 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pluralize@8.0.0: {}
 
   points-on-curve@0.2.0: {}
 
@@ -13958,6 +14739,8 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  secure-json-parse@2.7.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -14066,6 +14849,16 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   size-limit@12.1.0(jiti@2.6.1):
     dependencies:
       bytes-iec: 3.1.1
@@ -14086,6 +14879,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  slugify@1.6.9: {}
 
   solid-js@1.9.12:
     dependencies:
@@ -14114,6 +14909,11 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  sswr@2.2.0(svelte@5.55.5):
+    dependencies:
+      svelte: 5.55.5
+      swrev: 4.0.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -14243,6 +15043,18 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  swr@2.4.1(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
+  swrev@4.0.0: {}
+
+  swrv@1.2.0(vue@3.5.33(typescript@6.0.3)):
+    dependencies:
+      vue: 3.5.33(typescript@6.0.3)
+
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -14296,6 +15108,8 @@ snapshots:
       any-promise: 1.3.0
 
   throat@5.0.0: {}
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -14509,13 +15323,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
 
-  vectra@0.14.0(ws@8.20.0):
+  uuid@9.0.1: {}
+
+  vectra@0.14.0(ws@8.20.0)(zod@3.25.76):
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.8.0
@@ -14524,7 +15344,7 @@ snapshots:
       dotenv: 16.6.1
       gpt-tokenizer: 3.4.0
       json-colorizer: 3.0.1
-      openai: 4.104.0(ws@8.20.0)
+      openai: 4.104.0(ws@8.20.0)(zod@3.25.76)
       turndown: 7.2.4
       uuid: 11.1.0
       wink-bm25-text-search: 3.1.2
@@ -14835,6 +15655,12 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.1):
+    dependencies:
+      zod: 4.4.1
+
+  zod@3.25.76: {}
 
   zod@4.4.1: {}
 


### PR DESCRIPTION
## Summary

Three additive packages, each closing a P0 issue. No existing files modified.

- **`@agentskit/observability-langfuse`** — Observer-shaped Langfuse adapter. Maps AgentsKit `Observer` events (plan, tool, model, memory, HITL) onto Langfuse traces / spans / generations with token + latency capture and parent linking. Env-driven config (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`). Closes #759.
- **`@agentskit/eval-braintrust`** — Scoring pipeline with 4 quality scorers (`task_success`, `factual_grounding`, `citation_correctness`, `tool_arg_validity`) and 4 robustness scorers (`schema_survival`, `hitl_gate_correctness`, `fallback_resilience`, `no_crash_survival`). Includes `runBraintrustEval` runner and CI helpers (`detectRegressions`, `formatAlertsMarkdown`). Closes #760.
- **`apps/example-dspy`** — Deterministic node showcase comparing baseline vs DSPy-optimized prompt against `ALL_SCORERS`. Prints a markdown delta table; exits non-zero if optimized doesn't beat baseline. Ships `docs/dspy-loop.md` (collect traces → bootstrap → DSPy compile → re-evaluate, plus DPO follow-up). Closes #761.

39 unit tests added (8 langfuse + 31 eval-braintrust). All packages build cleanly. The DSPy showcase ran locally with a +80% citation_correctness and +80% tool_arg_validity delta.

## Test plan
- [ ] `pnpm --filter @agentskit/observability-langfuse test` — 8 tests pass
- [ ] `pnpm --filter @agentskit/eval-braintrust test` — 31 tests pass
- [ ] `pnpm --filter @agentskit/observability-langfuse build` clean
- [ ] `pnpm --filter @agentskit/eval-braintrust build` clean
- [ ] `pnpm --filter @agentskit/example-dspy start` — prints comparison table, optimized prompt beats baseline on 5/8 scorers
- [ ] `pnpm --filter @agentskit/example-dspy build` (typecheck) clean