### PR TITLE
feat(cli): agentskit rules — write editor configs for Cursor / Windsurf / Codex / Claude Code

### DIFF
--- a/.changeset/editor-integrations.md
+++ b/.changeset/editor-integrations.md
@@ -1,0 +1,16 @@
+---
+"@agentskit/cli": minor
+---
+
+Add `agentskit rules <editor>` — generates editor configuration so AI coding assistants know AgentsKit conventions without extra prompting. Closes #775 (Claude Code skill), #776 (Cursor / Windsurf rules), #778 (Codex / Aider profile).
+
+Supports `cursor`, `windsurf`, `codex`, `claude-code`, and `all`. Each:
+
+- **`cursor`** writes `.cursor/rules/agentskit.mdc` (Cursor MDC rule with `alwaysApply: true`).
+- **`windsurf`** writes `.windsurfrules` (plain markdown loaded into Cascade).
+- **`codex`** appends a YAML profile block to `AGENTS.md`, replacing any prior block in place. Refuses to touch an existing AGENTS.md without `--force` (load-bearing root file).
+- **`claude-code`** writes a `.claude/skills/agentskit/` skill bundle (SKILL.md + 6 slash commands wrapping `init` / `doctor` / `add-tool` / `add-skill` / `lint-pii` / `rules`).
+
+Idempotent: re-running with the same content reports `skipped`. Use `--force` to overwrite hand-edited rule files. `--out <dir>` targets a workspace root other than cwd.
+
+Unblocks the editor-integration cluster surfaced in the gap audit. With this merged, anyone using Claude Code / Cursor / Windsurf / Codex against an AgentsKit checkout can run one command and have the agent respect named-export-only, the no-bare-throw rule, package boundaries, and the for-agents/* manifest.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -10,6 +10,7 @@ import { registerRagCommand } from './rag'
 import { registerAiCommand } from './ai'
 import { registerFlowCommand } from './flow'
 import { registerPiiCommand } from './pii'
+import { registerRulesCommand } from './rules'
 
 export function createCli(): Command {
   const program = new Command()
@@ -28,6 +29,7 @@ export function createCli(): Command {
   registerAiCommand(program)
   registerFlowCommand(program)
   registerPiiCommand(program)
+  registerRulesCommand(program)
 
   return program
 }

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -1,0 +1,38 @@
+import type { Command } from 'commander'
+import { writeRules, type Editor } from '../rules'
+
+const VALID: Editor[] = ['cursor', 'windsurf', 'codex', 'claude-code', 'all']
+
+export function registerRulesCommand(program: Command): void {
+  program
+    .command('rules <editor>')
+    .description(
+      'Write editor rule files (cursor | windsurf | codex | claude-code | all). Teaches the editor AgentsKit conventions so generated code respects named-export-only, package boundaries, and the for-agents/* manifest.',
+    )
+    .option('--out <dir>', 'Workspace root to write files into (default: cwd)')
+    .option('-f, --force', 'Overwrite existing rule files (codex / claude-code skill always update in place)')
+    .action(async (editor: string, options: { out?: string; force?: boolean }) => {
+      if (!(VALID as string[]).includes(editor)) {
+        process.stderr.write(`unknown editor "${editor}". Valid: ${VALID.join(', ')}\n`)
+        process.exit(1)
+      }
+      const results = await writeRules(editor as Editor, {
+        rootDir: options.out,
+        force: options.force === true,
+      })
+      const counts = { wrote: 0, updated: 0, skipped: 0 }
+      for (const { editor: ed, files } of results) {
+        process.stdout.write(`\n[${ed}]\n`)
+        for (const f of files) {
+          counts[f.action]++
+          process.stdout.write(`  ${f.action.padEnd(7)} ${f.path}\n`)
+        }
+      }
+      process.stdout.write(
+        `\nDone — ${counts.wrote} wrote, ${counts.updated} updated, ${counts.skipped} skipped.\n`,
+      )
+      if (counts.skipped > 0 && options.force !== true) {
+        process.stdout.write(`(re-run with --force to overwrite skipped files)\n`)
+      }
+    })
+}

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -16,23 +16,29 @@ export function registerRulesCommand(program: Command): void {
         process.stderr.write(`unknown editor "${editor}". Valid: ${VALID.join(', ')}\n`)
         process.exit(1)
       }
-      const results = await writeRules(editor as Editor, {
-        rootDir: options.out,
-        force: options.force === true,
-      })
-      const counts = { wrote: 0, updated: 0, skipped: 0 }
-      for (const { editor: ed, files } of results) {
-        process.stdout.write(`\n[${ed}]\n`)
-        for (const f of files) {
-          counts[f.action]++
-          process.stdout.write(`  ${f.action.padEnd(7)} ${f.path}\n`)
+      try {
+        const results = await writeRules(editor as Editor, {
+          rootDir: options.out,
+          force: options.force === true,
+        })
+        const counts = { wrote: 0, updated: 0, skipped: 0 }
+        for (const { editor: ed, files } of results) {
+          process.stdout.write(`\n[${ed}]\n`)
+          for (const f of files) {
+            counts[f.action]++
+            process.stdout.write(`  ${f.action.padEnd(7)} ${f.path}\n`)
+          }
         }
-      }
-      process.stdout.write(
-        `\nDone — ${counts.wrote} wrote, ${counts.updated} updated, ${counts.skipped} skipped.\n`,
-      )
-      if (counts.skipped > 0 && options.force !== true) {
-        process.stdout.write(`(re-run with --force to overwrite skipped files)\n`)
+        process.stdout.write(
+          `\nDone — ${counts.wrote} wrote, ${counts.updated} updated, ${counts.skipped} skipped.\n`,
+        )
+        if (counts.skipped > 0 && options.force !== true) {
+          process.stdout.write(`(re-run with --force to overwrite skipped files)\n`)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        process.stderr.write(`\nrules failed: ${message}\n`)
+        process.exit(1)
       }
     })
 }

--- a/packages/cli/src/rules.ts
+++ b/packages/cli/src/rules.ts
@@ -1,9 +1,10 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
+import { ConfigError, ErrorCodes } from '@agentskit/core'
 import { CURSOR_RULE } from './rules/cursor'
 import { WINDSURF_RULE } from './rules/windsurf'
 import { CODEX_PROFILE } from './rules/codex'
-import { CLAUDE_CODE_SKILL } from './rules/claude-code'
+import { CLAUDE_CODE_SKILL, CLAUDE_CODE_SLASH_COMMANDS } from './rules/claude-code'
 
 export type Editor = 'cursor' | 'windsurf' | 'codex' | 'claude-code' | 'all'
 
@@ -58,6 +59,19 @@ async function writeWindsurf(rootDir: string, force: boolean): Promise<RulesWrit
  * previous profile block delimited by the sentinel comments. If
  * AGENTS.md does not exist, write it with just the profile (deployers
  * are expected to add the rest of the universal-agent guidance).
+ *
+ * Sentinel parsing rules:
+ *  - Search the END sentinel only AFTER the START sentinel — prevents
+ *    a stray `:end -->` inside YAML content from pulling the slice to
+ *    the wrong position.
+ *  - Find the LAST end after the start so a duplicate-paste of the
+ *    block collapses into one rather than half-overwriting.
+ *  - Refuse to modify if a START sentinel is present without any END
+ *    after it (file truncated mid-block) — the user has hand-edited
+ *    something we don't understand and we should not append on top.
+ *  - Require --force for ANY write to a populated AGENTS.md (in-place
+ *    block update OR first-time append). AGENTS.md is load-bearing
+ *    and every codex run on a populated one must be opt-in.
  */
 async function writeCodex(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
   const path = join(rootDir, 'AGENTS.md')
@@ -67,11 +81,20 @@ async function writeCodex(rootDir: string, force: boolean): Promise<RulesWriteRe
   } catch {
     // not present — write a fresh AGENTS.md with just the profile.
   }
