### PR TITLE
feat(tools,ink): email + teams + postgres-cdc integrations + ink visual regression

### DIFF
--- a/.changeset/email-integration.md
+++ b/.changeset/email-integration.md
@@ -1,0 +1,10 @@
+---
+"@agentskit/tools": minor
+---
+
+Add provider-agnostic email integration (`email`, `emailSend`, `emailFetch`) under `@agentskit/tools/integrations`.
+
+- Drivers (nodemailer, imapflow, mailparser) are not bundled — pass `EmailTransport` and `ImapClient` adapters from your provider of choice (Outlook, Fastmail, AWS SES, Postfix, ProtonMail bridge, etc.). Mirrors the injection pattern used by `postgres` and `browser-agent`.
+- `email_send` is destructive (`requiresConfirmation: true`), supports text/html bodies, multiple recipients, cc/bcc, and attachments.
+- `email_fetch` returns recent IMAP messages matching an optional filter (mailbox, unseenOnly, since, from, subject) with `maxFetch` cap and truncation flag.
+- Closes #726. Unblocks AgentsKitOS T-4 email trigger (downstream tracking AgentsKit-io/agentskit-os#165).

--- a/.changeset/postgres-cdc.md
+++ b/.changeset/postgres-cdc.md
@@ -1,0 +1,11 @@
+---
+"@agentskit/tools": minor
+---
+
+Add Postgres CDC primitives (`postgresCdc`, `postgresCdcStatus`, `postgresCdcCreateSlot`, `postgresCdcDropSlot`, `postgresCdcAdvance`, `postgresCdcPeek`, `createCdcStream`) under `@agentskit/tools/integrations`.
+
+- Slot-management tools run via an injected `CdcAdminClient` (any parameterised SQL runner — `pg`, Neon, Supabase). Heavy drivers (`pg-logical-replication`, `@supabase/realtime-js`) are not bundled. Slot names are validated with a strict identifier regex before reaching SQL.
+- `postgres_cdc_create_slot`, `postgres_cdc_drop_slot`, and `postgres_cdc_advance` set `requiresConfirmation: true`. "Already exists" / "does not exist" surface as result flags rather than errors so agents can stay idempotent.
+- `postgres_cdc_peek` uses `pg_logical_slot_peek_changes` (non-advancing) with a per-call `maxPeek` cap and truncation flag.
+- Continuous AsyncIterable streaming is exposed as `createCdcStream(config, { signal, startLsn })` — designed for the `@agentskit/triggers` T-9 CDC trigger, not for tool-execute semantics.
+- Closes #728. Downstream tracking AgentsKit-io/agentskit-os#167.

--- a/.changeset/teams-integration.md
+++ b/.changeset/teams-integration.md
@@ -1,0 +1,10 @@
+---
+"@agentskit/tools": minor
+---
+
+Add Microsoft Teams integration (`teams`, `teamsSendWebhook`, `teamsSendBot`, `adaptiveCard`, `messageCard`) under `@agentskit/tools/integrations`.
+
+- Two outbound paths: Incoming Webhook (no app registration, plain fetch) and Bot Framework via injected `TeamsBotClient` adapter (botbuilder is not bundled — wrap your driver of choice). Mirrors the injection pattern used by `email` and `browser-agent`; auth modes (app secret, certificate, managed identity) live inside the adapter.
+- `adaptiveCard()` builder produces v1.5 Adaptive Card payloads with title, body text, FactSet, and OpenUrl/Submit actions; `messageCard()` produces legacy O365 connector cards.
+- Inbound activity routing (`message`, `mentioned`, etc.) is intentionally out of scope — long-running listeners belong in `@agentskit/triggers` (AgentsKitOS T-6).
+- Closes #727. Downstream tracking AgentsKit-io/agentskit-os#166.

--- a/.changeset/visual-regression.md
+++ b/.changeset/visual-regression.md
@@ -1,0 +1,11 @@
+---
+"@agentskit/ink": patch
+---
+
+Add visual regression coverage for `@agentskit/ink` components — issue #253 (P0.42).
+
+`packages/ink/tests/visual.snap.test.tsx` snapshots the raw ANSI frame from `ink-testing-library` for every public component (Message, ToolCallView, ToolConfirmation, StatusHeader, ThinkingIndicator, InputBar) plus a ChatContainer composite, across stable role / status combinations. Snapshots capture color, style, and layout — any drift from a Box / Text refactor or theme change will fail the suite.
+
+Frozen `2026-01-01` dates, first-render-only sampling (so spinner / cursor frames stay deterministic), no animation timer dependence. Runs as part of standard `pnpm --filter @agentskit/ink test`.
+
+The React-side companion lives in the new `apps/visual-react/` Vite + Playwright harness — it is not bundled with `pnpm test` because it requires a Chromium browser binary; see `apps/visual-react/README.md` for setup, baseline, and CI integration steps.

--- a/apps/visual-react/README.md
+++ b/apps/visual-react/README.md
@@ -1,0 +1,62 @@
+# @agentskit/visual-react
+
+Visual regression harness for `@agentskit/react` components — issue [#253](https://github.com/AgentsKit-io/agentskit/issues/253).
+
+## What this is
+
+A small Vite app that renders each public component in a deterministic state, plus a Playwright suite that snapshots every state to PNG and compares against a committed baseline.
+
+The harness lives outside the standard `pnpm test` pipeline because it requires a Chromium browser binary (~150 MB). Run it explicitly when changing components or theme CSS.
+
+## One-time setup
+
+```bash
+pnpm --filter @agentskit/visual-react test:visual:install
+```
+
+This runs `playwright install --with-deps chromium`.
+
+## Generate / update baselines
+
+```bash
+pnpm --filter @agentskit/visual-react test:visual:update
+```
+
+Commit the resulting `tests/visual.spec.ts-snapshots/*.png` files. Review every changed image before pushing — the suite is the source of truth for what the components look like.
+
+## Verify against baselines
+
+```bash
+pnpm --filter @agentskit/visual-react test:visual
+```
+
+Fails if any case drifts outside `maxDiffPixelRatio: 0.001`. On failure, Playwright writes `*-actual.png` and `*-diff.png` next to the baseline.
+
+## Browse cases manually
+
+```bash
+pnpm --filter @agentskit/visual-react dev
+```
+
+Open http://127.0.0.1:4178 for the index, or jump straight to a case via `?case=<id>`. Add a new case in `src/Harness.tsx` — its id will automatically appear in `CASE_IDS` and the spec will pick it up.
+
+## Determinism rules
+
+- All `Date` values use a frozen `2026-01-01T00:00:00.000Z`.
+- Animations, transitions, and caret colour are stripped via injected CSS at test time.
+- Viewport, locale, timezone, colour scheme, and device scale are pinned in `playwright.config.ts`.
+- Tests run on the chromium project only — keep baselines small and avoid OS-dependent rendering.
+
+If a snapshot drifts without a real visual change, look for a missed source of non-determinism (font fallback, server-side date, Math.random) before regenerating the baseline.
+
+## CI
+
+Not wired into the default workflow yet. To enable, run:
+
+```yaml
+- run: pnpm --filter @agentskit/visual-react test:visual:install
+- run: pnpm --filter @agentskit/visual-react build
+- run: pnpm --filter @agentskit/visual-react test:visual
+```
+
+Cache the Playwright browser bundle at `~/.cache/ms-playwright`.

--- a/apps/visual-react/index.html
+++ b/apps/visual-react/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AgentsKit React — Visual Regression Harness</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; background: #ffffff; color: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      body[data-case] { padding: 24px; }
+      [data-case-frame] { width: 720px; max-width: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/visual-react/package.json
+++ b/apps/visual-react/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@agentskit/visual-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "preview": "vite preview --port 4179 --strictPort",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots",
+    "test:visual:install": "playwright install --with-deps chromium"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*",
+    "@agentskit/react": "workspace:*",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/visual-react/playwright.config.ts
+++ b/apps/visual-react/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 4178
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  expect: {
+    toHaveScreenshot: {
+      // Accept tiny anti-alias drift (browser/OS variance) but flag real changes.
+      maxDiffPixelRatio: 0.001,
+      animations: 'disabled',
+    },
+  },
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: 'retain-on-failure',
+    viewport: { width: 1024, height: 768 },
+    deviceScaleFactor: 1,
+    colorScheme: 'light',
+    locale: 'en-US',
+    timezoneId: 'UTC',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+})

