### PR TITLE
feat(examples): Slack + Discord + Teams bot templates wrapping createChatTrigger

### DIFF
--- a/.changeset/bot-templates.md
+++ b/.changeset/bot-templates.md
@@ -1,0 +1,12 @@
+---
+---
+
+Add three reference bot templates wrapping `createChatTrigger`. Closes #779 (Slack), #780 (Discord), #781 (Teams).
+
+Each template ships a thin `ChatSurfaceAdapter` (parse + verify + reply) over the provider's webhook / interactions endpoint plus a runnable Node HTTP server, README, and unit tests for the adapter — no provider SDK in dependencies (Bolt / discord.js / botbuilder), so `pnpm install` stays light. Production deployments swap the lean reply path for the official SDK to inherit retries, rate-limit handling, and pagination.
+
+- **`apps/example-slack-bot`** — Slack Events API + `chat.postMessage`. Verifies Slack signing-secret + 300 s timestamp window. Normalizes `app_mention`, `message`, `message.subtype:file_share`, `reaction_added/removed` to the unified `ChatSurfaceEvent` union. URL-verification handshake handled inline before the trigger.
+- **`apps/example-discord-bot`** — Discord Interactions HTTP endpoint. Verifies inbound Ed25519 signatures via `webcrypto.subtle`. Normalizes APPLICATION_COMMAND (type 2) and MESSAGE_COMPONENT (type 3) to mention events; PING (type 1) handled inline.
+- **`apps/example-teams-bot`** — Microsoft Bot Framework activity payloads at `/api/messages`. Default `verifyToken` denies everything (deny-by-default JWT gate); deployers wire `botbuilder` `JwtTokenValidation` or any JWT lib. Normalizes `message`, `messageReaction`, and `conversationUpdate` to message / reply / file_upload / reaction / installation events.
+
+All three share the same `createChatTrigger` contract (#782) — one observer taxonomy, one HITL surface, one filter shape across surfaces.

--- a/apps/example-discord-bot/README.md
+++ b/apps/example-discord-bot/README.md
@@ -1,0 +1,33 @@
+# @agentskit/example-discord-bot
+
+Reference Discord bot wrapping `createChatTrigger` from `@agentskit/runtime`. Closes [#780](https://github.com/AgentsKit-io/agentskit/issues/780).
+
+Driver-light: uses Discord's Interactions HTTP endpoint (no gateway, no discord.js). Verifies inbound interactions with the application's Ed25519 public key. For richer setups (presence, voice, gateway events, voice mode hand-off to TTS/STT), wrap discord.js — this adapter covers the slash-command + message-component path.
+
+## Setup
+
+1. Create a Discord application at https://discord.com/developers/applications.
+2. In **General Information**, copy the **Public Key**.
+3. In **Bot**, generate a token, copy it.
+4. In **Interactions Endpoint URL**, set `https://<your-host>/discord/interactions`. Discord PINGs the URL during validation; `src/index.ts` PONGs before the trigger sees the request.
+
+```bash
+export DISCORD_BOT_TOKEN=...
+export DISCORD_PUBLIC_KEY=<hex>
+pnpm --filter @agentskit/example-discord-bot dev
+```
+
+## What it normalizes
+
+| Discord interaction | Normalized type |
+|---|---|
+| Type 1 (PING) | `null` |
+| Type 2 (APPLICATION_COMMAND) | `mention` with `command` field + serialized options |
+| Type 3 (MESSAGE_COMPONENT) | `mention` with serialized data |
+| anything else | `null` (200 ignored) |
+
+## Security
+
+- Ed25519 signature verified via `webcrypto.subtle` against the application's hex public key.
+- Bot-on-bot loops filtered via `user.isBot` in the trigger config.
+- Replay protection beyond signature is the deployer's responsibility — interactions carry a unique `id`; dedup against `@agentskit/memory` if you need stronger replay defense than Discord's natural at-most-once delivery.

--- a/apps/example-discord-bot/package.json
+++ b/apps/example-discord-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@agentskit/example-discord-bot",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/example-discord-bot/src/adapter.ts
+++ b/apps/example-discord-bot/src/adapter.ts
@@ -1,0 +1,125 @@
+import { webcrypto } from 'node:crypto'
+import type { ChatSurfaceAdapter, ChatSurfaceEvent } from '@agentskit/runtime'
+
+/**
+ * Reference Discord adapter for the Interactions HTTP endpoint flow.
+ * Driver-light: uses Discord's REST API via `fetch` for replies,
+ * verifies inbound interactions with Discord's Ed25519 signature.
+ *
+ * For richer setups (presence, voice, gateway events), wrap discord.js
+ * — this adapter covers the slash-command + message-component path.
+ */
+
+export interface DiscordAdapterOptions {
+  /** Bot token from the Discord developer portal. */
+  botToken: string
+  /** Application's public key (hex) used to verify signed interactions. */
+  publicKey: string
+  /** Override fetch (for tests). */
+  fetch?: typeof fetch
+}
+
+interface DiscordInteraction {
+  /** 1=PING, 2=APPLICATION_COMMAND, 3=MESSAGE_COMPONENT, 5=MODAL_SUBMIT */
+  type: number
+  id: string
+  channel_id?: string
+  guild_id?: string
+  user?: { id: string; username?: string; bot?: boolean }
+  member?: { user?: { id: string; username?: string; bot?: boolean } }
+  data?: { name?: string; options?: Array<{ name: string; value: unknown }> }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16)
+  return out
+}
+
+async function verifyEd25519(publicKeyHex: string, signatureHex: string, message: string): Promise<boolean> {
+  try {
+    const subtle = (webcrypto as Crypto).subtle
+    const keyBytes = hexToBytes(publicKeyHex)
+    const sigBytes = hexToBytes(signatureHex)
+    const msgBytes = new TextEncoder().encode(message)
+    const key = await subtle.importKey(
+      'raw',
+      keyBytes.buffer.slice(keyBytes.byteOffset, keyBytes.byteOffset + keyBytes.byteLength) as ArrayBuffer,
+      { name: 'Ed25519' },
+      false,
+      ['verify'],
+    )
+    return await subtle.verify(
+      'Ed25519',
+      key,
+      sigBytes.buffer.slice(sigBytes.byteOffset, sigBytes.byteOffset + sigBytes.byteLength) as ArrayBuffer,
+      msgBytes.buffer.slice(msgBytes.byteOffset, msgBytes.byteOffset + msgBytes.byteLength) as ArrayBuffer,
+    )
+  } catch {
+    return false
+  }
+}
+
+export function discordAdapter(options: DiscordAdapterOptions): ChatSurfaceAdapter {
+  const fetchImpl = options.fetch ?? fetch
+
+  return {
+    surface: 'discord',
+
+    verify: async req => {
+      const headers = req.headers ?? {}
+      const sig = headers['x-signature-ed25519']
+      const ts = headers['x-signature-timestamp']
+      if (typeof sig !== 'string' || typeof ts !== 'string') return false
+      const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? '')
+      return verifyEd25519(options.publicKey, sig, ts + body)
+    },
+
+    parse: req => {
+      const interaction = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) as DiscordInteraction
+      // PING is for the registration handshake — let the integrating
+      // server PONG before the trigger sees it.
+      if (interaction.type === 1) return null
+
+      const userObj = interaction.user ?? interaction.member?.user
+      const meta = {
+        surface: 'discord' as const,
+        eventId: interaction.id,
+        channel: { id: interaction.channel_id ?? '' },
+        user: { id: userObj?.id ?? '', name: userObj?.username, isBot: Boolean(userObj?.bot) },
+      }
+
+      // Slash command (APPLICATION_COMMAND) → mention with command name.
+      if (interaction.type === 2) {
+        const command = interaction.data?.name
+        const text =
+          interaction.data?.options
+            ?.map(o => `${o.name}=${String(o.value)}`)
+            .join(' ') ?? ''
+        return { ...meta, type: 'mention', text, command }
+      }
+      // Component interaction (button / select) — surface as mention with
+      // the custom_id payload as text. Refines later if templates need
+      // a separate ChatSurfaceEvent variant for components.
+      if (interaction.type === 3) {
+        return { ...meta, type: 'mention', text: JSON.stringify(interaction.data ?? {}) }
+      }
+      return null
+    },
+
+    reply: async (event, text) => {
+      const channel = event.channel.id
+      if (!channel) return
+      await fetchImpl(`https://discord.com/api/v10/channels/${channel}/messages`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bot ${options.botToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ content: text }),
+      })
+    },
+  }
+}
+
+export type { ChatSurfaceEvent }