-  let next: string
   const startIdx = existing.indexOf(CODEX_BLOCK_START)
-  const endIdx = existing.indexOf(CODEX_BLOCK_END)
+  const endIdx =
+    startIdx >= 0
+      ? existing.lastIndexOf(CODEX_BLOCK_END, existing.length)
+      : -1
+  if (startIdx >= 0 && endIdx <= startIdx) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `${path}: found agentskit-codex-profile:start sentinel but no matching :end after it — refusing to modify a half-edited block.`,
+      hint: 'Restore the closing sentinel or remove the partial block, then re-run.',
+    })
+  }
+  let next: string
   if (startIdx >= 0 && endIdx > startIdx) {
-    // Replace the existing block in place.
     next =
       existing.slice(0, startIdx) +
       CODEX_PROFILE.trimEnd() +
@@ -82,9 +105,7 @@ async function writeCodex(rootDir: string, force: boolean): Promise<RulesWriteRe
     next = CODEX_PROFILE
   }
   if (next === existing) return [{ path, action: 'skipped' }]
-  if (existing && !force && startIdx < 0) {
-    // Existing AGENTS.md without our block — only append when --force,
-    // since the AGENTS.md is a load-bearing root file.
+  if (existing && !force) {
     return [{ path, action: 'skipped' }]
   }
   await ensureDir(path)
@@ -93,11 +114,21 @@ async function writeCodex(rootDir: string, force: boolean): Promise<RulesWriteRe
 }
 
 async function writeClaudeCode(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
-  const skillRoot = join(rootDir, '.claude', 'skills', 'agentskit')
   const out: RulesWriteResult['files'] = []
+  // Skill bundle (.claude/skills/<name>/SKILL.md) — Claude Code skill format.
+  const skillRoot = join(rootDir, '.claude', 'skills', 'agentskit')
   for (const file of CLAUDE_CODE_SKILL) {
     const abs = join(skillRoot, file.path)
     const action = await writeIfChanged(abs, file.contents, force)
+    out.push({ path: abs, action })
+  }
+  // Project-scoped slash commands (.claude/commands/*.md) — Claude Code's
+  // actual location for `/<name>` invocations. Skill bundles do not
+  // register slash commands automatically; the two surfaces are separate.
+  const commandsRoot = join(rootDir, '.claude', 'commands')
+  for (const cmd of CLAUDE_CODE_SLASH_COMMANDS) {
+    const abs = join(commandsRoot, cmd.path)
+    const action = await writeIfChanged(abs, cmd.contents, force)
     out.push({ path: abs, action })
   }
   return out

--- a/packages/cli/src/rules.ts
+++ b/packages/cli/src/rules.ts
@@ -1,0 +1,130 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { CURSOR_RULE } from './rules/cursor'
+import { WINDSURF_RULE } from './rules/windsurf'
+import { CODEX_PROFILE } from './rules/codex'
+import { CLAUDE_CODE_SKILL } from './rules/claude-code'
+
+export type Editor = 'cursor' | 'windsurf' | 'codex' | 'claude-code' | 'all'
+
+export interface RulesWriteResult {
+  editor: Editor
+  files: Array<{ path: string; action: 'wrote' | 'skipped' | 'updated' }>
+}
+
+const CODEX_BLOCK_START = '<!-- agentskit-codex-profile:start -->'
+const CODEX_BLOCK_END = '<!-- agentskit-codex-profile:end -->'
+
+async function ensureDir(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+}
+
+async function writeIfChanged(
+  absPath: string,
+  contents: string,
+  force: boolean,
+): Promise<'wrote' | 'skipped' | 'updated'> {
+  let existing: string | undefined
+  try {
+    existing = await readFile(absPath, 'utf8')
+  } catch {
+    // not present
+  }
+  if (existing === contents) return 'skipped'
+  if (existing !== undefined && !force) {
+    // Append-or-update flow handled by callers that need it; default
+    // here is to overwrite when contents differ AND force is on.
+    return 'skipped'
+  }
+  await ensureDir(absPath)
+  await writeFile(absPath, contents, 'utf8')
+  return existing === undefined ? 'wrote' : 'updated'
+}
+
+async function writeCursor(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
+  const path = join(rootDir, '.cursor', 'rules', 'agentskit.mdc')
+  const action = await writeIfChanged(path, CURSOR_RULE, force)
+  return [{ path, action }]
+}
+
+async function writeWindsurf(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
+  const path = join(rootDir, '.windsurfrules')
+  const action = await writeIfChanged(path, WINDSURF_RULE, force)
+  return [{ path, action }]
+}
+
+/**
+ * Codex profile is appended to the existing AGENTS.md, replacing any
+ * previous profile block delimited by the sentinel comments. If
+ * AGENTS.md does not exist, write it with just the profile (deployers
+ * are expected to add the rest of the universal-agent guidance).
+ */
+async function writeCodex(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
+  const path = join(rootDir, 'AGENTS.md')
+  let existing = ''
+  try {
+    existing = await readFile(path, 'utf8')
+  } catch {
+    // not present — write a fresh AGENTS.md with just the profile.
+  }
+  let next: string
+  const startIdx = existing.indexOf(CODEX_BLOCK_START)
+  const endIdx = existing.indexOf(CODEX_BLOCK_END)
+  if (startIdx >= 0 && endIdx > startIdx) {
+    // Replace the existing block in place.
+    next =
+      existing.slice(0, startIdx) +
+      CODEX_PROFILE.trimEnd() +
+      existing.slice(endIdx + CODEX_BLOCK_END.length)
+  } else if (existing) {
+    next = `${existing.replace(/\s+$/, '')}\n\n${CODEX_PROFILE}`
+  } else {
+    next = CODEX_PROFILE
+  }
+  if (next === existing) return [{ path, action: 'skipped' }]
+  if (existing && !force && startIdx < 0) {
+    // Existing AGENTS.md without our block — only append when --force,
+    // since the AGENTS.md is a load-bearing root file.
+    return [{ path, action: 'skipped' }]
+  }
+  await ensureDir(path)
+  await writeFile(path, next, 'utf8')
+  return [{ path, action: existing ? 'updated' : 'wrote' }]
+}
+
+async function writeClaudeCode(rootDir: string, force: boolean): Promise<RulesWriteResult['files']> {
+  const skillRoot = join(rootDir, '.claude', 'skills', 'agentskit')
+  const out: RulesWriteResult['files'] = []
+  for (const file of CLAUDE_CODE_SKILL) {
+    const abs = join(skillRoot, file.path)
+    const action = await writeIfChanged(abs, file.contents, force)
+    out.push({ path: abs, action })
+  }
+  return out
+}
+
+export async function writeRules(
+  editor: Editor,
+  options: { rootDir?: string; force?: boolean } = {},
+): Promise<RulesWriteResult[]> {
+  const root = resolve(options.rootDir ?? process.cwd())
+  const force = options.force === true
+  if (editor === 'all') {
+    return [
+      { editor: 'cursor', files: await writeCursor(root, force) },
+      { editor: 'windsurf', files: await writeWindsurf(root, force) },
+      { editor: 'codex', files: await writeCodex(root, force) },
+      { editor: 'claude-code', files: await writeClaudeCode(root, force) },
+    ]
+  }
+  switch (editor) {
+    case 'cursor':
+      return [{ editor, files: await writeCursor(root, force) }]
+    case 'windsurf':
+      return [{ editor, files: await writeWindsurf(root, force) }]
+    case 'codex':
+      return [{ editor, files: await writeCodex(root, force) }]
+    case 'claude-code':
+      return [{ editor, files: await writeClaudeCode(root, force) }]
+  }
+}

--- a/packages/cli/src/rules/claude-code.ts
+++ b/packages/cli/src/rules/claude-code.ts
@@ -1,0 +1,118 @@
+/**
+ * Claude Code skill bundle — written to `.claude/skills/agentskit/`
+ * by `agentskit rules claude-code`. Each command file is a slash
+ * command Claude Code can invoke against the running CLI.
+ */
+
+export interface ClaudeCodeFile {
+  /** Path relative to the skill root (e.g. `.claude/skills/agentskit/`). */
+  path: string
+  contents: string
+}
+
+export const CLAUDE_CODE_SKILL: ClaudeCodeFile[] = [
+  {
+    path: 'SKILL.md',
+    contents: `---
+name: agentskit
+description: Scaffold AgentsKit projects, add tools/skills, run doctor, and inspect the runtime — wraps the agentskit CLI with structured slash commands.
+---
+
+# AgentsKit
+
+Skill bundle for working with the AgentsKit toolkit from inside Claude Code.
+
+Use these slash commands to drive the existing \`@agentskit/cli\` without
+remembering its flags:
+
+- \`/agentskit:new-agent\` — interactive scaffold (\`agentskit init\`)
+- \`/agentskit:doctor\` — diagnose the local environment (\`agentskit doctor\`)
+- \`/agentskit:add-tool\` — add a tool integration template
+- \`/agentskit:add-skill\` — add a skill template
+- \`/agentskit:lint-pii\` — validate a PII taxonomy file
+- \`/agentskit:rules\` — write \`.cursor/rules\` / \`.windsurfrules\` / Codex
+  profile to the current repo
+
+When the user is inside an AgentsKit workspace, prefer the slash commands above
+over hand-rolling shell invocations — they share the canonical defaults.
+
+For convention reminders (named exports only, no bare throw, etc.), prompt
+Claude to read \`AGENTS.md\` at the workspace root.
+`,
+  },
+  {
+    path: 'commands/new-agent.md',
+    contents: `---
+description: Scaffold a new AgentsKit project (interactive)
+allowed-tools: Bash(npx agentskit init:*)
+---
+
+Run \`npx @agentskit/cli init\` interactively in the user's chosen directory.
+After scaffold completes, summarise the layout (templates created, next
+commands the user should run).
+`,
+  },
+  {
+    path: 'commands/doctor.md',
+    contents: `---
+description: Run the AgentsKit environment doctor and summarise findings
+allowed-tools: Bash(npx agentskit doctor:*)
+---
+
+Run \`npx @agentskit/cli doctor\` in the workspace root. Format the output
+into pass / warn / fail buckets and propose a fix for each fail / warn.
+`,
+  },
+  {
+    path: 'commands/add-tool.md',
+    contents: `---
+description: Add a tool template to the current package
+---
+
+Ask the user which tool to add. Use \`packages/templates/src/blueprints/tool.ts\`
+to scaffold the file under \`packages/<pkg>/src/tools/\`. Update the package's
+\`src/index.ts\` to re-export the new tool. Add a vitest mock test under
+\`packages/<pkg>/tests/\`.
+`,
+  },
+  {
+    path: 'commands/add-skill.md',
+    contents: `---
+description: Add a skill template to @agentskit/skills
+---
+
+Use \`packages/templates/src/blueprints/skill.ts\` to scaffold a new skill
+under \`packages/skills/src/\`. Re-export from the package index. Add a
+golden-dataset test fixture under \`packages/skills/tests/\` (10–50 input/
+expected examples, per the conventions).
+`,
+  },
+  {
+    path: 'commands/lint-pii.md',
+    contents: `---
+description: Validate a PII taxonomy JSON file
+allowed-tools: Bash(npx agentskit pii lint:*)
+---
+
+Ask the user for a path. Run \`npx @agentskit/cli pii lint <path>\` and
+display the report. If issues exist, suggest concrete fixes per the
+issue messages.
+`,
+  },
+  {
+    path: 'commands/rules.md',
+    contents: `---
+description: Write editor rule files (Cursor / Windsurf / Codex / Claude Code)
+allowed-tools: Bash(npx agentskit rules:*)
+---
+
+Ask which editor (or "all"). Run the matching:
+- \`npx @agentskit/cli rules cursor\`
+- \`npx @agentskit/cli rules windsurf\`
+- \`npx @agentskit/cli rules codex\`
+- \`npx @agentskit/cli rules claude-code\`
+
+After writing, summarise which files landed and what each one does.
+`,
+  },
+]

--- a/packages/cli/src/rules/claude-code.ts
+++ b/packages/cli/src/rules/claude-code.ts
@@ -1,11 +1,23 @@
 /**
- * Claude Code skill bundle — written to `.claude/skills/agentskit/`
- * by `agentskit rules claude-code`. Each command file is a slash
- * command Claude Code can invoke against the running CLI.
+ * Claude Code outputs split into two distinct surfaces:
+ *
+ *  - **Skill bundle** at `.claude/skills/agentskit/SKILL.md` — the
+ *    Anthropic skill-spec file. Skills don't auto-register slash
+ *    commands; they shape the conceptual capability the agent picks
+ *    up when relevant.
+ *
+ *  - **Project-scoped slash commands** at `.claude/commands/*.md` —
+ *    the actual `/<name>` invocations Claude Code surfaces in the
+ *    palette. These live alongside (not inside) the skill bundle.
+ *
+ * Both are real Claude Code conventions; they live at different paths
+ * and serve different purposes. Bundling slash commands inside a skill
+ * folder (as an earlier draft did) silently produces files Claude
+ * Code never reads.
  */
 
 export interface ClaudeCodeFile {
-  /** Path relative to the skill root (e.g. `.claude/skills/agentskit/`). */
+  /** Path relative to the surface root. */
   path: string
   contents: string
 }
@@ -15,33 +27,34 @@ export const CLAUDE_CODE_SKILL: ClaudeCodeFile[] = [
     path: 'SKILL.md',
     contents: `---
 name: agentskit
-description: Scaffold AgentsKit projects, add tools/skills, run doctor, and inspect the runtime — wraps the agentskit CLI with structured slash commands.
+description: Scaffold AgentsKit projects, add tools/skills, run doctor, and inspect the runtime — wraps the agentskit CLI.
 ---
 
 # AgentsKit
 
 Skill bundle for working with the AgentsKit toolkit from inside Claude Code.
 
-Use these slash commands to drive the existing \`@agentskit/cli\` without
-remembering its flags:
+Pair this skill with the project-scoped slash commands at \`.claude/commands/agentskit-*.md\`:
 
-- \`/agentskit:new-agent\` — interactive scaffold (\`agentskit init\`)
-- \`/agentskit:doctor\` — diagnose the local environment (\`agentskit doctor\`)
-- \`/agentskit:add-tool\` — add a tool integration template
-- \`/agentskit:add-skill\` — add a skill template
-- \`/agentskit:lint-pii\` — validate a PII taxonomy file
-- \`/agentskit:rules\` — write \`.cursor/rules\` / \`.windsurfrules\` / Codex
-  profile to the current repo
+- \`/agentskit-new-agent\` — interactive scaffold (\`agentskit init\`)
+- \`/agentskit-doctor\` — diagnose the local environment (\`agentskit doctor\`)
+- \`/agentskit-add-tool\` — add a tool integration template
+- \`/agentskit-add-skill\` — add a skill template
+- \`/agentskit-lint-pii\` — validate a PII taxonomy file
+- \`/agentskit-rules\` — write \`.cursor/rules\` / \`.windsurfrules\` / Codex profile
 
-When the user is inside an AgentsKit workspace, prefer the slash commands above
-over hand-rolling shell invocations — they share the canonical defaults.
+When the user is inside an AgentsKit workspace, prefer the slash commands over
+hand-rolling shell invocations — they share the canonical defaults.
 
-For convention reminders (named exports only, no bare throw, etc.), prompt
-Claude to read \`AGENTS.md\` at the workspace root.
+For convention reminders (named exports only, no bare throw, etc.), read
+\`AGENTS.md\` at the workspace root.
 `,
   },
+]
+
+export const CLAUDE_CODE_SLASH_COMMANDS: ClaudeCodeFile[] = [
   {
-    path: 'commands/new-agent.md',
+    path: 'agentskit-new-agent.md',
     contents: `---
 description: Scaffold a new AgentsKit project (interactive)
 allowed-tools: Bash(npx agentskit init:*)
@@ -53,7 +66,7 @@ commands the user should run).
 `,
   },
   {
-    path: 'commands/doctor.md',
+    path: 'agentskit-doctor.md',
     contents: `---
 description: Run the AgentsKit environment doctor and summarise findings
 allowed-tools: Bash(npx agentskit doctor:*)
@@ -64,7 +77,7 @@ into pass / warn / fail buckets and propose a fix for each fail / warn.
 `,
   },
   {
-    path: 'commands/add-tool.md',
+    path: 'agentskit-add-tool.md',
     contents: `---
 description: Add a tool template to the current package
 ---
@@ -76,7 +89,7 @@ to scaffold the file under \`packages/<pkg>/src/tools/\`. Update the package's
 `,
   },
   {
-    path: 'commands/add-skill.md',
+    path: 'agentskit-add-skill.md',
     contents: `---
 description: Add a skill template to @agentskit/skills
 ---
@@ -88,7 +101,7 @@ expected examples, per the conventions).
 `,
   },
   {
-    path: 'commands/lint-pii.md',
+    path: 'agentskit-lint-pii.md',
     contents: `---
 description: Validate a PII taxonomy JSON file
 allowed-tools: Bash(npx agentskit pii lint:*)
@@ -100,7 +113,7 @@ issue messages.
 `,
   },
   {
-    path: 'commands/rules.md',
+    path: 'agentskit-rules.md',
     contents: `---
 description: Write editor rule files (Cursor / Windsurf / Codex / Claude Code)
 allowed-tools: Bash(npx agentskit rules:*)

--- a/packages/cli/src/rules/codex.ts
+++ b/packages/cli/src/rules/codex.ts
@@ -1,0 +1,55 @@
+/**
+ * Codex / Aider profile block — appended to the existing AGENTS.md
+ * via `agentskit rules codex`. Codex and Aider both read AGENTS.md
+ * but benefit from a structured profile listing the test runner,
+ * allowed commands, and recommended models.
+ */
+export const CODEX_PROFILE = `<!-- agentskit-codex-profile:start -->
+## Codex / Aider profile
+
+Structured hints for CLI coding agents (OpenAI Codex, Aider, Claude Code,
+Cursor) running against this workspace. Update via \`agentskit rules codex\`.
+
+\`\`\`yaml
+# AgentsKit Codex profile v1
+profile: agentskit
+runtime: node-25
+package_manager: pnpm
+test_runner: vitest
+build_runner: turborepo
+
+allowed_commands:
+  - pnpm install
+  - pnpm build
+  - pnpm test
+  - pnpm lint
+  - pnpm changeset
+  - pnpm --filter @agentskit/* test
+  - pnpm --filter @agentskit/* lint
+  - pnpm --filter @agentskit/* build
+
+restricted_paths:
+  - packages/core/src/errors.ts        # Touch carefully — every package depends on the typed errors here.
+  - packages/core/src/security/        # Security-sensitive — small surface, requires review.
+  - docs/architecture/adrs/            # Contract changes need a new ADR + major bump.
+
+models_recommended:
+  - claude-sonnet-4-6                  # Default — long context, fast.
+  - gpt-5                              # Strong reasoning for refactors / cross-package work.
+  - claude-opus-4-7                    # Heavy refactors, contract redesigns.
+
+invariants:
+  core_max_kb_gzip: 10
+  no_default_exports: true
+  strict_typescript: true
+  no_bare_throw_new_error: true
+  named_exports_only: true
+  changeset_required_for_behavior_changes: true
+
+read_first:
+  - AGENTS.md
+  - apps/docs-next/content/docs/for-agents/
+  - docs/architecture/adrs/
+\`\`\`
+<!-- agentskit-codex-profile:end -->
+`

--- a/packages/cli/src/rules/cursor.ts
+++ b/packages/cli/src/rules/cursor.ts
@@ -1,0 +1,53 @@
+/**
+ * Cursor `.cursor/rules/agentskit.mdc` — applied to every file in the
+ * workspace. Teaches Cursor the AgentsKit conventions so generated
+ * code respects named-export-only, package boundaries, and the
+ * for-agents/* manifest without extra prompting.
+ */
+export const CURSOR_RULE = `---
+description: AgentsKit conventions — apply to every file in this workspace
+globs: ["**/*.ts", "**/*.tsx"]
+alwaysApply: true
+---
+
+# AgentsKit project rules
+
+When writing or editing TypeScript in this workspace, follow these rules. They
+are non-negotiable and enforced by CI.
+
+## Imports
+
+- Use **named exports only**. No \`export default\`.
+- Import from package roots: \`@agentskit/core\`, \`@agentskit/runtime\`, \`@agentskit/react\`,
+  \`@agentskit/ink\`, \`@agentskit/adapters\`, \`@agentskit/tools\`, \`@agentskit/skills\`,
+  \`@agentskit/memory\`, \`@agentskit/rag\`, \`@agentskit/observability\`, \`@agentskit/eval\`,
+  \`@agentskit/sandbox\`, \`@agentskit/cli\`, \`@agentskit/templates\`.
+- For tools subpaths, use \`@agentskit/tools/integrations\`, \`@agentskit/tools/mcp\`,
+  \`@agentskit/tools/mcp-devtools\`.
+
+## Types
+
+- TypeScript strict mode is on. **Do not use \`any\`** — use \`unknown\` and narrow.
+- Headless React components: no hardcoded styles, use \`data-ak-*\` attributes.
+
+## Errors
+
+- Never \`throw new Error(...)\` inside package source. Use the typed errors from
+  \`@agentskit/core\`: \`AdapterError\`, \`ToolError\`, \`MemoryError\`, \`RuntimeError\`,
+  \`SandboxError\`, \`SkillError\`, \`ConfigError\`. Pair with \`ErrorCodes.<...>\`.
+
+## Tests
+
+- vitest. Place tests under \`packages/<pkg>/tests/\` mirroring \`src/\`.
+- E2E lives in \`apps/example-*\` with Playwright.
+
+## Versioning
+
+- Every PR with a behavior change requires a Changeset (\`pnpm changeset\`).
+
+## Where to look first
+
+- Architecture, contracts, ADRs: \`docs/architecture/adrs/\`
+- Per-package conventions: \`packages/<pkg>/CONVENTIONS.md\`
+- Agent-facing index: \`AGENTS.md\` and \`apps/docs-next/content/docs/for-agents/\`
+`

--- a/packages/cli/src/rules/windsurf.ts
+++ b/packages/cli/src/rules/windsurf.ts
@@ -1,0 +1,36 @@
+/**
+ * Windsurf `.windsurfrules` — plain markdown loaded into Cascade's
+ * context for every chat in this workspace.
+ */
+export const WINDSURF_RULE = `# AgentsKit project rules (read first)
+
+This workspace builds AgentsKit — a JavaScript agent toolkit with a 10 KB core,
+six formal contracts, and ~19 plug-and-play packages. When generating or
+editing code, follow these rules — they are enforced by CI.
+
+## Imports
+- **Named exports only.** No \`export default\`.
+- Import from package roots (\`@agentskit/core\`, \`@agentskit/runtime\`, \`@agentskit/react\`, etc.).
+- Tools subpaths: \`@agentskit/tools/integrations\`, \`@agentskit/tools/mcp\`, \`@agentskit/tools/mcp-devtools\`.
+
+## Types
+- Strict mode TypeScript. **No \`any\`** — use \`unknown\` and narrow.
+
+## Errors
+- **Do not** \`throw new Error(...)\` in package source. Use \`AdapterError\` /
+  \`ToolError\` / \`MemoryError\` / \`RuntimeError\` / \`SandboxError\` / \`SkillError\` /
+  \`ConfigError\` from \`@agentskit/core\`, paired with \`ErrorCodes\`.
+
+## Tests
+- vitest. Tests live in \`packages/<pkg>/tests/\` mirroring \`src/\`.
+- E2E lives in \`apps/example-*\` with Playwright.
+
+## Versioning
+- Every behavior change needs a Changeset (\`pnpm changeset\`).
+
+## Read first
+- \`AGENTS.md\` — universal agent guidance
+- \`apps/docs-next/content/docs/for-agents/\` — per-package agent docs
+- \`docs/architecture/adrs/\` — six core contracts (Adapter, Tool, Memory, Retriever, Skill, Runtime)
+- \`packages/<pkg>/CONVENTIONS.md\` — per-package contribution rules
+`

--- a/packages/cli/tests/rules.test.ts
+++ b/packages/cli/tests/rules.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeRules } from '../src/rules'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'agentskit-rules-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('writeRules — cursor', () => {
+  it('writes .cursor/rules/agentskit.mdc on first run', async () => {
+    const [r] = await writeRules('cursor', { rootDir: root })
+    expect(r.editor).toBe('cursor')
+    expect(r.files).toHaveLength(1)
+    expect(r.files[0].action).toBe('wrote')
+    const body = readFileSync(r.files[0].path, 'utf8')
+    expect(body).toContain('alwaysApply: true')
+    expect(body).toContain('AgentsKit project rules')
+  })
+
+  it('skips when contents unchanged', async () => {
+    await writeRules('cursor', { rootDir: root })
+    const [r] = await writeRules('cursor', { rootDir: root })
+    expect(r.files[0].action).toBe('skipped')
+  })
+
+  it('overwrites with --force when contents differ', async () => {
+    await writeRules('cursor', { rootDir: root })
+    writeFileSync(join(root, '.cursor/rules/agentskit.mdc'), 'tampered', 'utf8')
+    const [r] = await writeRules('cursor', { rootDir: root, force: true })
+    expect(r.files[0].action).toBe('updated')
+    expect(readFileSync(r.files[0].path, 'utf8')).toContain('alwaysApply: true')
+  })
+
+  it('refuses to overwrite without --force when contents differ', async () => {
+    await writeRules('cursor', { rootDir: root })
+    writeFileSync(join(root, '.cursor/rules/agentskit.mdc'), 'tampered', 'utf8')
+    const [r] = await writeRules('cursor', { rootDir: root })
+    expect(r.files[0].action).toBe('skipped')
+    expect(readFileSync(r.files[0].path, 'utf8')).toBe('tampered')
+  })
+})
+
+describe('writeRules — windsurf', () => {
+  it('writes .windsurfrules', async () => {
+    const [r] = await writeRules('windsurf', { rootDir: root })
+    expect(r.files[0].path).toBe(join(root, '.windsurfrules'))
+    expect(readFileSync(r.files[0].path, 'utf8')).toContain('AgentsKit project rules')
+  })
+})
+
+describe('writeRules — codex (AGENTS.md profile block)', () => {
+  it('writes a fresh AGENTS.md when none exists', async () => {
+    const [r] = await writeRules('codex', { rootDir: root })
+    expect(r.files[0].action).toBe('wrote')
+    const body = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+    expect(body).toContain('agentskit-codex-profile:start')
+    expect(body).toContain('profile: agentskit')
+  })
+
+  it('appends the block to an existing AGENTS.md only with --force', async () => {
+    writeFileSync(join(root, 'AGENTS.md'), '# AGENTS\n\nExisting guidance.\n', 'utf8')
+    const [skip] = await writeRules('codex', { rootDir: root })
+    expect(skip.files[0].action).toBe('skipped')
+    expect(readFileSync(join(root, 'AGENTS.md'), 'utf8')).not.toContain('agentskit-codex-profile')
+
+    const [forced] = await writeRules('codex', { rootDir: root, force: true })
+    expect(forced.files[0].action).toBe('updated')
+    const body = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+    expect(body).toContain('Existing guidance.')
+    expect(body).toContain('agentskit-codex-profile:start')
+  })
+
+  it('replaces an existing profile block in place (idempotent)', async () => {
+    writeFileSync(
+      join(root, 'AGENTS.md'),
+      '# AGENTS\n\n<!-- agentskit-codex-profile:start -->\nold profile\n<!-- agentskit-codex-profile:end -->\n\nTrailing.\n',
+      'utf8',
+    )
+    const [r] = await writeRules('codex', { rootDir: root })
+    expect(r.files[0].action).toBe('updated')
+    const body = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+    expect(body).toContain('profile: agentskit')
+    expect(body).not.toContain('old profile')
+    expect(body).toContain('Trailing.')
+  })
+
+  it('skips when the profile block already matches', async () => {
+    await writeRules('codex', { rootDir: root })
+    const [r] = await writeRules('codex', { rootDir: root })
+    expect(r.files[0].action).toBe('skipped')
+  })
+})
+
+describe('writeRules — claude-code skill bundle', () => {
+  it('writes the SKILL.md and at least one slash command', async () => {
+    const [r] = await writeRules('claude-code', { rootDir: root })
+    const paths = r.files.map(f => f.path)
+    expect(paths).toContain(join(root, '.claude', 'skills', 'agentskit', 'SKILL.md'))
+    expect(paths.some(p => p.endsWith('commands/doctor.md'))).toBe(true)
+    expect(paths.some(p => p.endsWith('commands/new-agent.md'))).toBe(true)
+    expect(paths.some(p => p.endsWith('commands/rules.md'))).toBe(true)
+    const skill = readFileSync(join(root, '.claude/skills/agentskit/SKILL.md'), 'utf8')
+    expect(skill).toContain('name: agentskit')
+  })
+})
+
+describe('writeRules — all', () => {
+  it('runs every editor in one pass', async () => {
+    const results = await writeRules('all', { rootDir: root })
+    expect(results.map(r => r.editor)).toEqual(['cursor', 'windsurf', 'codex', 'claude-code'])
+    for (const r of results) {
+      expect(r.files.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/cli/tests/rules.test.ts
+++ b/packages/cli/tests/rules.test.ts
@@ -78,18 +78,58 @@ describe('writeRules — codex (AGENTS.md profile block)', () => {
     expect(body).toContain('agentskit-codex-profile:start')
   })
 
-  it('replaces an existing profile block in place (idempotent)', async () => {
+  it('requires --force even for in-place block replacement on a populated AGENTS.md', async () => {
     writeFileSync(
       join(root, 'AGENTS.md'),
       '# AGENTS\n\n<!-- agentskit-codex-profile:start -->\nold profile\n<!-- agentskit-codex-profile:end -->\n\nTrailing.\n',
       'utf8',
     )
-    const [r] = await writeRules('codex', { rootDir: root })
-    expect(r.files[0].action).toBe('updated')
+    const [skip] = await writeRules('codex', { rootDir: root })
+    expect(skip.files[0].action).toBe('skipped')
+    expect(readFileSync(join(root, 'AGENTS.md'), 'utf8')).toContain('old profile')
+
+    const [forced] = await writeRules('codex', { rootDir: root, force: true })
+    expect(forced.files[0].action).toBe('updated')
     const body = readFileSync(join(root, 'AGENTS.md'), 'utf8')
     expect(body).toContain('profile: agentskit')
     expect(body).not.toContain('old profile')
     expect(body).toContain('Trailing.')
+  })
+
+  it('collapses duplicate-pasted blocks into one (uses last :end)', async () => {
+    writeFileSync(
+      join(root, 'AGENTS.md'),
+      [
+        '# AGENTS\n',
+        '<!-- agentskit-codex-profile:start -->',
+        'OLD_BLOCK_ONE_MARKER',
+        '<!-- agentskit-codex-profile:end -->',
+        '<!-- agentskit-codex-profile:start -->',
+        'OLD_BLOCK_TWO_MARKER',
+        '<!-- agentskit-codex-profile:end -->',
+        'TRAILING_MARKER',
+      ].join('\n'),
+      'utf8',
+    )
+    const [r] = await writeRules('codex', { rootDir: root, force: true })
+    expect(r.files[0].action).toBe('updated')
+    const body = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+    expect(body.match(/agentskit-codex-profile:start/g) ?? []).toHaveLength(1)
+    expect(body.match(/agentskit-codex-profile:end/g) ?? []).toHaveLength(1)
+    expect(body).not.toContain('OLD_BLOCK_ONE_MARKER')
+    expect(body).not.toContain('OLD_BLOCK_TWO_MARKER')
+    expect(body).toContain('TRAILING_MARKER')
+  })
+
+  it('refuses to modify a half-edited block (start without end)', async () => {
+    writeFileSync(
+      join(root, 'AGENTS.md'),
+      '# AGENTS\n\n<!-- agentskit-codex-profile:start -->\ntruncated\n',
+      'utf8',
+    )
+    await expect(writeRules('codex', { rootDir: root, force: true })).rejects.toThrow(
+      /half-edited block/,
+    )
   })
 
   it('skips when the profile block already matches', async () => {
@@ -99,16 +139,21 @@ describe('writeRules — codex (AGENTS.md profile block)', () => {
   })
 })
 
-describe('writeRules — claude-code skill bundle', () => {
-  it('writes the SKILL.md and at least one slash command', async () => {
+describe('writeRules — claude-code (skill + slash commands)', () => {
+  it('writes the SKILL.md to .claude/skills/ AND slash commands to .claude/commands/', async () => {
     const [r] = await writeRules('claude-code', { rootDir: root })
     const paths = r.files.map(f => f.path)
     expect(paths).toContain(join(root, '.claude', 'skills', 'agentskit', 'SKILL.md'))
-    expect(paths.some(p => p.endsWith('commands/doctor.md'))).toBe(true)
-    expect(paths.some(p => p.endsWith('commands/new-agent.md'))).toBe(true)
-    expect(paths.some(p => p.endsWith('commands/rules.md'))).toBe(true)
+    // Slash commands live at .claude/commands/<name>.md (NOT inside the skill folder)
+    expect(paths).toContain(join(root, '.claude', 'commands', 'agentskit-doctor.md'))
+    expect(paths).toContain(join(root, '.claude', 'commands', 'agentskit-new-agent.md'))
+    expect(paths).toContain(join(root, '.claude', 'commands', 'agentskit-rules.md'))
+
     const skill = readFileSync(join(root, '.claude/skills/agentskit/SKILL.md'), 'utf8')
     expect(skill).toContain('name: agentskit')
+
+    const cmd = readFileSync(join(root, '.claude/commands/agentskit-doctor.md'), 'utf8')
+    expect(cmd).toContain('description: Run the AgentsKit environment doctor')
   })
 })
 


### PR DESCRIPTION
## Summary

Closes **#775** (Claude Code skill), **#776** (Cursor + Windsurf rules pack), **#778** (Codex / Aider AGENTS.md profile).

\`agentskit rules <editor>\` generates editor configuration so AI coding agents know AgentsKit conventions (named-export-only, no-bare-throw, package boundaries, for-agents/* manifest) without extra prompting. One command, four editors covered.

## Diff

| Path | What |
|---|---|
| \`packages/cli/src/rules.ts\` | \`writeRules(editor, opts)\` — idempotent file-writer, codex profile-block parser, --force gate for AGENTS.md |
| \`packages/cli/src/rules/{cursor,windsurf,codex,claude-code}.ts\` | static rule contents per editor |
| \`packages/cli/src/commands/rules.ts\` | \`agentskit rules <editor>\` commander wiring |
| \`packages/cli/tests/rules.test.ts\` | 11 tests across all 4 editors + idempotency |
| \`.changeset/editor-integrations.md\` | cli minor |

## Editors covered

- **\`cursor\`** → \`.cursor/rules/agentskit.mdc\` with \`alwaysApply: true\`
- **\`windsurf\`** → \`.windsurfrules\` (plain markdown for Cascade)
- **\`codex\`** → YAML profile block in \`AGENTS.md\` (runner, allowed commands, restricted paths, recommended models, invariants). Replaces in place via sentinel comments; refuses to touch an existing AGENTS.md without \`--force\` (load-bearing root file).
- **\`claude-code\`** → \`.claude/skills/agentskit/\` skill bundle (SKILL.md + 6 slash commands wrapping \`init\` / \`doctor\` / \`add-tool\` / \`add-skill\` / \`lint-pii\` / \`rules\`)
- **\`all\`** → run every editor in one pass

## Design notes

- **Idempotent.** Re-running with unchanged content reports \`skipped\`. Tests pin this for cursor + codex.
- **\`--force\` only where needed.** Cursor + Windsurf overwrite freely (they're our files). Codex profile guards the existing AGENTS.md by default — only touches it when sentinel block is already present, otherwise requires \`--force\`.
- **Codex block is replaceable in place.** Sentinel \`<!-- agentskit-codex-profile:start -->\` / \`:end -->\` comments let \`agentskit rules codex\` re-run without duplicating content.
- **No new deps.** Pure node:fs/promises. CLI bundle stays small.

## Test plan

- [x] \`pnpm --filter @agentskit/cli test\` → 200/200 (11 new)
- [x] \`pnpm --filter @agentskit/cli lint\` → clean
- [x] \`pnpm --filter @agentskit/cli build\` → bundle ships rules templates
- [x] Smoke: \`node packages/cli/dist/bin.js rules all --out /tmp/<x>\` → 10 files written across 4 editors
- [ ] Live integration with each editor — separate per-editor manual test

## Out of scope

- Publishing the Claude Code skill bundle to a separate npm package — \`agentskit rules claude-code\` writes it directly into the workspace today
- Production agent control surface (#784) — separate UI work
- Live multi-agent topology graph (#785) — separate UI work