### PR TITLE
feat(runtime): createChatTrigger — unified chat-surface contract

### DIFF
--- a/.changeset/chat-trigger.md
+++ b/.changeset/chat-trigger.md
@@ -1,0 +1,19 @@
+---
+"@agentskit/runtime": minor
+---
+
+Add `createChatTrigger` — unified trigger contract for chat-surface bots (Slack, Teams, Discord, WhatsApp, …). Closes #782.
+
+One trigger, six normalized event shapes, one observer hook, one HITL surface. Writing three divergent bot templates means three divergent test suites; this contract collapses them to one. Adapters are tiny — they wrap a provider SDK (Bolt, discord.js, Bot Framework) and turn raw events into a discriminated union of `ChatSurfaceEvent`s: `message`, `mention`, `reply`, `reaction`, `file_upload`, `installation`. Each event carries normalized `surface` / `channel` / `user` / `eventId` / optional `threadId` metadata.
+
+`createChatTrigger({ adapter, agent, … })` returns a framework-agnostic `WebhookHandler` ready for Express / Hono / Next route handlers. Built-in:
+
+- `verify` hook → 401 on bad signature
+- `parse` returning `null` → 200 ignored (stops surface retries)
+- `parse` throwing → 400 with the error
+- agent throwing → 500 with the error
+- `filter` for bot-on-bot loop guards or quiet-hours
+- `autoReply` posts the agent's output back via `adapter.reply`, swallowing reply errors so the agent's run still counts as handled
+- structured `onEvent` observer for received / skipped / handled / rejected / replied
+
+Unblocks the Slack (#779), Discord (#780), and Teams (#781) bot templates — they now share one contract instead of diverging. Reference adapters wrapping Bolt / discord.js / Bot Framework live in those template PRs; this PR ships the contract + factory + tests only.

--- a/apps/docs-next/content/docs/for-agents/runtime.mdx
+++ b/apps/docs-next/content/docs/for-agents/runtime.mdx
@@ -24,6 +24,7 @@ npm install @agentskit/runtime
 - `createDurableRunner` + `createInMemoryStepLog` / `createFileStepLog` — Temporal-style step-log durability. See [Durable execution](/docs/reference/recipes/durable-execution).
 - `createCronScheduler` (5-field cron + `every:<ms>`) + `createWebhookHandler` + `parseSchedule` + `cronMatches` — background agents. See [Background agents](/docs/reference/recipes/background-agents).
 - `compileFlow({ definition, registry })` + `validateFlow` + `flowToMermaid` — compile a YAML / object `FlowDefinition` into a durable DAG runner. See [Visual flows](/docs/agents/flow).
+- `createChatTrigger({ adapter, agent, ... })` — unified inbound trigger for chat-surface bots (Slack / Teams / Discord / WhatsApp). Wraps a `ChatSurfaceAdapter` that normalizes provider events into a `ChatSurfaceEvent` discriminated union (`message` / `mention` / `reply` / `reaction` / `file_upload` / `installation`). Returns a framework-agnostic `WebhookHandler`.
 
 ## Minimal example
 

--- a/packages/runtime/src/chat-trigger.ts
+++ b/packages/runtime/src/chat-trigger.ts
@@ -19,6 +19,13 @@ import { ConfigError, ErrorCodes } from '@agentskit/core'
 import type { AgentHandle } from './topologies'
 import type { WebhookHandler, WebhookRequest, WebhookResponse } from './background'
 
+/**
+ * Surface identifier. The four named surfaces preserve autocomplete in
+ * editors; `(string & {})` keeps the type extensible for adapters
+ * landing later (Mattermost, Telegram, Webex). **Caveat:** a `switch
+ * (event.surface)` will not be exhaustive — TS cannot warn about
+ * missing branches when the union is open. Use a default branch.
+ */
 export type ChatSurface = 'slack' | 'teams' | 'discord' | 'whatsapp' | (string & {})
 
 /** Stable identity of a sender across surfaces. */
@@ -128,14 +135,33 @@ export interface ChatSurfaceAdapter {
   surface: ChatSurface
   /** Parse an inbound webhook into a normalized event. Return `null` to ignore. */
   parse: (req: WebhookRequest) => Promise<ChatSurfaceEvent | null> | ChatSurfaceEvent | null
-  /** Verify the request signature. Return `false` to reject with 401. */
+  /**
+   * Verify the request signature. Return `false` to reject with 401.
+   * The factory refuses to construct without `verify` unless
+   * `{ strict: false }` is passed — explicit opt-out so unverified
+   * webhook handlers cannot ship by accident.
+   *
+   * **Replay protection** (eventId dedup, timestamp window) is the
+   * adapter's responsibility — the trigger does not enforce it. The
+   * normalized `eventId` and `receivedAt` fields exist precisely so
+   * adapters can implement dedup against a memory backend.
+   */
   verify?: (req: WebhookRequest) => Promise<boolean> | boolean
   /** Optional reply hook — used when the agent's output should post back. */
   reply?: (event: ChatSurfaceEvent, text: string) => Promise<void> | void
 }
 
 export interface ChatTriggerObserverEvent {
-  type: 'received' | 'skipped' | 'handled' | 'rejected' | 'replied'
+  /**
+   * - `received` → before any work
+   * - `skipped` → adapter parse returned null OR filter rejected
+   * - `handled` → agent ran successfully
+   * - `replied` → adapter.reply succeeded after handled (autoReply only)
+   * - `reply_failed` → adapter.reply threw after handled (HTTP still 200)
+   * - `rejected` → request did not produce a successful agent run
+   *   (verify failed, parse threw, agent threw)
+   */
+  type: 'received' | 'skipped' | 'handled' | 'rejected' | 'replied' | 'reply_failed'
   surface: ChatSurface
   event?: ChatSurfaceEvent
   /** Error or skip reason. */
@@ -163,6 +189,13 @@ export interface ChatTriggerOptions<TContext = unknown> {
   filter?: (event: ChatSurfaceEvent) => boolean
   /** Auto-reply with the agent's output via `adapter.reply` when present. */
   autoReply?: boolean
+  /**
+   * Reject construction when `adapter.verify` is missing. Default
+   * `true` — set to `false` only when you have an external auth
+   * proxy in front of the trigger. Surfaces the footgun at author
+   * time instead of accepting spoofed webhooks at runtime.
+   */
+  strict?: boolean
   /** Observability hook. */
   onEvent?: (event: ChatTriggerObserverEvent) => void
 }
@@ -202,6 +235,14 @@ export function createChatTrigger<TContext = unknown>(
     throw new ConfigError({
       code: ErrorCodes.AK_CONFIG_INVALID,
       message: 'createChatTrigger: agent is required',
+    })
+  }
+  const strict = options.strict !== false
+  if (strict && !options.adapter.verify) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createChatTrigger: adapter.verify is missing — refusing to construct an unverified trigger',
+      hint: 'Implement adapter.verify (signature check + replay protection) or pass `{ strict: false }` if an external auth proxy guards the trigger.',
     })
   }
 