--- a/apps/example-discord-bot/src/index.ts
+++ b/apps/example-discord-bot/src/index.ts
@@ -1,0 +1,69 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { createRuntime, createChatTrigger } from '@agentskit/runtime'
+import type { AdapterFactory } from '@agentskit/core'
+import { discordAdapter } from './adapter'
+
+function demoAdapter(): AdapterFactory {
+  return {
+    createSource: () => ({
+      stream: async function* () {
+        yield { type: 'text' as const, content: 'Hi from AgentsKit on Discord!' }
+        yield { type: 'done' as const }
+      },
+      abort: () => {},
+    }),
+  }
+}
+
+const runtime = createRuntime({
+  adapter: demoAdapter(),
+  systemPrompt: 'You are a helpful assistant in a Discord guild.',
+})
+
+const adapter = discordAdapter({
+  botToken: process.env.DISCORD_BOT_TOKEN ?? '',
+  publicKey: process.env.DISCORD_PUBLIC_KEY ?? '',
+})
+
+const trigger = createChatTrigger({
+  adapter,
+  agent: { name: 'discord-bot', run: async task => (await runtime.run(task)).content },
+  autoReply: true,
+  filter: e => !e.user.isBot,
+  onEvent: e => console.log(`[discord] ${e.type}${e.reason ? ` — ${e.reason}` : ''}`),
+})
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  if (req.url !== '/discord/interactions' || req.method !== 'POST') {
+    res.writeHead(404).end('not found')
+    return
+  }
+  const raw = await readBody(req)
+  // PING handshake — must respond inline before the trigger.
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed.type === 1) {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ type: 1 }))
+      return
+    }
+  } catch {
+    // fall through
+  }
+  const headers: Record<string, string> = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (typeof v === 'string') headers[k.toLowerCase()] = v
+  }
+  const result = await trigger.handler({ headers, body: raw })
+  res.writeHead(result.status, result.headers).end(typeof result.body === 'string' ? result.body : JSON.stringify(result.body))
+})
+
+const port = Number(process.env.PORT ?? 3001)
+server.listen(port, () => {
+  console.log(`Discord bot listening on :${port}/discord/interactions`)
+})

--- a/apps/example-discord-bot/src/index.ts
+++ b/apps/example-discord-bot/src/index.ts
@@ -45,7 +45,19 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     return
   }
   const raw = await readBody(req)
-  // PING handshake — must respond inline before the trigger.
+  const headers: Record<string, string> = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (typeof v === 'string') headers[k.toLowerCase()] = v
+  }
+  // Verify the Ed25519 signature BEFORE the PING handshake. Discord
+  // explicitly requires PING validation — bots that skip it can be
+  // hijacked at registration time.
+  const verified = await adapter.verify!({ headers, body: raw })
+  if (!verified) {
+    res.writeHead(401).end('unauthorized')
+    return
+  }
+  // After signature passes, PONG to the registration ping.
   try {
     const parsed = JSON.parse(raw)
     if (parsed.type === 1) {
@@ -54,10 +66,6 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     }
   } catch {
     // fall through
-  }
-  const headers: Record<string, string> = {}
-  for (const [k, v] of Object.entries(req.headers)) {
-    if (typeof v === 'string') headers[k.toLowerCase()] = v
   }
   const result = await trigger.handler({ headers, body: raw })
   res.writeHead(result.status, result.headers).end(typeof result.body === 'string' ? result.body : JSON.stringify(result.body))

