### PR TITLE
fix(tests): stabilize two CI flakes blocking unrelated PRs

### DIFF
--- a/.changeset/flaky-tests.md
+++ b/.changeset/flaky-tests.md
@@ -1,0 +1,10 @@
+---
+---
+
+Stabilize two CI flakes blocking unrelated PRs.
+
+`packages/memory/tests/file-vector.test.ts` vectra block — bump per-test timeout to 30 s. Vectra cold-starts the on-disk index on first `store()`; on slow CI runners that alone exceeds the vitest 5 s default.
+
+`packages/ink/tests/ToolConfirmation.test.tsx` — replace the single 20 ms flush with five chained 20 ms waits (~100 ms total). Three tests using the `capturedHandler` closure pattern need React + ink-testing-library multiple commit cycles between key presses.
+
+No production code changes.

--- a/packages/ink/tests/ToolConfirmation.test.tsx
+++ b/packages/ink/tests/ToolConfirmation.test.tsx
@@ -39,9 +39,16 @@ const key = (overrides: Partial<Key> = {}): Key => ({
   ...overrides,
 } as Key)
 
-// Give React time to commit state updates between key presses so the mock's
-// capturedHandler closure picks up the latest index.
-const flush = () => new Promise(r => setTimeout(r, 20))
+// Give React time to commit state updates between key presses so the
+// mock's capturedHandler closure picks up the latest index. Drain a
+// few macrotasks — a single setTimeout(20) was enough on macOS but
+// flaked on slow Linux CI runners; chaining gives React + ink-testing-
+// library multiple commit cycles before the next key press.
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await new Promise(r => setTimeout(r, 20))
+  }
+}
 
 const pendingCall: ToolCall = {
   id: 'tc-1',

--- a/packages/memory/tests/file-vector.test.ts
+++ b/packages/memory/tests/file-vector.test.ts
@@ -97,6 +97,11 @@ describe('fileVectorMemory with vectra', () => {
     try { await rm(dirPath, { recursive: true, force: true }) } catch {}
   })
 
+  // Vectra cold-starts the on-disk index on first store(). The 5s
+  // vitest default flakes on cold CI runners; 30s gives slow disks
+  // enough headroom while still failing fast on real regressions.
+  const VECTRA_TIMEOUT = 30_000
+
   it('stores and retrieves documents', async () => {
     const mem = fileVectorMemory({ path: dirPath })
     await mem.store([doc1, doc2])
@@ -106,7 +111,7 @@ describe('fileVectorMemory with vectra', () => {
     expect(results.length).toBeGreaterThanOrEqual(1)
     expect(results[0].id).toBe('doc-1')
     expect(results[0].content).toBe('The quick brown fox')
-  })
+  }, VECTRA_TIMEOUT)
 
   it('delete removes documents', async () => {
     const mem = fileVectorMemory({ path: dirPath })
@@ -116,5 +121,5 @@ describe('fileVectorMemory with vectra', () => {
     const results = await mem.search(doc1.embedding, { topK: 10 })
     const ids = results.map(r => r.id)
     expect(ids).not.toContain('doc-1')
-  })
+  }, VECTRA_TIMEOUT)
 })


### PR DESCRIPTION
## Summary

Two pre-existing flakes have failed multiple PRs this week (#765, #802, #803, #805) without ever pointing at a real product regression. Both are timing-only — neither test asserts anything new.

## Diff

| Path | Fix |
|---|---|
| \`packages/memory/tests/file-vector.test.ts\` | Bump per-test timeout to 30 s on the vectra block. Vectra cold-starts the on-disk index on first \`store()\`; on slow CI runners that alone exceeds the vitest 5 s default. |
| \`packages/ink/tests/ToolConfirmation.test.tsx\` | Replace the single \`setTimeout(20)\` flush with five chained 20 ms waits (~100 ms total). Three tests using the \`capturedHandler\` closure pattern need React + ink-testing-library multiple commit cycles between key presses to read the updated state — 20 ms passed on macOS but flaked on Linux. |

## Why bother

Each flake costs an admin-merge bypass on otherwise-green PRs and noise on the CI dashboard. Two surgical fixes drain that pool without changing any production behaviour.

## Test plan

- [x] \`pnpm --filter @agentskit/memory test\` → 90/90
- [x] \`pnpm --filter @agentskit/ink test\` → 69/69