--- a/apps/visual-react/src/Harness.tsx
+++ b/apps/visual-react/src/Harness.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect } from 'react'
+import {
+  ChatContainer,
+  InputBar,
+  Message,
+  ThinkingIndicator,
+  ToolCallView,
+  ToolConfirmation,
+} from '@agentskit/react'
+import type { ChatReturn, Message as MessageType, ToolCall } from '@agentskit/core'
+
+const FROZEN_DATE = new Date('2026-01-01T00:00:00.000Z')
+
+function buildMessage(overrides: Partial<MessageType>): MessageType {
+  return {
+    id: overrides.id ?? 'm-1',
+    role: 'assistant',
+    content: '',
+    status: 'complete',
+    createdAt: FROZEN_DATE,
+    ...overrides,
+  }
+}
+
+function buildToolCall(overrides: Partial<ToolCall>): ToolCall {
+  return {
+    id: overrides.id ?? 'tc-1',
+    name: 'get_weather',
+    args: { city: 'San Francisco' },
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+function stubChat(input = ''): ChatReturn {
+  return {
+    messages: [],
+    input,
+    setInput: () => {},
+    send: async () => {},
+    abort: () => {},
+    clear: () => {},
+    status: 'idle',
+    approve: () => {},
+    deny: () => {},
+  } as unknown as ChatReturn
+}
+
+interface CaseDef {
+  id: string
+  render: () => React.ReactNode
+}
+
+const CASES: CaseDef[] = [
+  {
+    id: 'message-user',
+    render: () => <Message message={buildMessage({ role: 'user', content: 'Hello, what is the weather?' })} />,
+  },
+  {
+    id: 'message-assistant',
+    render: () => <Message message={buildMessage({ content: 'The weather in SF is 72°F and sunny.' })} />,
+  },
+  {
+    id: 'message-streaming',
+    render: () => (
+      <Message message={buildMessage({ content: 'Working on it...', status: 'streaming' })} />
+    ),
+  },
+  {
+    id: 'message-tool',
+    render: () => <Message message={buildMessage({ role: 'tool', content: '72°F sunny' })} />,
+  },
+  {
+    id: 'thinking-indicator',
+    render: () => <ThinkingIndicator visible />,
+  },
+  {
+    id: 'thinking-indicator-custom-label',
+    render: () => <ThinkingIndicator visible label="Reasoning" />,
+  },
+  {
+    id: 'tool-call-pending',
+    render: () => <ToolCallView toolCall={buildToolCall({ status: 'pending' })} />,
+  },
+  {
+    id: 'tool-call-running',
+    render: () => <ToolCallView toolCall={buildToolCall({ status: 'running' })} />,
+  },
+  {
+    id: 'tool-call-complete',
+    render: () => (
+      <ToolCallView toolCall={buildToolCall({ status: 'complete', result: '72°F, sunny' })} />
+    ),
+  },
+  {
+    id: 'tool-confirmation',
+    render: () => (
+      <ToolConfirmation
+        toolCall={buildToolCall({ status: 'requires_confirmation' })}
+        onApprove={() => {}}
+        onDeny={() => {}}
+      />
+    ),
+  },
+  {
+    id: 'input-bar-empty',
+    render: () => <InputBar chat={stubChat('')} />,
+  },
+  {
+    id: 'input-bar-typed',
+    render: () => <InputBar chat={stubChat('Hello world')} />,
+  },
+  {
+    id: 'input-bar-disabled',
+    render: () => <InputBar chat={stubChat('')} disabled />,
+  },
+  {
+    id: 'chat-container-composite',
+    render: () => (
+      <ChatContainer>
+        <Message message={buildMessage({ id: 'u', role: 'user', content: 'Weather in SF?' })} />
+        <ToolCallView toolCall={buildToolCall({ status: 'complete', result: '72°F sunny' })} />
+        <Message
+          message={buildMessage({ id: 'a', content: 'It is sunny and 72°F in San Francisco.' })}
+        />
+        <InputBar chat={stubChat('')} />
+      </ChatContainer>
+    ),
+  },
+]
+
+export const CASE_IDS: string[] = CASES.map(c => c.id)
+
+function Index() {
+  return (
+    <main>
+      <h1>AgentsKit React — Visual Regression Harness</h1>
+      <p>Append <code>?case=&lt;id&gt;</code> to view a deterministic component frame.</p>
+      <ul>
+        {CASES.map(c => (
+          <li key={c.id}>
+            <a href={`?case=${c.id}`}>{c.id}</a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+
+export function Harness() {
+  const params = new URLSearchParams(window.location.search)
+  const caseId = params.get('case')
+
+  useEffect(() => {
+    if (caseId) {
+      document.body.dataset.case = caseId
+    } else {
+      delete document.body.dataset.case
+    }
+  }, [caseId])
+
+  if (!caseId) return <Index />
+  const found = CASES.find(c => c.id === caseId)
+  if (!found) {
+    return (
+      <main>
+        <p>Unknown case: <code>{caseId}</code></p>
+        <p><a href="/">back</a></p>
+      </main>
+    )
+  }
+  return (
+    <div data-case-frame data-case-id={caseId}>
+      {found.render()}
+    </div>
+  )
+}

--- a/apps/visual-react/src/main.tsx
+++ b/apps/visual-react/src/main.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { Harness } from './Harness'
+// @ts-expect-error CSS side-effect import has no type declarations
+import '@agentskit/react/theme'
+
+const root = createRoot(document.getElementById('root')!)
+root.render(<Harness />)

--- a/apps/visual-react/tests/visual.spec.ts
+++ b/apps/visual-react/tests/visual.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+import { CASE_IDS } from '../src/Harness'
+
+for (const caseId of CASE_IDS) {
+  test(`visual: ${caseId}`, async ({ page }) => {
+    await page.goto(`/?case=${caseId}`)
+    const frame = page.locator('[data-case-frame]')
+    await expect(frame).toBeVisible()
+    // Disable caret blink + animations via CSS injection so screenshots
+    // are byte-stable across runs.
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation: none !important;
+          transition: none !important;
+          caret-color: transparent !important;
+        }
+      `,
+    })
+    await expect(frame).toHaveScreenshot(`${caseId}.png`)
+  })
+}

--- a/apps/visual-react/tsconfig.json
+++ b/apps/visual-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client", "@playwright/test"]
+  },
+  "include": ["src", "tests", "vite.config.ts", "playwright.config.ts"]
+}

--- a/apps/visual-react/vite.config.ts
+++ b/apps/visual-react/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4178, strictPort: true },
+  preview: { port: 4179, strictPort: true },
+})

--- a/packages/ink/tests/__snapshots__/visual.snap.test.tsx.snap
+++ b/packages/ink/tests/__snapshots__/visual.snap.test.tsx.snap
@@ -1,0 +1,129 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`visual regression — ChatContainer composite > renders user + assistant exchange with tool call 1`] = `
+"❯ you
+weather in SF?
+
+╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ✓ get_weather  · complete                                                                        │
+│ args: {"city":"San Francisco"}                                                                   │
+│ 72°F sunny                                                                                       │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+✦ assistant
+It is sunny and 72°F."
+`;
+
+exports[`visual regression — InputBar > disabled 1`] = `
+"input disabled
+❯"
+`;
+
+exports[`visual regression — InputBar > idle — empty input shows placeholder hint 1`] = `
+"Type a message...
+❯"
+`;
+
+exports[`visual regression — InputBar > idle — typed input 1`] = `
+"Type a message...
+❯ hello world"
+`;
+
+exports[`visual regression — Message > assistant message — markdown 1`] = `
+"✦ assistant
+# Forecast
+
+  * **SF**: sunny
+  * *NYC*: cloudy"
+`;
+
+exports[`visual regression — Message > assistant message — plain text 1`] = `
+"✦ assistant
+It is sunny and 72°F."
+`;
+
+exports[`visual regression — Message > assistant message — streaming 1`] = `
+"✦ assistant  · streaming
+Working on it"
+`;
+
+exports[`visual regression — Message > assistant with token usage footer 1`] = `
+"✦ assistant
+Done.
+tokens  ↑1.2k  ↓350  ·  1.6k total"
+`;
+
+exports[`visual regression — Message > tool result message — truncated 1`] = `
+"  ⚙ tool result
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxx…"
+`;
+
+exports[`visual regression — Message > user message 1`] = `
+"❯ you
+What is the weather in SF?"
+`;
+
+exports[`visual regression — StatusHeader > full segments 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ✦ AgentsKit CLI                                                                                  │
+│ provider=openai  ·  model=gpt-4o-mini  ·  mode=live  ·  tools=get_weather,web_search  ·  msgs=4… │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — StatusHeader > title only 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ✦ Custom CLI                                                                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ThinkingIndicator > hidden — renders nothing 1`] = `""`;
+
+exports[`visual regression — ThinkingIndicator > visible — custom label 1`] = `"⠋ Reasoning"`;
+
+exports[`visual regression — ThinkingIndicator > visible — first spinner frame 1`] = `"⠋ Thinking"`;
+
+exports[`visual regression — ToolCallView > complete — expanded with result 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ✓ get_weather  · complete                                                                        │
+│ args: {"city":"San Francisco"}                                                                   │
+│ 72°F, sunny                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ToolCallView > error — expanded with error message 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ✗ get_weather  · error                                                                           │
+│ args: {"city":"San Francisco"}                                                                   │
+│ API rate limit exceeded                                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ToolCallView > pending — collapsed 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ○ get_weather  · pending                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ToolCallView > running — collapsed (first spinner frame) 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ⠋ get_weather  · running                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ToolConfirmation > renders three options with first selected 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ ⚠  Allow get_weather?                                                                            │
+│ {"city":"San Francisco"}                                                                         │
+│                                                                                                  │
+│ ❯ 1. Yes  — allow this call                                                                      │
+│   2. Yes, for session  — stop asking for this tool                                               │
+│   3. No  — deny and tell the model why                                                           │
+│ ↑/↓ to move, Enter to pick, 1–3 for shortcuts                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`visual regression — ToolConfirmation > returns nothing when toolCall is not awaiting confirmation 1`] = `""`;

--- a/packages/ink/tests/visual.snap.test.tsx
+++ b/packages/ink/tests/visual.snap.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render } from 'ink-testing-library'
+import { ChatContainer } from '../src/components/ChatContainer'
+import { InputBar } from '../src/components/InputBar'
+import { Message } from '../src/components/Message'
+import { StatusHeader } from '../src/components/StatusHeader'
+import { ThinkingIndicator } from '../src/components/ThinkingIndicator'
+import { ToolCallView } from '../src/components/ToolCallView'
+import { ToolConfirmation } from '../src/components/ToolConfirmation'
+import type { ChatReturn, Message as MessageType, ToolCall } from '@agentskit/core'
+
+/**
+ * Visual regression for @agentskit/ink components — issue #253.
+ *
+ * Snapshots capture the raw ANSI frame from `ink-testing-library`,
+ * which includes color, style, and layout. Snapshot only the first
+ * synchronous frame to avoid spinner / cursor frame drift; this is
+ * deterministic because animation timers fire after first render.
+ */
+
+const FROZEN_DATE = new Date('2026-01-01T00:00:00.000Z')
+
+function buildMessage(overrides: Partial<MessageType>): MessageType {
+  return {
+    id: 'm-1',
+    role: 'assistant',
+    content: '',
+    status: 'complete',
+    createdAt: FROZEN_DATE,
+    ...overrides,
+  }
+}
+
+function buildToolCall(overrides: Partial<ToolCall>): ToolCall {
+  return {
+    id: 'tc-1',
+    name: 'get_weather',
+    args: { city: 'San Francisco' },
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+function stubChat(input = ''): ChatReturn {
+  return {
+    messages: [],
+    input,
+    setInput: () => {},
+    send: async () => {},
+    abort: () => {},
+    clear: () => {},
+    status: 'idle',
+    approve: () => {},
+    deny: () => {},
+  } as unknown as ChatReturn
+}
+
+describe('visual regression — Message', () => {
+  it('user message', () => {
+    const { lastFrame } = render(<Message message={buildMessage({ role: 'user', content: 'What is the weather in SF?' })} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('assistant message — plain text', () => {
+    const { lastFrame } = render(
+      <Message message={buildMessage({ content: 'It is sunny and 72°F.' })} markdown={false} />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('assistant message — markdown', () => {
+    const { lastFrame } = render(
+      <Message message={buildMessage({ content: '# Forecast\n\n- **SF**: sunny\n- *NYC*: cloudy' })} />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('assistant message — streaming', () => {
+    const { lastFrame } = render(
+      <Message message={buildMessage({ content: 'Working on it', status: 'streaming' })} markdown={false} />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('tool result message — truncated', () => {
+    const { lastFrame } = render(
+      <Message message={buildMessage({ role: 'tool', content: 'x'.repeat(800) })} />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('assistant with token usage footer', () => {
+    const { lastFrame } = render(
+      <Message
+        message={buildMessage({
+          content: 'Done.',
+          metadata: { usage: { promptTokens: 1200, completionTokens: 350, totalTokens: 1550 } },
+        })}
+        markdown={false}
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — ToolCallView', () => {
+  it('pending — collapsed', () => {
+    const { lastFrame } = render(<ToolCallView toolCall={buildToolCall({ status: 'pending' })} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('running — collapsed (first spinner frame)', () => {
+    const { lastFrame } = render(<ToolCallView toolCall={buildToolCall({ status: 'running' })} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('complete — expanded with result', () => {
+    const { lastFrame } = render(
+      <ToolCallView
+        toolCall={buildToolCall({ status: 'complete', result: '72°F, sunny' })}
+        expanded
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('error — expanded with error message', () => {
+    const { lastFrame } = render(
+      <ToolCallView
+        toolCall={buildToolCall({ status: 'error', error: 'API rate limit exceeded' })}
+        expanded
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — ToolConfirmation', () => {
+  it('renders three options with first selected', () => {
+    const { lastFrame } = render(
+      <ToolConfirmation
+        toolCall={buildToolCall({ status: 'requires_confirmation' })}
+        onApprove={() => {}}
+        onDeny={() => {}}
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('returns nothing when toolCall is not awaiting confirmation', () => {
+    const { lastFrame } = render(
+      <ToolConfirmation
+        toolCall={buildToolCall({ status: 'complete' })}
+        onApprove={() => {}}
+        onDeny={() => {}}
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — StatusHeader', () => {
+  it('full segments', () => {
+    const { lastFrame } = render(
+      <StatusHeader
+        provider="openai"
+        model="gpt-4o-mini"
+        mode="live"
+        tools={['get_weather', 'web_search']}
+        messageCount={4}
+        sessionId="abcdef0123456789"
+      />,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('title only', () => {
+    const { lastFrame } = render(<StatusHeader title="Custom CLI" />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — ThinkingIndicator', () => {
+  it('visible — first spinner frame', () => {
+    const { lastFrame } = render(<ThinkingIndicator visible />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('visible — custom label', () => {
+    const { lastFrame } = render(<ThinkingIndicator visible label="Reasoning" />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('hidden — renders nothing', () => {
+    const { lastFrame } = render(<ThinkingIndicator visible={false} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — InputBar', () => {
+  it('idle — empty input shows placeholder hint', () => {
+    const { lastFrame } = render(<InputBar chat={stubChat('')} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('idle — typed input', () => {
+    const { lastFrame } = render(<InputBar chat={stubChat('hello world')} />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+
+  it('disabled', () => {
+    const { lastFrame } = render(<InputBar chat={stubChat('')} disabled />)
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})
+
+describe('visual regression — ChatContainer composite', () => {
+  it('renders user + assistant exchange with tool call', () => {
+    const { lastFrame } = render(
+      <ChatContainer>
+        <Message message={buildMessage({ id: 'u', role: 'user', content: 'weather in SF?' })} />
+        <ToolCallView toolCall={buildToolCall({ status: 'complete', result: '72°F sunny' })} expanded />
+        <Message message={buildMessage({ content: 'It is sunny and 72°F.' })} markdown={false} />
+      </ChatContainer>,
+    )
+    expect(lastFrame()).toMatchSnapshot()
+  })
+})

--- a/packages/tools/src/integrations/email.ts
+++ b/packages/tools/src/integrations/email.ts
@@ -1,0 +1,237 @@
+import { ConfigError, ErrorCodes, ToolError, defineTool } from '@agentskit/core'
+
+/**
+ * Provider-agnostic email tools (SMTP send + IMAP fetch). Heavy
+ * drivers (nodemailer, imapflow, mailparser) are not bundled — pass
+ * an `EmailTransport` and/or `ImapClient` adapter that wraps your
+ * driver of choice. A reference nodemailer/imapflow adapter lives in
+ * the AgentsKitOS triggers package.
+ */
+
+export interface EmailAttachment {
+  filename: string
+  /** UTF-8 text contents. Use `contentBase64` for binary. */
+  content?: string
+  contentBase64?: string
+  contentType?: string
+}
+
+export interface EmailSendMessage {
+  from: string
+  to: string | string[]
+  cc?: string | string[]
+  bcc?: string | string[]
+  subject: string
+  text?: string
+  html?: string
+  attachments?: EmailAttachment[]
+}
+
+export interface EmailSendResult {
+  messageId: string
+  accepted?: string[]
+  rejected?: string[]
+}
+
+export interface EmailTransport {
+  send: (msg: EmailSendMessage) => Promise<EmailSendResult>
+}
+
+export interface EmailMessage {
+  id: string
+  uid?: number
+  from: string
+  to: string[]
+  subject: string
+  /** ISO 8601 timestamp. */
+  date: string
+  text?: string
+  html?: string
+  attachments?: Array<{ filename: string; contentType: string; size: number }>
+}
+
+export interface ImapFetchOptions {
+  mailbox?: string
+  unseenOnly?: boolean
+  /** ISO date string. Only return messages on/after this date. */
+  since?: string
+  from?: string
+  subject?: string
+  /** Hard cap on returned messages. Default 50. */
+  limit?: number
+}
+
+export interface ImapClient {
+  fetch: (opts: ImapFetchOptions) => Promise<EmailMessage[]>
+}
+
+export interface EmailConfig {
+  transport?: EmailTransport
+  imap?: ImapClient
+  /** Default mailbox for fetch. Default 'INBOX'. */
+  defaultMailbox?: string
+  /** Hard cap applied to fetch limits. Default 200. */
+  maxFetch?: number
+}
+
+function asArray(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) return undefined
+  return Array.isArray(value) ? value : [value]
+}
+
+export function emailSend(config: EmailConfig) {
+  if (!config.transport) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'emailSend: config.transport is required',
+      hint: 'Provide an EmailTransport adapter (e.g. wrap nodemailer.createTransport).',
+    })
+  }
+  const transport = config.transport
+  return defineTool({
+    name: 'email_send',
+    description: 'Send an email via the configured SMTP transport.',
+    schema: {
+      type: 'object',
+      properties: {
+        from: { type: 'string' },
+        to: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'array', items: { type: 'string' } },
+          ],
+        },
+        cc: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'array', items: { type: 'string' } },
+          ],
+        },
+        bcc: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'array', items: { type: 'string' } },
+          ],
+        },
+        subject: { type: 'string' },
+        text: { type: 'string' },
+        html: { type: 'string' },
+        attachments: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              filename: { type: 'string' },
+              content: { type: 'string' },
+              contentBase64: { type: 'string' },
+              contentType: { type: 'string' },
+            },
+            required: ['filename'],
+          },
+        },
+      },
+      required: ['from', 'to', 'subject'],
+    } as const,
+    requiresConfirmation: true,
+    async execute(args) {
+      const text = typeof args.text === 'string' ? args.text : undefined
+      const html = typeof args.html === 'string' ? args.html : undefined
+      if (!text && !html) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: 'email_send: provide text or html body',
+        })
+      }
+      const to = asArray(args.to as string | string[])
+      if (!to || to.length === 0) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: 'email_send: to is required',
+        })
+      }
+      try {
+        const result = await transport.send({
+          from: String(args.from),
+          to,
+          cc: asArray(args.cc as string | string[] | undefined),
+          bcc: asArray(args.bcc as string | string[] | undefined),
+          subject: String(args.subject),
+          text,
+          html,
+          attachments: Array.isArray(args.attachments)
+            ? (args.attachments as EmailAttachment[])
+            : undefined,
+        })
+        return {
+          messageId: result.messageId,
+          accepted: result.accepted ?? [],
+          rejected: result.rejected ?? [],
+        }
+      } catch (err) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `email_send: ${err instanceof Error ? err.message : String(err)}`,
+          hint: 'Verify SMTP host, credentials, and that the transport adapter resolves errors as exceptions.',
+        })
+      }
+    },
+  })
+}
+
+export function emailFetch(config: EmailConfig) {
+  if (!config.imap) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'emailFetch: config.imap is required',
+      hint: 'Provide an ImapClient adapter (e.g. wrap imapflow.fetch).',
+    })
+  }
+  const client = config.imap
+  const defaultMailbox = config.defaultMailbox ?? 'INBOX'
+  const maxFetch = Math.max(1, config.maxFetch ?? 200)
+  return defineTool({
+    name: 'email_fetch',
+    description: 'Fetch a batch of recent IMAP messages matching an optional filter.',
+    schema: {
+      type: 'object',
+      properties: {
+        mailbox: { type: 'string' },
+        unseen_only: { type: 'boolean' },
+        since: { type: 'string', description: 'ISO date string. Only return messages on/after this date.' },
+        from: { type: 'string' },
+        subject: { type: 'string' },
+        limit: { type: 'number' },
+      },
+    } as const,
+    async execute(args) {
+      const requested = typeof args.limit === 'number' ? args.limit : 50
+      const limit = Math.min(maxFetch, Math.max(1, requested))
+      const messages = await client.fetch({
+        mailbox: typeof args.mailbox === 'string' ? args.mailbox : defaultMailbox,
+        unseenOnly: args.unseen_only === true,
+        since: typeof args.since === 'string' ? args.since : undefined,
+        from: typeof args.from === 'string' ? args.from : undefined,
+        subject: typeof args.subject === 'string' ? args.subject : undefined,
+        limit,
+      })
+      return {
+        count: messages.length,
+        truncated: messages.length >= limit,
+        messages,
+      }
+    },
+  })
+}
+
+export function email(config: EmailConfig) {
+  const tools = []
+  if (config.transport) tools.push(emailSend(config))
+  if (config.imap) tools.push(emailFetch(config))
+  if (tools.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'email: provide at least one of `transport` or `imap`',
+    })
+  }
+  return tools
+}

--- a/packages/tools/src/integrations/index.ts
+++ b/packages/tools/src/integrations/index.ts
@@ -13,8 +13,39 @@ export type { NotionConfig } from './notion'
 export { discord, discordPostMessage } from './discord'
 export type { DiscordConfig } from './discord'
 
+export {
+  teams,
+  teamsSendWebhook,
+  teamsSendBot,
+  adaptiveCard,
+  messageCard,
+} from './teams'
+export type {
+  TeamsConfig,
+  TeamsWebhookConfig,
+  TeamsBotConfig,
+  TeamsBotClient,
+  TeamsBotMessage,
+  TeamsBotSendResult,
+  TeamsAdaptiveCard,
+  TeamsAdaptiveCardAction,
+  TeamsMessageCard,
+} from './teams'
+
 export { gmail, gmailListMessages, gmailSendEmail } from './gmail'
 export type { GmailConfig } from './gmail'
+
+export { email, emailSend, emailFetch } from './email'
+export type {
+  EmailConfig,
+  EmailTransport,
+  ImapClient,
+  ImapFetchOptions,
+  EmailMessage,
+  EmailSendMessage,
+  EmailSendResult,
+  EmailAttachment,
+} from './email'
 
 export {
   googleCalendar,
@@ -31,6 +62,25 @@ export type { PostgresConfig, PostgresExecuteResult } from './postgres'
 
 export { postgresWithRoles } from './postgres-roles'
 export type { PostgresRolesConfig } from './postgres-roles'
+
+export {
+  postgresCdc,
+  postgresCdcStatus,
+  postgresCdcCreateSlot,
+  postgresCdcDropSlot,
+  postgresCdcAdvance,
+  postgresCdcPeek,
+  createCdcStream,
+} from './postgres-cdc'
+export type {
+  PostgresCdcConfig,
+  CdcAdminClient,
+  CdcStreamClient,
+  CdcStreamOptions,
+  CdcChangeEvent,
+  CdcSlotStatus,
+  CdcOp,
+} from './postgres-cdc'
 
 export { jira, jiraSearchIssues, jiraCreateIssue } from './jira'
 export type { JiraConfig } from './jira'

--- a/packages/tools/src/integrations/postgres-cdc.ts
+++ b/packages/tools/src/integrations/postgres-cdc.ts
@@ -65,12 +65,22 @@ export interface PostgresCdcConfig {
 }
 
 const VALID_IDENT = /^[A-Za-z_][A-Za-z0-9_]{0,62}$/
+const VALID_LSN = /^[0-9A-Fa-f]{1,8}\/[0-9A-Fa-f]{1,8}$/
 
 function assertIdent(name: string, label: string): void {
   if (!VALID_IDENT.test(name)) {
     throw new ConfigError({
       code: ErrorCodes.AK_CONFIG_INVALID,
       message: `${label} must match /^[A-Za-z_][A-Za-z0-9_]{0,62}$/, got: ${name}`,
+    })
+  }
+}
+
+function assertLsn(value: string, label: string): void {
+  if (!VALID_LSN.test(value)) {
+    throw new ToolError({
+      code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+      message: `${label} must look like '0/16B6360', got: ${value}`,
     })
   }
 }
@@ -194,6 +204,7 @@ export function postgresCdcAdvance(config: PostgresCdcConfig) {
     requiresConfirmation: true,
     async execute({ lsn }) {
       const target = String(lsn)
+      assertLsn(target, 'lsn')
       try {
         const result = await admin.execute(
           'SELECT pg_replication_slot_advance($1, $2::pg_lsn) AS info',
@@ -229,6 +240,7 @@ export function postgresCdcPeek(config: PostgresCdcConfig) {
       const requested = typeof limit === 'number' ? limit : 25
       const n = Math.min(cap, Math.max(1, requested))
       const upto = typeof upto_lsn === 'string' ? upto_lsn : null
+      if (upto !== null) assertLsn(upto, 'upto_lsn')
       try {
         const result = await admin.execute(
           'SELECT lsn::text AS lsn, xid::text AS xid, data FROM pg_logical_slot_peek_changes($1, $2::pg_lsn, $3)',

--- a/packages/tools/src/integrations/postgres-cdc.ts
+++ b/packages/tools/src/integrations/postgres-cdc.ts
@@ -1,0 +1,283 @@
+import { ConfigError, ErrorCodes, ToolError, defineTool } from '@agentskit/core'
+import type { PostgresExecuteResult } from './postgres'
+
+/**
+ * Postgres change-data-capture (CDC) primitives. Two consumer modes:
+ *
+ *   - Logical replication (`pgoutput` / `wal2json`) via
+ *     `pg-logical-replication` or your own streaming client.
+ *   - Supabase realtime via `@supabase/realtime-js`.
+ *
+ * Heavy drivers are not bundled — pass a `CdcAdminClient` (any
+ * parameterised SQL runner: `pg`, Neon `sql`, Supabase
+ * `postgres.query`) for the slot-management tools, and a
+ * `CdcStreamClient` adapter for long-running streams (used by
+ * `@agentskit/triggers` in AgentsKitOS T-9).
+ *
+ * Tool primitives are one-shot and fit `execute` semantics: status,
+ * create/drop slot, advance, peek-N. The continuous AsyncIterable
+ * stream is exposed as a helper, not a tool.
+ */
+
+export type CdcOp = 'insert' | 'update' | 'delete' | 'truncate' | 'schema'
+
+export interface CdcChangeEvent {
+  op: CdcOp
+  schema: string
+  table: string
+  lsn?: string
+  commitTs?: string
+  before?: Record<string, unknown>
+  after?: Record<string, unknown>
+}
+
+export interface CdcSlotStatus {
+  slotName: string
+  active: boolean
+  walLagBytes?: number
+  restartLsn?: string
+  confirmedFlushLsn?: string
+  plugin?: string
+  database?: string
+}
+
+export interface CdcAdminClient {
+  execute: (sql: string, params: unknown[]) => Promise<PostgresExecuteResult>
+}
+
+export interface CdcStreamOptions {
+  signal?: AbortSignal
+  startLsn?: string
+}
+
+export interface CdcStreamClient {
+  stream: (options?: CdcStreamOptions) => AsyncIterable<CdcChangeEvent>
+}
+
+export interface PostgresCdcConfig {
+  admin?: CdcAdminClient
+  stream?: CdcStreamClient
+  slotName: string
+  publication?: string
+  plugin?: 'pgoutput' | 'wal2json'
+  /** Cap rows returned by peek. Default 100. */
+  maxPeek?: number
+}
+
+const VALID_IDENT = /^[A-Za-z_][A-Za-z0-9_]{0,62}$/
+
+function assertIdent(name: string, label: string): void {
+  if (!VALID_IDENT.test(name)) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `${label} must match /^[A-Za-z_][A-Za-z0-9_]{0,62}$/, got: ${name}`,
+    })
+  }
+}
+
+function requireAdmin(config: PostgresCdcConfig, fn: string): CdcAdminClient {
+  if (!config.admin) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `${fn}: config.admin is required`,
+      hint: 'Provide a CdcAdminClient adapter (e.g. wrap pg.Pool.query).',
+    })
+  }
+  return config.admin
+}
+
+export function postgresCdcStatus(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdcStatus')
+  assertIdent(config.slotName, 'slotName')
+  return defineTool({
+    name: 'postgres_cdc_status',
+    description: 'Inspect a Postgres logical replication slot — active, restart/confirmed LSN, WAL lag bytes.',
+    schema: { type: 'object', properties: {} } as const,
+    async execute() {
+      const result = await admin.execute(
+        `SELECT slot_name, plugin, database, active, restart_lsn::text AS restart_lsn,
+                confirmed_flush_lsn::text AS confirmed_flush_lsn,
+                pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint AS wal_lag_bytes
+         FROM pg_replication_slots
+         WHERE slot_name = $1`,
+        [config.slotName],
+      )
+      const row = result.rows[0]
+      if (!row) {
+        return { exists: false as const, slotName: config.slotName }
+      }
+      const status: CdcSlotStatus & { exists: true } = {
+        exists: true,
+        slotName: String(row.slot_name),
+        active: Boolean(row.active),
+        plugin: row.plugin == null ? undefined : String(row.plugin),
+        database: row.database == null ? undefined : String(row.database),
+        restartLsn: row.restart_lsn == null ? undefined : String(row.restart_lsn),
+        confirmedFlushLsn:
+          row.confirmed_flush_lsn == null ? undefined : String(row.confirmed_flush_lsn),
+        walLagBytes: row.wal_lag_bytes == null ? undefined : Number(row.wal_lag_bytes),
+      }
+      return status
+    },
+  })
+}
+
+export function postgresCdcCreateSlot(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdcCreateSlot')
+  assertIdent(config.slotName, 'slotName')
+  const plugin = config.plugin ?? 'pgoutput'
+  return defineTool({
+    name: 'postgres_cdc_create_slot',
+    description: 'Create a Postgres logical replication slot if it does not already exist.',
+    schema: { type: 'object', properties: {} } as const,
+    requiresConfirmation: true,
+    async execute() {
+      try {
+        const result = await admin.execute(
+          'SELECT pg_create_logical_replication_slot($1, $2) AS info',
+          [config.slotName, plugin],
+        )
+        return { created: true, slotName: config.slotName, plugin, info: result.rows[0]?.info }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        if (/already exists/i.test(message)) {
+          return { created: false, slotName: config.slotName, plugin, reason: 'exists' as const }
+        }
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `postgres_cdc_create_slot: ${message}`,
+          hint: 'Check wal_level=logical, max_replication_slots, and that the role has REPLICATION.',
+        })
+      }
+    },
+  })
+}
+
+export function postgresCdcDropSlot(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdcDropSlot')
+  assertIdent(config.slotName, 'slotName')
+  return defineTool({
+    name: 'postgres_cdc_drop_slot',
+    description: 'Drop a Postgres logical replication slot. Destructive — frees retained WAL.',
+    schema: { type: 'object', properties: {} } as const,
+    requiresConfirmation: true,
+    async execute() {
+      try {
+        await admin.execute('SELECT pg_drop_replication_slot($1)', [config.slotName])
+        return { dropped: true, slotName: config.slotName }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        if (/does not exist/i.test(message)) {
+          return { dropped: false, slotName: config.slotName, reason: 'missing' as const }
+        }
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `postgres_cdc_drop_slot: ${message}`,
+          hint: 'A slot cannot be dropped while a replication client is still connected.',
+        })
+      }
+    },
+  })
+}
+
+export function postgresCdcAdvance(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdcAdvance')
+  assertIdent(config.slotName, 'slotName')
+  return defineTool({
+    name: 'postgres_cdc_advance',
+    description: 'Advance a logical replication slot to a target LSN. Discards intermediate changes.',
+    schema: {
+      type: 'object',
+      properties: { lsn: { type: 'string', description: 'Target LSN, e.g. 0/16B6360' } },
+      required: ['lsn'],
+    } as const,
+    requiresConfirmation: true,
+    async execute({ lsn }) {
+      const target = String(lsn)
+      try {
+        const result = await admin.execute(
+          'SELECT pg_replication_slot_advance($1, $2::pg_lsn) AS info',
+          [config.slotName, target],
+        )
+        return { advanced: true, slotName: config.slotName, targetLsn: target, info: result.rows[0]?.info }
+      } catch (err) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `postgres_cdc_advance: ${err instanceof Error ? err.message : String(err)}`,
+          hint: 'pg_replication_slot_advance requires Postgres ≥ 11 and a logical slot.',
+        })
+      }
+    },
+  })
+}
+
+export function postgresCdcPeek(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdcPeek')
+  assertIdent(config.slotName, 'slotName')
+  const cap = Math.max(1, config.maxPeek ?? 100)
+  return defineTool({
+    name: 'postgres_cdc_peek',
+    description: 'Peek up to N changes from a logical slot without advancing the confirmed LSN.',
+    schema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: `Max changes to return. Capped at ${cap}.` },
+        upto_lsn: { type: 'string', description: 'Optional upper-bound LSN.' },
+      },
+    } as const,
+    async execute({ limit, upto_lsn }) {
+      const requested = typeof limit === 'number' ? limit : 25
+      const n = Math.min(cap, Math.max(1, requested))
+      const upto = typeof upto_lsn === 'string' ? upto_lsn : null
+      try {
+        const result = await admin.execute(
+          'SELECT lsn::text AS lsn, xid::text AS xid, data FROM pg_logical_slot_peek_changes($1, $2::pg_lsn, $3)',
+          [config.slotName, upto, n],
+        )
+        const changes = result.rows.map(row => ({
+          lsn: row.lsn == null ? undefined : String(row.lsn),
+          xid: row.xid == null ? undefined : String(row.xid),
+          data: row.data == null ? undefined : String(row.data),
+        }))
+        return { count: changes.length, truncated: changes.length >= n, changes }
+      } catch (err) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `postgres_cdc_peek: ${err instanceof Error ? err.message : String(err)}`,
+          hint: 'pg_logical_slot_peek_changes requires the same plugin as the slot was created with.',
+        })
+      }
+    },
+  })
+}
+
+export function postgresCdc(config: PostgresCdcConfig) {
+  const admin = requireAdmin(config, 'postgresCdc')
+  void admin
+  return [
+    postgresCdcStatus(config),
+    postgresCdcCreateSlot(config),
+    postgresCdcDropSlot(config),
+    postgresCdcAdvance(config),
+    postgresCdcPeek(config),
+  ]
+}
+
+/**
+ * Helper for AgentsKitOS T-9 CDC trigger and other long-running
+ * consumers. Returns an AsyncIterable from the injected stream
+ * client; aborts cleanly when the supplied AbortSignal fires.
+ */
+export function createCdcStream(
+  config: PostgresCdcConfig,
+  options?: CdcStreamOptions,
+): AsyncIterable<CdcChangeEvent> {
+  if (!config.stream) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createCdcStream: config.stream is required',
+      hint: 'Provide a CdcStreamClient adapter (pg-logical-replication or @supabase/realtime-js).',
+    })
+  }
+  return config.stream.stream(options)
+}

--- a/packages/tools/src/integrations/teams.ts
+++ b/packages/tools/src/integrations/teams.ts
@@ -1,0 +1,273 @@
+import { ConfigError, ErrorCodes, ToolError, defineTool } from '@agentskit/core'
+import type { HttpToolOptions } from './http'
+
+/**
+ * Microsoft Teams integration. Two outbound paths:
+ *
+ *  - Incoming Webhook (no app registration required): pass `webhookUrl`.
+ *    Best for one-way notifications, supports MessageCard + Adaptive Cards.
+ *
+ *  - Bot Framework (rich bidirectional): pass a `TeamsBotClient` adapter.
+ *    botbuilder is not bundled — wrap it (or your Graph/REST client) to
+ *    keep this package driver-free. Auth (app secret, certificate,
+ *    managed identity) is handled inside your adapter.
+ *
+ * Inbound activity routing (`message`, `mentioned`, etc.) lives in
+ * `@agentskit/triggers` (AgentsKitOS) — this package only owns tool
+ * primitives, not long-running listeners.
+ */
+
+export interface TeamsWebhookConfig extends HttpToolOptions {
+  webhookUrl: string
+}
+
+export interface TeamsBotMessage {
+  /** Conversation id (channel or 1:1). */
+  conversationId: string
+  serviceUrl?: string
+  text?: string
+  /** Optional Adaptive Card or MessageCard attachment. */
+  card?: TeamsAdaptiveCard | TeamsMessageCard
+  /** Reply to a specific activity id (creates a thread reply). */
+  replyToId?: string
+}
+
+export interface TeamsBotSendResult {
+  id: string
+  conversationId: string
+}
+
+export interface TeamsBotClient {
+  send: (msg: TeamsBotMessage) => Promise<TeamsBotSendResult>
+}
+
+export interface TeamsBotConfig {
+  client: TeamsBotClient
+}
+
+export interface TeamsConfig {
+  webhook?: TeamsWebhookConfig
+  bot?: TeamsBotConfig
+}
+
+export interface TeamsAdaptiveCardAction {
+  type: 'Action.OpenUrl' | 'Action.Submit'
+  title: string
+  url?: string
+  data?: Record<string, unknown>
+}
+
+export interface TeamsAdaptiveCard {
+  contentType: 'application/vnd.microsoft.card.adaptive'
+  content: {
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json'
+    type: 'AdaptiveCard'
+    version: '1.5'
+    body: Array<Record<string, unknown>>
+    actions?: TeamsAdaptiveCardAction[]
+  }
+}
+
+export interface TeamsMessageCard {
+  contentType: 'application/vnd.microsoft.teams.card.o365connector'
+  content: {
+    '@type': 'MessageCard'
+    '@context': 'https://schema.org/extensions'
+    summary?: string
+    themeColor?: string
+    title?: string
+    text?: string
+  }
+}
+
+/**
+ * Build a Teams Adaptive Card payload (v1.5). Keep `body` simple —
+ * one TextBlock per paragraph; pass `actions` for buttons.
+ */
+export function adaptiveCard(input: {
+  title?: string
+  text?: string
+  facts?: Array<{ title: string; value: string }>
+  actions?: TeamsAdaptiveCardAction[]
+}): TeamsAdaptiveCard {
+  const body: Array<Record<string, unknown>> = []
+  if (input.title) {
+    body.push({ type: 'TextBlock', size: 'Large', weight: 'Bolder', text: input.title, wrap: true })
+  }
+  if (input.text) {
+    body.push({ type: 'TextBlock', text: input.text, wrap: true })
+  }
+  if (input.facts && input.facts.length > 0) {
+    body.push({ type: 'FactSet', facts: input.facts })
+  }
+  return {
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: {
+      $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+      type: 'AdaptiveCard',
+      version: '1.5',
+      body,
+      ...(input.actions && input.actions.length > 0 ? { actions: input.actions } : {}),
+    },
+  }
+}
+
+/**
+ * Build a legacy O365 connector MessageCard. Simpler than Adaptive
+ * Cards but still rendered by Teams Incoming Webhooks.
+ */
+export function messageCard(input: {
+  title?: string
+  text?: string
+  summary?: string
+  themeColor?: string
+}): TeamsMessageCard {
+  return {
+    contentType: 'application/vnd.microsoft.teams.card.o365connector',
+    content: {
+      '@type': 'MessageCard',
+      '@context': 'https://schema.org/extensions',
+      summary: input.summary ?? input.title ?? 'Notification',
+      themeColor: input.themeColor,
+      title: input.title,
+      text: input.text,
+    },
+  }
+}
+
+export function teamsSendWebhook(config: TeamsWebhookConfig) {
+  if (!config.webhookUrl) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'teamsSendWebhook: webhookUrl is required',
+    })
+  }
+  const fetchImpl = config.fetch ?? globalThis.fetch
+  const timeoutMs = config.timeoutMs ?? 20_000
+  return defineTool({
+    name: 'teams_send_webhook',
+    description: 'Post a message or Adaptive Card to a Microsoft Teams channel via Incoming Webhook.',
+    schema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Plain text body. Ignored when `card` is provided.' },
+        title: { type: 'string', description: 'Convenience: wrap into a MessageCard with this title.' },
+        card: {
+          type: 'object',
+          description: 'Pre-built Adaptive Card or MessageCard payload (use `adaptiveCard()`/`messageCard()` builders).',
+        },
+      },
+    } as const,
+    async execute(args) {
+      if (!fetchImpl) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: 'teams_send_webhook: no fetch available',
+          hint: 'Run on Node ≥ 18 or pass config.fetch.',
+        })
+      }
+      const text = typeof args.text === 'string' ? args.text : undefined
+      const title = typeof args.title === 'string' ? args.title : undefined
+      const card = (args.card ?? undefined) as TeamsAdaptiveCard | TeamsMessageCard | undefined
+
+      let payload: Record<string, unknown>
+      if (card) {
+        payload = { type: 'message', attachments: [card] }
+      } else if (text || title) {
+        payload = { type: 'message', attachments: [messageCard({ title, text })] }
+      } else {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: 'teams_send_webhook: provide text, title, or card',
+        })
+      }
+
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), timeoutMs)
+      try {
+        const response = await fetchImpl(config.webhookUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', ...config.headers },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        })
+        if (!response.ok) {
+          const body = await response.text().catch(() => '')
+          throw new ToolError({
+            code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+            message: `teams_send_webhook: HTTP ${response.status} ${response.statusText}: ${body.slice(0, 200)}`,
+            hint: 'Verify the webhook URL is current and the channel still exists.',
+          })
+        }
+        return { ok: true, status: response.status }
+      } finally {
+        clearTimeout(timer)
+      }
+    },
+  })
+}
+
+export function teamsSendBot(config: TeamsBotConfig) {
+  if (!config.client) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'teamsSendBot: client is required',
+      hint: 'Provide a TeamsBotClient adapter (e.g. wrap botbuilder TurnContext.sendActivity).',
+    })
+  }
+  const client = config.client
+  return defineTool({
+    name: 'teams_send_bot',
+    description: 'Send a message or Adaptive Card via the configured Teams Bot Framework client.',
+    schema: {
+      type: 'object',
+      properties: {
+        conversation_id: { type: 'string' },
+        service_url: { type: 'string' },
+        text: { type: 'string' },
+        card: { type: 'object' },
+        reply_to_id: { type: 'string', description: 'Activity id to reply in-thread.' },
+      },
+      required: ['conversation_id'],
+    } as const,
+    async execute(args) {
+      const text = typeof args.text === 'string' ? args.text : undefined
+      const card = (args.card ?? undefined) as TeamsAdaptiveCard | TeamsMessageCard | undefined
+      if (!text && !card) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: 'teams_send_bot: provide text or card',
+        })
+      }
+      try {
+        const result = await client.send({
+          conversationId: String(args.conversation_id),
+          serviceUrl: typeof args.service_url === 'string' ? args.service_url : undefined,
+          text,
+          card,
+          replyToId: typeof args.reply_to_id === 'string' ? args.reply_to_id : undefined,
+        })
+        return { id: result.id, conversationId: result.conversationId }
+      } catch (err) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+          message: `teams_send_bot: ${err instanceof Error ? err.message : String(err)}`,
+          hint: 'Check Bot Framework credentials and that the conversation reference is still valid.',
+        })
+      }
+    },
+  })
+}
+
+export function teams(config: TeamsConfig) {
+  const tools = []
+  if (config.webhook) tools.push(teamsSendWebhook(config.webhook))
+  if (config.bot) tools.push(teamsSendBot(config.bot))
+  if (tools.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'teams: provide at least one of `webhook` or `bot`',
+    })
+  }
+  return tools
+}

--- a/packages/tools/tests/email.test.ts
+++ b/packages/tools/tests/email.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  email,
+  emailFetch,
+  emailSend,
+  type EmailMessage,
+  type EmailTransport,
+  type ImapClient,
+} from '../src/integrations/email'
+
+const stubCtx = { messages: [], call: { id: 'c', name: 'x', args: {}, status: 'running' as const } }
+
+function makeTransport(overrides?: Partial<EmailTransport>): { transport: EmailTransport; sent: unknown[] } {
+  const sent: unknown[] = []
+  const transport: EmailTransport = {
+    send: vi.fn(async (msg) => {
+      sent.push(msg)
+      return { messageId: '<abc@local>', accepted: ['x@y.z'], rejected: [] }
+    }),
+    ...overrides,
+  }
+  return { transport, sent }
+}
+
+function makeImap(messages: EmailMessage[]): { imap: ImapClient; calls: unknown[] } {
+  const calls: unknown[] = []
+  const imap: ImapClient = {
+    fetch: vi.fn(async (opts) => {
+      calls.push(opts)
+      return messages
+    }),
+  }
+  return { imap, calls }
+}
+
+describe('emailSend', () => {
+  it('throws ConfigError when transport missing', () => {
+    expect(() => emailSend({})).toThrow(/transport is required/)
+  })
+
+  it('sends with normalized to as array', async () => {
+    const { transport, sent } = makeTransport()
+    const tool = emailSend({ transport })
+    const result = (await tool.execute!(
+      { from: 'a@b.c', to: 'x@y.z', subject: 'hi', text: 'hello' },
+      stubCtx,
+    )) as { messageId: string; accepted: string[] }
+    expect(result.messageId).toBe('<abc@local>')
+    expect(result.accepted).toEqual(['x@y.z'])
+    expect(sent[0]).toMatchObject({ to: ['x@y.z'], subject: 'hi', text: 'hello' })
+  })
+
+  it('keeps to[] as array, forwards cc/bcc/html', async () => {
+    const { transport, sent } = makeTransport()
+    const tool = emailSend({ transport })
+    await tool.execute!(
+      {
+        from: 'a@b.c',
+        to: ['x@y.z', 'q@r.s'],
+        cc: 'c@c.c',
+        bcc: ['b@b.b'],
+        subject: 'subj',
+        html: '<p>hi</p>',
+      },
+      stubCtx,
+    )
+    expect(sent[0]).toMatchObject({
+      to: ['x@y.z', 'q@r.s'],
+      cc: ['c@c.c'],
+      bcc: ['b@b.b'],
+      html: '<p>hi</p>',
+    })
+  })
+
+  it('rejects when both text and html missing', async () => {
+    const { transport } = makeTransport()
+    const tool = emailSend({ transport })
+    await expect(
+      tool.execute!({ from: 'a@b.c', to: 'x@y.z', subject: 's' }, stubCtx),
+    ).rejects.toThrow(/text or html/)
+  })
+
+  it('rejects when to is empty array', async () => {
+    const { transport } = makeTransport()
+    const tool = emailSend({ transport })
+    await expect(
+      tool.execute!({ from: 'a@b.c', to: [], subject: 's', text: 't' }, stubCtx),
+    ).rejects.toThrow(/to is required/)
+  })
+
+  it('wraps transport errors as ToolError', async () => {
+    const transport: EmailTransport = {
+      send: async () => {
+        throw new Error('smtp 535 auth failed')
+      },
+    }
+    const tool = emailSend({ transport })
+    await expect(
+      tool.execute!({ from: 'a@b.c', to: 'x@y.z', subject: 's', text: 't' }, stubCtx),
+    ).rejects.toThrow(/email_send: smtp 535 auth failed/)
+  })
+
+  it('forwards attachments through', async () => {
+    const { transport, sent } = makeTransport()
+    const tool = emailSend({ transport })
+    await tool.execute!(
+      {
+        from: 'a@b.c',
+        to: 'x@y.z',
+        subject: 's',
+        text: 't',
+        attachments: [{ filename: 'r.txt', content: 'hi' }],
+      },
+      stubCtx,
+    )
+    expect(sent[0]).toMatchObject({ attachments: [{ filename: 'r.txt', content: 'hi' }] })
+  })
+
+  it('sets requiresConfirmation: true', () => {
+    const { transport } = makeTransport()
+    const tool = emailSend({ transport })
+    expect(tool.requiresConfirmation).toBe(true)
+  })
+})
+
+describe('emailFetch', () => {
+  const sample: EmailMessage = {
+    id: 'm1',
+    uid: 1,
+    from: 'a@b.c',
+    to: ['me@me.me'],
+    subject: 'hello',
+    date: '2026-01-01T00:00:00.000Z',
+    text: 'hi',
+  }
+
+  it('throws ConfigError when imap missing', () => {
+    expect(() => emailFetch({})).toThrow(/imap is required/)
+  })
+
+  it('passes filter through and uses default mailbox', async () => {
+    const { imap, calls } = makeImap([sample])
+    const tool = emailFetch({ imap })
+    const result = (await tool.execute!(
+      { unseen_only: true, from: 'a@b.c' },
+      stubCtx,
+    )) as { count: number; messages: EmailMessage[] }
+    expect(result.count).toBe(1)
+    expect(result.messages[0]).toEqual(sample)
+    expect(calls[0]).toMatchObject({ mailbox: 'INBOX', unseenOnly: true, from: 'a@b.c', limit: 50 })
+  })
+
+  it('respects custom mailbox + maxFetch cap', async () => {
+    const { imap, calls } = makeImap([sample])
+    const tool = emailFetch({ imap, defaultMailbox: 'Updates', maxFetch: 10 })
+    await tool.execute!({ limit: 1000 }, stubCtx)
+    expect(calls[0]).toMatchObject({ mailbox: 'Updates', limit: 10 })
+  })
+
+  it('reports truncated when result count >= limit', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({ ...sample, id: `m${i}`, uid: i }))
+    const { imap } = makeImap(many)
+    const tool = emailFetch({ imap, maxFetch: 5 })
+    const result = (await tool.execute!({ limit: 5 }, stubCtx)) as { truncated: boolean }
+    expect(result.truncated).toBe(true)
+  })
+})
+
+describe('email()', () => {
+  it('returns send + fetch when both adapters provided', () => {
+    const { transport } = makeTransport()
+    const { imap } = makeImap([])
+    const tools = email({ transport, imap })
+    expect(tools.map(t => t.name)).toEqual(['email_send', 'email_fetch'])
+  })
+
+  it('returns only send when imap missing', () => {
+    const { transport } = makeTransport()
+    expect(email({ transport }).map(t => t.name)).toEqual(['email_send'])
+  })
+
+  it('returns only fetch when transport missing', () => {
+    const { imap } = makeImap([])
+    expect(email({ imap }).map(t => t.name)).toEqual(['email_fetch'])
+  })
+
+  it('throws when neither adapter provided', () => {
+    expect(() => email({})).toThrow(/at least one/)
+  })
+})

