### PR TITLE
feat(landing): standalone marketing site at apps/landing

### DIFF
--- a/.changeset/landing-page.md
+++ b/.changeset/landing-page.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add `apps/landing` — standalone Next.js 16 marketing page for AgentsKit, independent from `apps/docs-next`. Closes #230 (P0.19).
+
+Tailwind v4, dark theme, design tokens scoped to the app. No workspace dependencies — pure marketing surface that won't pull the agent runtime into the page bundle. Sections: hero, code sample, four pillars, packages grid, install CTA, footer. Standalone Next output for easy Vercel / Cloudflare / Node deployment.

--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -1,0 +1,6 @@
+.next/
+node_modules/
+*.log
+.env*.local
+.vercel/
+next-env.d.ts.tsbuildinfo

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,0 +1,67 @@
+# @agentskit/landing
+
+Standalone Next.js 16 landing page for AgentsKit — issue [#230](https://github.com/AgentsKit-io/agentskit/issues/230) (P0.19).
+
+Independent from `apps/docs-next`. Deployed at the apex domain (`agentskit.io`); docs live at `docs.agentskit.io`.
+
+## Stack
+
+- Next.js 16 (App Router, standalone output)
+- React 19
+- Tailwind CSS v4 (PostCSS plugin)
+- Zero dependencies on workspace packages — pure marketing surface, no MDX, no SDK examples that drag the agent runtime into the bundle.
+
+## Develop
+
+```bash
+pnpm --filter @agentskit/landing dev
+```
+
+Opens on http://127.0.0.1:4180.
+
+## Build / start
+
+```bash
+pnpm --filter @agentskit/landing build
+pnpm --filter @agentskit/landing start
+```
+
+## Structure
+
+```
+app/
+  globals.css           # Tailwind + design tokens
+  layout.tsx            # root layout + metadata
+  page.tsx              # composition only
+  _components/
+    header.tsx
+    hero.tsx
+    code-sample.tsx
+    pillars.tsx
+    packages-grid.tsx
+    install-cta.tsx
+    footer.tsx
+    links.ts            # all external URLs (single source)
+public/
+  favicon.svg
+```
+
+Add a new section by writing it under `app/_components/` and dropping it into `app/page.tsx`. Keep the file count low; this surface is intentionally narrow.
+
+## Design tokens
+
+Defined in `app/globals.css` under `@theme`:
+
+| token | value |
+|---|---|
+| `--color-bg` | `#0a0a0b` |
+| `--color-bg-soft` | `#131316` |
+| `--color-fg` | `#f5f5f7` |
+| `--color-accent` | `#7c5cff` |
+| `--color-accent-soft` | `#a690ff` |
+
+Mirror updates here into `apps/docs-next/styles/` if cross-surface visual consistency is needed.
+
+## Deploy
+
+Vercel project `agentskit-landing` (separate from `agentskit-doc`). Output mode is `standalone` — works on Vercel, Cloudflare Pages, or any Node host.

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -2,7 +2,7 @@
 
 Standalone Next.js 16 landing page for AgentsKit — issue [#230](https://github.com/AgentsKit-io/agentskit/issues/230) (P0.19).
 
-Independent from `apps/docs-next`. Deployed at the apex domain (`agentskit.io`); docs live at `docs.agentskit.io`.
+Independent from `apps/docs-next`. Eventual target: apex `agentskit.io` for landing, `docs.agentskit.io` (or `agentskit.io/docs`) for the Fumadocs site. Until that DNS migration ships, all `LINKS.docs` URLs point at the current `www.agentskit.io/docs` paths.
 
 ## Stack
 
@@ -64,4 +64,5 @@ Mirror updates here into `apps/docs-next/styles/` if cross-surface visual consis
 
 ## Deploy
 
-Vercel project `agentskit-landing` (separate from `agentskit-doc`). Output mode is `standalone` — works on Vercel, Cloudflare Pages, or any Node host.
+- **Vercel** (default): no extra flags. The `vercel.json` here installs with `--frozen-lockfile` and uses an `ignoreCommand` scoped to `apps/landing` + the workspace lockfile so unrelated commits don't trigger a rebuild.
+- **Self-hosted** (Cloudflare Pages, Node server, Docker): set `NEXT_OUTPUT_STANDALONE=1` to switch Next to `output: 'standalone'`. Avoid this on Vercel — it bypasses ISR / Edge Functions / Image Optimization.

--- a/apps/landing/app/_components/code-sample.tsx
+++ b/apps/landing/app/_components/code-sample.tsx
@@ -1,0 +1,36 @@
+const CODE = `import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
+import { anthropic } from '@agentskit/adapters'
+import '@agentskit/react/theme'
+
+export function App() {
+  const chat = useChat({
+    adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY }),
+  })
+
+  return (
+    <ChatContainer>
+      {chat.messages.map(m => <Message key={m.id} message={m} />)}
+      <InputBar chat={chat} />
+    </ChatContainer>
+  )
+}`
+
+export function CodeSample() {
+  return (
+    <section className="mx-auto max-w-4xl px-6 py-12">
+      <div className="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-soft)]">
+        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2 text-xs text-[var(--color-fg-soft)]">
+          <div className="flex items-center gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+          </div>
+          <span>chat.tsx — 10 lines, fully streaming</span>
+        </div>
+        <pre className="overflow-x-auto p-5 font-mono text-sm leading-relaxed text-[var(--color-fg)]">
+          <code>{CODE}</code>
+        </pre>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/app/_components/footer.tsx
+++ b/apps/landing/app/_components/footer.tsx
@@ -1,12 +1,14 @@
 import { LINKS } from './links'
 
+const YEAR = new Date().getFullYear()
+
 export function Footer() {
   return (
     <footer className="mt-10 border-t border-[var(--color-border)]">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-6 py-10 md:flex-row">
         <div className="flex items-center gap-2 text-sm text-[var(--color-fg-soft)]">
           <span aria-hidden className="inline-block h-4 w-4 rounded bg-gradient-to-br from-[var(--color-accent)] to-[var(--color-accent-soft)]" />
-          <span>AgentsKit · MIT licensed · {new Date().getFullYear()}</span>
+          <span>AgentsKit · MIT licensed · {YEAR}</span>
         </div>
         <nav className="flex flex-wrap items-center gap-5 text-sm text-[var(--color-fg-soft)]">
           <a href={LINKS.docs} className="hover:text-[var(--color-fg)]">Docs</a>

--- a/apps/landing/app/_components/footer.tsx
+++ b/apps/landing/app/_components/footer.tsx
@@ -1,0 +1,22 @@
+import { LINKS } from './links'
+
+export function Footer() {
+  return (
+    <footer className="mt-10 border-t border-[var(--color-border)]">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-6 py-10 md:flex-row">
+        <div className="flex items-center gap-2 text-sm text-[var(--color-fg-soft)]">
+          <span aria-hidden className="inline-block h-4 w-4 rounded bg-gradient-to-br from-[var(--color-accent)] to-[var(--color-accent-soft)]" />
+          <span>AgentsKit · MIT licensed · {new Date().getFullYear()}</span>
+        </div>
+        <nav className="flex flex-wrap items-center gap-5 text-sm text-[var(--color-fg-soft)]">
+          <a href={LINKS.docs} className="hover:text-[var(--color-fg)]">Docs</a>
+          <a href={LINKS.github} className="hover:text-[var(--color-fg)]">GitHub</a>
+          <a href={LINKS.discord} className="hover:text-[var(--color-fg)]">Discord</a>
+          <a href={LINKS.npm} className="hover:text-[var(--color-fg)]">npm</a>
+          <a href={LINKS.manifesto} className="hover:text-[var(--color-fg)]">Manifesto</a>
+          <a href={LINKS.roadmap} className="hover:text-[var(--color-fg)]">Roadmap</a>
+        </nav>
+      </div>
+    </footer>
+  )
+}

--- a/apps/landing/app/_components/header.tsx
+++ b/apps/landing/app/_components/header.tsx
@@ -1,0 +1,25 @@
+import { LINKS } from './links'
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-[var(--color-border)] bg-[var(--color-bg)]/85 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <a href="/" className="flex items-center gap-2 font-semibold tracking-tight">
+          <span aria-hidden className="inline-block h-6 w-6 rounded-md bg-gradient-to-br from-[var(--color-accent)] to-[var(--color-accent-soft)]" />
+          AgentsKit
+        </a>
+        <nav className="flex items-center gap-6 text-sm text-[var(--color-fg-soft)]">
+          <a href={LINKS.docs} className="hover:text-[var(--color-fg)]">Docs</a>
+          <a href={LINKS.roadmap} className="hover:text-[var(--color-fg)]">Roadmap</a>
+          <a href={LINKS.discord} className="hover:text-[var(--color-fg)]">Discord</a>
+          <a
+            href={LINKS.github}
+            className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-[var(--color-fg)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent-soft)]"
+          >
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/apps/landing/app/_components/hero.tsx
+++ b/apps/landing/app/_components/hero.tsx
@@ -1,0 +1,33 @@
+import { LINKS } from './links'
+
+export function Hero() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 pt-20 pb-16 text-center">
+      <p className="mb-5 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] px-3 py-1 text-xs text-[var(--color-fg-soft)]">
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
+        v1 contracts frozen — 19 packages stable
+      </p>
+      <h1 className="mx-auto max-w-3xl text-balance text-5xl font-semibold tracking-tight md:text-6xl">
+        Ship AI agents in JavaScript without gluing 8 libraries.
+      </h1>
+      <p className="mx-auto mt-6 max-w-2xl text-balance text-lg text-[var(--color-fg-soft)]">
+        AgentsKit is the agent toolkit JavaScript actually deserves. A 10 KB core. Six formal contracts.
+        Every adapter, tool, skill, memory, retriever, and runtime is substitutable.
+      </p>
+      <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+        <a
+          href={LINKS.docs}
+          className="rounded-md bg-[var(--color-accent)] px-5 py-3 text-sm font-medium text-white shadow-lg shadow-[var(--color-accent)]/20 transition hover:bg-[var(--color-accent-soft)]"
+        >
+          Get started
+        </a>
+        <a
+          href={LINKS.github}
+          className="rounded-md border border-[var(--color-border)] px-5 py-3 text-sm font-medium hover:border-[var(--color-accent)]"
+        >
+          Star on GitHub →
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/app/_components/install-cta.tsx
+++ b/apps/landing/app/_components/install-cta.tsx
@@ -1,0 +1,27 @@
+import { LINKS } from './links'
+
+export function InstallCta() {
+  return (
+    <section className="mx-auto max-w-4xl px-6 py-20 text-center">
+      <h2 className="mb-6 text-3xl font-semibold tracking-tight">Install in seconds</h2>
+      <div className="mx-auto inline-flex items-center gap-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-soft)] px-5 py-4 font-mono text-sm">
+        <span className="text-[var(--color-fg-soft)]">$</span>
+        <span>pnpm add @agentskit/react @agentskit/adapters</span>
+      </div>
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <a
+          href={LINKS.docs}
+          className="rounded-md bg-[var(--color-accent)] px-5 py-3 text-sm font-medium text-white transition hover:bg-[var(--color-accent-soft)]"
+        >
+          Read the docs
+        </a>
+        <a
+          href={LINKS.discord}
+          className="rounded-md border border-[var(--color-border)] px-5 py-3 text-sm font-medium hover:border-[var(--color-accent)]"
+        >
+          Join Discord
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/app/_components/links.ts
+++ b/apps/landing/app/_components/links.ts
@@ -1,0 +1,8 @@
+export const LINKS = {
+  docs: 'https://www.agentskit.io/docs',
+  github: 'https://github.com/AgentsKit-io/agentskit',
+  discord: 'https://discord.gg/zx6z2p4jVb',
+  npm: 'https://www.npmjs.com/org/agentskit',
+  manifesto: 'https://github.com/AgentsKit-io/agentskit/blob/main/MANIFESTO.md',
+  roadmap: 'https://github.com/orgs/AgentsKit-io/projects/1',
+} as const

--- a/apps/landing/app/_components/packages-grid.tsx
+++ b/apps/landing/app/_components/packages-grid.tsx
@@ -1,0 +1,47 @@
+import { LINKS } from './links'
+
+const PACKAGES = [
+  { name: 'core', tag: 'foundation' },
+  { name: 'adapters', tag: 'providers' },
+  { name: 'react', tag: 'ui' },
+  { name: 'vue', tag: 'ui' },
+  { name: 'svelte', tag: 'ui' },
+  { name: 'solid', tag: 'ui' },
+  { name: 'ink', tag: 'ui' },
+  { name: 'angular', tag: 'ui' },
+  { name: 'react-native', tag: 'ui' },
+  { name: 'runtime', tag: 'agents' },
+  { name: 'tools', tag: 'agents' },
+  { name: 'skills', tag: 'agents' },
+  { name: 'memory', tag: 'data' },
+  { name: 'rag', tag: 'data' },
+  { name: 'sandbox', tag: 'safety' },
+  { name: 'observability', tag: 'ops' },
+  { name: 'eval', tag: 'ops' },
+  { name: 'cli', tag: 'tooling' },
+  { name: 'templates', tag: 'tooling' },
+] as const
+
+export function PackagesGrid() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-10 text-center">
+        <h2 className="text-3xl font-semibold tracking-tight">Nineteen focused packages</h2>
+        <p className="mt-3 text-[var(--color-fg-soft)]">Pick what you need. Mix freely. Stay in plain JavaScript.</p>
+      </div>
+      <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {PACKAGES.map(pkg => (
+          <li key={pkg.name}>
+            <a
+              href={`${LINKS.docs}/reference/packages/${pkg.name}`}
+              className="block rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-soft)] px-4 py-3 transition hover:border-[var(--color-accent)]"
+            >
+              <div className="font-mono text-sm">@agentskit/{pkg.name}</div>
+              <div className="mt-1 text-xs text-[var(--color-fg-soft)]">{pkg.tag}</div>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/landing/app/_components/pillars.tsx
+++ b/apps/landing/app/_components/pillars.tsx
@@ -1,0 +1,39 @@
+const PILLARS = [
+  {
+    title: 'Tiny core',
+    body: '@agentskit/core is under 10 KB gzipped with zero dependencies. Types, events, contracts. Nothing else.',
+  },
+  {
+    title: 'Six contracts',
+    body: 'Adapter, Tool, Skill, Memory, Retriever, Runtime. Swap any implementation without touching the rest.',
+  },
+  {
+    title: 'Plug & Play',
+    body: 'Start with one package, grow into the full stack. Every package is independently installable.',
+  },
+  {
+    title: 'No lock-in',
+    body: 'MIT licensed. Works with OpenAI, Anthropic, Gemini, Grok, Ollama, DeepSeek, and any ReadableStream.',
+  },
+] as const
+
+export function Pillars() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <h2 className="mb-12 text-center text-3xl font-semibold tracking-tight">
+        Built like a kit, not a framework
+      </h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {PILLARS.map(p => (
+          <div
+            key={p.title}
+            className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-soft)] p-6 transition hover:border-[var(--color-accent)]"
+          >
+            <h3 className="mb-2 text-lg font-semibold">{p.title}</h3>
+            <p className="text-sm leading-relaxed text-[var(--color-fg-soft)]">{p.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -1,0 +1,40 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-bg: #0a0a0b;
+  --color-bg-soft: #131316;
+  --color-fg: #f5f5f7;
+  --color-fg-soft: #a1a1aa;
+  --color-border: #232328;
+  --color-accent: #7c5cff;
+  --color-accent-soft: #a690ff;
+  --color-success: #34d399;
+
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+::selection {
+  background: var(--color-accent);
+  color: var(--color-bg);
+}

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import './globals.css'
+
+export const metadata: Metadata = {
+  title: 'AgentsKit.js — Ship AI agents in JavaScript without gluing 8 libraries',
+  description:
+    'One ecosystem for chat UI, runtime, tools, memory, RAG, and observability. Start with one package, grow into the full stack. MIT, 10 KB core.',
+  metadataBase: new URL('https://www.agentskit.io'),
+  openGraph: {
+    title: 'AgentsKit.js',
+    description:
+      'Chat UI, runtime, tools, memory, RAG, observability. One ecosystem. Zero lock-in. 10 KB core.',
+    type: 'website',
+    url: 'https://www.agentskit.io',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AgentsKit.js',
+    description: 'Chat UI, runtime, tools, memory, RAG, observability. One ecosystem.',
+  },
+  icons: { icon: '/favicon.svg' },
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -1,0 +1,21 @@
+import { Header } from './_components/header'
+import { Hero } from './_components/hero'
+import { CodeSample } from './_components/code-sample'
+import { Pillars } from './_components/pillars'
+import { PackagesGrid } from './_components/packages-grid'
+import { InstallCta } from './_components/install-cta'
+import { Footer } from './_components/footer'
+
+export default function HomePage() {
+  return (
+    <main>
+      <Header />
+      <Hero />
+      <CodeSample />
+      <Pillars />
+      <PackagesGrid />
+      <InstallCta />
+      <Footer />
+    </main>
+  )
+}

--- a/apps/landing/next-env.d.ts
+++ b/apps/landing/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+}
+
+export default nextConfig

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  // Vercel manages its own output. Set NEXT_OUTPUT_STANDALONE=1 in
+  // self-hosted environments (Cloudflare Pages, Node, Docker) to
+  // produce a standalone server bundle instead.
+  ...(process.env.NEXT_OUTPUT_STANDALONE ? { output: 'standalone' } : {}),
 }
 
 export default nextConfig

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@agentskit/landing",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbo --port 4180",
+    "build": "next build",
+    "start": "next start --port 4180",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "^16.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.4",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "tailwindcss": "^4.2.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/landing/postcss.config.mjs
+++ b/apps/landing/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}

--- a/apps/landing/public/favicon.svg
+++ b/apps/landing/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c5cff"/>
+      <stop offset="100%" stop-color="#a690ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" fill="url(#g)"/>
+  <path d="M10 22L16 8l6 14h-3.5l-1-2.5h-3l-1 2.5H10z" fill="#fff"/>
+</svg>

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "pnpm --filter @agentskit/landing build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": ".next",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../../package.json ../../pnpm-lock.yaml"
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -4,5 +4,5 @@
   "buildCommand": "pnpm --filter @agentskit/landing build",
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../../package.json ../../pnpm-lock.yaml"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- apps/landing package.json pnpm-lock.yaml pnpm-workspace.yaml"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,37 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  apps/landing:
+    dependencies:
+      next:
+        specifier: ^16.2.4
+        version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.2.4
+        version: 4.2.4
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/visual-react:
     dependencies:
       '@agentskit/core':


### PR DESCRIPTION
## Summary

Closes **#230** (P0.19). New `apps/landing` — standalone Next.js 16 + Tailwind v4 marketing site, independent from `apps/docs-next`.

Apex domain (`agentskit.io`) → landing. Docs stay on `docs.agentskit.io`.

## Why split

\`apps/docs-next\` carries Fumadocs, MDX content, Sandpack, Vercel Analytics, ~12 workspace deps, and a slow build. The landing surface needs none of that — every byte spent on docs infra hurts above-the-fold latency on the marketing page. Splitting:

- Lets the marketing page deploy in seconds, not minutes
- Avoids dragging the agent runtime into the marketing bundle
- Lets each surface evolve independently (designers can iterate on landing without touching MDX pipelines)

## Diff

| Path | What |
|---|---|
| \`apps/landing/app/page.tsx\` | composition only — pulls each section |
| \`apps/landing/app/_components/{header,hero,code-sample,pillars,packages-grid,install-cta,footer}.tsx\` | seven sections |
| \`apps/landing/app/_components/links.ts\` | single source for external URLs |
| \`apps/landing/app/globals.css\` | Tailwind v4 + \`@theme\` design tokens |
| \`apps/landing/{next.config.mjs,vercel.json,tsconfig.json,postcss.config.mjs}\` | minimal config, \`output: 'standalone'\` |
| \`apps/landing/public/favicon.svg\` | inline SVG mark |
| \`apps/landing/README.md\` | structure, tokens, deploy notes |
| \`.changeset/landing-page.md\` | empty changeset (no published packages affected) |

Zero changes to `packages/*` or `apps/docs-next`.

## Test plan

- [x] \`pnpm --filter @agentskit/landing lint\` → clean
- [x] \`pnpm --filter @agentskit/landing build\` → static prerender, both routes \`/\` and \`/_not-found\`
- [ ] Visual review on the Vercel preview deploy
- [ ] Set up the \`agentskit-landing\` Vercel project + apex domain DNS in a follow-up