--- a/apps/example-discord-bot/tests/adapter.test.ts
+++ b/apps/example-discord-bot/tests/adapter.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+import { discordAdapter } from '../src/adapter'
+
+const TOKEN = 'bot-token'
+const PUBLIC_KEY = '0'.repeat(64)
+
+describe('discordAdapter — verify', () => {
+  it('rejects when signature headers missing', async () => {
+    const a = discordAdapter({ botToken: TOKEN, publicKey: PUBLIC_KEY })
+    expect(await a.verify!({ headers: {}, body: '{}' })).toBe(false)
+  })
+
+  it('rejects when signature is malformed (gracefully, no throw)', async () => {
+    const a = discordAdapter({ botToken: TOKEN, publicKey: PUBLIC_KEY })
+    const ok = await a.verify!({
+      headers: {
+        'x-signature-ed25519': 'not-hex',
+        'x-signature-timestamp': '1',
+      },
+      body: '{}',
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('discordAdapter — parse', () => {
+  const a = discordAdapter({ botToken: TOKEN, publicKey: PUBLIC_KEY })
+
+  it('returns null for PING (type 1)', () => {
+    expect(a.parse({ headers: {}, body: { type: 1, id: 'I0' } })).toBeNull()
+  })
+
+  it('normalizes APPLICATION_COMMAND to mention with command + serialized options', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 2,
+        id: 'I1',
+        channel_id: 'C1',
+        member: { user: { id: 'U1', username: 'alice' } },
+        data: {
+          name: 'ask',
+          options: [
+            { name: 'q', value: 'hello' },
+            { name: 'lang', value: 'en' },
+          ],
+        },
+      },
+    }) as { type: string; command: string; text: string; user: { name: string } }
+    expect(r.type).toBe('mention')
+    expect(r.command).toBe('ask')
+    expect(r.text).toBe('q=hello lang=en')
+    expect(r.user.name).toBe('alice')
+  })
+
+  it('normalizes MESSAGE_COMPONENT (type 3) to a mention with serialized data', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 3,
+        id: 'I2',
+        channel_id: 'C1',
+        user: { id: 'U2' },
+        data: { custom_id: 'btn-yes' },
+      },
+    }) as { type: string; text: string }
+    expect(r.type).toBe('mention')
+    expect(r.text).toContain('btn-yes')
+  })
+
+  it('flags bot users via isBot', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 2,
+        id: 'I3',
+        channel_id: 'C1',
+        user: { id: 'U3', bot: true },
+        data: { name: 'noop' },
+      },
+    }) as { user: { isBot: boolean } }
+    expect(r.user.isBot).toBe(true)
+  })
+
+  it('returns null for unknown interaction types', () => {
+    expect(a.parse({ headers: {}, body: { type: 99, id: 'I4' } })).toBeNull()
+  })
+})
+
+describe('discordAdapter — reply', () => {
+  it('POSTs to /channels/:id/messages with Bot auth', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = []
+    const fakeFetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} })
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+    const a = discordAdapter({ botToken: TOKEN, publicKey: PUBLIC_KEY, fetch: fakeFetch })
+    await a.reply!(
+      {
+        type: 'mention',
+        surface: 'discord',
+        eventId: 'E',
+        channel: { id: 'C9' },
+        user: { id: 'U1' },
+        text: 'cmd',
+      },
+      'reply text',
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://discord.com/api/v10/channels/C9/messages')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.authorization).toBe(`Bot ${TOKEN}`)
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ content: 'reply text' })
+  })
+
+  it('skips when channel is empty', async () => {
+    const fakeFetch = vi.fn() as unknown as typeof fetch
+    const a = discordAdapter({ botToken: TOKEN, publicKey: PUBLIC_KEY, fetch: fakeFetch })
+    await a.reply!(
+      { type: 'message', surface: 'discord', eventId: 'E', channel: { id: '' }, user: { id: 'U1' }, text: 'x' },
+      'reply',
+    )
+    expect(fakeFetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/example-discord-bot/tsconfig.json
+++ b/apps/example-discord-bot/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules"]
+}

--- a/apps/example-slack-bot/README.md
+++ b/apps/example-slack-bot/README.md
@@ -1,0 +1,39 @@
+# @agentskit/example-slack-bot
+
+Reference Slack bot wrapping `createChatTrigger` from `@agentskit/runtime`. Closes [#779](https://github.com/AgentsKit-io/agentskit/issues/779).
+
+Driver-light: uses Slack's Events API webhook + `chat.postMessage` REST endpoint via `fetch`. No Bolt dependency. For production, swap the `reply` body to wrap Bolt's `app.client.chat.postMessage` so retries, rate-limit handling, and pagination come for free.
+
+## Setup
+
+1. Create a Slack app at https://api.slack.com/apps.
+2. Enable **Event Subscriptions** with these bot events: `app_mention`, `message.channels`, `message.im`, `reaction_added` (optional), `file_shared` (optional).
+3. Set the request URL to `https://<your-host>/slack/events`.
+4. Install the app to a workspace; copy the **Bot User OAuth Token** (`xoxb-…`) and the **Signing Secret**.
+
+```bash
+export SLACK_BOT_TOKEN=xoxb-...
+export SLACK_SIGNING_SECRET=...
+pnpm --filter @agentskit/example-slack-bot dev
+```
+
+URL-verification handshake is handled in `src/index.ts` before the trigger runs.
+
+## What it normalizes
+
+`src/adapter.ts` exposes a `slackAdapter()` that turns Slack Events API payloads into the unified `ChatSurfaceEvent` discriminated union from `@agentskit/runtime`:
+
+| Slack inner event | Normalized type |
+|---|---|
+| `app_mention` | `mention` |
+| `message` (in thread) | `reply` |
+| `message` | `message` |
+| `message` (subtype `file_share`) | `file_upload` |
+| `reaction_added` / `reaction_removed` | `reaction` |
+| anything else | `null` (200 ignored) |
+
+## Security
+
+- Slack signing secret + 300s timestamp window both enforced in `verify`. Replays older than that are rejected.
+- Bot-on-bot loops filtered via `user.isBot` in the trigger config.
+- Replay protection beyond the timestamp window (eventId dedup against memory) is the deployer's responsibility — wire `@agentskit/memory` and skip when `eventId` was seen before.

--- a/apps/example-slack-bot/package.json
+++ b/apps/example-slack-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@agentskit/example-slack-bot",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/example-slack-bot/src/adapter.ts
+++ b/apps/example-slack-bot/src/adapter.ts
@@ -47,8 +47,20 @@ interface SlackInnerEvent {
 }
 
 function constantTimeEquals(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+  // Pad to a common length so an attacker cannot derive signature
+  // length from response timing. The expected Slack signature is a
+  // fixed-length hex digest (`v0=` + 64 chars), so equal length is
+  // the common case — but we hold the line for malformed inputs too.
+  const len = Math.max(a.length, b.length)
+  const ab = Buffer.alloc(len)
+  const bb = Buffer.alloc(len)
+  ab.write(a)
+  bb.write(b)
+  // Pre-verify lengths via timingSafeEqual on length bytes themselves
+  // so the result still depends on the original lengths matching.
+  const lengthsMatch = a.length === b.length
+  const bytesMatch = timingSafeEqual(ab, bb)
+  return lengthsMatch && bytesMatch
 }
 
 export function slackAdapter(options: SlackAdapterOptions): ChatSurfaceAdapter {

--- a/apps/example-slack-bot/src/adapter.ts
+++ b/apps/example-slack-bot/src/adapter.ts
@@ -1,0 +1,148 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { ChatSurfaceAdapter, ChatSurfaceEvent } from '@agentskit/runtime'
+
+/**
+ * Reference Slack adapter wrapping the standard Events API webhook
+ * payload + Web API for replies. Intentionally driver-light — uses
+ * `fetch` against `chat.postMessage` rather than pulling Bolt in.
+ *
+ * Production deployments should swap `fetch` reply for Bolt's
+ * `app.client.chat.postMessage` so retries / rate-limit handling /
+ * pagination come for free.
+ */
+
+export interface SlackAdapterOptions {
+  /** Bot OAuth token (`xoxb-...`). */
+  botToken: string
+  /** Slack signing secret used to verify incoming Events API requests. */
+  signingSecret: string
+  /** Reject events older than this many seconds. Default 300 (5 min). */
+  maxAgeSeconds?: number
+  /** Override fetch (for tests). */
+  fetch?: typeof fetch
+}
+
+interface SlackEnvelope {
+  type: 'url_verification' | 'event_callback' | string
+  challenge?: string
+  event_id?: string
+  event_time?: number
+  team_id?: string
+  event?: SlackInnerEvent
+}
+
+interface SlackInnerEvent {
+  type: string
+  subtype?: string
+  text?: string
+  user?: string
+  channel?: string
+  ts?: string
+  thread_ts?: string
+  bot_id?: string
+  event_ts?: string
+  reaction?: string
+  item?: { channel?: string; ts?: string }
+  files?: Array<{ name: string; mimetype?: string; url_private?: string; size?: number }>
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+}
+
+export function slackAdapter(options: SlackAdapterOptions): ChatSurfaceAdapter {
+  const fetchImpl = options.fetch ?? fetch
+  const maxAge = (options.maxAgeSeconds ?? 300) * 1000
+
+  return {
+    surface: 'slack',
+
+    verify: req => {
+      const headers = req.headers ?? {}
+      const ts = headers['x-slack-request-timestamp']
+      const sig = headers['x-slack-signature']
+      if (typeof ts !== 'string' || typeof sig !== 'string') return false
+      const tsMs = Number(ts) * 1000
+      if (!Number.isFinite(tsMs)) return false
+      // Reject replays outside the freshness window.
+      if (Math.abs(Date.now() - tsMs) > maxAge) return false
+
+      const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? '')
+      const base = `v0:${ts}:${body}`
+      const expected =
+        'v0=' + createHmac('sha256', options.signingSecret).update(base).digest('hex')
+      return constantTimeEquals(sig, expected)
+    },
+
+    parse: req => {
+      const envelope = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) as SlackEnvelope
+      // url_verification handshake → adapter returns null; the trigger
+      // returns 200 'ignored', and the integrating server must echo
+      // the challenge separately. Templates wire this in src/index.ts.
+      if (envelope.type === 'url_verification') return null
+      if (envelope.type !== 'event_callback' || !envelope.event) return null
+
+      const inner = envelope.event
+      const meta = {
+        surface: 'slack' as const,
+        eventId: envelope.event_id ?? inner.event_ts ?? inner.ts ?? `${Date.now()}`,
+        receivedAt:
+          envelope.event_time !== undefined
+            ? new Date(envelope.event_time * 1000).toISOString()
+            : undefined,
+        channel: { id: inner.channel ?? inner.item?.channel ?? '' },
+        user: { id: inner.user ?? '', isBot: Boolean(inner.bot_id) },
+        threadId: inner.thread_ts,
+      }
+
+      if (inner.type === 'app_mention') {
+        return { ...meta, type: 'mention', text: inner.text ?? '' }
+      }
+      if (inner.type === 'message') {
+        if (inner.subtype === 'file_share' && inner.files?.[0]) {
+          const f = inner.files[0]
+          return {
+            ...meta,
+            type: 'file_upload',
+            name: f.name,
+            contentType: f.mimetype,
+            url: f.url_private,
+            sizeBytes: f.size,
+          }
+        }
+        if (inner.thread_ts && inner.thread_ts !== inner.ts) {
+          return { ...meta, type: 'reply', text: inner.text ?? '', parentId: inner.thread_ts }
+        }
+        return { ...meta, type: 'message', text: inner.text ?? '' }
+      }
+      if (inner.type === 'reaction_added' || inner.type === 'reaction_removed') {
+        return {
+          ...meta,
+          type: 'reaction',
+          messageId: inner.item?.ts ?? '',
+          emoji: inner.reaction ?? '',
+          added: inner.type === 'reaction_added',
+        }
+      }
+      // Surface-specific event we don't normalize — let the trigger 200-ignore.
+      return null
+    },
+
+    reply: async (event, text) => {
+      const channel = event.channel.id
+      if (!channel) return
+      const thread_ts = 'threadId' in event ? event.threadId : undefined
+      await fetchImpl('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${options.botToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ channel, text, thread_ts }),
+      })
+    },
+  }
+}
+
+export type { ChatSurfaceEvent }

--- a/apps/example-slack-bot/src/index.ts
+++ b/apps/example-slack-bot/src/index.ts
@@ -1,0 +1,77 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { createRuntime } from '@agentskit/runtime'
+import { createChatTrigger } from '@agentskit/runtime'
+import type { AdapterFactory } from '@agentskit/core'
+import { slackAdapter } from './adapter'
+
+// --- Demo adapter — swap for openai({}) / anthropic({}) etc. ---
+
+function demoAdapter(): AdapterFactory {
+  return {
+    createSource: () => ({
+      stream: async function* () {
+        yield { type: 'text' as const, content: 'Hi from AgentsKit on Slack!' }
+        yield { type: 'done' as const }
+      },
+      abort: () => {},
+    }),
+  }
+}
+
+// --- Wire trigger ---
+
+const runtime = createRuntime({
+  adapter: demoAdapter(),
+  systemPrompt: 'You are a helpful assistant in a Slack workspace.',
+})
+
+const adapter = slackAdapter({
+  botToken: process.env.SLACK_BOT_TOKEN ?? '',
+  signingSecret: process.env.SLACK_SIGNING_SECRET ?? '',
+})
+
+const trigger = createChatTrigger({
+  adapter,
+  agent: { name: 'slack-bot', run: async task => (await runtime.run(task)).content },
+  autoReply: true,
+  filter: e => !e.user.isBot,
+  onEvent: e => console.log(`[slack] ${e.type}${e.reason ? ` — ${e.reason}` : ''}`),
+})
+
+// --- Minimal HTTP server ---
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  if (req.url !== '/slack/events' || req.method !== 'POST') {
+    res.writeHead(404).end('not found')
+    return
+  }
+  const raw = await readBody(req)
+  // Slack URL-verification handshake bypasses the trigger — Slack
+  // expects the raw `challenge` echoed back synchronously.
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed.type === 'url_verification' && typeof parsed.challenge === 'string') {
+      res.writeHead(200, { 'content-type': 'text/plain' }).end(parsed.challenge)
+      return
+    }
+  } catch {
+    // fall through to the trigger which will 400 on bad JSON
+  }
+  const headers: Record<string, string> = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (typeof v === 'string') headers[k.toLowerCase()] = v
+  }
+  const result = await trigger.handler({ headers, body: raw })
+  res.writeHead(result.status, result.headers).end(typeof result.body === 'string' ? result.body : JSON.stringify(result.body))
+})
+
+const port = Number(process.env.PORT ?? 3000)
+server.listen(port, () => {
+  console.log(`Slack bot listening on :${port}/slack/events`)
+})