--- a/packages/tools/tests/postgres-cdc.test.ts
+++ b/packages/tools/tests/postgres-cdc.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createCdcStream,
+  postgresCdc,
+  postgresCdcAdvance,
+  postgresCdcCreateSlot,
+  postgresCdcDropSlot,
+  postgresCdcPeek,
+  postgresCdcStatus,
+  type CdcAdminClient,
+  type CdcChangeEvent,
+  type CdcStreamClient,
+} from '../src/integrations/postgres-cdc'
+
+const stubCtx = { messages: [], call: { id: 'c', name: 'x', args: {}, status: 'running' as const } }
+
+interface QueuedReply {
+  rows: Array<Record<string, unknown>>
+  rowCount?: number
+  error?: Error
+}
+
+function makeAdmin(replies: QueuedReply[] = []): { admin: CdcAdminClient; calls: Array<{ sql: string; params: unknown[] }> } {
+  const calls: Array<{ sql: string; params: unknown[] }> = []
+  const queue = [...replies]
+  const admin: CdcAdminClient = {
+    execute: vi.fn(async (sql, params) => {
+      calls.push({ sql, params })
+      const next = queue.shift()
+      if (!next) return { rows: [], rowCount: 0 }
+      if (next.error) throw next.error
+      return { rows: next.rows, rowCount: next.rowCount ?? next.rows.length }
+    }),
+  }
+  return { admin, calls }
+}
+
+describe('slot name validation', () => {
+  it('rejects invalid identifiers at construction', () => {
+    const { admin } = makeAdmin()
+    expect(() => postgresCdcStatus({ admin, slotName: 'has spaces' })).toThrow(/slotName must match/)
+    expect(() => postgresCdcStatus({ admin, slotName: 'drop-slot;--' })).toThrow(/slotName must match/)
+  })
+
+  it('rejects when admin client missing', () => {
+    expect(() => postgresCdcStatus({ slotName: 'agent_slot' })).toThrow(/admin is required/)
+  })
+})
+
+describe('postgresCdcStatus', () => {
+  it('returns exists:false when slot is missing', async () => {
+    const { admin, calls } = makeAdmin([{ rows: [] }])
+    const tool = postgresCdcStatus({ admin, slotName: 'agent_slot' })
+    const result = (await tool.execute!({}, stubCtx)) as { exists: boolean; slotName: string }
+    expect(result).toEqual({ exists: false, slotName: 'agent_slot' })
+    expect(calls[0].params).toEqual(['agent_slot'])
+  })
+
+  it('maps slot row to CdcSlotStatus shape', async () => {
+    const { admin } = makeAdmin([
+      {
+        rows: [
+          {
+            slot_name: 'agent_slot',
+            plugin: 'pgoutput',
+            database: 'app',
+            active: true,
+            restart_lsn: '0/16B6360',
+            confirmed_flush_lsn: '0/16B6400',
+            wal_lag_bytes: 1024n,
+          },
+        ],
+      },
+    ])
+    const tool = postgresCdcStatus({ admin, slotName: 'agent_slot' })
+    const result = (await tool.execute!({}, stubCtx)) as {
+      exists: boolean
+      walLagBytes: number
+      restartLsn: string
+    }
+    expect(result.exists).toBe(true)
+    expect(result.walLagBytes).toBe(1024)
+    expect(result.restartLsn).toBe('0/16B6360')
+  })
+})
+
+describe('postgresCdcCreateSlot', () => {
+  it('creates with default pgoutput plugin', async () => {
+    const { admin, calls } = makeAdmin([{ rows: [{ info: 'ok' }] }])
+    const tool = postgresCdcCreateSlot({ admin, slotName: 'agent_slot' })
+    const result = (await tool.execute!({}, stubCtx)) as { created: boolean; plugin: string }
+    expect(result).toMatchObject({ created: true, plugin: 'pgoutput' })
+    expect(calls[0].params).toEqual(['agent_slot', 'pgoutput'])
+  })
+
+  it('treats "already exists" as not-created, no throw', async () => {
+    const { admin } = makeAdmin([{ rows: [], error: new Error('replication slot "x" already exists') }])
+    const tool = postgresCdcCreateSlot({ admin, slotName: 'agent_slot', plugin: 'wal2json' })
+    const result = (await tool.execute!({}, stubCtx)) as { created: boolean; reason: string }
+    expect(result).toMatchObject({ created: false, reason: 'exists' })
+  })
+
+  it('wraps unexpected errors as ToolError', async () => {
+    const { admin } = makeAdmin([{ rows: [], error: new Error('permission denied for function pg_create_logical_replication_slot') }])
+    const tool = postgresCdcCreateSlot({ admin, slotName: 'agent_slot' })
+    await expect(tool.execute!({}, stubCtx)).rejects.toThrow(/permission denied/)
+  })
+
+  it('sets requiresConfirmation: true', () => {
+    const { admin } = makeAdmin()
+    expect(postgresCdcCreateSlot({ admin, slotName: 'agent_slot' }).requiresConfirmation).toBe(true)
+  })
+})
+
+describe('postgresCdcDropSlot', () => {
+  it('reports missing as not-dropped', async () => {
+    const { admin } = makeAdmin([{ rows: [], error: new Error('replication slot "x" does not exist') }])
+    const tool = postgresCdcDropSlot({ admin, slotName: 'agent_slot' })
+    const result = (await tool.execute!({}, stubCtx)) as { dropped: boolean; reason: string }
+    expect(result).toMatchObject({ dropped: false, reason: 'missing' })
+  })
+
+  it('drops successfully and is destructive', async () => {
+    const { admin } = makeAdmin([{ rows: [] }])
+    const tool = postgresCdcDropSlot({ admin, slotName: 'agent_slot' })
+    expect(tool.requiresConfirmation).toBe(true)
+    const result = await tool.execute!({}, stubCtx)
+    expect(result).toMatchObject({ dropped: true })
+  })
+})
+
+describe('postgresCdcAdvance', () => {
+  it('forwards target LSN', async () => {
+    const { admin, calls } = makeAdmin([{ rows: [{ info: 'ok' }] }])
+    const tool = postgresCdcAdvance({ admin, slotName: 'agent_slot' })
+    const result = (await tool.execute!({ lsn: '0/16B6500' }, stubCtx)) as { targetLsn: string }
+    expect(result.targetLsn).toBe('0/16B6500')
+    expect(calls[0].params).toEqual(['agent_slot', '0/16B6500'])
+  })
+})
+
+describe('postgresCdcPeek', () => {
+  it('caps requested limit at maxPeek', async () => {
+    const { admin, calls } = makeAdmin([{ rows: [] }])
+    const tool = postgresCdcPeek({ admin, slotName: 'agent_slot', maxPeek: 10 })
+    await tool.execute!({ limit: 1000 }, stubCtx)
+    expect(calls[0].params).toEqual(['agent_slot', null, 10])
+  })
+
+  it('returns mapped changes + truncated flag', async () => {
+    const { admin } = makeAdmin([
+      {
+        rows: [
+          { lsn: '0/1', xid: '500', data: 'BEGIN' },
+          { lsn: '0/2', xid: '500', data: 'INSERT...' },
+        ],
+      },
+    ])
+    const tool = postgresCdcPeek({ admin, slotName: 'agent_slot', maxPeek: 2 })
+    const result = (await tool.execute!({ limit: 2 }, stubCtx)) as {
+      count: number
+      truncated: boolean
+      changes: Array<{ lsn: string }>
+    }
+    expect(result.count).toBe(2)
+    expect(result.truncated).toBe(true)
+    expect(result.changes[0].lsn).toBe('0/1')
+  })
+
+  it('forwards upto_lsn when provided', async () => {
+    const { admin, calls } = makeAdmin([{ rows: [] }])
+    const tool = postgresCdcPeek({ admin, slotName: 'agent_slot' })
+    await tool.execute!({ upto_lsn: '0/16B6500' }, stubCtx)
+    expect(calls[0].params[1]).toBe('0/16B6500')
+  })
+})
+
+describe('postgresCdc()', () => {
+  it('returns the five primitives in order', () => {
+    const { admin } = makeAdmin()
+    const tools = postgresCdc({ admin, slotName: 'agent_slot' })
+    expect(tools.map(t => t.name)).toEqual([
+      'postgres_cdc_status',
+      'postgres_cdc_create_slot',
+      'postgres_cdc_drop_slot',
+      'postgres_cdc_advance',
+      'postgres_cdc_peek',
+    ])
+  })
+})
+
+describe('createCdcStream', () => {
+  it('throws when stream client missing', () => {
+    expect(() => createCdcStream({ slotName: 'agent_slot' })).toThrow(/stream is required/)
+  })
+
+  it('forwards options to the injected stream client', async () => {
+    const events: CdcChangeEvent[] = [
+      { op: 'insert', schema: 'public', table: 'users', after: { id: 1 } },
+      { op: 'update', schema: 'public', table: 'users', before: { id: 1 }, after: { id: 1, name: 'x' } },
+    ]
+    const seen: Array<{ startLsn?: string }> = []
+    const stream: CdcStreamClient = {
+      stream: vi.fn((opts) => {
+        seen.push({ startLsn: opts?.startLsn })
+        return (async function* () {
+          for (const e of events) yield e
+        })()
+      }),
+    }
+    const out: CdcChangeEvent[] = []
+    for await (const event of createCdcStream({ slotName: 'agent_slot', stream }, { startLsn: '0/1' })) {
+      out.push(event)
+    }
+    expect(out).toEqual(events)
+    expect(seen[0]).toEqual({ startLsn: '0/1' })
+  })
+})

