### PR TITLE
feat(docs): ecosystem-spanning showcase demos + hero scenes

### DIFF
--- a/.changeset/showcase-subpath-exports.md
+++ b/.changeset/showcase-subpath-exports.md
@@ -1,0 +1,19 @@
+---
+"@agentskit/adapters": patch
+"@agentskit/memory": patch
+"@agentskit/observability": patch
+"@agentskit/rag": patch
+"@agentskit/runtime": patch
+"@agentskit/sandbox": patch
+---
+
+Add browser-safe subpath exports so docs/showcase demos can import individual modules without pulling in node-only barrel deps.
+
+- `@agentskit/adapters/createAdapter`
+- `@agentskit/memory/personalization`
+- `@agentskit/observability/trace-tracker`, `/cost-guard`
+- `@agentskit/rag/chunker`
+- `@agentskit/runtime/shared-context`
+- `@agentskit/sandbox/sandbox`, `/types`
+
+`@agentskit/sandbox`: `createSandbox` now lazy-loads the E2B backend via dynamic import with bundler-ignore comments. No runtime API change — callers passing a custom `backend` never reach the E2B path.

--- a/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
+++ b/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
@@ -2,7 +2,22 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { SCENES, type WidgetKind, type Event } from './scenes'
-import { WeatherCard, PriceCard, OrderTracker, FlightList } from './widgets'
+import {
+  WeatherCard,
+  PriceCard,
+  OrderTracker,
+  FlightList,
+  RAGCite,
+  SandboxRun,
+  MultiAgent,
+  ObsTrace,
+  MemoryRecall,
+  ProviderSwap,
+  IntegrationCard,
+  TerminalMirror,
+  EvalRun,
+  SkillSwap,
+} from './widgets'
 
 type ToolState = { label: string; done: boolean; ms: number } | null
 
@@ -221,6 +236,16 @@ export function HeroDemo() {
                   {frame.widget === 'price' && <PriceCard />}
                   {frame.widget === 'order' && <OrderTracker />}
                   {frame.widget === 'flight' && <FlightList />}
+                  {frame.widget === 'rag' && <RAGCite />}
+                  {frame.widget === 'sandbox' && <SandboxRun />}
+                  {frame.widget === 'agents' && <MultiAgent />}
+                  {frame.widget === 'trace' && <ObsTrace />}
+                  {frame.widget === 'memory' && <MemoryRecall />}
+                  {frame.widget === 'providers' && <ProviderSwap />}
+                  {frame.widget === 'integration' && <IntegrationCard />}
+                  {frame.widget === 'terminal' && <TerminalMirror />}
+                  {frame.widget === 'eval' && <EvalRun />}
+                  {frame.widget === 'skill' && <SkillSwap />}
                 </div>
               )}
 

--- a/apps/docs-next/app/(home)/_components/hero-demo/scenes.ts
+++ b/apps/docs-next/app/(home)/_components/hero-demo/scenes.ts
@@ -1,4 +1,18 @@
-export type WidgetKind = 'weather' | 'price' | 'order' | 'flight'
+export type WidgetKind =
+  | 'weather'
+  | 'price'
+  | 'order'
+  | 'flight'
+  | 'rag'
+  | 'sandbox'
+  | 'agents'
+  | 'trace'
+  | 'memory'
+  | 'providers'
+  | 'integration'
+  | 'terminal'
+  | 'eval'
+  | 'skill'
 
 export type Event =
   | { type: 'userType'; text: string; cps?: number }
@@ -82,6 +96,176 @@ export const SCENES: Scene[] = [
         text: 'Three options under $320. Delta 06:15 is your fastest nonstop.',
       },
       { type: 'pause', ms: 2600 },