--- a/apps/example-slack-bot/src/index.ts
+++ b/apps/example-slack-bot/src/index.ts
@@ -52,8 +52,20 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     return
   }
   const raw = await readBody(req)
-  // Slack URL-verification handshake bypasses the trigger — Slack
-  // expects the raw `challenge` echoed back synchronously.
+  const headers: Record<string, string> = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (typeof v === 'string') headers[k.toLowerCase()] = v
+  }
+  // Verify the Slack signature BEFORE handling URL-verification.
+  // Skipping the check on PING would let any unauthenticated client
+  // confirm the endpoint is live and shaped correctly.
+  const verified = await adapter.verify!({ headers, body: raw })
+  if (!verified) {
+    res.writeHead(401).end('unauthorized')
+    return
+  }
+  // After signature passes, peel off the URL-verification handshake;
+  // Slack expects the raw `challenge` echoed back synchronously.
   try {
     const parsed = JSON.parse(raw)
     if (parsed.type === 'url_verification' && typeof parsed.challenge === 'string') {
@@ -62,10 +74,6 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     }
   } catch {
     // fall through to the trigger which will 400 on bad JSON
-  }
-  const headers: Record<string, string> = {}
-  for (const [k, v] of Object.entries(req.headers)) {
-    if (typeof v === 'string') headers[k.toLowerCase()] = v
   }
   const result = await trigger.handler({ headers, body: raw })
   res.writeHead(result.status, result.headers).end(typeof result.body === 'string' ? result.body : JSON.stringify(result.body))