--- a/packages/tools/tests/postgres-cdc.test.ts
+++ b/packages/tools/tests/postgres-cdc.test.ts
@@ -137,6 +137,13 @@ describe('postgresCdcAdvance', () => {
     expect(result.targetLsn).toBe('0/16B6500')
     expect(calls[0].params).toEqual(['agent_slot', '0/16B6500'])
   })
+
+  it('rejects malformed LSN before reaching the database', async () => {
+    const { admin, calls } = makeAdmin()
+    const tool = postgresCdcAdvance({ admin, slotName: 'agent_slot' })
+    await expect(tool.execute!({ lsn: "'; DROP TABLE x" }, stubCtx)).rejects.toThrow(/lsn must look like/)
+    expect(calls).toHaveLength(0)
+  })
 })
 
 describe('postgresCdcPeek', () => {
@@ -172,6 +179,13 @@ describe('postgresCdcPeek', () => {
     const tool = postgresCdcPeek({ admin, slotName: 'agent_slot' })
     await tool.execute!({ upto_lsn: '0/16B6500' }, stubCtx)
     expect(calls[0].params[1]).toBe('0/16B6500')
+  })
+
+  it('rejects malformed upto_lsn before reaching the database', async () => {
+    const { admin, calls } = makeAdmin()
+    const tool = postgresCdcPeek({ admin, slotName: 'agent_slot' })
+    await expect(tool.execute!({ upto_lsn: 'not-an-lsn' }, stubCtx)).rejects.toThrow(/upto_lsn must look like/)
+    expect(calls).toHaveLength(0)
   })
 })
 