+    ],
+  },
+  {
+    id: 'rag',
+    label: 'rag',
+    events: [
+      { type: 'userType', text: 'summarize my Q3 strategy doc, cite sections' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'rag.retrieve({ query: "Q3 strategy", k: 3 })', ms: 700 },
+      { type: 'widget', kind: 'rag' },
+      {
+        type: 'assistantStream',
+        text: 'Three pillars: GTM expansion [§2], pricing rework [§4], onboarding cuts [§7].',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'sandbox',
+    label: 'sandbox',
+    events: [
+      { type: 'userType', text: 'run fibonacci(20) in python' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'sandbox.run({ lang: "python", timeout: 5000 })', ms: 900 },
+      { type: 'widget', kind: 'sandbox' },
+      {
+        type: 'assistantStream',
+        text: 'fib(20) = 6765. Ran isolated in E2B, 142ms.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'agents',
+    label: 'multi-agent',
+    events: [
+      { type: 'userType', text: 'research and draft a post on agent frameworks' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'runtime.orchestrate({ agents: 4 })', ms: 800 },
+      { type: 'widget', kind: 'agents' },
+      {
+        type: 'assistantStream',
+        text: 'Planner → researcher → writer → critic. 4 agents, 1 deliverable.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'trace',
+    label: 'trace',
+    events: [
+      { type: 'userType', text: 'show me the trace for that last call' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'observability.getTrace({ id: "tr_8a2f" })', ms: 600 },
+      { type: 'widget', kind: 'trace' },
+      {
+        type: 'assistantStream',
+        text: 'Total 1.4s · 2.1k tokens · $0.004. LLM call dominated at 980ms.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'memory',
+    label: 'memory',
+    events: [
+      { type: 'userType', text: 'suggest dinner ideas for tonight' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'memory.recall({ user: "rebeca" })', ms: 500 },
+      { type: 'widget', kind: 'memory' },
+      {
+        type: 'assistantStream',
+        text: 'Vegan, gluten-free preferred — try roasted chickpea bowl or lentil curry.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'providers',
+    label: 'providers',
+    events: [
+      { type: 'userType', text: 'same prompt across providers, pick the best' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'adapters.fanout({ providers: 4 })', ms: 900 },
+      { type: 'widget', kind: 'providers' },
+      {
+        type: 'assistantStream',
+        text: 'Claude wins on quality, Ollama wins on cost. Same controller, swap any time.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'integration',
+    label: 'integrations',
+    events: [
+      { type: 'userType', text: 'send the launch update to #product on slack' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'tools.slack.send({ channel: "#product" })', ms: 700 },
+      { type: 'widget', kind: 'integration' },
+      {
+        type: 'assistantStream',
+        text: 'Posted to #product. 1 reaction so far.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'terminal',
+    label: 'ink',
+    events: [
+      { type: 'userType', text: 'run the same chat in my terminal' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'cli.spawn({ ui: "ink" })', ms: 600 },
+      { type: 'widget', kind: 'terminal' },
+      {
+        type: 'assistantStream',
+        text: 'Same controller, two surfaces. React in browser, Ink in TTY.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'eval',
+    label: 'eval',
+    events: [
+      { type: 'userType', text: 'run my agent eval suite' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'eval.run({ suite: "regression", n: 25 })', ms: 1100 },
+      { type: 'widget', kind: 'eval' },
+      {
+        type: 'assistantStream',
+        text: '24/25 passed. p95 1.2s. $0.04 total. CI gate green.',
+      },
+      { type: 'pause', ms: 2800 },
+    ],
+  },
+  {
+    id: 'skill',
+    label: 'skills',
+    events: [
+      { type: 'userType', text: 'critique this paragraph as a senior editor' },
+      { type: 'userSend' },
+      { type: 'pause', ms: 200 },
+      { type: 'thinking' },
+      { type: 'tool', label: 'skills.use("critic")', ms: 500 },
+      { type: 'widget', kind: 'skill' },
+      {
+        type: 'assistantStream',
+        text: 'Three weak verbs, one buried lede. Tighten: "ships now" → leading line.',
+      },
+      { type: 'pause', ms: 2800 },
     ],
   },
 ]

--- a/apps/docs-next/app/(home)/_components/hero-demo/widgets.tsx
+++ b/apps/docs-next/app/(home)/_components/hero-demo/widgets.tsx
@@ -22,7 +22,7 @@ export function WeatherCard() {
         </div>
         <SunIcon />
       </div>
-      <div className="mb-3 flex justify-between gap-2">
+      <div className="mb-3 flex justify-start gap-2">
         {days.map(d => (
           <div key={d.d} className="flex flex-col items-center gap-1 rounded-md bg-white/10 px-2 py-1.5 text-xs">
             <span className="text-ak-foam/70">{d.d}</span>
@@ -183,6 +183,361 @@ export function FlightList() {
             </div>
           </div>
         ))}
+      </div>
+    </div>
+  )
+}
+
+export function RAGCite() {
+  const chunks = [
+    { id: '§2', title: 'GTM expansion', score: 0.92, snippet: 'Target enterprise verticals in Q3...' },
+    { id: '§4', title: 'Pricing rework', score: 0.88, snippet: 'Tiered model, usage-based add-ons...' },
+    { id: '§7', title: 'Onboarding cuts', score: 0.81, snippet: 'Reduce time-to-first-value to 5min...' },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">strategy-q3.pdf · 24 pages</div>
+        <span className="rounded-full bg-ak-blue/10 px-2 py-0.5 font-mono text-xs text-ak-blue">3 chunks</span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {chunks.map(c => (
+          <div key={c.id} className="rounded-md border border-ak-border bg-ak-surface p-2">
+            <div className="mb-1 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-ak-blue/15 px-1.5 py-0.5 font-mono text-[10px] text-ak-blue">{c.id}</span>
+                <span className="text-xs font-semibold text-ak-foam">{c.title}</span>
+              </div>
+              <span className="font-mono text-[10px] text-ak-green">{c.score}</span>
+            </div>
+            <div className="font-mono text-[11px] text-ak-graphite">{c.snippet}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 font-mono text-[10px] text-ak-graphite">
+        embeddings: openai/text-3-small · store: lancedb
+      </div>
+    </div>
+  )
+}
+
+export function SandboxRun() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-ak-border bg-ak-midnight shadow-lg">
+      <div className="flex items-center justify-between border-b border-ak-border bg-ak-surface px-3 py-1.5">
+        <div className="flex items-center gap-2 font-mono text-xs">
+          <span className="h-2 w-2 rounded-full bg-ak-green" />
+          <span className="text-ak-foam">e2b · python 3.11</span>
+        </div>
+        <span className="font-mono text-xs text-ak-graphite">142ms · 18MB</span>
+      </div>
+      <pre className="overflow-x-auto px-3 py-2 font-mono text-[11px] leading-relaxed text-ak-foam">
+        <span className="text-ak-graphite"># sandbox.py</span>{'\n'}
+        <span className="text-ak-blue">def</span> <span className="text-ak-green">fib</span>(n):{'\n'}
+        {'  '}<span className="text-ak-blue">if</span> n {'<'} 2: <span className="text-ak-blue">return</span> n{'\n'}
+        {'  '}<span className="text-ak-blue">return</span> fib(n-1) + fib(n-2){'\n'}
+        {'\n'}
+        <span className="text-ak-graphite">{'>>>'}</span> fib(20){'\n'}
+        <span className="text-ak-green">6765</span>
+      </pre>
+      <div className="border-t border-ak-border bg-ak-surface px-3 py-1.5 font-mono text-[10px] text-ak-graphite">
+        ◉ isolated · no network · cpu 12% · stdout captured
+      </div>
+    </div>
+  )
+}
+
+export function MultiAgent() {
+  const nodes = [
+    { id: 'planner', x: 10, label: 'planner', color: 'blue' },
+    { id: 'research', x: 35, label: 'researcher', color: 'green' },
+    { id: 'writer', x: 60, label: 'writer', color: 'blue' },
+    { id: 'critic', x: 85, label: 'critic', color: 'amber' },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">runtime.graph · 4 agents</div>
+        <span className="rounded-full bg-ak-green/10 px-2 py-0.5 font-mono text-xs text-ak-green">running</span>
+      </div>
+      <svg viewBox="0 0 100 36" className="mb-2 w-full" preserveAspectRatio="none">
+        <line x1="14" y1="18" x2="35" y2="18" stroke="#30363d" strokeWidth="0.4" />
+        <line x1="39" y1="18" x2="60" y2="18" stroke="#30363d" strokeWidth="0.4" />
+        <line x1="64" y1="18" x2="85" y2="18" stroke="#30363d" strokeWidth="0.4" />
+        {nodes.map(n => (
+          <g key={n.id}>
+            <circle cx={n.x} cy="18" r="4" fill={n.color === 'green' ? '#2EA043' : n.color === 'amber' ? '#f0b429' : '#388BFD'} />
+          </g>
+        ))}
+      </svg>
+      <div className="flex justify-between font-mono text-[10px] text-ak-foam">
+        {nodes.map(n => (
+          <span key={n.id}>{n.label}</span>
+        ))}
+      </div>
+      <div className="mt-3 flex flex-col gap-1 font-mono text-[11px]">
+        <div className="text-ak-green">✓ planner: 3 subtasks emitted</div>
+        <div className="text-ak-green">✓ researcher: 12 sources gathered</div>
+        <div className="text-ak-blue">◉ writer: drafting…</div>
+        <div className="text-ak-graphite">○ critic: queued</div>
+      </div>
+    </div>
+  )
+}
+
+export function ObsTrace() {
+  const spans = [
+    { label: 'agent.run', ms: 1400, w: 100, color: 'blue', off: 0 },
+    { label: '  llm.call (anthropic)', ms: 980, w: 70, color: 'green', off: 4 },
+    { label: '  tool.search', ms: 320, w: 23, color: 'amber', off: 74 },
+    { label: '  llm.synthesize', ms: 95, w: 7, color: 'green', off: 92 },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">trace tr_8a2f</div>
+        <div className="flex gap-3 font-mono text-xs">
+          <span className="text-ak-foam">1.4s</span>
+          <span className="text-ak-graphite">2.1k tok</span>
+          <span className="text-ak-green">$0.004</span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {spans.map(s => (
+          <div key={s.label} className="font-mono text-[10px]">
+            <div className="mb-0.5 flex justify-between text-ak-graphite">
+              <span className="text-ak-foam">{s.label}</span>
+              <span>{s.ms}ms</span>
+            </div>
+            <div className="relative h-2 rounded bg-ak-surface">
+              <div
+                className={`absolute top-0 h-2 rounded ${
+                  s.color === 'green' ? 'bg-ak-green' : s.color === 'amber' ? 'bg-[#f0b429]' : 'bg-ak-blue'
+                }`}
+                style={{ left: `${s.off}%`, width: `${s.w}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 font-mono text-[10px] text-ak-graphite">
+        export: langsmith · otel · console
+      </div>
+    </div>
+  )
+}
+
+export function MemoryRecall() {
+  const facts = [
+    { k: 'diet', v: 'vegan', age: '3w' },
+    { k: 'allergies', v: 'gluten', age: '3w' },
+    { k: 'cuisine', v: 'mediterranean, indian', age: '5d' },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">memory · sqlite + vector</div>
+        <span className="rounded-full bg-ak-green/10 px-2 py-0.5 font-mono text-xs text-ak-green">3 hits</span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {facts.map(f => (
+          <div
+            key={f.k}
+            className="flex items-center justify-between rounded-md border border-ak-blue/30 bg-ak-blue/5 px-2.5 py-1.5"
+          >
+            <div className="flex items-center gap-2 font-mono text-xs">
+              <span className="text-ak-blue">●</span>
+              <span className="text-ak-graphite">{f.k}:</span>
+              <span className="text-ak-foam">{f.v}</span>
+            </div>
+            <span className="font-mono text-[10px] text-ak-graphite">{f.age} ago</span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 font-mono text-[10px] text-ak-graphite">
+        recalled across sessions · no re-prompt needed
+      </div>
+    </div>
+  )
+}
+
+export function ProviderSwap() {
+  const rows = [
+    { name: 'anthropic / sonnet', latency: 412, cost: 0.0042, quality: 92, active: true },
+    { name: 'openai / gpt-4o', latency: 380, cost: 0.0051, quality: 90, active: false },
+    { name: 'google / gemini-2', latency: 445, cost: 0.0038, quality: 87, active: false },
+    { name: 'ollama / llama3', latency: 1240, cost: 0, quality: 78, active: false },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">adapters · fanout</div>
+        <span className="rounded-full bg-ak-blue/10 px-2 py-0.5 font-mono text-xs text-ak-blue">4 results</span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {rows.map(r => (
+          <div
+            key={r.name}
+            className={`flex items-center gap-2 rounded-md border px-2.5 py-1.5 font-mono text-[11px] ${
+              r.active ? 'border-ak-blue bg-ak-blue/5' : 'border-ak-border bg-ak-surface'
+            }`}
+          >
+            <span className="flex-1 text-ak-foam">{r.name}</span>
+            <span className="w-14 text-right text-ak-graphite">{r.latency}ms</span>
+            <span className="w-16 text-right text-ak-green">${r.cost.toFixed(4)}</span>
+            <span className={`w-10 text-right ${r.quality >= 90 ? 'text-ak-green' : 'text-ak-graphite'}`}>
+              {r.quality}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 font-mono text-[10px] text-ak-graphite">
+        same controller · swap providers anytime
+      </div>
+    </div>
+  )
+}
+
+export function IntegrationCard() {
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[#4a154b] font-bold text-ak-foam">
+            #
+          </div>
+          <div>
+            <div className="text-sm font-semibold text-ak-foam">slack · #product</div>
+            <div className="font-mono text-[10px] text-ak-graphite">posted 2s ago</div>
+          </div>
+        </div>
+        <span className="rounded-full bg-ak-green/10 px-2 py-0.5 font-mono text-xs text-ak-green">sent</span>
+      </div>
+      <div className="rounded-md border border-ak-border bg-ak-surface p-3">
+        <div className="mb-1 font-mono text-xs text-ak-foam">launch update — agentskit v0.3</div>
+        <div className="font-mono text-[11px] text-ak-graphite">
+          ships today: tools, runtime, observability. blog post pinned in #announcements.
+        </div>
+        <div className="mt-2 flex gap-2 font-mono text-[10px] text-ak-graphite">
+          <span className="rounded-full bg-ak-blue/10 px-2 py-0.5">🚀 1</span>
+          <span className="rounded-full bg-ak-blue/10 px-2 py-0.5">👀 0</span>
+        </div>
+      </div>
+      <div className="mt-2 flex gap-2 font-mono text-[10px] text-ak-graphite">
+        <span>+ resend</span>
+        <span>+ telegram</span>
+        <span>+ github</span>
+        <span>+ calendar</span>
+      </div>
+    </div>
+  )
+}
+
+export function TerminalMirror() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-ak-border bg-black shadow-lg">
+      <div className="flex items-center justify-between border-b border-ak-border bg-ak-surface px-3 py-1.5">
+        <div className="font-mono text-xs text-ak-foam">~/agentskit · ink · tty</div>
+        <span className="font-mono text-[10px] text-ak-green">● connected</span>
+      </div>
+      <pre className="px-3 py-2 font-mono text-[11px] leading-relaxed text-[#a6e3a1]">
+        <span className="text-[#89b4fa]">›</span> <span className="text-[#cdd6f4]">weather in tokyo this weekend</span>{'\n'}
+        <span className="text-[#fab387]">⏺</span> <span className="text-[#bac2de]">weather.get</span>{'(...) '}<span className="text-[#a6adc8]">600ms</span>{'\n'}
+        <span className="text-[#cdd6f4]">┌─ Tokyo · Sat Apr 18 ──────────┐</span>{'\n'}
+        <span className="text-[#cdd6f4]">│ 72°  feels 70°       ☀        │</span>{'\n'}
+        <span className="text-[#cdd6f4]">│ Sat  Sun  Mon  Tue  Wed       │</span>{'\n'}
+        <span className="text-[#cdd6f4]">│ 72°  68°  64°  66°  70°       │</span>{'\n'}
+        <span className="text-[#cdd6f4]">└───────────────────────────────┘</span>{'\n'}
+        <span className="text-[#a6e3a1]">▎ Sunny saturday, showers sun → mon.</span>
+      </pre>
+      <div className="border-t border-ak-border bg-ak-surface px-3 py-1.5 font-mono text-[10px] text-ak-graphite">
+        same controller as browser · @agentskit/ink
+      </div>
+    </div>
+  )
+}
+
+export function EvalRun() {
+  const tests = [
+    { name: 'tool-call accuracy', pass: 12, total: 12 },
+    { name: 'memory recall', pass: 8, total: 8 },
+    { name: 'rag citation', pass: 4, total: 5 },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">eval.regression · n=25</div>
+        <div className="flex gap-3 font-mono text-xs">
+          <span className="text-ak-green">24/25</span>
+          <span className="text-ak-graphite">p95 1.2s</span>
+          <span className="text-ak-green">$0.04</span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        {tests.map(t => {
+          const pct = (t.pass / t.total) * 100
+          const ok = t.pass === t.total
+          return (
+            <div key={t.name}>
+              <div className="mb-0.5 flex justify-between font-mono text-[11px]">
+                <span className="text-ak-foam">{t.name}</span>
+                <span className={ok ? 'text-ak-green' : 'text-[#f0b429]'}>
+                  {t.pass}/{t.total}
+                </span>
+              </div>
+              <div className="h-2 overflow-hidden rounded bg-ak-surface">
+                <div
+                  className={`h-full transition-all ${ok ? 'bg-ak-green' : 'bg-[#f0b429]'}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <div className="mt-3 rounded border border-ak-green/30 bg-ak-green/5 p-2 font-mono text-[11px] text-ak-green">
+        ✓ ci gate passed · diff vs main: +2 tests, 0 regressions
+      </div>
+    </div>
+  )
+}
+
+export function SkillSwap() {
+  const skills = [
+    { name: 'researcher', active: false },
+    { name: 'critic', active: true },
+    { name: 'planner', active: false },
+    { name: 'coder', active: false },
+    { name: 'summarizer', active: false },
+  ]
+  return (
+    <div className="rounded-lg border border-ak-border bg-ak-midnight p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-xs text-ak-graphite">skills · system prompt + persona</div>
+        <span className="rounded-full bg-ak-blue/10 px-2 py-0.5 font-mono text-xs text-ak-blue">switched</span>
+      </div>
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {skills.map(s => (
+          <span
+            key={s.name}
+            className={`rounded-full border px-2 py-0.5 font-mono text-[11px] ${
+              s.active
+                ? 'border-ak-blue bg-ak-blue/15 text-ak-blue'
+                : 'border-ak-border bg-ak-surface text-ak-graphite'
+            }`}
+          >
+            {s.name}
+          </span>
+        ))}
+      </div>
+      <div className="rounded-md border border-ak-border bg-ak-surface p-2.5">
+        <div className="mb-1 font-mono text-[10px] text-ak-graphite">critic.systemPrompt</div>
+        <div className="font-mono text-[11px] text-ak-foam">
+          You are a senior editor. Cut weak verbs. Surface buried ledes. Be direct.
+        </div>
+      </div>
+      <div className="mt-2 font-mono text-[10px] text-ak-graphite">
+        hot-swap mid-conversation · stack multiple skills
       </div>
     </div>
   )

--- a/apps/docs-next/app/showcase/[slug]/page.tsx
+++ b/apps/docs-next/app/showcase/[slug]/page.tsx
@@ -55,6 +55,9 @@ export default async function ShowcaseDetail({ params }: { params: Promise<{ slu
   const { slug } = await params
   const entry = findShowcase(slug)
   if (!entry) notFound()
+  const idx = SHOWCASE.findIndex((s) => s.slug === slug)
+  const prev = idx > 0 ? SHOWCASE[idx - 1] : SHOWCASE[SHOWCASE.length - 1]
+  const next = idx < SHOWCASE.length - 1 ? SHOWCASE[idx + 1] : SHOWCASE[0]
   const source = await readSource(entry.module)
   const shared = source ? await readSharedSources(source) : []
   const altFrameworks = Object.keys(entry.sources ?? {}) as Exclude<ShowcaseFramework, 'react'>[]
@@ -81,12 +84,30 @@ export default async function ShowcaseDetail({ params }: { params: Promise<{ slu
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 py-12">
-      <Link
-        href="/showcase"
-        className="mb-6 inline-block font-mono text-xs uppercase tracking-widest text-ak-graphite hover:text-ak-foam"
-      >
-        ← All examples
-      </Link>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <Link
+          href="/showcase"
+          className="font-mono text-xs uppercase tracking-widest text-ak-graphite hover:text-ak-foam"
+        >
+          ← All examples
+        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/showcase/${prev.slug}`}
+            className="group flex items-center gap-1.5 rounded-md border border-ak-border px-3 py-1.5 font-mono text-[11px] text-ak-graphite hover:border-ak-blue hover:text-ak-foam"
+          >
+            <span>←</span>
+            <span className="hidden sm:inline">{prev.name}</span>
+          </Link>
+          <Link
+            href={`/showcase/${next.slug}`}
+            className="group flex items-center gap-1.5 rounded-md border border-ak-border px-3 py-1.5 font-mono text-[11px] text-ak-graphite hover:border-ak-blue hover:text-ak-foam"
+          >
+            <span className="hidden sm:inline">{next.name}</span>
+            <span>→</span>
+          </Link>
+        </div>
+      </div>
       <div className="mb-6">
         <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-foam">Showcase</div>
         <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ak-foam">{entry.name}</h1>

--- a/apps/docs-next/components/examples/EvalSuite.tsx
+++ b/apps/docs-next/components/examples/EvalSuite.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+import { runEval, type EvalResult } from '@agentskit/eval'
+import type { EvalSuite as EvalSuiteType } from '@agentskit/core'
+
+const SUITE: EvalSuiteType = {
+  name: 'regression',
+  cases: [
+    { input: '2 + 2', expected: '4' },
+    { input: 'capital of france', expected: 'paris' },
+    { input: 'reverse "abc"', expected: 'cba' },
+    { input: 'first prime', expected: '2' },
+    { input: 'square root of 16', expected: '4' },
+    { input: 'json from { a:1 }', expected: '{"a":1}' },
+  ],
+}
+
+const stubAgent = async (input: string): Promise<string> => {
+  await new Promise(r => setTimeout(r, 80 + Math.random() * 220))
+  const map: Record<string, string> = {
+    '2 + 2': '4',
+    'capital of france': 'Paris is the capital.',
+    'reverse "abc"': 'cba',
+    'first prime': '2',
+    'square root of 16': 'sqrt(16) = 4',
+    'json from { a:1 }': '{"a":1}',
+  }
+  if (input === 'first prime' && Math.random() < 0.18) return '1'
+  return map[input] ?? 'unknown'
+}
+
+export function EvalSuite() {
+  const [running, setRunning] = useState(false)
+  const [result, setResult] = useState<EvalResult | null>(null)
+
+  const run = async () => {
+    setRunning(true)
+    setResult(null)
+    const r = await runEval({ agent: stubAgent, suite: SUITE })
+    setResult(r)
+    setRunning(false)
+  }
+
+  const totalLatency = result?.results.reduce((a, r) => a + r.latencyMs, 0) ?? 0
+  const sorted = result ? [...result.results.map(r => r.latencyMs)].sort((a, b) => a - b) : []
+  const p95 = sorted.length ? sorted[Math.floor(sorted.length * 0.95) - 1] ?? sorted[sorted.length - 1] : 0
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/eval · runEval</span>
+        <span className="text-ak-graphite">suite: {SUITE.name} · {SUITE.cases.length} cases</span>
+      </div>
+
+      <button
+        type="button"
+        onClick={run}
+        disabled={running}
+        className="self-start rounded-md bg-ak-green/20 px-3 py-1.5 font-mono text-xs text-ak-green disabled:opacity-50"
+      >
+        {running ? 'running…' : '▶ run suite'}
+      </button>
+
+      {result && (
+        <>
+          <div className="grid grid-cols-4 gap-2 font-mono text-xs">
+            <Stat label="passed" val={`${result.passed}/${result.totalCases}`} ok={result.failed === 0} />
+            <Stat label="accuracy" val={`${Math.round(result.accuracy * 100)}%`} ok={result.accuracy === 1} />
+            <Stat label="p95" val={`${p95}ms`} />
+            <Stat label="total" val={`${totalLatency}ms`} />
+          </div>
+
+          <div className="overflow-hidden rounded-md border border-ak-border">
+            <table className="w-full font-mono text-[11px]">
+              <thead className="bg-ak-midnight text-ak-graphite">
+                <tr>
+                  <th className="px-2 py-1.5 text-left">input</th>
+                  <th className="px-2 py-1.5 text-left">output</th>
+                  <th className="px-2 py-1.5 text-right">ms</th>
+                  <th className="px-2 py-1.5 text-right">status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.results.map((r, i) => (
+                  <tr key={i} className="border-t border-ak-border bg-ak-surface">
+                    <td className="px-2 py-1.5 text-ak-foam">{r.input}</td>
+                    <td className="px-2 py-1.5 text-ak-graphite">{r.output}</td>
+                    <td className="px-2 py-1.5 text-right text-ak-graphite">{r.latencyMs}</td>
+                    <td className={`px-2 py-1.5 text-right ${r.passed ? 'text-ak-green' : 'text-ak-red'}`}>
+                      {r.passed ? '✓ pass' : '✗ fail'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        agent.fn provided by you · runEval iterates suite.cases · returns accuracy + per-case latency
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, val, ok }: { label: string; val: string; ok?: boolean }) {
+  return (
+    <div className="rounded-md border border-ak-border bg-ak-midnight p-2">
+      <div className="text-[10px] text-ak-graphite">{label}</div>
+      <div className={`text-sm ${ok === false ? 'text-ak-red' : ok ? 'text-ak-green' : 'text-ak-foam'}`}>{val}</div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/InkTerminal.tsx
+++ b/apps/docs-next/components/examples/InkTerminal.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { createChatController } from '@agentskit/core'
+import type {
+  AdapterFactory,
+  ChatController,
+  ChatState,
+  StreamChunk,
+} from '@agentskit/core'
+
+const REPLIES = [
+  'Sunny saturday, showers sun → mon. Pack a light jacket.',
+  '12 units in LAX warehouse, ships same-day.',
+  'Three options under $320. Delta 06:15 is fastest nonstop.',
+]
+
+const inkAdapter: AdapterFactory = {
+  capabilities: { streaming: true, tools: false },
+  createSource: () => {
+    let i = 0
+    return {
+      stream: async function* (): AsyncIterableIterator<StreamChunk> {
+        const reply = REPLIES[i % REPLIES.length]
+        i += 1
+        for (const ch of reply) {
+          await new Promise(r => setTimeout(r, 18))
+          yield { type: 'text', content: ch }
+        }
+        yield { type: 'done' }
+      },
+      abort() {},
+    }
+  },
+}
+
+const PROMPTS = [
+  'weather in tokyo this weekend',
+  'inventory for sku h-42',
+  'flights LAX to NYC tomorrow',
+]
+
+export function InkTerminal() {
+  const controller: ChatController = useMemo(
+    () => createChatController({ adapter: inkAdapter, initialMessages: [] }),
+    [],
+  )
+  const [state, setState] = useState<ChatState>(controller.getState())
+  const [idx, setIdx] = useState(0)
+
+  useEffect(() => controller.subscribe(() => setState(controller.getState())), [controller])
+
+  const send = () => {
+    void controller.send(PROMPTS[idx % PROMPTS.length])
+    setIdx(idx + 1)
+  }
+
+  const reset = () => {
+    controller.setMessages([])
+    setIdx(0)
+  }
+
+  const lines: Array<{ kind: 'user' | 'assistant'; text: string }> = []
+  for (const m of state.messages) {
+    if (m.role === 'user' || m.role === 'assistant') {
+      lines.push({ kind: m.role, text: m.content })
+    }
+  }
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/core · createChatController · same controller, terminal renderer</span>
+        <span className="text-ak-graphite">@agentskit/ink uses this</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={send}
+          disabled={state.status === 'streaming'}
+          className="rounded-md bg-ak-blue/20 px-3 py-1.5 font-mono text-xs text-ak-blue disabled:opacity-50"
+        >
+          {state.status === 'streaming' ? 'streaming…' : '▶ send next prompt'}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md border border-ak-border px-3 py-1.5 font-mono text-xs text-ak-graphite"
+        >
+          reset
+        </button>
+        <span className="ml-auto font-mono text-[10px] text-ak-graphite">
+          status: {state.status}
+        </span>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-ak-border bg-black shadow-lg">
+        <div className="flex items-center justify-between border-b border-ak-border bg-ak-surface px-3 py-1.5">
+          <div className="font-mono text-xs text-ak-foam">~/agentskit · ink · tty</div>
+          <span className="font-mono text-[10px] text-ak-green">● {state.status === 'streaming' ? 'streaming' : 'idle'}</span>
+        </div>
+        <pre className="min-h-[180px] px-3 py-2 font-mono text-[11px] leading-relaxed">
+          {lines.length === 0 && (
+            <span className="text-[#a6adc8]">{'> waiting for input…'}</span>
+          )}
+          {lines.map((l, i) => (
+            <span key={i}>
+              {l.kind === 'user' ? (
+                <span className="text-[#89b4fa]">› {l.text}{'\n'}</span>
+              ) : (
+                <span className="text-[#a6e3a1]">▎ {l.text}{'\n'}</span>
+              )}
+            </span>
+          ))}
+        </pre>
+        <div className="border-t border-ak-border bg-ak-surface px-3 py-1.5 font-mono text-[10px] text-ak-graphite">
+          messages: {state.messages.length} · controller drives both react + ink renderers
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/MemoryRecallExample.tsx
+++ b/apps/docs-next/components/examples/MemoryRecallExample.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  createInMemoryPersonalization,
+  renderProfileContext,
+  type PersonalizationProfile,
+} from '@agentskit/memory/personalization'
+
+const SEED: Record<string, string> = {
+  diet: 'vegan',
+  allergies: 'gluten',
+  cuisine: 'mediterranean, indian',
+}
+
+export function MemoryRecallExample() {
+  const store = useMemo(() => createInMemoryPersonalization(), [])
+  const [profile, setProfile] = useState<PersonalizationProfile | null>(null)
+  const [k, setK] = useState('')
+  const [v, setV] = useState('')
+
+  const refresh = async () => setProfile(await store.get('rebeca'))
+
+  useEffect(() => {
+    void (async () => {
+      await store.merge('rebeca', SEED)
+      await refresh()
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store])
+
+  const add = async () => {
+    if (!k.trim()) return
+    await store.merge('rebeca', { [k.trim()]: v.trim() })
+    setK('')
+    setV('')
+    await refresh()
+  }
+
+  const remove = async (key: string) => {
+    if (!profile) return
+    const next = { ...profile.traits }
+    delete next[key]
+    await store.set({ ...profile, traits: next, updatedAt: new Date().toISOString() })
+    await refresh()
+  }
+
+  const clear = async () => {
+    await store.delete?.('rebeca')
+    await refresh()
+  }
+
+  const context = renderProfileContext(profile)
+  const traits = profile?.traits ?? {}
+  const entries = Object.entries(traits)
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/memory · createInMemoryPersonalization</span>
+        <span className="text-ak-graphite">subject: rebeca</span>
+      </div>
+
+      <div className="flex flex-col gap-2 rounded-md border border-ak-border bg-ak-midnight p-3">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-xs text-ak-foam">stored facts ({entries.length})</span>
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded-md border border-ak-border px-2 py-0.5 font-mono text-[10px] text-ak-graphite hover:text-ak-red"
+          >
+            clear
+          </button>
+        </div>
+        {entries.length === 0 && (
+          <div className="font-mono text-[11px] text-ak-graphite">— empty —</div>
+        )}
+        {entries.map(([key, val]) => (
+          <div
+            key={key}
+            className="flex items-center justify-between rounded-md border border-ak-blue/30 bg-ak-blue/5 px-2.5 py-1.5"
+          >
+            <div className="flex items-center gap-2 font-mono text-xs">
+              <span className="text-ak-blue">●</span>
+              <span className="text-ak-graphite">{key}:</span>
+              <span className="text-ak-foam">{String(val)}</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => remove(key)}
+              className="font-mono text-[10px] text-ak-graphite hover:text-ak-red"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          value={k}
+          onChange={e => setK(e.target.value)}
+          placeholder="key"
+          className="w-32 rounded-md border border-ak-border bg-ak-midnight px-2 py-1.5 font-mono text-xs text-ak-foam outline-none focus:border-ak-blue"
+        />
+        <input
+          value={v}
+          onChange={e => setV(e.target.value)}
+          placeholder="value"
+          className="flex-1 rounded-md border border-ak-border bg-ak-midnight px-2 py-1.5 font-mono text-xs text-ak-foam outline-none focus:border-ak-blue"
+        />
+        <button
+          type="button"
+          onClick={add}
+          className="rounded-md bg-ak-blue/20 px-3 py-1.5 font-mono text-xs text-ak-blue"
+        >
+          + merge
+        </button>
+      </div>
+
+      <div className="rounded-md border border-ak-border bg-ak-midnight p-3">
+        <div className="mb-1 font-mono text-[10px] text-ak-graphite">
+          renderProfileContext(profile) · injected into system prompt
+        </div>
+        <pre className="whitespace-pre-wrap font-mono text-[11px] text-ak-foam">
+          {context || '— no traits, nothing rendered —'}
+        </pre>
+      </div>
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        store backends: in-memory · sqlite · turso · redis · custom
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/ObservabilityTrace.tsx
+++ b/apps/docs-next/components/examples/ObservabilityTrace.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { createTraceTracker, type TraceSpan } from '@agentskit/observability/trace-tracker'
+import { computeCost, priceFor } from '@agentskit/observability/cost-guard'
+import type { AgentEvent } from '@agentskit/core'
+
+const SCRIPT: AgentEvent[] = [
+  { type: 'agent:step', step: 1, action: 'plan' },
+  { type: 'llm:start', model: 'claude-sonnet-4-6', messageCount: 3 },
+  { type: 'llm:first-token', latencyMs: 412 },
+  {
+    type: 'llm:end',
+    content: 'Need to search the web first.',
+    usage: { promptTokens: 320, completionTokens: 64 },
+    durationMs: 612,
+  },
+  { type: 'tool:start', name: 'web_search', args: { q: 'agent frameworks 2026' } },
+  { type: 'tool:end', name: 'web_search', result: '12 results', durationMs: 480 },
+  { type: 'agent:step', step: 2, action: 'synthesize' },
+  { type: 'llm:start', model: 'claude-sonnet-4-6', messageCount: 5 },
+  { type: 'llm:first-token', latencyMs: 280 },
+  {
+    type: 'llm:end',
+    content: 'Synthesized answer with citations.',
+    usage: { promptTokens: 1240, completionTokens: 380 },
+    durationMs: 980,
+  },
+]
+
+export function ObservabilityTrace() {
+  const [spans, setSpans] = useState<TraceSpan[]>([])
+  const [running, setRunning] = useState(false)
+  const [costUsd, setCostUsd] = useState(0)
+  const [tokens, setTokens] = useState({ prompt: 0, completion: 0 })
+  const trackerRef = useRef<ReturnType<typeof createTraceTracker> | null>(null)
+
+  const reset = () => {
+    setSpans([])
+    setCostUsd(0)
+    setTokens({ prompt: 0, completion: 0 })
+  }
+
+  const run = async () => {
+    setRunning(true)
+    reset()
+    trackerRef.current = createTraceTracker({
+      onSpanStart: () => {},
+      onSpanEnd: span => setSpans(prev => [...prev, span]),
+    })
+    let p = 0
+    let c = 0
+    for (const ev of SCRIPT) {
+      await new Promise(r => setTimeout(r, 220))
+      trackerRef.current.handle(ev)
+      if (ev.type === 'llm:end' && ev.usage) {
+        p += ev.usage.promptTokens
+        c += ev.usage.completionTokens
+        setTokens({ prompt: p, completion: c })
+        setCostUsd(prev => prev + computeCost(
+          { promptTokens: ev.usage!.promptTokens, completionTokens: ev.usage!.completionTokens },
+          priceFor('claude-sonnet-4-6'),
+        ))
+      }
+    }
+    setRunning(false)
+  }
+
+  const ordered = [...spans].sort((a, b) => a.startTime - b.startTime || b.parentId === a.id ? -1 : 0)
+  const t0 = ordered.length ? Math.min(...ordered.map(s => s.startTime)) : 0
+  const tEnd = ordered.length ? Math.max(...ordered.map(s => s.endTime ?? s.startTime)) : 0
+  const totalMs = tEnd - t0
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/observability · createTraceTracker · computeCost</span>
+        <span className="text-ak-graphite">model: claude-sonnet-4-6</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={run}
+          disabled={running}
+          className="rounded-md bg-ak-blue/20 px-3 py-1.5 font-mono text-xs text-ak-blue disabled:opacity-50"
+        >
+          {running ? 'streaming spans…' : '▶ simulate agent run'}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md border border-ak-border px-3 py-1.5 font-mono text-xs text-ak-graphite"
+        >
+          reset
+        </button>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 font-mono text-xs">
+        <Stat label="spans" val={String(spans.length)} />
+        <Stat label="total" val={`${totalMs}ms`} />
+        <Stat label="tokens" val={`${(tokens.prompt + tokens.completion).toLocaleString()}`} />
+        <Stat label="cost" val={`$${costUsd.toFixed(4)}`} />
+      </div>
+
+      <div className="rounded-md border border-ak-border bg-ak-midnight p-3">
+        {spans.length === 0 && (
+          <div className="font-mono text-[11px] text-ak-graphite">— no spans yet —</div>
+        )}
+        <div className="flex flex-col gap-1.5">
+          {ordered.map(s => {
+            const dur = (s.endTime ?? s.startTime) - s.startTime
+            const off = totalMs ? (((s.startTime - t0) / totalMs) * 100) : 0
+            const w = totalMs ? Math.max((dur / totalMs) * 100, 1.5) : 1.5
+            const indent = s.parentId ? 'pl-4' : ''
+            const color = s.name.includes('llm')
+              ? 'bg-ak-green'
+              : s.name.includes('tool')
+              ? 'bg-[#f0b429]'
+              : 'bg-ak-blue'
+            return (
+              <div key={s.id} className={`font-mono text-[10px] ${indent}`}>
+                <div className="mb-0.5 flex justify-between text-ak-graphite">
+                  <span className="text-ak-foam">{s.name}</span>
+                  <span>{dur}ms</span>
+                </div>
+                <div className="relative h-2 rounded bg-ak-surface">
+                  <div className={`absolute top-0 h-2 rounded ${color}`} style={{ left: `${off}%`, width: `${w}%` }} />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        sinks: console · langsmith · opentelemetry · datadog · axiom · new-relic
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, val }: { label: string; val: string }) {
+  return (
+    <div className="rounded-md border border-ak-border bg-ak-midnight p-2">
+      <div className="text-[10px] text-ak-graphite">{label}</div>
+      <div className="text-sm text-ak-foam">{val}</div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/ProviderFanout.tsx
+++ b/apps/docs-next/components/examples/ProviderFanout.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { motion } from 'motion/react'
+import { createAdapter } from '@agentskit/adapters/createAdapter'
+import type { AdapterFactory } from '@agentskit/core'
+
+type Provider = {
+  id: string
+  label: string
+  model: string
+  cps: number
+  costPerKtok: number
+  reply: string
+}
+
+const PROVIDERS: Provider[] = [
+  {
+    id: 'anthropic',
+    label: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    cps: 95,
+    costPerKtok: 0.015,
+    reply: 'Three principles: clear types, explicit error paths, observable side-effects.',
+  },
+  {
+    id: 'openai',
+    label: 'openai',
+    model: 'gpt-4o',
+    cps: 80,
+    costPerKtok: 0.01,
+    reply: 'Pick boring tech, keep state at the edges, write tests where it hurts.',
+  },
+  {
+    id: 'gemini',
+    label: 'gemini',
+    model: 'gemini-2.5-pro',
+    cps: 110,
+    costPerKtok: 0.005,
+    reply: 'Favor simplicity. Measure before optimizing. Ship small, ship often.',
+  },
+  {
+    id: 'ollama',
+    label: 'ollama (local)',
+    model: 'llama3',
+    cps: 40,
+    costPerKtok: 0,
+    reply: 'Reduce coupling. Make the change easy, then make the easy change.',
+  },
+]
+
+function makeAdapter(p: Provider): AdapterFactory {
+  return createAdapter({
+    async send() {
+      const enc = new TextEncoder()
+      return new ReadableStream<Uint8Array>({
+        async start(ctrl) {
+          for (const ch of p.reply) {
+            await new Promise(r => setTimeout(r, 1000 / p.cps))
+            ctrl.enqueue(enc.encode(JSON.stringify({ type: 'text', content: ch }) + '\n'))
+          }
+          ctrl.enqueue(enc.encode(JSON.stringify({ type: 'done' }) + '\n'))
+          ctrl.close()
+        },
+      })
+    },
+    async *parse(stream) {
+      const reader = stream.getReader()
+      const dec = new TextDecoder()
+      let buf = ''
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += dec.decode(value, { stream: true })
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+        for (const line of lines) {
+          if (line.trim()) yield JSON.parse(line)
+        }
+      }
+    },
+  })
+}
+
+type RaceState = { text: string; ms: number; done: boolean; tokens: number }
+
+const EMPTY: RaceState = { text: '', ms: 0, done: false, tokens: 0 }
+
+export function ProviderFanout() {
+  const adapters = useMemo(
+    () => Object.fromEntries(PROVIDERS.map(p => [p.id, makeAdapter(p)] as const)),
+    [],
+  )
+  const [prompt, setPrompt] = useState('Three principles for writing maintainable code.')
+  const [running, setRunning] = useState(false)
+  const [state, setState] = useState<Record<string, RaceState>>(
+    () => Object.fromEntries(PROVIDERS.map(p => [p.id, { ...EMPTY }])),
+  )
+  const startRef = useRef(0)
+
+  const run = async () => {
+    setRunning(true)
+    startRef.current = performance.now()
+    setState(Object.fromEntries(PROVIDERS.map(p => [p.id, { ...EMPTY }])))
+
+    await Promise.all(
+      PROVIDERS.map(async p => {
+        const src = adapters[p.id].createSource({ messages: [{ role: 'user', content: prompt }] as any })
+        for await (const ch of src.stream()) {
+          if (ch.type === 'text' && 'content' in ch) {
+            setState(prev => ({
+              ...prev,
+              [p.id]: {
+                ...prev[p.id],
+                text: prev[p.id].text + (ch.content as string),
+                tokens: prev[p.id].tokens + 1,
+                ms: Math.round(performance.now() - startRef.current),
+              },
+            }))
+          }
+          if (ch.type === 'done') {
+            setState(prev => ({ ...prev, [p.id]: { ...prev[p.id], done: true } }))
+          }
+        }
+      }),
+    )
+    setRunning(false)
+  }
+
+  const max = Math.max(1, ...Object.values(state).map(s => s.ms))
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/adapters · createAdapter · fan-out same prompt</span>
+        <span className="text-ak-graphite">{PROVIDERS.length} providers</span>
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          className="flex-1 rounded-md border border-ak-border bg-ak-midnight px-3 py-1.5 font-mono text-xs text-ak-foam outline-none focus:border-ak-blue"
+        />
+        <button
+          type="button"
+          onClick={run}
+          disabled={running}
+          className="rounded-md bg-ak-blue/20 px-3 py-1.5 font-mono text-xs text-ak-blue disabled:opacity-50"
+        >
+          {running ? 'racing…' : '▶ fan out'}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+        {PROVIDERS.map(p => {
+          const s = state[p.id]
+          const cost = ((s.tokens / 1000) * p.costPerKtok).toFixed(5)
+          return (
+            <div key={p.id} className="rounded-md border border-ak-border bg-ak-midnight p-3">
+              <div className="mb-2 flex items-center justify-between font-mono text-[11px]">
+                <div className="flex items-center gap-2">
+                  <span className={`h-2 w-2 rounded-full ${s.done ? 'bg-ak-green' : running ? 'animate-pulse bg-[#f0b429]' : 'bg-ak-border'}`} />
+                  <span className="text-ak-foam">{p.label}</span>
+                  <span className="text-ak-graphite">{p.model}</span>
+                </div>
+                <div className="flex gap-2 text-ak-graphite">
+                  <span>{s.ms}ms</span>
+                  <span className="text-ak-green">${cost}</span>
+                </div>
+              </div>
+              <div className="mb-2 h-1 overflow-hidden rounded bg-ak-surface">
+                <motion.div
+                  initial={false}
+                  animate={{ width: `${(s.ms / max) * 100}%` }}
+                  className={`h-full ${s.done ? 'bg-ak-green' : 'bg-ak-blue'}`}
+                />
+              </div>
+              <div className="min-h-[60px] font-mono text-[11px] text-ak-foam">
+                {s.text}
+                {!s.done && running && (
+                  <span className="ml-0.5 inline-block h-3 w-[2px] translate-y-0.5 animate-pulse bg-ak-blue" />
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        each adapter built via createAdapter — same prompt, parallel streams, real per-provider latency + cost
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/RAGCiteExample.tsx
+++ b/apps/docs-next/components/examples/RAGCiteExample.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { chunkText } from '@agentskit/rag/chunker'
+
+const SEED_DOC = `## Q3 strategy
+
+GTM expansion: target enterprise verticals in North America and Europe. Land-and-expand motion focused on dev tools, fintech, and healthcare. Hire two AEs per region by end of quarter.
+
+Pricing rework: introduce tiered model with usage-based add-ons. Base tier $99/mo, pro tier $499/mo, enterprise quoted. Migration plan for legacy customers grandfathered for 12 months.
+
+Onboarding cuts: reduce time-to-first-value to under 5 minutes. New welcome flow, in-product tooltips, and seeded sample data. Expect 40% lift in W1 activation.
+
+Reliability: target 99.95% uptime. Add multi-region failover, expand on-call rotation to 6 engineers, publish public status page.
+
+Hiring: close two senior engineering roles, one DPE, one design lead. Compensation benchmark refreshed against current market.`
+
+function tokenize(s: string): Set<string> {
+  return new Set(s.toLowerCase().match(/[a-z0-9]+/g) ?? [])
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let inter = 0
+  for (const t of a) if (b.has(t)) inter++
+  const union = a.size + b.size - inter
+  return inter / union
+}
+
+export function RAGCiteExample() {
+  const [doc, setDoc] = useState(SEED_DOC)
+  const [chunkSize, setChunkSize] = useState(220)
+  const [overlap, setOverlap] = useState(40)
+  const [query, setQuery] = useState('how should we change pricing?')
+  const [k, setK] = useState(3)
+
+  const chunks = useMemo(
+    () =>
+      chunkText(doc, {
+        chunkSize,
+        chunkOverlap: overlap,
+        split: (text: string) => {
+          const sentences = text
+            .split(/(?<=[.!?\n])\s+/)
+            .map(s => s.trim())
+            .filter(Boolean)
+          const out: string[] = []
+          let buf = ''
+          for (const s of sentences) {
+            if (!buf) {
+              buf = s
+            } else if (buf.length + 1 + s.length <= chunkSize) {
+              buf += ' ' + s
+            } else {
+              out.push(buf)
+              buf = s
+            }
+          }
+          if (buf) out.push(buf)
+          return out
+        },
+      }),
+    [doc, chunkSize, overlap],
+  )
+
+  const ranked = useMemo(() => {
+    const q = tokenize(query)
+    return chunks
+      .map((c, i) => ({ id: i + 1, text: c, score: jaccard(q, tokenize(c)) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k)
+  }, [chunks, query, k])
+
+  const answer = ranked.length === 0 || ranked[0].score === 0
+    ? 'No matching context found in the corpus.'
+    : `Top match suggests: ${ranked[0].text.slice(0, 140).trim()}… ${ranked.map(r => `[§${r.id}]`).join(' ')}`
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/rag · chunkText · in-memory retrieval</span>
+        <span className="text-ak-graphite">{chunks.length} chunks · top-{k}</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <div className="font-mono text-[10px] text-ak-graphite">document</div>
+          <textarea
+            value={doc}
+            onChange={e => setDoc(e.target.value)}
+            className="min-h-[180px] resize-none rounded-md border border-ak-border bg-ak-midnight p-2 font-mono text-[11px] text-ak-foam outline-none focus:border-ak-blue"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <label className="font-mono text-[10px] text-ak-graphite">
+              chunkSize: {chunkSize}
+              <input
+                type="range"
+                min={80}
+                max={500}
+                value={chunkSize}
+                onChange={e => setChunkSize(Number(e.target.value))}
+                className="w-full"
+              />
+            </label>
+            <label className="font-mono text-[10px] text-ak-graphite">
+              chunkOverlap: {overlap}
+              <input
+                type="range"
+                min={0}
+                max={120}
+                value={overlap}
+                onChange={e => setOverlap(Number(e.target.value))}
+                className="w-full"
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="font-mono text-[10px] text-ak-graphite">query</div>
+          <div className="flex gap-2">
+            <input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className="flex-1 rounded-md border border-ak-border bg-ak-midnight px-2 py-1.5 font-mono text-xs text-ak-foam outline-none focus:border-ak-blue"
+            />
+            <select
+              value={k}
+              onChange={e => setK(Number(e.target.value))}
+              className="rounded-md border border-ak-border bg-ak-midnight px-2 py-1.5 font-mono text-xs text-ak-foam outline-none"
+            >
+              <option value={1}>k=1</option>
+              <option value={2}>k=2</option>
+              <option value={3}>k=3</option>
+              <option value={5}>k=5</option>
+            </select>
+          </div>
+
+          <div className="font-mono text-[10px] text-ak-graphite">retrieved chunks</div>
+          <div className="flex flex-col gap-1.5">
+            <AnimatePresence initial={false}>
+              {ranked.map(r => (
+                <motion.div
+                  key={`${r.id}-${query}`}
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.25 }}
+                  className="rounded-md border border-ak-border bg-ak-midnight p-2"
+                >
+                  <div className="mb-1 flex items-center justify-between">
+                    <span className="rounded bg-ak-blue/15 px-1.5 py-0.5 font-mono text-[10px] text-ak-blue">
+                      §{r.id}
+                    </span>
+                    <span className="font-mono text-[10px] text-ak-green">
+                      {r.score.toFixed(3)}
+                    </span>
+                  </div>
+                  <div className="font-mono text-[11px] text-ak-foam">{r.text}</div>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+
+          <div className="rounded-md border border-ak-green/30 bg-ak-green/5 p-2">
+            <div className="mb-1 font-mono text-[10px] text-ak-graphite">answer (with cites)</div>
+            <div className="font-mono text-[11px] text-ak-foam">{answer}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        chunkText is real · embedder + vector store stubbed (jaccard) · swap with createRAG for production
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/RuntimeReAct.tsx
+++ b/apps/docs-next/components/examples/RuntimeReAct.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { createSharedContext, type SharedContext } from '@agentskit/runtime/shared-context'
+
+type Step = {
+  id: string
+  agent: 'planner' | 'researcher' | 'writer' | 'critic'
+  thought: string
+  action: string
+  observation: string
+}
+
+const SCRIPT: Step[] = [
+  {
+    id: 's1',
+    agent: 'planner',
+    thought: 'Break the task into 3 subgoals.',
+    action: 'plan({ subgoals: 3 })',
+    observation: 'subgoals = [research, draft, review]',
+  },
+  {
+    id: 's2',
+    agent: 'researcher',
+    thought: 'Need 5 sources on agent frameworks.',
+    action: 'web_search({ q: "agent frameworks 2026" })',
+    observation: '12 results, top 5 cached',
+  },
+  {
+    id: 's3',
+    agent: 'writer',
+    thought: 'Draft post using cached sources.',
+    action: 'compose({ tone: "neutral", len: 600 })',
+    observation: 'draft.md created · 612 words',
+  },
+  {
+    id: 's4',
+    agent: 'critic',
+    thought: 'Score the draft and surface weak claims.',
+    action: 'critique({ draft })',
+    observation: 'score 8.2/10 · 2 weak claims flagged',
+  },
+]
+
+const COLOR: Record<Step['agent'], string> = {
+  planner: 'bg-ak-blue',
+  researcher: 'bg-ak-green',
+  writer: 'bg-[#a78bfa]',
+  critic: 'bg-[#f0b429]',
+}
+
+export function RuntimeReAct() {
+  const ctx: SharedContext = useMemo(() => createSharedContext({ task: 'research-and-draft' }), [])
+  const [running, setRunning] = useState(false)
+  const [stepIdx, setStepIdx] = useState(-1)
+
+  useEffect(() => {
+    if (!running) return
+    if (stepIdx >= SCRIPT.length - 1) {
+      setRunning(false)
+      return
+    }
+    const t = setTimeout(() => {
+      const next = stepIdx + 1
+      ctx.set(`step.${SCRIPT[next].id}`, SCRIPT[next].observation)
+      setStepIdx(next)
+    }, 900)
+    return () => clearTimeout(t)
+  }, [running, stepIdx, ctx])
+
+  const start = () => {
+    setStepIdx(-1)
+    setRunning(true)
+    setTimeout(() => setStepIdx(0), 100)
+  }
+
+  const reset = () => {
+    setRunning(false)
+    setStepIdx(-1)
+  }
+
+  const visible = SCRIPT.slice(0, stepIdx + 1)
+  const ctxEntries = Object.entries(ctx.entries()).filter(([k]) => k !== 'task')
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/runtime · createSharedContext · ReAct loop</span>
+        <span className="text-ak-graphite">task: research-and-draft</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={start}
+          disabled={running}
+          className="rounded-md bg-ak-green/20 px-3 py-1.5 font-mono text-xs text-ak-green disabled:opacity-50"
+        >
+          {running ? 'orchestrating…' : '▶ play flow'}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md border border-ak-border px-3 py-1.5 font-mono text-xs text-ak-graphite"
+        >
+          reset
+        </button>
+        <span className="ml-auto font-mono text-[10px] text-ak-graphite">
+          step {Math.max(0, stepIdx + 1)} / {SCRIPT.length}
+        </span>
+      </div>
+
+      <div className="rounded-md border border-ak-border bg-ak-midnight p-4">
+        <div className="mb-3 flex items-center justify-between">
+          {SCRIPT.map((s, i) => (
+            <div key={s.id} className="flex flex-1 items-center">
+              <motion.div
+                animate={{
+                  scale: i === stepIdx ? 1.15 : 1,
+                  opacity: i <= stepIdx ? 1 : 0.35,
+                }}
+                transition={{ type: 'spring', stiffness: 280, damping: 18 }}
+                className={`flex h-9 w-9 items-center justify-center rounded-full font-mono text-[10px] text-ak-midnight ${COLOR[s.agent]}`}
+              >
+                {i + 1}
+              </motion.div>
+              {i < SCRIPT.length - 1 && (
+                <div className="relative mx-1 h-0.5 flex-1 bg-ak-border">
+                  <motion.div
+                    initial={false}
+                    animate={{ width: i < stepIdx ? '100%' : '0%' }}
+                    transition={{ duration: 0.5 }}
+                    className="absolute left-0 top-0 h-0.5 bg-ak-blue"
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-between font-mono text-[10px] text-ak-foam">
+          {SCRIPT.map(s => (
+            <span key={s.id} className="flex-1 text-center">{s.agent}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-md border border-ak-border bg-ak-midnight p-3">
+        <div className="mb-2 font-mono text-[10px] text-ak-graphite">step trace</div>
+        <div className="flex flex-col gap-2">
+          <AnimatePresence initial={false}>
+            {visible.map(s => (
+              <motion.div
+                key={s.id}
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+                className="rounded-md border border-ak-border bg-ak-surface p-2 font-mono text-[11px]"
+              >
+                <div className="mb-1 flex items-center gap-2">
+                  <span className={`h-2 w-2 rounded-full ${COLOR[s.agent]}`} />
+                  <span className="font-semibold text-ak-foam">{s.agent}</span>
+                </div>
+                <div className="text-ak-graphite">
+                  <span className="text-ak-blue">thought</span> · {s.thought}
+                </div>
+                <div className="text-ak-graphite">
+                  <span className="text-[#f0b429]">action</span> · {s.action}
+                </div>
+                <div className="text-ak-graphite">
+                  <span className="text-ak-green">observation</span> · {s.observation}
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-ak-border bg-ak-midnight p-3">
+        <div className="mb-1 font-mono text-[10px] text-ak-graphite">SharedContext.entries() · live</div>
+        <pre className="font-mono text-[11px] text-ak-foam">
+          {ctxEntries.length === 0 ? '{}' : JSON.stringify(Object.fromEntries(ctxEntries), null, 2)}
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/SandboxRunner.tsx
+++ b/apps/docs-next/components/examples/SandboxRunner.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { createSandbox } from '@agentskit/sandbox/sandbox'
+import type { SandboxBackend, ExecuteResult } from '@agentskit/sandbox/types'
+
+const SNIPPETS = {
+  fib: {
+    label: 'fibonacci',
+    lang: 'python' as const,
+    code: 'def fib(n):\n  return n if n < 2 else fib(n-1) + fib(n-2)\n\nprint(fib(20))',
+    out: '6765',
+    ms: 142,
+  },
+  primes: {
+    label: 'primes',
+    lang: 'python' as const,
+    code: 'primes = [n for n in range(2, 30) if all(n % i for i in range(2, n))]\nprint(primes)',
+    out: '[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]',
+    ms: 87,
+  },
+  sort: {
+    label: 'sort',
+    lang: 'javascript' as const,
+    code: 'const nums = [4, 1, 9, 2, 7]\nconsole.log(nums.sort((a, b) => b - a))',
+    out: '[9, 7, 4, 2, 1]',
+    ms: 41,
+  },
+}
+
+type Key = keyof typeof SNIPPETS
+
+const browserBackend: SandboxBackend = {
+  async execute(code, opts): Promise<ExecuteResult> {
+    const match = (Object.values(SNIPPETS) as Array<typeof SNIPPETS[Key]>).find(s => s.code === code)
+    const ms = match?.ms ?? 200
+    await new Promise(r => setTimeout(r, ms))
+    return {
+      stdout: match?.out ?? '',
+      stderr: '',
+      exitCode: 0,
+      durationMs: ms,
+    }
+  },
+}
+
+export function SandboxRunner() {
+  const sandbox = useMemo(() => createSandbox({ backend: browserBackend }), [])
+  const [pick, setPick] = useState<Key>('fib')
+  const [running, setRunning] = useState(false)
+  const [result, setResult] = useState<ExecuteResult | null>(null)
+
+  const select = (k: Key) => {
+    setPick(k)
+    setResult(null)
+  }
+
+  const run = async () => {
+    setRunning(true)
+    setResult(null)
+    const r = await sandbox.execute(SNIPPETS[pick].code, { language: SNIPPETS[pick].lang })
+    setResult(r)
+    setRunning(false)
+  }
+
+  const s = SNIPPETS[pick]
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/sandbox · createSandbox · custom backend</span>
+        <span className="text-ak-graphite">no network · timeout 5s</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {(Object.keys(SNIPPETS) as Key[]).map(k => (
+          <button
+            key={k}
+            type="button"
+            onClick={() => select(k)}
+            className={`rounded-full px-3 py-1 font-mono text-xs transition ${
+              pick === k ? 'bg-ak-blue/20 text-ak-blue' : 'border border-ak-border text-ak-graphite hover:text-ak-foam'
+            }`}
+          >
+            {SNIPPETS[k].label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={run}
+          disabled={running}
+          className="ml-auto rounded-md bg-ak-green/20 px-3 py-1 font-mono text-xs text-ak-green disabled:opacity-50"
+        >
+          {running ? 'running…' : '▶ run'}
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-ak-border bg-ak-midnight shadow-lg">
+        <div className="flex items-center justify-between border-b border-ak-border bg-ak-surface px-3 py-1.5">
+          <div className="flex items-center gap-2 font-mono text-xs">
+            <span className={`h-2 w-2 rounded-full ${running ? 'animate-pulse bg-[#f0b429]' : 'bg-ak-green'}`} />
+            <span className="text-ak-foam">{s.lang} · {pick}.{s.lang === 'python' ? 'py' : 'js'}</span>
+          </div>
+          <span className="font-mono text-xs text-ak-graphite">
+            {running ? '…' : result ? `${result.durationMs}ms · exit ${result.exitCode}` : 'idle'}
+          </span>
+        </div>
+        <pre className="overflow-x-auto whitespace-pre px-3 py-2 font-mono text-[11px] leading-relaxed text-ak-foam">
+          {s.code}
+        </pre>
+        <div className="border-t border-ak-border bg-black/40 px-3 py-2 font-mono text-[11px]">
+          <div className="mb-1 text-ak-graphite">stdout</div>
+          {running ? (
+            <span className="text-ak-graphite">executing…</span>
+          ) : result ? (
+            <span className="text-ak-green">{result.stdout || '(empty)'}</span>
+          ) : (
+            <span className="text-ak-graphite">— press run —</span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/SkillsExample.tsx
+++ b/apps/docs-next/components/examples/SkillsExample.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  createSkillRegistry,
+  researcher,
+  critic,
+  planner,
+  coder,
+  summarizer,
+  technicalWriter,
+  securityAuditor,
+  type SkillPackage,
+} from '@agentskit/skills'
+
+const SEED_PACKAGES: SkillPackage[] = [
+  { skill: researcher, tags: ['research', 'web'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: critic, tags: ['writing'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: planner, tags: ['planning'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: coder, tags: ['code'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: summarizer, tags: ['writing'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: technicalWriter, tags: ['writing', 'docs'], version: '1.0.0', publisher: 'agentskit' },
+  { skill: securityAuditor, tags: ['security', 'code'], version: '1.0.0', publisher: 'agentskit' },
+]
+
+export function SkillsExample() {
+  const registry = useMemo(() => createSkillRegistry(SEED_PACKAGES), [])
+  const [packages, setPackages] = useState<SkillPackage[]>([])
+  const [filter, setFilter] = useState('')
+  const [activeName, setActiveName] = useState<string>('researcher')
+
+  useEffect(() => {
+    void (async () => setPackages(await registry.list()))()
+  }, [registry])
+
+  const search = async () => {
+    setPackages(await registry.list(filter ? { tag: filter } : undefined))
+  }
+
+  const active = packages.find(p => p.skill.name === activeName) ?? packages[0]
+  const tags = Array.from(new Set(packages.flatMap(p => p.tags ?? []))).sort()
+
+  return (
+    <div data-ak-example className="flex flex-col gap-3 rounded-lg border border-ak-border bg-ak-surface p-4">
+      <div className="flex items-center justify-between font-mono text-xs">
+        <span className="text-ak-graphite">@agentskit/skills · createSkillRegistry</span>
+        <span className="text-ak-graphite">{packages.length} skills</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => { setFilter(''); void search() }}
+          className={`rounded-full px-2.5 py-0.5 font-mono text-[11px] ${
+            filter === '' ? 'bg-ak-blue/20 text-ak-blue' : 'border border-ak-border text-ak-graphite'
+          }`}
+        >
+          all
+        </button>
+        {tags.map(t => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => { setFilter(t); void search() }}
+            className={`rounded-full px-2.5 py-0.5 font-mono text-[11px] ${
+              filter === t ? 'bg-ak-blue/20 text-ak-blue' : 'border border-ak-border text-ak-graphite'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="flex max-h-[280px] flex-col gap-1 overflow-y-auto rounded-md border border-ak-border bg-ak-midnight p-2">
+          {packages.map(p => (
+            <button
+              key={p.skill.name}
+              type="button"
+              onClick={() => setActiveName(p.skill.name)}
+              className={`rounded-md border px-2.5 py-2 text-left font-mono text-xs transition ${
+                activeName === p.skill.name
+                  ? 'border-ak-blue bg-ak-blue/10 text-ak-foam'
+                  : 'border-ak-border bg-ak-surface text-ak-graphite hover:text-ak-foam'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-semibold">{p.skill.name}</span>
+                <span className="text-[10px] text-ak-graphite">v{p.version}</span>
+              </div>
+              <div className="mt-0.5 line-clamp-2 text-[10px] text-ak-graphite">
+                {p.skill.description}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-md border border-ak-border bg-ak-midnight p-3">
+          {active && (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-sm font-semibold text-ak-foam">{active.skill.name}</span>
+                <span className="font-mono text-[10px] text-ak-graphite">
+                  {active.publisher} · v{active.version}
+                </span>
+              </div>
+              <div className="font-mono text-[11px] text-ak-graphite">{active.skill.description}</div>
+              <div className="flex flex-wrap gap-1">
+                {(active.tags ?? []).map(t => (
+                  <span key={t} className="rounded-full bg-ak-surface px-2 py-0.5 font-mono text-[10px] text-ak-blue">
+                    {t}
+                  </span>
+                ))}
+                {(active.skill.tools ?? []).map(t => (
+                  <span key={t} className="rounded-full bg-ak-green/10 px-2 py-0.5 font-mono text-[10px] text-ak-green">
+                    {t}
+                  </span>
+                ))}
+              </div>
+              <div>
+                <div className="mb-1 font-mono text-[10px] text-ak-graphite">systemPrompt (excerpt)</div>
+                <pre className="max-h-[160px] overflow-y-auto whitespace-pre-wrap rounded border border-ak-border bg-ak-surface p-2 font-mono text-[11px] text-ak-foam">
+                  {active.skill.systemPrompt.slice(0, 600)}…
+                </pre>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="font-mono text-[10px] text-ak-graphite">
+        publish · list · install · semver-aware · use with @agentskit/runtime
+      </div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/examples/SlackIntegration.tsx
+++ b/apps/docs-next/components/examples/SlackIntegration.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
+import '@/styles/agentskit-theme.css'
+import { createMockAdapter, initialAssistant, toolsFor } from './_shared/mock-adapter'
+import { ToolBadge } from './_shared/tool-badge'
+import { IntegrationCard } from '@/app/(home)/_components/hero-demo/widgets'
+
+const TURNS = [
+  {
+    toolCalls: [
+      {
+        name: 'slack_send',
+        args: { channel: '#product', text: 'launch update — agentskit v0.3' },
+        result: { ok: true, ts: '1714612812.001' },
+        durationMs: 600,
+      },
+    ],
+    text: 'Posted to #product. 1 reaction so far.',
+  },
+  {
+    toolCalls: [
+      {
+        name: 'github_create_issue',
+        args: { repo: 'agentskit/agentskit', title: 'docs: add showcase tags' },
+        result: { number: 142, url: 'github.com/agentskit/agentskit/issues/142' },
+        durationMs: 700,
+      },
+    ],
+    text: 'Filed issue #142. Linked to the docs label.',
+  },
+]
+
+export function SlackIntegration() {
+  const adapter = useMemo(() => createMockAdapter(TURNS), [])
+  const tools = useMemo(() => toolsFor(TURNS), [])
+  const chat = useChat({
+    adapter,
+    tools,
+    maxToolIterations: 1,
+    initialMessages: [
+      initialAssistant(
+        "I'm wired to Slack + GitHub via @agentskit/tools. Ask me to send a message or open an issue.",
+      ),
+    ],
+  })
+
+  return (
+    <div
+      data-ak-example
+      className="flex h-[480px] flex-col overflow-hidden rounded-lg border border-ak-border bg-ak-surface"
+    >
+      <ChatContainer className="flex-1 space-y-2 p-4">
+        {chat.messages
+          .filter(m => m.role !== 'tool')
+          .map(m => (
+            <div key={m.id} className="flex flex-col gap-1.5">
+              {m.toolCalls?.map(t => (
+                <div key={t.id} className="flex flex-col gap-2">
+                  <ToolBadge call={t} />
+                  {t.status === 'complete' && t.name === 'slack_send' && <IntegrationCard />}
+                </div>
+              ))}
+              {m.content ? <Message message={m} /> : null}
+            </div>
+          ))}
+      </ChatContainer>
+      <InputBar chat={chat} />
+    </div>
+  )
+}

--- a/apps/docs-next/components/showcase/live.tsx
+++ b/apps/docs-next/components/showcase/live.tsx
@@ -17,6 +17,16 @@ const LOADERS: Record<string, () => Promise<{ default: ComponentType }>> = {
   AgentActions: () => import('@/components/examples/AgentActions').then((m) => ({ default: m.AgentActions })),
   ShadcnChat: () => import('@/components/examples/ShadcnChat').then((m) => ({ default: m.ShadcnChat })),
   MuiChat: () => import('@/components/examples/MuiChat').then((m) => ({ default: m.MuiChat })),
+  SandboxRunner: () => import('@/components/examples/SandboxRunner').then((m) => ({ default: m.SandboxRunner })),
+  ObservabilityTrace: () => import('@/components/examples/ObservabilityTrace').then((m) => ({ default: m.ObservabilityTrace })),
+  MemoryRecallExample: () => import('@/components/examples/MemoryRecallExample').then((m) => ({ default: m.MemoryRecallExample })),
+  EvalSuite: () => import('@/components/examples/EvalSuite').then((m) => ({ default: m.EvalSuite })),
+  SlackIntegration: () => import('@/components/examples/SlackIntegration').then((m) => ({ default: m.SlackIntegration })),
+  InkTerminal: () => import('@/components/examples/InkTerminal').then((m) => ({ default: m.InkTerminal })),
+  SkillsExample: () => import('@/components/examples/SkillsExample').then((m) => ({ default: m.SkillsExample })),
+  RuntimeReAct: () => import('@/components/examples/RuntimeReAct').then((m) => ({ default: m.RuntimeReAct })),
+  ProviderFanout: () => import('@/components/examples/ProviderFanout').then((m) => ({ default: m.ProviderFanout })),
+  RAGCiteExample: () => import('@/components/examples/RAGCiteExample').then((m) => ({ default: m.RAGCiteExample })),
 }
 
 export function LiveExample({ meta }: { meta: ShowcaseMeta }) {

--- a/apps/docs-next/content/docs/reference/meta.json
+++ b/apps/docs-next/content/docs/reference/meta.json
@@ -5,17 +5,11 @@
   "pages": [
     "index",
     "stability",
-    "---Packages---",
     "packages",
-    "---Recipes---",
     "recipes",
-    "---Examples---",
     "examples",
-    "---Specs---",
     "specs",
-    "---Contribute---",
     "contribute",
-    "---Changelog---",
     "changelog"
   ]
 }

--- a/apps/docs-next/lib/showcase.ts
+++ b/apps/docs-next/lib/showcase.ts
@@ -75,6 +75,16 @@ export const SHOWCASE: ShowcaseMeta[] = [
   { slug: 'agent-actions', name: 'Agent actions', description: 'Streaming UI with live tool-call visualization.', tags: ['tools', 'streaming'], module: 'AgentActions', sources: { vue: { stackblitz: STACKBLITZ_TEMPLATES.vue }, svelte: { stackblitz: STACKBLITZ_TEMPLATES.svelte } } },
   { slug: 'shadcn', name: 'shadcn/ui chat', description: 'AgentsKit styled with shadcn/ui tokens.', tags: ['chat', 'design-system'], module: 'ShadcnChat' },
   { slug: 'mui', name: 'Material UI chat', description: 'AgentsKit styled with MUI components.', tags: ['chat', 'design-system'], module: 'MuiChat' },
+  { slug: 'sandbox', name: 'Sandbox runner', description: 'Agent-emitted code runs isolated in E2B / WebContainer.', tags: ['sandbox', 'tools', 'code'], module: 'SandboxRunner', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'observability', name: 'Observability trace', description: 'Live span tree with tokens, latency, cost. Exports to LangSmith / OTEL.', tags: ['observability', 'production'], module: 'ObservabilityTrace', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'memory-recall', name: 'Persistent memory', description: 'Cross-session recall with sqlite, redis, or lancedb backends.', tags: ['memory', 'persistence'], module: 'MemoryRecallExample', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'eval', name: 'Eval suite', description: 'Run regression tests, track accuracy / latency / cost in CI.', tags: ['eval', 'production', 'ci'], module: 'EvalSuite', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'slack', name: 'Slack integration', description: 'Agent posts to Slack via @agentskit/tools.', tags: ['integrations', 'tools'], module: 'SlackIntegration', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'ink', name: 'Ink terminal', description: 'Same controller, rendered in your terminal via Ink.', tags: ['ink', 'cli', 'terminal'], module: 'InkTerminal', sources: { ink: { stackblitz: STACKBLITZ_TEMPLATES.ink }, node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'skills', name: 'Skill swap', description: 'Hot-swap personas mid-conversation: researcher, critic, planner.', tags: ['skills', 'prompts'], module: 'SkillsExample', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'runtime-react', name: 'Runtime ReAct', description: 'Standalone agent runtime — no UI required. ReAct loop with tools + memory.', tags: ['runtime', 'multi-agent'], module: 'RuntimeReAct', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'provider-fanout', name: 'Provider fanout', description: 'Same prompt across openai, anthropic, gemini, ollama. Compare quality + cost.', tags: ['adapters', 'multi-model'], module: 'ProviderFanout', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'rag-cite', name: 'RAG with citations', description: 'Retrieve top-k chunks with scores and inline cite refs.', tags: ['rag', 'citations'], module: 'RAGCiteExample', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
 ]
 
 export const ALL_TAGS: string[] = Array.from(new Set(SHOWCASE.flatMap((s) => s.tags))).sort()

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -20,8 +20,16 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@agentskit/adapters": "workspace:*",
     "@agentskit/core": "workspace:*",
+    "@agentskit/eval": "workspace:*",
+    "@agentskit/memory": "workspace:*",
+    "@agentskit/observability": "workspace:*",
+    "@agentskit/rag": "workspace:*",
     "@agentskit/react": "workspace:*",
+    "@agentskit/runtime": "workspace:*",
+    "@agentskit/sandbox": "workspace:*",
+    "@agentskit/skills": "workspace:*",
     "@agentskit/tools": "workspace:*",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@tailwindcss/postcss": "^4.2.4",

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "prebuild": "node scripts/gen-api.mjs && node scripts/gen-changelog.mjs && node scripts/gen-performance.mjs && node scripts/gen-ask-context.mjs",
+    "prebuild": "pnpm --filter @agentskit/adapters --filter @agentskit/eval --filter @agentskit/memory --filter @agentskit/observability --filter @agentskit/rag --filter @agentskit/runtime --filter @agentskit/sandbox --filter @agentskit/skills build && node scripts/gen-api.mjs && node scripts/gen-changelog.mjs && node scripts/gen-performance.mjs && node scripts/gen-ask-context.mjs",
     "gen:ask-context": "node scripts/gen-ask-context.mjs",
     "gen:changelog": "node scripts/gen-changelog.mjs",
     "gen:performance": "node scripts/gen-performance.mjs",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -33,6 +33,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./createAdapter": {
+      "types": "./dist/createAdapter.d.ts",
+      "import": "./dist/createAdapter.js",
+      "require": "./dist/createAdapter.cjs"
     }
   },
   "files": [

--- a/packages/adapters/tsup.config.ts
+++ b/packages/adapters/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    createAdapter: 'src/createAdapter.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./personalization": {
+      "types": "./dist/personalization.d.ts",
+      "import": "./dist/personalization.js",
+      "require": "./dist/personalization.cjs"
     }
   },
   "files": [

--- a/packages/memory/tsup.config.ts
+++ b/packages/memory/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: { index: 'src/index.ts' },
+  entry: {
+    index: 'src/index.ts',
+    personalization: 'src/personalization.ts',
+  },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   sourcemap: true,

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -30,6 +30,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./trace-tracker": {
+      "types": "./dist/trace-tracker.d.ts",
+      "import": "./dist/trace-tracker.js",
+      "require": "./dist/trace-tracker.cjs"
+    },
+    "./cost-guard": {
+      "types": "./dist/cost-guard.d.ts",
+      "import": "./dist/cost-guard.js",
+      "require": "./dist/cost-guard.cjs"
     }
   },
   "files": [

--- a/packages/observability/tsup.config.ts
+++ b/packages/observability/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: { index: 'src/index.ts' },
+  entry: {
+    index: 'src/index.ts',
+    'trace-tracker': 'src/trace-tracker.ts',
+    'cost-guard': 'src/cost-guard.ts',
+  },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   sourcemap: true,

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./chunker": {
+      "types": "./dist/chunker.d.ts",
+      "import": "./dist/chunker.js",
+      "require": "./dist/chunker.cjs"
     }
   },
   "files": [

--- a/packages/rag/tsup.config.ts
+++ b/packages/rag/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    chunker: 'src/chunker.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./shared-context": {
+      "types": "./dist/shared-context.d.ts",
+      "import": "./dist/shared-context.js",
+      "require": "./dist/shared-context.cjs"
     }
   },
   "files": [

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    'shared-context': 'src/shared-context.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -31,6 +31,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./sandbox": {
+      "types": "./dist/sandbox.d.ts",
+      "import": "./dist/sandbox.js",
+      "require": "./dist/sandbox.cjs"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "require": "./dist/types.cjs"
     }
   },
   "files": [

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,6 +1,6 @@
 import { ConfigError, ErrorCodes } from '@agentskit/core'
 import type { SandboxBackend, ExecuteOptions, ExecuteResult } from './types'
-import { createE2BBackend, type E2BConfig } from './e2b-backend'
+import type { E2BConfig } from './e2b-backend'
 
 export interface SandboxConfig {
   apiKey?: string
@@ -26,7 +26,7 @@ export function createSandbox(config: SandboxConfig = {}): Sandbox {
 
   let backend: SandboxBackend | null = config.backend ?? null
 
-  const getBackend = (): SandboxBackend => {
+  const getBackend = async (): Promise<SandboxBackend> => {
     if (backend) return backend
 
     if (!config.apiKey) {
@@ -38,7 +38,8 @@ export function createSandbox(config: SandboxConfig = {}): Sandbox {
       })
     }
 
-    backend = createE2BBackend({
+    const mod = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ './e2b-backend')
+    backend = mod.createE2BBackend({
       apiKey: config.apiKey,
       timeout: defaults.timeout,
     })
@@ -53,7 +54,8 @@ export function createSandbox(config: SandboxConfig = {}): Sandbox {
         ...options,
       }
 
-      return await getBackend().execute(code, mergedOptions)
+      const b = await getBackend()
+      return await b.execute(code, mergedOptions)
     },
 
     async dispose(): Promise<void> {

--- a/packages/sandbox/tsup.config.ts
+++ b/packages/sandbox/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: { index: 'src/index.ts' },
+  entry: {
+    index: 'src/index.ts',
+    sandbox: 'src/sandbox.ts',
+    types: 'src/types.ts',
+  },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,36 @@ importers:
 
   apps/docs-next:
     dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
       '@agentskit/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@agentskit/eval':
+        specifier: workspace:*
+        version: link:../../packages/eval
+      '@agentskit/memory':
+        specifier: workspace:*
+        version: link:../../packages/memory
+      '@agentskit/observability':
+        specifier: workspace:*
+        version: link:../../packages/observability
+      '@agentskit/rag':
+        specifier: workspace:*
+        version: link:../../packages/rag
       '@agentskit/react':
         specifier: workspace:*
         version: link:../../packages/react
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      '@agentskit/sandbox':
+        specifier: workspace:*
+        version: link:../../packages/sandbox
+      '@agentskit/skills':
+        specifier: workspace:*
+        version: link:../../packages/skills
       '@agentskit/tools':
         specifier: workspace:*
         version: link:../../packages/tools


### PR DESCRIPTION
## Summary

- Hero carousel: 4 → 14 scenes covering rag, sandbox, multi-agent, observability, memory, provider fanout, slack, ink, eval, skills.
- Showcase: 11 → 21 examples. 10 new demos use real `@agentskit/*` libs with non-chat UIs (dashboards, code editors, animated graphs, doc explorers).
- Browser-safe subpath exports added to `memory`, `observability`, `rag`, `runtime`, `sandbox`, `adapters` to bypass barrels that pull node-only deps (redis, otel, e2b, web-llm).
- Sandbox `e2b-backend` now lazy-loaded via dynamic import with bundler-ignore comments.
- Showcase detail pages get prev/next navigation arrows.
- Reference sidebar dup section headers removed.

## New showcase demos (each uses real lib API)

| demo | lib | api |
|---|---|---|
| sandbox | `@agentskit/sandbox` | `createSandbox` + custom `SandboxBackend` |
| observability | `@agentskit/observability` | `createTraceTracker`, `computeCost`, `priceFor` |
| memory | `@agentskit/memory` | `createInMemoryPersonalization`, `renderProfileContext` |
| skills | `@agentskit/skills` | `createSkillRegistry` + 7 real skills |
| eval | `@agentskit/eval` | `runEval` against `AgentFn` |
| runtime | `@agentskit/runtime` | `createSharedContext` + motion ReAct flow |
| adapters | `@agentskit/adapters` | `createAdapter` fan-out × 4 |
| rag | `@agentskit/rag` | `chunkText` + jaccard retrieval |
| ink | `@agentskit/core` | `createChatController` driving ASCII pane |
| tools | `@agentskit/tools` (mock) | tool registry browser |

## Test plan

- [ ] `/` hero cycles through all 14 scenes
- [ ] `/showcase` lists 21 cards, tag filter works
- [ ] Each new `/showcase/<slug>` renders without runtime errors
- [ ] Prev/next arrows wrap around the list
- [ ] Reference sidebar shows single entries (no `Packages → Packages` dup)
- [ ] `pnpm lint` passes