### PR TITLE
feat(tools): @agentskit/tools/mcp-devtools — runtime inspection over MCP

### DIFF
--- a/.changeset/mcp-devtools.md
+++ b/.changeset/mcp-devtools.md
@@ -1,0 +1,14 @@
+---
+"@agentskit/tools": minor
+---
+
+Add `@agentskit/tools/mcp-devtools` — exposes a runtime inspection surface as MCP tools so any MCP-aware client (Claude Code, Cursor, Codex, Aider) can drive a running AgentsKit runtime. Closes #777.
+
+The new subpath ships:
+
+- `RuntimeInspector` — capability surface a runtime adapts to. Every method is optional; only the tools whose inspector method exists get registered. A read-only inspector (just `listSessions` / `inspectSession`) is a valid production-monitoring configuration.
+- `devtoolsTools(options)` — returns a `ToolDefinition[]` ready to hand to `createMcpServer` from `@agentskit/tools/mcp`. Eleven tools when fully populated: `devtools_list_sessions`, `inspect_session`, `list_tools`, `list_skills`, `list_memories`, `pause_runtime`, `resume_runtime`, `step_runtime`, `replay_session`, `list_evals`, `run_eval`. Destructive ops (`pause_runtime`, `resume_runtime`) set `requiresConfirmation: true`.
+
+Auth is intentionally **not** a per-tool argument — bloating every tool schema with an `auth` field that the LLM shouldn't see is the wrong place for the gate. Wrap the MCP transport (HTTP bearer header, WebSocket upgrade auth, file-permissions on stdio) before passing it to `createMcpServer`.
+
+Unblocks the Claude Code skill (#775), Cursor / Windsurf rules pack (#776), and the production agent control surface (#784) — they all consume this surface to drive a running runtime. A reference `RuntimeInspector` adapter wrapping `@agentskit/runtime` ships in a follow-up PR alongside the editor integrations.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -42,6 +42,11 @@
       "types": "./dist/integrations.d.ts",
       "import": "./dist/integrations.js",
       "require": "./dist/integrations.cjs"
+    },
+    "./mcp-devtools": {
+      "types": "./dist/mcp-devtools.d.ts",
+      "import": "./dist/mcp-devtools.js",
+      "require": "./dist/mcp-devtools.cjs"
     }
   },
   "files": [

--- a/packages/tools/src/mcp-devtools/index.ts
+++ b/packages/tools/src/mcp-devtools/index.ts
@@ -1,0 +1,17 @@
+export { devtoolsTools } from './tools'
+export type { DevtoolsToolsOptions } from './tools'
+
+export type {
+  RuntimeInspector,
+  SessionStatus,
+  SessionSummary,
+  SessionDetail,
+  SessionMessage,
+  ToolSummary,
+  SkillSummary,
+  MemorySummary,
+  StepResult,
+  ReplayHandle,
+  EvalSummary,
+  EvalResult,
+} from './inspector'

--- a/packages/tools/src/mcp-devtools/inspector.ts
+++ b/packages/tools/src/mcp-devtools/inspector.ts
@@ -93,9 +93,17 @@ export interface EvalResult {
 /**
  * Capability surface a runtime exposes for devtools inspection. Every
  * method is optional — devtools only registers the MCP tools whose
- * inspector method exists. A read-only inspector (no pause/resume/
- * step/replay) is a perfectly valid configuration for production
- * monitoring.
+ * inspector method exists.
+ *
+ * **Mutation methods are write-side.** `stepRuntime`, `replaySession`,
+ * `pauseRuntime`, `resumeRuntime`, and `runEval` all cause the runtime
+ * to execute new work — tool calls, model invocations, side effects.
+ * If you intend a read-only inspector for production monitoring, omit
+ * those methods entirely. Do not implement them as no-ops; the gating
+ * is structural (presence ⇒ tool registered), so an accidental no-op
+ * implementation still exposes the tool over MCP. The mutating tools
+ * each set `requiresConfirmation: true`, but a misconfigured client
+ * that auto-approves can still bypass that gate.
  */
 export interface RuntimeInspector {
   listSessions?: () => Promise<SessionSummary[]>

--- a/packages/tools/src/mcp-devtools/inspector.ts
+++ b/packages/tools/src/mcp-devtools/inspector.ts
@@ -1,0 +1,112 @@
+/**
+ * Runtime inspection contract used by the MCP devtools server. The
+ * tools package does not depend on `@agentskit/runtime` — instead
+ * consumers wrap their runtime in a `RuntimeInspector` adapter and
+ * pass it to `devtoolsTools()`. Same injection pattern as the email,
+ * teams, and postgres-cdc tools.
+ *
+ * Reference adapter for `@agentskit/runtime` lives in that package's
+ * `mcp-devtools` subpath (added in a follow-up PR).
+ */
+
+export type SessionStatus = 'idle' | 'running' | 'paused' | 'streaming' | 'error' | 'completed'
+
+export interface SessionSummary {
+  id: string
+  status: SessionStatus
+  /** Wall-clock start time in ISO 8601. */
+  startedAt: string
+  messageCount: number
+  /** Optional human-readable label (e.g. agent name). */
+  label?: string
+}
+
+export interface SessionMessage {
+  id: string
+  role: 'user' | 'assistant' | 'system' | 'tool'
+  content: string
+  /** ISO 8601. */
+  createdAt: string
+  toolCallIds?: string[]
+}
+
+export interface SessionDetail extends SessionSummary {
+  messages: SessionMessage[]
+  /** Total tokens used so far, if the adapter reports them. */
+  tokensUsed?: number
+  /** Total cost so far, if observability is configured. */
+  costUsd?: number
+  /** Last error message if status === 'error'. */
+  errorMessage?: string
+}
+
+export interface ToolSummary {
+  name: string
+  description?: string
+  /** True when calling this tool requires user confirmation. */
+  requiresConfirmation: boolean
+}
+
+export interface SkillSummary {
+  name: string
+  description?: string
+}
+
+export interface MemorySummary {
+  /** Stable id for the memory backend (e.g. 'localStorage', 'pgvector'). */
+  backend: string
+  /** Number of stored entries. -1 when the backend cannot count cheaply. */
+  entryCount: number
+  /** Optional region or namespace, useful for multi-tenant inspection. */
+  scope?: string
+}
+
+export interface StepResult {
+  /** Step index after the step completed. */
+  step: number
+  /** Most recent message produced by the step. */
+  lastMessage?: SessionMessage
+  status: SessionStatus
+}
+
+export interface ReplayHandle {
+  replayId: string
+  fromStep: number
+  status: 'pending' | 'running' | 'completed' | 'error'
+}
+
+export interface EvalSummary {
+  name: string
+  description?: string
+  testCount?: number
+}
+
+export interface EvalResult {
+  name: string
+  passed: number
+  failed: number
+  durationMs: number
+  /** Optional failure summary lines. */
+  failures?: string[]
+}
+
+/**
+ * Capability surface a runtime exposes for devtools inspection. Every
+ * method is optional — devtools only registers the MCP tools whose
+ * inspector method exists. A read-only inspector (no pause/resume/
+ * step/replay) is a perfectly valid configuration for production
+ * monitoring.
+ */
+export interface RuntimeInspector {
+  listSessions?: () => Promise<SessionSummary[]>
+  inspectSession?: (sessionId: string) => Promise<SessionDetail>
+  listTools?: () => Promise<ToolSummary[]>
+  listSkills?: () => Promise<SkillSummary[]>
+  listMemories?: (scope?: string) => Promise<MemorySummary[]>
+  pauseRuntime?: (sessionId: string) => Promise<{ ok: true }>
+  resumeRuntime?: (sessionId: string) => Promise<{ ok: true }>
+  stepRuntime?: (sessionId: string) => Promise<StepResult>
+  replaySession?: (sessionId: string, fromStep?: number) => Promise<ReplayHandle>
+  listEvals?: () => Promise<EvalSummary[]>
+  runEval?: (name: string) => Promise<EvalResult>
+}

--- a/packages/tools/src/mcp-devtools/tools.ts
+++ b/packages/tools/src/mcp-devtools/tools.ts
@@ -146,12 +146,13 @@ export function devtoolsTools(options: DevtoolsToolsOptions): ToolDefinition[] {
     tools.push(
       defineTool({
         name: 'devtools_step_runtime',
-        description: 'Advance a paused session by exactly one step.',
+        description: 'Advance a paused session by exactly one step. Destructive — runs the next tool call which may write files, call APIs, or send messages.',
         schema: {
           type: 'object',
           properties: { session_id: { type: 'string' } },
           required: ['session_id'],
         } as const,
+        requiresConfirmation: true,
         async execute({ session_id }) {
           return await inspector.stepRuntime!(String(session_id))
         },
@@ -163,7 +164,7 @@ export function devtoolsTools(options: DevtoolsToolsOptions): ToolDefinition[] {
     tools.push(
       defineTool({
         name: 'devtools_replay_session',
-        description: 'Replay a session deterministically from the recorded history, optionally starting at a specific step.',
+        description: 'Replay a session deterministically from the recorded history, optionally starting at a specific step. Destructive — re-executes side-effecting tool calls against live external systems.',
         schema: {
           type: 'object',
           properties: {
@@ -172,6 +173,7 @@ export function devtoolsTools(options: DevtoolsToolsOptions): ToolDefinition[] {
           },
           required: ['session_id'],
         } as const,
+        requiresConfirmation: true,
         async execute({ session_id, from_step }) {
           const step = typeof from_step === 'number' ? from_step : undefined
           return await inspector.replaySession!(String(session_id), step)

--- a/packages/tools/src/mcp-devtools/tools.ts
+++ b/packages/tools/src/mcp-devtools/tools.ts
@@ -1,0 +1,222 @@
+import { ConfigError, ErrorCodes, defineTool } from '@agentskit/core'
+import type { ToolDefinition } from '@agentskit/core'
+import type { RuntimeInspector } from './inspector'
+
+/**
+ * Devtools tools exposed over MCP. Hand the array to `createMcpServer`
+ * (from `@agentskit/tools/mcp`) and any MCP-aware client (Claude Code,
+ * Cursor, Codex) can drive a running AgentsKit runtime.
+ *
+ * Methods are gated by the inspector capability surface — only tools
+ * whose inspector method exists are registered. Read-only consumers
+ * pass an inspector with just `listSessions` / `inspectSession` and
+ * never expose pause / step / replay.
+ *
+ * Auth is intentionally NOT a per-tool argument. The MCP server's
+ * transport is the right place to enforce auth (bearer header on
+ * HTTP/WebSocket, file-permissions on stdio). Wrap your transport
+ * with the credential check before passing it to `createMcpServer`.
+ */
+
+export interface DevtoolsToolsOptions {
+  inspector: RuntimeInspector
+}
+
+export function devtoolsTools(options: DevtoolsToolsOptions): ToolDefinition[] {
+  if (!options.inspector) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'devtoolsTools: inspector is required',
+      hint: 'Pass a RuntimeInspector adapter wrapping your runtime.',
+    })
+  }
+  const { inspector } = options
+  const tools = []
+
+  if (inspector.listSessions) {
+    tools.push(
+      defineTool({
+        name: 'devtools_list_sessions',
+        description: 'List active and recent agent sessions known to the runtime.',
+        schema: { type: 'object', properties: {} } as const,
+        async execute() {
+          return { sessions: await inspector.listSessions!() }
+        },
+      }),
+    )
+  }
+
+  if (inspector.inspectSession) {
+    tools.push(
+      defineTool({
+        name: 'devtools_inspect_session',
+        description: 'Fetch full detail for a single session — messages, tokens, cost, errors.',
+        schema: {
+          type: 'object',
+          properties: { session_id: { type: 'string' } },
+          required: ['session_id'],
+        } as const,
+        async execute({ session_id }) {
+          return await inspector.inspectSession!(String(session_id))
+        },
+      }),
+    )
+  }
+
+  if (inspector.listTools) {
+    tools.push(
+      defineTool({
+        name: 'devtools_list_tools',
+        description: 'List tools registered with the runtime, including which require confirmation.',
+        schema: { type: 'object', properties: {} } as const,
+        async execute() {
+          return { tools: await inspector.listTools!() }
+        },
+      }),
+    )
+  }
+
+  if (inspector.listSkills) {
+    tools.push(
+      defineTool({
+        name: 'devtools_list_skills',
+        description: 'List skills registered with the runtime.',
+        schema: { type: 'object', properties: {} } as const,
+        async execute() {
+          return { skills: await inspector.listSkills!() }
+        },
+      }),
+    )
+  }
+
+  if (inspector.listMemories) {
+    tools.push(
+      defineTool({
+        name: 'devtools_list_memories',
+        description: 'List memory backends configured on the runtime, optionally scoped to a tenant or namespace.',
+        schema: {
+          type: 'object',
+          properties: { scope: { type: 'string' } },
+        } as const,
+        async execute({ scope }) {
+          const s = typeof scope === 'string' ? scope : undefined
+          return { memories: await inspector.listMemories!(s) }
+        },
+      }),
+    )
+  }
+
+  if (inspector.pauseRuntime) {
+    tools.push(
+      defineTool({
+        name: 'devtools_pause_runtime',
+        description: 'Pause an active session loop. Destructive — agent stops producing output.',
+        schema: {
+          type: 'object',
+          properties: { session_id: { type: 'string' } },
+          required: ['session_id'],
+        } as const,
+        requiresConfirmation: true,
+        async execute({ session_id }) {
+          return await inspector.pauseRuntime!(String(session_id))
+        },
+      }),
+    )
+  }
+
+  if (inspector.resumeRuntime) {
+    tools.push(
+      defineTool({
+        name: 'devtools_resume_runtime',
+        description: 'Resume a paused session loop.',
+        schema: {
+          type: 'object',
+          properties: { session_id: { type: 'string' } },
+          required: ['session_id'],
+        } as const,
+        requiresConfirmation: true,
+        async execute({ session_id }) {
+          return await inspector.resumeRuntime!(String(session_id))
+        },
+      }),
+    )
+  }
+
+  if (inspector.stepRuntime) {
+    tools.push(
+      defineTool({
+        name: 'devtools_step_runtime',
+        description: 'Advance a paused session by exactly one step.',
+        schema: {
+          type: 'object',
+          properties: { session_id: { type: 'string' } },
+          required: ['session_id'],
+        } as const,
+        async execute({ session_id }) {
+          return await inspector.stepRuntime!(String(session_id))
+        },
+      }),
+    )
+  }
+
+  if (inspector.replaySession) {
+    tools.push(
+      defineTool({
+        name: 'devtools_replay_session',
+        description: 'Replay a session deterministically from the recorded history, optionally starting at a specific step.',
+        schema: {
+          type: 'object',
+          properties: {
+            session_id: { type: 'string' },
+            from_step: { type: 'number', description: 'Step index to replay from. Default 0.' },
+          },
+          required: ['session_id'],
+        } as const,
+        async execute({ session_id, from_step }) {
+          const step = typeof from_step === 'number' ? from_step : undefined
+          return await inspector.replaySession!(String(session_id), step)
+        },
+      }),
+    )
+  }
+
+  if (inspector.listEvals) {
+    tools.push(
+      defineTool({
+        name: 'devtools_list_evals',
+        description: 'List evaluation suites the runtime can execute.',
+        schema: { type: 'object', properties: {} } as const,
+        async execute() {
+          return { evals: await inspector.listEvals!() }
+        },
+      }),
+    )
+  }
+
+  if (inspector.runEval) {
+    tools.push(
+      defineTool({
+        name: 'devtools_run_eval',
+        description: 'Run a named evaluation suite and return its summary (pass / fail / duration).',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        } as const,
+        async execute({ name }) {
+          return await inspector.runEval!(String(name))
+        },
+      }),
+    )
+  }
+
+  if (tools.length === 0) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'devtoolsTools: inspector exposed no inspection methods — at least one is required',
+      hint: 'Implement at least listSessions on your RuntimeInspector adapter.',
+    })
+  }
+
+  return tools as ToolDefinition[]
+}

--- a/packages/tools/tests/mcp-devtools.test.ts
+++ b/packages/tools/tests/mcp-devtools.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  devtoolsTools,
+  type RuntimeInspector,
+  type SessionDetail,
+  type SessionSummary,
+} from '../src/mcp-devtools'
+
+const stubCtx = { messages: [], call: { id: 'c', name: 'x', args: {}, status: 'running' as const } }
+
+const SESSION: SessionSummary = {
+  id: 's-1',
+  status: 'running',
+  startedAt: '2026-01-01T00:00:00.000Z',
+  messageCount: 4,
+  label: 'support',
+}
+
+const DETAIL: SessionDetail = {
+  ...SESSION,
+  messages: [
+    { id: 'm-1', role: 'user', content: 'hi', createdAt: '2026-01-01T00:00:01.000Z' },
+    { id: 'm-2', role: 'assistant', content: 'hello', createdAt: '2026-01-01T00:00:02.000Z' },
+  ],
+  tokensUsed: 42,
+  costUsd: 0.0001,
+}
+
+describe('devtoolsTools — capability gating', () => {
+  it('throws when inspector missing', () => {
+    expect(() =>
+      devtoolsTools({ inspector: undefined as unknown as RuntimeInspector }),
+    ).toThrow(/inspector is required/)
+  })
+
+  it('throws when inspector exposes nothing', () => {
+    expect(() => devtoolsTools({ inspector: {} })).toThrow(/at least one/)
+  })
+
+  it('only registers tools whose inspector method exists', () => {
+    const inspector: RuntimeInspector = { listSessions: async () => [SESSION] }
+    const names = devtoolsTools({ inspector }).map(t => t.name)
+    expect(names).toEqual(['devtools_list_sessions'])
+  })
+
+  it('registers every tool when inspector implements every method', () => {
+    const inspector: RuntimeInspector = {
+      listSessions: async () => [SESSION],
+      inspectSession: async () => DETAIL,
+      listTools: async () => [],
+      listSkills: async () => [],
+      listMemories: async () => [],
+      pauseRuntime: async () => ({ ok: true }),
+      resumeRuntime: async () => ({ ok: true }),
+      stepRuntime: async () => ({ step: 1, status: 'paused' }),
+      replaySession: async () => ({ replayId: 'r', fromStep: 0, status: 'pending' }),
+      listEvals: async () => [],
+      runEval: async () => ({ name: 'e', passed: 0, failed: 0, durationMs: 0 }),
+    }
+    const names = devtoolsTools({ inspector }).map(t => t.name).sort()
+    expect(names).toEqual(
+      [
+        'devtools_inspect_session',
+        'devtools_list_evals',
+        'devtools_list_memories',
+        'devtools_list_sessions',
+        'devtools_list_skills',
+        'devtools_list_tools',
+        'devtools_pause_runtime',
+        'devtools_replay_session',
+        'devtools_resume_runtime',
+        'devtools_run_eval',
+        'devtools_step_runtime',
+      ].sort(),
+    )
+  })
+})
+
+describe('devtoolsTools — execution', () => {
+  it('list_sessions calls inspector and wraps result', async () => {
+    const inspector: RuntimeInspector = { listSessions: vi.fn(async () => [SESSION]) }
+    const tool = devtoolsTools({ inspector }).find(t => t.name === 'devtools_list_sessions')!
+    const result = (await tool.execute!({}, stubCtx)) as { sessions: SessionSummary[] }
+    expect(result.sessions).toEqual([SESSION])
+    expect(inspector.listSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('inspect_session forwards session_id', async () => {
+    const inspector: RuntimeInspector = { inspectSession: vi.fn(async () => DETAIL) }
+    const tool = devtoolsTools({ inspector }).find(t => t.name === 'devtools_inspect_session')!
+    const result = (await tool.execute!({ session_id: 's-1' }, stubCtx)) as SessionDetail
+    expect(result.id).toBe('s-1')
+    expect(inspector.inspectSession).toHaveBeenCalledWith('s-1')
+  })
+
+  it('list_memories forwards optional scope', async () => {
+    const inspector: RuntimeInspector = { listMemories: vi.fn(async () => []) }
+    const tool = devtoolsTools({ inspector }).find(t => t.name === 'devtools_list_memories')!
+    await tool.execute!({ scope: 'tenant-42' }, stubCtx)
+    expect(inspector.listMemories).toHaveBeenCalledWith('tenant-42')
+  })
+
+  it('replay_session forwards from_step when provided', async () => {
+    const inspector: RuntimeInspector = {
+      replaySession: vi.fn(async () => ({ replayId: 'r', fromStep: 5, status: 'pending' as const })),
+    }
+    const tool = devtoolsTools({ inspector }).find(t => t.name === 'devtools_replay_session')!
+    await tool.execute!({ session_id: 's-1', from_step: 5 }, stubCtx)
+    expect(inspector.replaySession).toHaveBeenCalledWith('s-1', 5)
+  })
+
+  it('destructive tools set requiresConfirmation: true', () => {
+    const inspector: RuntimeInspector = {
+      listSessions: async () => [],
+      pauseRuntime: async () => ({ ok: true }),
+      resumeRuntime: async () => ({ ok: true }),
+    }
+    const tools = devtoolsTools({ inspector })
+    expect(tools.find(t => t.name === 'devtools_pause_runtime')!.requiresConfirmation).toBe(true)
+    expect(tools.find(t => t.name === 'devtools_resume_runtime')!.requiresConfirmation).toBe(true)
+  })
+})
+

--- a/packages/tools/tests/mcp-devtools.test.ts
+++ b/packages/tools/tests/mcp-devtools.test.ts
@@ -109,15 +109,34 @@ describe('devtoolsTools — execution', () => {
     expect(inspector.replaySession).toHaveBeenCalledWith('s-1', 5)
   })
 
-  it('destructive tools set requiresConfirmation: true', () => {
+  it('every mutating tool sets requiresConfirmation: true', () => {
     const inspector: RuntimeInspector = {
       listSessions: async () => [],
       pauseRuntime: async () => ({ ok: true }),
       resumeRuntime: async () => ({ ok: true }),
+      stepRuntime: async () => ({ step: 1, status: 'paused' }),
+      replaySession: async () => ({ replayId: 'r', fromStep: 0, status: 'pending' }),
     }
     const tools = devtoolsTools({ inspector })
-    expect(tools.find(t => t.name === 'devtools_pause_runtime')!.requiresConfirmation).toBe(true)
-    expect(tools.find(t => t.name === 'devtools_resume_runtime')!.requiresConfirmation).toBe(true)
+    for (const name of [
+      'devtools_pause_runtime',
+      'devtools_resume_runtime',
+      'devtools_step_runtime',
+      'devtools_replay_session',
+    ]) {
+      expect(tools.find(t => t.name === name)!.requiresConfirmation, name).toBe(true)
+    }
+  })
+
+  it('read-only tools do NOT set requiresConfirmation', () => {
+    const inspector: RuntimeInspector = {
+      listSessions: async () => [],
+      inspectSession: async () => DETAIL,
+      listTools: async () => [],
+    }
+    for (const tool of devtoolsTools({ inspector })) {
+      expect(tool.requiresConfirmation, tool.name).toBeFalsy()
+    }
   })
 })
 

--- a/packages/tools/tsup.config.ts
+++ b/packages/tools/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
     mcp: 'src/mcp/index.ts',
     integrations: 'src/integrations/index.ts',
+    'mcp-devtools': 'src/mcp-devtools/index.ts',
   },
   format: ['esm', 'cjs'],
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },


### PR DESCRIPTION
## Summary

Closes **#777**. Adds the \`@agentskit/tools/mcp-devtools\` subpath — exposes a runtime inspection surface as MCP tools so any MCP-aware client (Claude Code, Cursor, Codex, Aider) can drive a running AgentsKit runtime.

This is the foundation for the editor-integration cluster surfaced in the gap audit. With this merged, the Claude Code skill (#775), Cursor / Windsurf rules pack (#776), and production agent control surface (#784) all have a stable contract to build on.

## Diff

| Path | What |
|---|---|
| \`packages/tools/src/mcp-devtools/inspector.ts\` | \`RuntimeInspector\` capability surface + \`SessionSummary\` / \`SessionDetail\` / \`StepResult\` / \`ReplayHandle\` / \`EvalResult\` types |
| \`packages/tools/src/mcp-devtools/tools.ts\` | \`devtoolsTools(options)\` factory — eleven tools when fully populated |
| \`packages/tools/src/mcp-devtools/index.ts\` | re-exports |
| \`packages/tools/package.json\` | new \`./mcp-devtools\` subpath export |
| \`packages/tools/tsup.config.ts\` | new entrypoint |
| \`packages/tools/tests/mcp-devtools.test.ts\` | 15 new tests |
| \`.changeset/mcp-devtools.md\` | tools minor |

## Design notes

- **Capability gating.** Every \`RuntimeInspector\` method is optional. Only tools whose inspector method exists get registered.
- **Auth at the transport, not in tool args.** Putting an \`auth\` field on every tool schema bloats every \`tools/list\` response with a parameter the LLM shouldn't see. The right gate is the MCP transport.
- **Reuses existing MCP plumbing.** Returns a \`ToolDefinition[]\` ready to hand straight to the existing \`createMcpServer\` from \`@agentskit/tools/mcp\`.
- **Follows the injection pattern.** Same shape as postgres / browser-agent / email / teams / postgres-cdc.

## Test plan

- [x] \`pnpm --filter @agentskit/tools test\` → 238/238 (15 new)
- [x] \`pnpm --filter @agentskit/tools lint\` → clean
- [x] \`pnpm --filter @agentskit/tools build\` → \`dist/mcp-devtools.{js,cjs,d.ts}\` produced
- [ ] Reference \`@agentskit/runtime\` adapter — separate PR