--- a/packages/tools/tests/teams.test.ts
+++ b/packages/tools/tests/teams.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  adaptiveCard,
+  messageCard,
+  teams,
+  teamsSendBot,
+  teamsSendWebhook,
+  type TeamsBotClient,
+} from '../src/integrations/teams'
+
+const stubCtx = { messages: [], call: { id: 'c', name: 'x', args: {}, status: 'running' as const } }
+const WEBHOOK = 'https://outlook.office.com/webhook/abc'
+
+function fakeFetch(impl: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    return impl(String(input), init ?? {})
+  }) as unknown as typeof fetch
+}
+
+describe('adaptiveCard()', () => {
+  it('builds title + text + facts + actions', () => {
+    const card = adaptiveCard({
+      title: 'Deploy ok',
+      text: 'commit abc',
+      facts: [{ title: 'env', value: 'prod' }],
+      actions: [{ type: 'Action.OpenUrl', title: 'logs', url: 'https://x' }],
+    })
+    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
+    expect(card.content.version).toBe('1.5')
+    expect(card.content.body).toHaveLength(3)
+    expect(card.content.actions).toHaveLength(1)
+  })
+
+  it('omits actions when none provided', () => {
+    const card = adaptiveCard({ title: 'hi' })
+    expect(card.content.actions).toBeUndefined()
+  })
+})
+
+describe('messageCard()', () => {
+  it('falls back summary to title', () => {
+    const card = messageCard({ title: 'Build failed' })
+    expect(card.content.summary).toBe('Build failed')
+    expect(card.content['@type']).toBe('MessageCard')
+  })
+})
+
+describe('teamsSendWebhook', () => {
+  it('throws when webhookUrl missing', () => {
+    expect(() => teamsSendWebhook({ webhookUrl: '' })).toThrow(/webhookUrl is required/)
+  })
+
+  it('wraps plain text into a MessageCard attachment', async () => {
+    let captured: Record<string, unknown> = {}
+    const fetch = fakeFetch((_url, init) => {
+      captured = JSON.parse(String(init.body))
+      return new Response(null, { status: 200 })
+    })
+    const tool = teamsSendWebhook({ webhookUrl: WEBHOOK, fetch })
+    const result = await tool.execute!({ text: 'hello', title: 'Greeting' }, stubCtx)
+    expect(result).toEqual({ ok: true, status: 200 })
+    expect(captured.type).toBe('message')
+    const attachments = captured.attachments as Array<{ content: { title: string } }>
+    expect(attachments[0].content.title).toBe('Greeting')
+  })
+
+  it('forwards a pre-built Adaptive Card untouched', async () => {
+    let captured: Record<string, unknown> = {}
+    const fetch = fakeFetch((_url, init) => {
+      captured = JSON.parse(String(init.body))
+      return new Response(null, { status: 200 })
+    })
+    const tool = teamsSendWebhook({ webhookUrl: WEBHOOK, fetch })
+    const card = adaptiveCard({ title: 'x' })
+    await tool.execute!({ card }, stubCtx)
+    expect((captured.attachments as unknown[])[0]).toEqual(card)
+  })
+
+  it('rejects when no body, title, or card', async () => {
+    const tool = teamsSendWebhook({ webhookUrl: WEBHOOK, fetch: fakeFetch(() => new Response()) })
+    await expect(tool.execute!({}, stubCtx)).rejects.toThrow(/text, title, or card/)
+  })
+
+  it('reports non-2xx as ToolError', async () => {
+    const fetch = fakeFetch(() => new Response('rate limited', { status: 429 }))
+    const tool = teamsSendWebhook({ webhookUrl: WEBHOOK, fetch })
+    await expect(tool.execute!({ text: 'hi' }, stubCtx)).rejects.toThrow(/HTTP 429/)
+  })
+})
+
+function makeBotClient(overrides?: Partial<TeamsBotClient>): { client: TeamsBotClient; sent: unknown[] } {
+  const sent: unknown[] = []
+  const client: TeamsBotClient = {
+    send: vi.fn(async (msg) => {
+      sent.push(msg)
+      return { id: 'act-1', conversationId: msg.conversationId }
+    }),
+    ...overrides,
+  }
+  return { client, sent }
+}
+
+describe('teamsSendBot', () => {
+  it('throws when client missing', () => {
+    expect(() => teamsSendBot({ client: undefined as unknown as TeamsBotClient })).toThrow(/client is required/)
+  })
+
+  it('sends text + reply_to_id to the injected client', async () => {
+    const { client, sent } = makeBotClient()
+    const tool = teamsSendBot({ client })
+    const result = (await tool.execute!(
+      { conversation_id: 'conv-1', text: 'hi', reply_to_id: 'act-0' },
+      stubCtx,
+    )) as { id: string; conversationId: string }
+    expect(result).toEqual({ id: 'act-1', conversationId: 'conv-1' })
+    expect(sent[0]).toMatchObject({ conversationId: 'conv-1', text: 'hi', replyToId: 'act-0' })
+  })
+
+  it('rejects when both text and card missing', async () => {
+    const { client } = makeBotClient()
+    const tool = teamsSendBot({ client })
+    await expect(tool.execute!({ conversation_id: 'c' }, stubCtx)).rejects.toThrow(/text or card/)
+  })
+
+  it('wraps client errors as ToolError', async () => {
+    const client: TeamsBotClient = {
+      send: async () => {
+        throw new Error('401 unauthorized')
+      },
+    }
+    const tool = teamsSendBot({ client })
+    await expect(
+      tool.execute!({ conversation_id: 'c', text: 't' }, stubCtx),
+    ).rejects.toThrow(/teams_send_bot: 401 unauthorized/)
+  })
+})
+
+describe('teams()', () => {
+  it('returns webhook + bot tools when both configured', () => {
+    const { client } = makeBotClient()
+    const tools = teams({ webhook: { webhookUrl: WEBHOOK }, bot: { client } })
+    expect(tools.map(t => t.name)).toEqual(['teams_send_webhook', 'teams_send_bot'])
+  })
+
+  it('throws when neither configured', () => {
+    expect(() => teams({})).toThrow(/at least one/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,40 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  apps/visual-react:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.59.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/adapters:
     dependencies:
       '@agentskit/core':


### PR DESCRIPTION
## Summary

Batch of four issues delivered against `origin/main`:

- **#726** — provider-agnostic SMTP/IMAP email integration in `@agentskit/tools/integrations`
- **#727** — Microsoft Teams integration (Incoming Webhook + Bot Framework + Adaptive Card builder)
- **#728** — Postgres CDC primitives (slot status/create/drop/advance/peek + `createCdcStream` helper)
- **#253** (P0.42) — visual regression: 21 ANSI frame snapshots for `@agentskit/ink`, plus a `apps/visual-react/` Playwright harness scaffold for the React side

All three new tool integrations follow the existing **injection pattern** (`postgres`, `browser-agent`): heavy drivers (`nodemailer`, `imapflow`, `botbuilder`, `pg-logical-replication`) are not bundled — consumers wrap the driver of their choice. Auth modes (OAuth, app secrets, certificates, managed identity) live inside the adapter.

Long-running streams (IMAP IDLE, Teams activity routing, CDC AsyncIterable) are exposed as helpers, not tools — they belong to `@agentskit/triggers` in AgentsKitOS, not the one-shot `execute` semantics of the tools package.

## What's in the diff

| Path | What |
|---|---|
| `packages/tools/src/integrations/email.ts` | `email`, `emailSend`, `emailFetch` factories |
| `packages/tools/src/integrations/teams.ts` | `teams`, `teamsSendWebhook`, `teamsSendBot`, `adaptiveCard`, `messageCard` |
| `packages/tools/src/integrations/postgres-cdc.ts` | 5 slot tools + `createCdcStream` helper, strict identifier validation |
| `packages/tools/src/integrations/index.ts` | re-exports |
| `packages/tools/tests/{email,teams,postgres-cdc}.test.ts` | 47 new unit tests (227 total in package) |
| `packages/ink/tests/visual.snap.test.tsx` | 21 ANSI frame snapshots |
| `apps/visual-react/` | Vite + Playwright harness (`?case=<id>` routing) |
| `.changeset/*.md` | 4 changesets (3 minor on tools, 1 patch on ink) |

## Test plan

- [x] `pnpm --filter @agentskit/tools test` → 227/227 passing
- [x] `pnpm --filter @agentskit/tools lint` → clean
- [x] `pnpm --filter @agentskit/tools build` → ESM 84 KB, DTS 35 KB (integrations bundle)
- [x] `pnpm --filter @agentskit/ink test` → 69/69 passing (21 new snapshots, two consecutive runs identical → deterministic)
- [x] `pnpm --filter @agentskit/ink lint` → clean
- [x] `pnpm --filter @agentskit/visual-react lint` → clean
- [ ] Visual baselines for the React harness — left for a follow-up after the first `playwright install` on a stable machine; see `apps/visual-react/README.md`

## Out of scope

- Inbound activity routing for Teams (`message`, `mentioned`, `installation`) — belongs in `@agentskit/triggers` (AgentsKitOS T-6)
- IMAP IDLE long-running listener — same, T-4
- CDC AsyncIterable continuous consumer wiring — same, T-9
- React visual baseline PNGs — follow-up commit