--- a/apps/example-slack-bot/tests/adapter.test.ts
+++ b/apps/example-slack-bot/tests/adapter.test.ts
@@ -1,0 +1,195 @@
+import { createHmac } from 'node:crypto'
+import { describe, expect, it, vi } from 'vitest'
+import { slackAdapter } from '../src/adapter'
+
+const SECRET = 'test-secret'
+const TOKEN = 'xoxb-test'
+
+function signed(body: string, ts = Math.floor(Date.now() / 1000)): { headers: Record<string, string>; body: string } {
+  const sig =
+    'v0=' + createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex')
+  return {
+    body,
+    headers: {
+      'x-slack-request-timestamp': String(ts),
+      'x-slack-signature': sig,
+    },
+  }
+}
+
+describe('slackAdapter — verify', () => {
+  it('accepts a correctly signed request', async () => {
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET })
+    const { headers, body } = signed('{"type":"event_callback"}')
+    expect(await a.verify!({ headers, body })).toBe(true)
+  })
+
+  it('rejects when signature header is missing', async () => {
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET })
+    expect(await a.verify!({ headers: {}, body: '{}' })).toBe(false)
+  })
+
+  it('rejects when signature does not match the body', async () => {
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET })
+    const { headers } = signed('{"a":1}')
+    expect(await a.verify!({ headers, body: '{"a":2}' })).toBe(false)
+  })
+
+  it('rejects replays older than maxAgeSeconds', async () => {
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET, maxAgeSeconds: 60 })
+    const old = Math.floor(Date.now() / 1000) - 600
+    const { headers, body } = signed('{}', old)
+    expect(await a.verify!({ headers, body })).toBe(false)
+  })
+})
+
+describe('slackAdapter — parse', () => {
+  const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET })
+
+  it('returns null for url_verification', () => {
+    const r = a.parse({ headers: {}, body: { type: 'url_verification', challenge: 'x' } })
+    expect(r).toBeNull()
+  })
+
+  it('normalizes app_mention to a mention event', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev1',
+        event_time: 1767225600,
+        event: {
+          type: 'app_mention',
+          text: '<@U999> hi',
+          user: 'U1',
+          channel: 'C1',
+          event_ts: '1735689600.000100',
+        },
+      },
+    }) as { type: string; text: string; surface: string; user: { id: string }; receivedAt: string }
+    expect(r.type).toBe('mention')
+    expect(r.text).toBe('<@U999> hi')
+    expect(r.surface).toBe('slack')
+    expect(r.user.id).toBe('U1')
+    expect(r.receivedAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('normalizes plain message in a thread to a reply event', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev2',
+        event: {
+          type: 'message',
+          text: 'replying',
+          user: 'U2',
+          channel: 'C1',
+          ts: '2.0',
+          thread_ts: '1.0',
+        },
+      },
+    }) as { type: string; parentId: string }
+    expect(r.type).toBe('reply')
+    expect(r.parentId).toBe('1.0')
+  })
+
+  it('normalizes message subtype file_share to file_upload', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev3',
+        event: {
+          type: 'message',
+          subtype: 'file_share',
+          user: 'U1',
+          channel: 'C1',
+          files: [{ name: 'r.pdf', mimetype: 'application/pdf', url_private: 'https://x', size: 42 }],
+        },
+      },
+    }) as { type: string; name: string; sizeBytes: number }
+    expect(r.type).toBe('file_upload')
+    expect(r.name).toBe('r.pdf')
+    expect(r.sizeBytes).toBe(42)
+  })
+
+  it('normalizes reaction_added', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev4',
+        event: {
+          type: 'reaction_added',
+          user: 'U1',
+          reaction: 'thumbsup',
+          item: { channel: 'C1', ts: '1.0' },
+        },
+      },
+    }) as { type: string; emoji: string; added: boolean }
+    expect(r.type).toBe('reaction')
+    expect(r.emoji).toBe('thumbsup')
+    expect(r.added).toBe(true)
+  })
+
+  it('flags bot messages via user.isBot', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev5',
+        event: { type: 'message', user: 'U1', channel: 'C1', text: 'auto', bot_id: 'B1' },
+      },
+    }) as { user: { isBot: boolean } }
+    expect(r.user.isBot).toBe(true)
+  })
+
+  it('returns null for unrecognised inner event types', () => {
+    const r = a.parse({
+      headers: {},
+      body: { type: 'event_callback', event: { type: 'team_join' } },
+    })
+    expect(r).toBeNull()
+  })
+})
+
+describe('slackAdapter — reply', () => {
+  it('POSTs to chat.postMessage with bearer + thread_ts', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = []
+    const fakeFetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} })
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET, fetch: fakeFetch })
+    await a.reply!(
+      {
+        type: 'reply',
+        surface: 'slack',
+        eventId: 'E',
+        channel: { id: 'C1' },
+        user: { id: 'U1' },
+        threadId: '1.0',
+        text: 'src',
+        parentId: '1.0',
+      },
+      'hello world',
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://slack.com/api/chat.postMessage')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.authorization).toBe(`Bearer ${TOKEN}`)
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body).toEqual({ channel: 'C1', text: 'hello world', thread_ts: '1.0' })
+  })
+
+  it('skips when channel id is empty', async () => {
+    const fakeFetch = vi.fn() as unknown as typeof fetch
+    const a = slackAdapter({ botToken: TOKEN, signingSecret: SECRET, fetch: fakeFetch })
+    await a.reply!(
+      { type: 'message', surface: 'slack', eventId: 'E', channel: { id: '' }, user: { id: 'U1' }, text: 'x' },
+      'reply',
+    )
+    expect(fakeFetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/example-slack-bot/tsconfig.json
+++ b/apps/example-slack-bot/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules"]
+}

--- a/apps/example-teams-bot/README.md
+++ b/apps/example-teams-bot/README.md
@@ -1,0 +1,42 @@
+# @agentskit/example-teams-bot
+
+Reference Microsoft Teams bot wrapping `createChatTrigger` from `@agentskit/runtime`. Closes [#781](https://github.com/AgentsKit-io/agentskit/issues/781).
+
+Driver-light: consumes Bot Framework activity payloads at `/api/messages` and verifies the inbound JWT via an injected `verifyToken` callback. No `botbuilder` / `microsoft-graph-client` dependency in this template — wire `botbuilder`'s `JwtTokenValidation.authenticateRequest` (or any JWT lib against Microsoft's OpenID config) in production.
+
+## Setup
+
+1. Register a bot in **Azure Bot Service**. Create an Azure AD app (single-tenant, multi-tenant, or managed identity — your choice). Copy the App ID + secret (or certificate / managed identity).
+2. Set the messaging endpoint to `https://<your-host>/api/messages`.
+3. Sideload the Teams app manifest into a Teams tenant.
+
+```bash
+export TEAMS_APP_ID=...
+export TEAMS_APP_SECRET=...
+# Skip JWT validation only for local development:
+export TEAMS_DISABLE_AUTH=1
+pnpm --filter @agentskit/example-teams-bot dev
+```
+
+`src/index.ts` ships a stub `verifyToken` that **returns false unless `TEAMS_DISABLE_AUTH=1`** so you can't accidentally deploy without JWT validation.
+
+## What it normalizes
+
+| Bot Framework activity | Normalized type |
+|---|---|
+| `message` | `message` (or `reply` when `replyToId` set, `file_upload` when attachment present) |
+| `messageReaction` | `reaction` |
+| `conversationUpdate` (membersAdded) | `installation: 'installed'` |
+| `conversationUpdate` (membersRemoved) | `installation: 'uninstalled'` |
+| `typing` / `invoke` / `endOfConversation` / unknown | `null` (200 ignored) |
+
+## Replies
+
+`teamsAdapter` requires an injected `TeamsServiceClient`. Wrap `botbuilder`'s `BotFrameworkAdapter.createConnectorClient(serviceUrl).conversations.replyToActivity(...)` in production. The bundled stub logs to console.
+
+## Auth modes
+
+The injected `verifyToken` callback receives `(token, request)` so you can plug:
+- **App ID + secret** — standard `botbuilder` `JwtTokenValidation`
+- **Certificate-based** — Azure AD certificate credential
+- **Managed identity** — Azure-hosted identity, no shared secrets

--- a/apps/example-teams-bot/package.json
+++ b/apps/example-teams-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@agentskit/example-teams-bot",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/example-teams-bot/src/adapter.ts
+++ b/apps/example-teams-bot/src/adapter.ts
@@ -59,6 +59,29 @@ function defaultVerifyToken(): false {
 
 export function teamsAdapter(options: TeamsAdapterOptions): ChatSurfaceAdapter {
   const verifyToken = options.verifyToken ?? defaultVerifyToken
+  // Bot Framework replies need the inbound activity's `serviceUrl`,
+  // but ChatSurfaceEvent has no surface-specific extension slot. Stash
+  // it keyed by eventId at parse time, look it up at reply time, evict
+  // on use to avoid unbounded growth. Best-effort: events that never
+  // get replied to age out after `serviceUrlTtlMs`.
+  const serviceUrlByEventId = new Map<string, { url: string; expiresAt: number }>()
+  const SERVICE_URL_TTL_MS = 60_000
+
+  function rememberServiceUrl(eventId: string, url: string): void {
+    const now = Date.now()
+    // Opportunistic eviction.
+    for (const [k, v] of serviceUrlByEventId) {
+      if (v.expiresAt < now) serviceUrlByEventId.delete(k)
+    }
+    serviceUrlByEventId.set(eventId, { url, expiresAt: now + SERVICE_URL_TTL_MS })
+  }
+
+  function takeServiceUrl(eventId: string): string {
+    const entry = serviceUrlByEventId.get(eventId)
+    if (!entry) return ''
+    serviceUrlByEventId.delete(eventId)
+    return entry.url
+  }
 
   return {
     surface: 'teams',
@@ -77,9 +100,11 @@ export function teamsAdapter(options: TeamsAdapterOptions): ChatSurfaceAdapter {
 
     parse: req => {
       const activity = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) as TeamsActivity
+      const eventId = activity.id ?? `${Date.now()}`
+      if (activity.serviceUrl) rememberServiceUrl(eventId, activity.serviceUrl)
       const meta = {
         surface: 'teams' as const,
-        eventId: activity.id ?? `${Date.now()}`,
+        eventId,
         receivedAt: activity.timestamp,
         channel: {
           id: activity.conversation?.id ?? '',
@@ -138,13 +163,18 @@ export function teamsAdapter(options: TeamsAdapterOptions): ChatSurfaceAdapter {
     },
 
     reply: async (event, text) => {
-      // The `WebhookRequest` body is already discarded, but Bot Framework
-      // needs `serviceUrl` to send the reply. Deployers should pass it
-      // through `buildContext` and inject it into a wrapper before
-      // calling `reply`. Here we expose the canonical shape and rely on
-      // the injected `serviceClient` to know `serviceUrl`.
+      const serviceUrl = takeServiceUrl(event.eventId)
+      if (!serviceUrl) {
+        // No captured serviceUrl — most likely a duplicate reply on
+        // the same event, or an event that was never parsed by this
+        // adapter instance. Refuse the reply rather than send to the
+        // wrong endpoint.
+        throw new Error(
+          `teamsAdapter.reply: no serviceUrl for eventId ${event.eventId} (already replied or expired after 60s)`,
+        )
+      }
       await options.serviceClient.sendMessage({
-        serviceUrl: '', // populated by the serviceClient wrapper from the captured activity
+        serviceUrl,
         conversationId: event.channel.id,
         text,
         replyToId: 'threadId' in event ? event.threadId : undefined,

--- a/apps/example-teams-bot/src/adapter.ts
+++ b/apps/example-teams-bot/src/adapter.ts
@@ -1,0 +1,156 @@
+import type { ChatSurfaceAdapter, ChatSurfaceEvent } from '@agentskit/runtime'
+
+/**
+ * Reference Microsoft Teams adapter consuming Bot Framework activity
+ * payloads. Driver-light: no botbuilder dependency. Verification of
+ * the inbound JWT (`Authorization: Bearer …` from the Bot Framework
+ * service) is delegated to a `verifyToken` callback so deployers can
+ * plug `botbuilder` or `jose` without forcing a heavy default.
+ *
+ * Reply path expects an injected `serviceClient` that knows how to
+ * post to the channel's `serviceUrl` — abstracting auth + signing
+ * keeps this adapter free of Azure SDKs.
+ */
+
+export interface TeamsAdapterOptions {
+  /**
+   * Verify the inbound `Authorization: Bearer <jwt>` header. Default:
+   * **deny everything** so you cannot forget to plug auth in. Wire
+   * to `botbuilder`'s `JwtTokenValidation.authenticateRequest` or any
+   * JWT lib in production.
+   */
+  verifyToken?: (token: string, req: { headers: Record<string, string>; body: unknown }) => Promise<boolean> | boolean
+  /** Post a reply to a conversation via the Bot Framework service URL. */
+  serviceClient: TeamsServiceClient
+}
+
+export interface TeamsServiceClient {
+  /** Send a text reply into a conversation. */
+  sendMessage: (params: {
+    serviceUrl: string
+    conversationId: string
+    text: string
+    replyToId?: string
+  }) => Promise<void>
+}
+
+interface TeamsActivity {
+  /** 'message' | 'conversationUpdate' | 'messageReaction' | 'invoke' | 'typing' | ... */
+  type: string
+  id?: string
+  timestamp?: string
+  serviceUrl?: string
+  channelId?: string
+  conversation?: { id: string; name?: string; isGroup?: boolean; conversationType?: string }
+  from?: { id: string; name?: string; aadObjectId?: string }
+  recipient?: { id: string; name?: string }
+  text?: string
+  replyToId?: string
+  attachments?: Array<{ name?: string; contentType?: string; contentUrl?: string }>
+  reactionsAdded?: Array<{ type: string }>
+  reactionsRemoved?: Array<{ type: string }>
+  membersAdded?: Array<{ id: string; aadObjectId?: string }>
+  membersRemoved?: Array<{ id: string }>
+}
+
+function defaultVerifyToken(): false {
+  return false
+}
+
+export function teamsAdapter(options: TeamsAdapterOptions): ChatSurfaceAdapter {
+  const verifyToken = options.verifyToken ?? defaultVerifyToken
+
+  return {
+    surface: 'teams',
+
+    verify: async req => {
+      const headers: Record<string, string> = {}
+      for (const [k, v] of Object.entries(req.headers ?? {})) {
+        if (typeof v === 'string') headers[k] = v
+      }
+      const auth = headers['authorization']
+      if (typeof auth !== 'string' || !auth.toLowerCase().startsWith('bearer ')) return false
+      const token = auth.slice('bearer '.length).trim()
+      if (!token) return false
+      return await verifyToken(token, { headers, body: req.body })
+    },
+
+    parse: req => {
+      const activity = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) as TeamsActivity
+      const meta = {
+        surface: 'teams' as const,
+        eventId: activity.id ?? `${Date.now()}`,
+        receivedAt: activity.timestamp,
+        channel: {
+          id: activity.conversation?.id ?? '',
+          name: activity.conversation?.name,
+          kind: activity.conversation?.isGroup ? ('group' as const) : ('channel' as const),
+        },
+        user: { id: activity.from?.id ?? '', name: activity.from?.name },
+        threadId: activity.replyToId,
+      }
+
+      if (activity.type === 'message') {
+        if (activity.attachments?.[0]?.contentUrl) {
+          const a = activity.attachments[0]
+          return {
+            ...meta,
+            type: 'file_upload',
+            name: a.name ?? 'attachment',
+            contentType: a.contentType,
+            url: a.contentUrl,
+          }
+        }
+        if (activity.replyToId) {
+          return { ...meta, type: 'reply', text: activity.text ?? '', parentId: activity.replyToId }
+        }
+        // Teams "@mention" still arrives as `type: 'message'`; surface it
+        // as `mention` when the text starts with the bot's name. We can't
+        // know the bot name at adapter level without configuration, so
+        // just treat all messages as `message` and let consumers refine
+        // via filter / buildTask if they need explicit mention semantics.
+        return { ...meta, type: 'message', text: activity.text ?? '' }
+      }
+      if (activity.type === 'messageReaction') {
+        const reaction = activity.reactionsAdded?.[0] ?? activity.reactionsRemoved?.[0]
+        if (!reaction) return null
+        return {
+          ...meta,
+          type: 'reaction',
+          messageId: activity.replyToId ?? '',
+          emoji: reaction.type,
+          added: Boolean(activity.reactionsAdded?.length),
+        }
+      }
+      if (activity.type === 'conversationUpdate') {
+        if (activity.membersAdded?.length || activity.membersRemoved?.length) {
+          return {
+            ...meta,
+            type: 'installation',
+            action: activity.membersAdded?.length ? 'installed' : 'uninstalled',
+            tenantId: activity.from?.aadObjectId ?? activity.conversation?.id ?? '',
+          }
+        }
+        return null
+      }
+      // typing / invoke / endOfConversation etc. — let the trigger 200-ignore.
+      return null
+    },
+
+    reply: async (event, text) => {
+      // The `WebhookRequest` body is already discarded, but Bot Framework
+      // needs `serviceUrl` to send the reply. Deployers should pass it
+      // through `buildContext` and inject it into a wrapper before
+      // calling `reply`. Here we expose the canonical shape and rely on
+      // the injected `serviceClient` to know `serviceUrl`.
+      await options.serviceClient.sendMessage({
+        serviceUrl: '', // populated by the serviceClient wrapper from the captured activity
+        conversationId: event.channel.id,
+        text,
+        replyToId: 'threadId' in event ? event.threadId : undefined,
+      })
+    },
+  }
+}
+
+export type { ChatSurfaceEvent }

--- a/apps/example-teams-bot/src/index.ts
+++ b/apps/example-teams-bot/src/index.ts
@@ -1,0 +1,72 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { createRuntime, createChatTrigger } from '@agentskit/runtime'
+import type { AdapterFactory } from '@agentskit/core'
+import { teamsAdapter, type TeamsServiceClient } from './adapter'
+
+function demoAdapter(): AdapterFactory {
+  return {
+    createSource: () => ({
+      stream: async function* () {
+        yield { type: 'text' as const, content: 'Hi from AgentsKit on Teams!' }
+        yield { type: 'done' as const }
+      },
+      abort: () => {},
+    }),
+  }
+}
+
+const runtime = createRuntime({
+  adapter: demoAdapter(),
+  systemPrompt: 'You are a helpful assistant in a Microsoft Teams channel.',
+})
+
+// Production: replace with botbuilder's `BotFrameworkAdapter.createConnectorClient(serviceUrl)`
+// + `client.conversations.replyToActivity(...)`. The demo client logs.
+const serviceClient: TeamsServiceClient = {
+  async sendMessage({ conversationId, text }) {
+    console.log(`[teams reply] ${conversationId}: ${text}`)
+  },
+}
+
+// Production: replace with `botbuilder`'s `JwtTokenValidation` or any JWT lib
+// validating against Microsoft Bot Framework's OpenID config.
+const verifyToken = async (_token: string) => {
+  if (process.env.TEAMS_DISABLE_AUTH === '1') return true
+  console.warn('[teams] verifyToken stub returns false — wire JWT validation before going live')
+  return false
+}
+
+const adapter = teamsAdapter({ serviceClient, verifyToken })
+
+const trigger = createChatTrigger({
+  adapter,
+  agent: { name: 'teams-bot', run: async task => (await runtime.run(task)).content },
+  autoReply: true,
+  filter: e => e.user.id !== '',
+  onEvent: e => console.log(`[teams] ${e.type}${e.reason ? ` — ${e.reason}` : ''}`),
+})
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  if (req.url !== '/api/messages' || req.method !== 'POST') {
+    res.writeHead(404).end('not found')
+    return
+  }
+  const raw = await readBody(req)
+  const headers: Record<string, string> = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (typeof v === 'string') headers[k.toLowerCase()] = v
+  }
+  const result = await trigger.handler({ headers, body: raw })
+  res.writeHead(result.status, result.headers).end(typeof result.body === 'string' ? result.body : JSON.stringify(result.body))
+})
+
+const port = Number(process.env.PORT ?? 3978)
+server.listen(port, () => {
+  console.log(`Teams bot listening on :${port}/api/messages`)
+})

--- a/apps/example-teams-bot/tests/adapter.test.ts
+++ b/apps/example-teams-bot/tests/adapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest'
+import { teamsAdapter, type TeamsServiceClient } from '../src/adapter'
+
+const stubClient: TeamsServiceClient = { sendMessage: vi.fn(async () => {}) }
+
+describe('teamsAdapter — verify', () => {
+  it('rejects when Authorization header is missing', async () => {
+    const a = teamsAdapter({ serviceClient: stubClient, verifyToken: async () => true })
+    expect(await a.verify!({ headers: {}, body: {} })).toBe(false)
+  })
+
+  it('rejects when Authorization is not a Bearer token', async () => {
+    const a = teamsAdapter({ serviceClient: stubClient, verifyToken: async () => true })
+    expect(
+      await a.verify!({ headers: { authorization: 'Basic xyz' }, body: {} }),
+    ).toBe(false)
+  })
+
+  it('default verifyToken refuses everything (deny by default)', async () => {
+    const a = teamsAdapter({ serviceClient: stubClient })
+    expect(
+      await a.verify!({
+        headers: { authorization: 'Bearer eyJ.x.y' },
+        body: {},
+      }),
+    ).toBe(false)
+  })
+
+  it('passes Bearer token + request to verifyToken callback', async () => {
+    const verifyToken = vi.fn(async () => true)
+    const a = teamsAdapter({ serviceClient: stubClient, verifyToken })
+    const ok = await a.verify!({
+      headers: { authorization: 'Bearer abc.def.ghi' },
+      body: { hi: true },
+    })
+    expect(ok).toBe(true)
+    expect(verifyToken).toHaveBeenCalledWith(
+      'abc.def.ghi',
+      expect.objectContaining({ headers: expect.any(Object), body: { hi: true } }),
+    )
+  })
+})
+
+describe('teamsAdapter — parse', () => {
+  const a = teamsAdapter({ serviceClient: stubClient, verifyToken: async () => true })
+
+  it('normalizes message → message event', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'message',
+        id: 'A1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        conversation: { id: 'C1' },
+        from: { id: 'U1', name: 'alice' },
+        text: 'hi bot',
+      },
+    }) as { type: string; text: string; receivedAt: string; user: { name: string } }
+    expect(r.type).toBe('message')
+    expect(r.text).toBe('hi bot')
+    expect(r.receivedAt).toBe('2026-01-01T00:00:00.000Z')
+    expect(r.user.name).toBe('alice')
+  })
+
+  it('normalizes message with replyToId → reply event', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'message',
+        id: 'A2',
+        conversation: { id: 'C1' },
+        from: { id: 'U1' },
+        text: 'thread reply',
+        replyToId: 'A1',
+      },
+    }) as { type: string; parentId: string }
+    expect(r.type).toBe('reply')
+    expect(r.parentId).toBe('A1')
+  })
+
+  it('normalizes message with attachment → file_upload', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'message',
+        id: 'A3',
+        conversation: { id: 'C1' },
+        from: { id: 'U1' },
+        attachments: [{ name: 'r.pdf', contentType: 'application/pdf', contentUrl: 'https://x' }],
+      },
+    }) as { type: string; name: string }
+    expect(r.type).toBe('file_upload')
+    expect(r.name).toBe('r.pdf')
+  })
+
+  it('normalizes messageReaction (added)', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'messageReaction',
+        id: 'A4',
+        conversation: { id: 'C1' },
+        from: { id: 'U1' },
+        replyToId: 'A1',
+        reactionsAdded: [{ type: 'like' }],
+      },
+    }) as { type: string; emoji: string; added: boolean; messageId: string }
+    expect(r.type).toBe('reaction')
+    expect(r.emoji).toBe('like')
+    expect(r.added).toBe(true)
+    expect(r.messageId).toBe('A1')
+  })
+
+  it('normalizes conversationUpdate.membersAdded → installation installed', () => {
+    const r = a.parse({
+      headers: {},
+      body: {
+        type: 'conversationUpdate',
+        id: 'A5',
+        conversation: { id: 'C1' },
+        from: { id: 'U1', aadObjectId: 'TEN1' },
+        membersAdded: [{ id: 'BOT' }],
+      },
+    }) as { type: string; action: string; tenantId: string }
+    expect(r.type).toBe('installation')
+    expect(r.action).toBe('installed')
+    expect(r.tenantId).toBe('TEN1')
+  })
+
+  it('returns null for typing / invoke / unknown activities', () => {
+    expect(
+      a.parse({
+        headers: {},
+        body: { type: 'typing', conversation: { id: 'C1' }, from: { id: 'U1' } },
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('teamsAdapter — reply', () => {
+  it('forwards conversationId + text to the injected serviceClient', async () => {
+    const sendMessage = vi.fn(async () => {})
+    const a = teamsAdapter({ serviceClient: { sendMessage }, verifyToken: async () => true })
+    await a.reply!(
+      {
+        type: 'reply',
+        surface: 'teams',
+        eventId: 'E',
+        channel: { id: 'C1' },
+        user: { id: 'U1' },
+        threadId: 'A1',
+        text: 'src',
+        parentId: 'A1',
+      },
+      'reply',
+    )
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'C1', text: 'reply', replyToId: 'A1' }),
+    )
+  })
+})

--- a/apps/example-teams-bot/tests/adapter.test.ts
+++ b/apps/example-teams-bot/tests/adapter.test.ts
@@ -138,24 +138,61 @@ describe('teamsAdapter — parse', () => {
 })
 
 describe('teamsAdapter — reply', () => {
-  it('forwards conversationId + text to the injected serviceClient', async () => {
+  it('threads serviceUrl from parse → reply via the injected serviceClient', async () => {
     const sendMessage = vi.fn(async () => {})
     const a = teamsAdapter({ serviceClient: { sendMessage }, verifyToken: async () => true })
+    a.parse({
+      headers: {},
+      body: {
+        type: 'message',
+        id: 'A1',
+        serviceUrl: 'https://smba.trafficmanager.net/eu/',
+        conversation: { id: 'C1' },
+        from: { id: 'U1' },
+        text: 'hi',
+      },
+    })
     await a.reply!(
       {
-        type: 'reply',
+        type: 'message',
         surface: 'teams',
-        eventId: 'E',
+        eventId: 'A1',
         channel: { id: 'C1' },
         user: { id: 'U1' },
-        threadId: 'A1',
-        text: 'src',
-        parentId: 'A1',
+        text: 'hi',
       },
       'reply',
     )
     expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ conversationId: 'C1', text: 'reply', replyToId: 'A1' }),
+      expect.objectContaining({
+        conversationId: 'C1',
+        text: 'reply',
+        serviceUrl: 'https://smba.trafficmanager.net/eu/',
+      }),
     )
+  })
+
+  it('refuses to reply when no serviceUrl was captured', async () => {
+    const sendMessage = vi.fn(async () => {})
+    const a = teamsAdapter({ serviceClient: { sendMessage }, verifyToken: async () => true })
+    await expect(
+      a.reply!(
+        { type: 'message', surface: 'teams', eventId: 'NEVER-SEEN', channel: { id: 'C1' }, user: { id: 'U1' }, text: 'x' },
+        'reply',
+      ),
+    ).rejects.toThrow(/no serviceUrl/)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('evicts serviceUrl after one reply', async () => {
+    const sendMessage = vi.fn(async () => {})
+    const a = teamsAdapter({ serviceClient: { sendMessage }, verifyToken: async () => true })
+    a.parse({
+      headers: {},
+      body: { type: 'message', id: 'A1', serviceUrl: 'https://x', conversation: { id: 'C1' }, from: { id: 'U1' } },
+    })
+    const event = { type: 'message' as const, surface: 'teams' as const, eventId: 'A1', channel: { id: 'C1' }, user: { id: 'U1' }, text: 'x' }
+    await a.reply!(event, 'first')
+    await expect(a.reply!(event, 'second')).rejects.toThrow(/no serviceUrl/)
   })
 })

--- a/apps/example-teams-bot/tsconfig.json
+++ b/apps/example-teams-bot/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/example-discord-bot:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/example-dspy:
     dependencies:
       '@agentskit/eval-braintrust':
@@ -359,6 +384,56 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  apps/example-slack-bot:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  apps/example-teams-bot:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/example-webllm:
     dependencies:
@@ -11190,7 +11265,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Closes **#779** (Slack), **#780** (Discord), **#781** (Teams). Three reference bot templates wrap the \`createChatTrigger\` contract from #804 — one observer taxonomy, one HITL surface, one filter shape across surfaces.

## Diff

| Path | What |
|---|---|
| \`apps/example-slack-bot/src/adapter.ts\` | Slack Events API adapter — signing-secret + 300s timestamp verify, normalizes app_mention / message / file_share / reaction |
| \`apps/example-discord-bot/src/adapter.ts\` | Discord Interactions adapter — Ed25519 verify via \`webcrypto.subtle\`, normalizes APPLICATION_COMMAND + MESSAGE_COMPONENT |
| \`apps/example-teams-bot/src/adapter.ts\` | Bot Framework adapter — deny-by-default JWT verify (deployer wires \`botbuilder\` JwtTokenValidation), normalizes message / messageReaction / conversationUpdate |
| \`apps/example-{slack,discord,teams}-bot/src/index.ts\` | Node HTTP server wiring \`createChatTrigger\` |
| \`apps/example-{slack,discord,teams}-bot/tests/adapter.test.ts\` | 33 total unit tests (Slack 13, Discord 9, Teams 11) |
| \`apps/example-{slack,discord,teams}-bot/README.md\` | Setup, env vars, what's normalized, security notes |
| \`.changeset/bot-templates.md\` | empty changeset (no published packages affected) |

## Design notes

- **Driver-light.** No Bolt / discord.js / botbuilder in dependencies — keeps \`pnpm install\` light. Production deployments swap the lean reply path for the official SDK to inherit retries, rate-limit handling, pagination. Documented in each README.
- **Slack URL-verification + Discord PING handled inline.** Both providers expect synchronous handshake responses before the trigger sees the request.
- **Teams JWT defaults to deny.** \`teamsAdapter\` requires the deployer to inject \`verifyToken\`; the default is \`() => false\` so a missing call cannot ship a wide-open bot. README explicitly warns about \`TEAMS_DISABLE_AUTH=1\` being local-only.
- **Bot-loop guard via \`user.isBot\`.** Each template's trigger sets \`filter: e => !e.user.isBot\` (or equivalent for Teams).

## Test plan

- [x] \`pnpm --filter @agentskit/example-slack-bot test\` → 13/13
- [x] \`pnpm --filter @agentskit/example-discord-bot test\` → 9/9
- [x] \`pnpm --filter @agentskit/example-teams-bot test\` → 11/11
- [x] \`pnpm --filter @agentskit/example-{slack,discord,teams}-bot lint\` → clean
- [ ] Live smoke against each surface — separate per-surface manual test

## Out of scope

- CLI \`init\` blueprints for these templates (separate follow-up — \`packages/templates/blueprints/\` lacks a chat-bot generator today)
- Voice mode hand-off (Discord) — separate issue if needed
- SSO / Adaptive Card HITL approvals (Teams) — separate issue