@@ -249,7 +290,7 @@ export function createChatTrigger<TContext = unknown>(
           options.onEvent?.({ type: 'replied', surface, event })
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
-          options.onEvent?.({ type: 'rejected', surface, event, reason: `reply error: ${message}` })
+          options.onEvent?.({ type: 'reply_failed', surface, event, reason: message })
           // 200 still — the agent ran, only the post-reply failed.
         }
       }
@@ -258,7 +299,8 @@ export function createChatTrigger<TContext = unknown>(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       options.onEvent?.({ type: 'rejected', surface, event, reason: message })
-      return { status: 500, body: message }
+      // Don't leak raw error details into surface platform logs.
+      return { status: 500, body: 'internal error' }
     }
   }
 

--- a/packages/runtime/src/chat-trigger.ts
+++ b/packages/runtime/src/chat-trigger.ts
@@ -1,0 +1,266 @@
+/**
+ * Unified chat-surface trigger contract — same agent listens on
+ * Slack, Teams, Discord, WhatsApp, etc. Adapters parse raw provider
+ * events into a normalized `ChatSurfaceEvent`; the trigger wires the
+ * event into a runtime-bound agent and returns a framework-agnostic
+ * webhook response.
+ *
+ * Why a single contract: writing three divergent bot templates means
+ * three divergent test suites, three observability pipes, three places
+ * to enforce HITL. One contract → one set of tests, one observer hook,
+ * one HITL surface across every chat surface.
+ *
+ * Closes #782. Reference adapters wrapping Bolt (Slack), discord.js,
+ * and Bot Framework (Teams) ship in `@agentskit/triggers` (AgentsKitOS)
+ * and the per-surface bot templates (#779, #780, #781).
+ */
+
+import { ConfigError, ErrorCodes } from '@agentskit/core'
+import type { AgentHandle } from './topologies'
+import type { WebhookHandler, WebhookRequest, WebhookResponse } from './background'
+
+export type ChatSurface = 'slack' | 'teams' | 'discord' | 'whatsapp' | (string & {})
+
+/** Stable identity of a sender across surfaces. */
+export interface ChatSurfaceUser {
+  id: string
+  /** Display name when available. */
+  name?: string
+  /** True when the sender is a bot (including this agent). */
+  isBot?: boolean
+}
+
+/** Channel / room / DM identifier. */
+export interface ChatSurfaceChannel {
+  id: string
+  /** Optional human-readable channel name. */
+  name?: string
+  /** Whether the channel is a 1:1 DM, group DM, or shared channel. */
+  kind?: 'dm' | 'group' | 'channel' | 'thread'
+}
+
+/** Common metadata every event carries. */
+export interface ChatSurfaceMeta {
+  surface: ChatSurface
+  channel: ChatSurfaceChannel
+  user: ChatSurfaceUser
+  /** Surface-native event id (Slack `event_id`, Discord interaction id, etc.). */
+  eventId: string
+  /** Thread / parent message id when the event is in-thread. */
+  threadId?: string
+  /** ISO 8601 timestamp from the surface, when available. */
+  receivedAt?: string
+}
+
+/** A plain text message addressed to nobody in particular. */
+export interface ChatMessageEvent extends ChatSurfaceMeta {
+  type: 'message'
+  text: string
+}
+
+/** A direct mention of the bot or a slash command. */
+export interface ChatMentionEvent extends ChatSurfaceMeta {
+  type: 'mention'
+  text: string
+  /** Slash command name without leading '/' (when applicable). */
+  command?: string
+}
+
+/** Reply inside an existing thread. */
+export interface ChatReplyEvent extends ChatSurfaceMeta {
+  type: 'reply'
+  text: string
+  /** Required: parent message id being replied to. */
+  parentId: string
+}
+
+/** Emoji reaction added or removed on a message. */
+export interface ChatReactionEvent extends ChatSurfaceMeta {
+  type: 'reaction'
+  /** Reacted-to message id. */
+  messageId: string
+  /** Emoji shortcode, e.g. `thumbsup`. */
+  emoji: string
+  /** True when the reaction was added; false when removed. */
+  added: boolean
+}
+
+/** File / attachment upload. */
+export interface ChatFileUploadEvent extends ChatSurfaceMeta {
+  type: 'file_upload'
+  /** File name as supplied by the surface. */
+  name: string
+  /** MIME type when known. */
+  contentType?: string
+  /** URL the surface exposes for download (may require surface auth). */
+  url?: string
+  /** Size in bytes when reported. */
+  sizeBytes?: number
+}
+
+/** App installed in a workspace / guild / tenant. */
+export interface ChatInstallationEvent extends ChatSurfaceMeta {
+  type: 'installation'
+  /** Install / uninstall action. */
+  action: 'installed' | 'uninstalled'
+  /** Tenant / workspace / guild id. */
+  tenantId: string
+}
+
+export type ChatSurfaceEvent =
+  | ChatMessageEvent
+  | ChatMentionEvent
+  | ChatReplyEvent
+  | ChatReactionEvent
+  | ChatFileUploadEvent
+  | ChatInstallationEvent
+
+export type ChatSurfaceEventType = ChatSurfaceEvent['type']
+
+/**
+ * Surface adapter contract. An adapter wraps a provider SDK (Bolt,
+ * discord.js, Bot Framework) and turns raw inbound events into the
+ * normalized `ChatSurfaceEvent`. Returning `null` from `parse` is a
+ * deliberate skip — the trigger emits a `'skipped'` observer event
+ * and returns a 200 so the surface stops retrying.
+ */
+export interface ChatSurfaceAdapter {
+  surface: ChatSurface
+  /** Parse an inbound webhook into a normalized event. Return `null` to ignore. */
+  parse: (req: WebhookRequest) => Promise<ChatSurfaceEvent | null> | ChatSurfaceEvent | null
+  /** Verify the request signature. Return `false` to reject with 401. */
+  verify?: (req: WebhookRequest) => Promise<boolean> | boolean
+  /** Optional reply hook — used when the agent's output should post back. */
+  reply?: (event: ChatSurfaceEvent, text: string) => Promise<void> | void
+}
+
+export interface ChatTriggerObserverEvent {
+  type: 'received' | 'skipped' | 'handled' | 'rejected' | 'replied'
+  surface: ChatSurface
+  event?: ChatSurfaceEvent
+  /** Error or skip reason. */
+  reason?: string
+}
+
+export interface ChatTriggerOptions<TContext = unknown> {
+  adapter: ChatSurfaceAdapter
+  agent: AgentHandle<TContext>
+  /**
+   * Build the agent task from the parsed event. Default: pull
+   * `event.text` for message / mention / reply, fall back to a
+   * structured JSON encoding for events without text (reaction, file).
+   */
+  buildTask?: (event: ChatSurfaceEvent) => string
+  /**
+   * Build the per-event runtime context (e.g. tenant id, user id).
+   * Default: `{ event }`.
+   */
+  buildContext?: (event: ChatSurfaceEvent) => TContext
+  /**
+   * Filter events before running the agent. Return `false` to skip.
+   * Useful for ignoring bot-on-bot loops or off-hours messages.
+   */
+  filter?: (event: ChatSurfaceEvent) => boolean
+  /** Auto-reply with the agent's output via `adapter.reply` when present. */
+  autoReply?: boolean
+  /** Observability hook. */
+  onEvent?: (event: ChatTriggerObserverEvent) => void
+}
+
+function defaultBuildTask(event: ChatSurfaceEvent): string {
+  if (event.type === 'message' || event.type === 'mention' || event.type === 'reply') {
+    return event.text
+  }
+  return JSON.stringify(event)
+}
+
+function defaultBuildContext<TContext>(event: ChatSurfaceEvent): TContext {
+  return { event } as unknown as TContext
+}
+
+export interface ChatTrigger {
+  handler: WebhookHandler
+  surface: ChatSurface
+}
+
+/**
+ * Build a unified chat-surface trigger. Wire the returned `handler`
+ * into your HTTP framework (Express / Hono / Next route handler) at
+ * the surface's webhook URL.
+ */
+export function createChatTrigger<TContext = unknown>(
+  options: ChatTriggerOptions<TContext>,
+): ChatTrigger {
+  if (!options.adapter) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createChatTrigger: adapter is required',
+      hint: 'Pass a ChatSurfaceAdapter (e.g. wrap Bolt, discord.js, or Bot Framework).',
+    })
+  }
+  if (!options.agent) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createChatTrigger: agent is required',
+    })
+  }
+
+  const buildTask = options.buildTask ?? defaultBuildTask
+  const buildContext = options.buildContext ?? defaultBuildContext<TContext>
+  const surface = options.adapter.surface
+
+  const handler: WebhookHandler = async req => {
+    options.onEvent?.({ type: 'received', surface })
+
+    if (options.adapter.verify) {
+      const ok = await options.adapter.verify(req)
+      if (!ok) {
+        options.onEvent?.({ type: 'rejected', surface, reason: 'verify returned false' })
+        return { status: 401, body: 'unauthorized' }
+      }
+    }
+
+    let event: ChatSurfaceEvent | null
+    try {
+      event = await options.adapter.parse(req)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      options.onEvent?.({ type: 'rejected', surface, reason: `parse error: ${message}` })
+      return { status: 400, body: message }
+    }
+
+    if (event === null) {
+      options.onEvent?.({ type: 'skipped', surface, reason: 'adapter returned null' })
+      return { status: 200, body: 'ignored' }
+    }
+
+    if (options.filter && !options.filter(event)) {
+      options.onEvent?.({ type: 'skipped', surface, event, reason: 'filter rejected' })
+      return { status: 200, body: 'filtered' }
+    }
+
+    try {
+      const result = await options.agent.run(buildTask(event), buildContext(event))
+      options.onEvent?.({ type: 'handled', surface, event })
+
+      if (options.autoReply && options.adapter.reply) {
+        try {
+          await options.adapter.reply(event, result)
+          options.onEvent?.({ type: 'replied', surface, event })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          options.onEvent?.({ type: 'rejected', surface, event, reason: `reply error: ${message}` })
+          // 200 still — the agent ran, only the post-reply failed.
+        }
+      }
+
+      return { status: 200, body: result, headers: { 'content-type': 'text/plain; charset=utf-8' } }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      options.onEvent?.({ type: 'rejected', surface, event, reason: message })
+      return { status: 500, body: message }
+    }
+  }
+
+  return { handler, surface }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -71,3 +71,22 @@ export type {
   SpeculateOutput,
   SpeculatePicker,
 } from './speculate'
+export { createChatTrigger } from './chat-trigger'
+export type {
+  ChatSurface,
+  ChatSurfaceEvent,
+  ChatSurfaceEventType,
+  ChatSurfaceAdapter,
+  ChatSurfaceUser,
+  ChatSurfaceChannel,
+  ChatSurfaceMeta,
+  ChatMessageEvent,
+  ChatMentionEvent,
+  ChatReplyEvent,
+  ChatReactionEvent,
+  ChatFileUploadEvent,
+  ChatInstallationEvent,
+  ChatTrigger,
+  ChatTriggerOptions,
+  ChatTriggerObserverEvent,
+} from './chat-trigger'

--- a/packages/runtime/tests/chat-trigger.test.ts
+++ b/packages/runtime/tests/chat-trigger.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createChatTrigger,
+  type ChatMessageEvent,
+  type ChatSurfaceAdapter,
+  type ChatSurfaceEvent,
+  type ChatTriggerObserverEvent,
+} from '../src/chat-trigger'
+import type { AgentHandle } from '../src/topologies'
+import type { WebhookRequest } from '../src/background'
+
+function agent(impl: (task: string) => Promise<string> | string = async () => 'ok'): AgentHandle {
+  return { name: 'a', run: async task => impl(task) }
+}
+
+const REQ: WebhookRequest = { method: 'POST', headers: {}, body: { text: 'hi' } }
+
+const SAMPLE_MESSAGE: ChatMessageEvent = {
+  type: 'message',
+  surface: 'slack',
+  channel: { id: 'C1', name: 'general', kind: 'channel' },
+  user: { id: 'U1', name: 'alice' },
+  eventId: 'E1',
+  text: 'hello bot',
+  receivedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function buildAdapter(overrides: Partial<ChatSurfaceAdapter> = {}): ChatSurfaceAdapter {
+  return {
+    surface: 'slack',
+    parse: () => SAMPLE_MESSAGE,
+    ...overrides,
+  }
+}
+
+describe('createChatTrigger — config guards', () => {
+  it('throws when adapter missing', () => {
+    expect(() =>
+      createChatTrigger({ adapter: undefined as unknown as ChatSurfaceAdapter, agent: agent() }),
+    ).toThrow(/adapter is required/)
+  })
+
+  it('throws when agent missing', () => {
+    expect(() =>
+      createChatTrigger({ adapter: buildAdapter(), agent: undefined as unknown as AgentHandle }),
+    ).toThrow(/agent is required/)
+  })
+})
+
+describe('createChatTrigger — happy path', () => {
+  it('parses, runs, returns 200 with the agent reply body', async () => {
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: agent(async task => `echo:${task}`),
+      onEvent: e => events.push(e),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('echo:hello bot')
+    expect(events.map(e => e.type)).toEqual(['received', 'handled'])
+    expect(trig.surface).toBe('slack')
+  })
+
+  it('builds task from event.text by default for message/mention/reply', async () => {
+    let seen = ''
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: agent(async task => {
+        seen = task
+        return ''
+      }),
+    })
+    await trig.handler(REQ)
+    expect(seen).toBe('hello bot')
+  })
+
+  it('falls back to JSON.stringify for non-text events', async () => {
+    let seen = ''
+    const reaction: ChatSurfaceEvent = {
+      type: 'reaction',
+      surface: 'slack',
+      channel: { id: 'C1' },
+      user: { id: 'U1' },
+      eventId: 'E2',
+      messageId: 'M1',
+      emoji: 'thumbsup',
+      added: true,
+    }
+    const trig = createChatTrigger({
+      adapter: buildAdapter({ parse: () => reaction }),
+      agent: agent(async task => {
+        seen = task
+        return ''
+      }),
+    })
+    await trig.handler(REQ)
+    expect(seen).toContain('"type":"reaction"')
+    expect(seen).toContain('"emoji":"thumbsup"')
+  })
+
+  it('honours buildTask + buildContext overrides', async () => {
+    let seen: { task: string; ctx: unknown } | null = null
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: { name: 'a', run: async (task, ctx) => { seen = { task, ctx }; return '' } },
+      buildTask: e => `routed:${e.eventId}`,
+      buildContext: e => ({ tenant: e.user.id }),
+    })
+    await trig.handler(REQ)
+    expect(seen).toEqual({ task: 'routed:E1', ctx: { tenant: 'U1' } })
+  })
+})
+
+describe('createChatTrigger — adapter signals', () => {
+  it('returns 401 when verify returns false', async () => {
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter({ verify: () => false }),
+      agent: agent(),
+      onEvent: e => events.push(e),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(401)
+    expect(res.body).toBe('unauthorized')
+    expect(events.map(e => e.type)).toEqual(['received', 'rejected'])
+    expect(events[1]!.reason).toContain('verify')
+  })
+
+  it('returns 200 ignored when adapter parse returns null', async () => {
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter({ parse: () => null }),
+      agent: agent(),
+      onEvent: e => events.push(e),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('ignored')
+    expect(events.map(e => e.type)).toEqual(['received', 'skipped'])
+  })
+
+  it('returns 400 when adapter parse throws', async () => {
+    const trig = createChatTrigger({
+      adapter: buildAdapter({
+        parse: () => {
+          throw new Error('bad payload')
+        },
+      }),
+      agent: agent(),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(400)
+    expect(res.body).toContain('bad payload')
+  })
+
+  it('returns 500 when the agent throws', async () => {
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: agent(async () => {
+        throw new Error('boom')
+      }),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(500)
+    expect(res.body).toBe('boom')
+  })
+})
+
+describe('createChatTrigger — filter', () => {
+  it('skips when filter returns false', async () => {
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: agent(),
+      filter: e => e.user.id !== 'U1',
+      onEvent: e => events.push(e),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('filtered')
+    expect(events.map(e => e.type)).toEqual(['received', 'skipped'])
+  })
+
+  it('skips bot-on-bot loops via isBot filter', async () => {
+    const trig = createChatTrigger({
+      adapter: buildAdapter({
+        parse: () => ({ ...SAMPLE_MESSAGE, user: { id: 'U2', isBot: true } }),
+      }),
+      agent: agent(),
+      filter: e => !e.user.isBot,
+    })
+    const res = await trig.handler(REQ)
+    expect(res.body).toBe('filtered')
+  })
+})
+
+describe('createChatTrigger — autoReply', () => {
+  it('calls adapter.reply when autoReply is on and reply is provided', async () => {
+    const reply = vi.fn()
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter({ reply }),
+      agent: agent(async () => 'reply text'),
+      autoReply: true,
+      onEvent: e => events.push(e),
+    })
+    await trig.handler(REQ)
+    expect(reply).toHaveBeenCalledWith(SAMPLE_MESSAGE, 'reply text')
+    expect(events.map(e => e.type)).toEqual(['received', 'handled', 'replied'])
+  })
+
+  it('still returns 200 when reply throws (agent already ran)', async () => {
+    const events: ChatTriggerObserverEvent[] = []
+    const trig = createChatTrigger({
+      adapter: buildAdapter({
+        reply: () => {
+          throw new Error('post failed')
+        },
+      }),
+      agent: agent(async () => 'ok'),
+      autoReply: true,
+      onEvent: e => events.push(e),
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(200)
+    expect(events.find(e => e.reason?.includes('reply error'))).toBeDefined()
+  })
+
+  it('does not call reply when autoReply is off', async () => {
+    const reply = vi.fn()
+    const trig = createChatTrigger({
+      adapter: buildAdapter({ reply }),
+      agent: agent(),
+    })
+    await trig.handler(REQ)
+    expect(reply).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when autoReply is on but adapter.reply is missing', async () => {
+    const trig = createChatTrigger({
+      adapter: buildAdapter(),
+      agent: agent(),
+      autoReply: true,
+    })
+    const res = await trig.handler(REQ)
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('createChatTrigger — surface union', () => {
+  it('preserves the surface name from adapter', () => {
+    for (const surface of ['slack', 'teams', 'discord', 'whatsapp', 'mattermost'] as const) {
+      const trig = createChatTrigger({
+        adapter: buildAdapter({ surface }),
+        agent: agent(),
+      })
+      expect(trig.surface).toBe(surface)
+    }
+  })
+})

--- a/packages/runtime/tests/chat-trigger.test.ts
+++ b/packages/runtime/tests/chat-trigger.test.ts
@@ -29,6 +29,7 @@ function buildAdapter(overrides: Partial<ChatSurfaceAdapter> = {}): ChatSurfaceA
   return {
     surface: 'slack',
     parse: () => SAMPLE_MESSAGE,
+    verify: () => true,
     ...overrides,
   }
 }
@@ -44,6 +45,25 @@ describe('createChatTrigger — config guards', () => {
     expect(() =>
       createChatTrigger({ adapter: buildAdapter(), agent: undefined as unknown as AgentHandle }),
     ).toThrow(/agent is required/)
+  })
+
+  it('throws by default when adapter.verify is missing (strict mode)', () => {
+    expect(() =>
+      createChatTrigger({
+        adapter: { surface: 'slack', parse: () => SAMPLE_MESSAGE },
+        agent: agent(),
+      }),
+    ).toThrow(/refusing to construct an unverified trigger/)
+  })
+
+  it('allows missing verify when strict: false', () => {
+    expect(() =>
+      createChatTrigger({
+        adapter: { surface: 'slack', parse: () => SAMPLE_MESSAGE },
+        agent: agent(),
+        strict: false,
+      }),
+    ).not.toThrow()
   })
 })
 
@@ -154,16 +174,21 @@ describe('createChatTrigger — adapter signals', () => {
     expect(res.body).toContain('bad payload')
   })
 
-  it('returns 500 when the agent throws', async () => {
+  it('returns 500 with a generic body when the agent throws (no error leak to surface logs)', async () => {
+    const events: ChatTriggerObserverEvent[] = []
     const trig = createChatTrigger({
       adapter: buildAdapter(),
       agent: agent(async () => {
-        throw new Error('boom')
+        throw new Error('secret stack detail')
       }),
+      onEvent: e => events.push(e),
     })
     const res = await trig.handler(REQ)
     expect(res.status).toBe(500)
-    expect(res.body).toBe('boom')
+    expect(res.body).toBe('internal error')
+    expect(res.body).not.toContain('secret stack detail')
+    // Full message still surfaces in observer for monitoring.
+    expect(events.find(e => e.type === 'rejected')!.reason).toBe('secret stack detail')
   })
 })
 
@@ -210,7 +235,7 @@ describe('createChatTrigger — autoReply', () => {
     expect(events.map(e => e.type)).toEqual(['received', 'handled', 'replied'])
   })
 
-  it('still returns 200 when reply throws (agent already ran)', async () => {
+  it('emits reply_failed (not rejected) when reply throws after handled', async () => {
     const events: ChatTriggerObserverEvent[] = []
     const trig = createChatTrigger({
       adapter: buildAdapter({
@@ -224,7 +249,8 @@ describe('createChatTrigger — autoReply', () => {
     })
     const res = await trig.handler(REQ)
     expect(res.status).toBe(200)
-    expect(events.find(e => e.reason?.includes('reply error'))).toBeDefined()
+    expect(events.map(e => e.type)).toEqual(['received', 'handled', 'reply_failed'])
+    expect(events.find(e => e.type === 'reply_failed')!.reason).toBe('post failed')
   })
 
   it('does not call reply when autoReply is off', async () => {


### PR DESCRIPTION
## Summary

Closes **#782**. Adds \`createChatTrigger\` to \`@agentskit/runtime\` — one contract, six normalized event shapes, one observer hook, one HITL surface across Slack, Teams, Discord, WhatsApp, etc.

This is the foundation the three bot templates (#779 Slack, #780 Discord, #781 Teams) need to avoid diverging. Without it each template would re-invent event normalization, signature verification, filter logic, observer events, and reply plumbing.

## Diff

| Path | What |
|---|---|
| \`packages/runtime/src/chat-trigger.ts\` | \`createChatTrigger\` factory + \`ChatSurfaceEvent\` discriminated union (message / mention / reply / reaction / file_upload / installation) + \`ChatSurfaceAdapter\` contract |
| \`packages/runtime/src/index.ts\` | re-exports |
| \`packages/runtime/tests/chat-trigger.test.ts\` | 20 new tests |
| \`.changeset/chat-trigger.md\` | runtime minor |

## Design notes

- **Discriminated union over inheritance.** Six event shapes share the \`ChatSurfaceMeta\` base (surface / channel / user / eventId / threadId / receivedAt) but each carries its own typed payload. TS narrows by \`event.type\`.
- **Adapter is two methods + one optional.** \`parse(req) → ChatSurfaceEvent | null\` for normalization, \`verify(req) → boolean\` for signature checks, \`reply(event, text)\` for autoReply. Everything else lives in the trigger.
- **Skip semantics are explicit.** \`parse\` returning \`null\` returns 200 \`'ignored'\` so the surface stops retrying. \`filter\` returning \`false\` returns 200 \`'filtered'\`. Both fire \`onEvent: 'skipped'\` with a reason.
- **Auto-reply is best-effort.** If \`adapter.reply\` throws after the agent has run, the handler still returns 200 (the agent ran successfully — only the post-action failed). The reply error surfaces via \`onEvent: 'rejected'\` for monitoring.
- **No new dependencies.** Builds on the existing \`WebhookHandler\` / \`WebhookRequest\` shape from \`background.ts\` so existing Express / Hono / Next adapters work unchanged.

## Test plan

- [x] \`pnpm --filter @agentskit/runtime test\` → 126/126 (20 new)
- [x] \`pnpm --filter @agentskit/runtime lint\` → clean
- [x] \`pnpm --filter @agentskit/runtime build\` → \`createChatTrigger\` exported in \`dist/index.{js,cjs,d.ts}\`
- [ ] Reference adapters wrapping Bolt / discord.js / Bot Framework — ship in #779 / #780 / #781