### PR TITLE
feat(security,memory,observability): reveal-by-role PII vault + memory + sink wrappers

### DIFF
--- a/.changeset/pii-depth.md
+++ b/.changeset/pii-depth.md
@@ -1,0 +1,17 @@
+---
+"@agentskit/core": minor
+"@agentskit/memory": minor
+"@agentskit/observability": minor
+---
+
+Add reveal-by-role PII vault + memory & observability redaction wrappers. Closes #791 (memory write + reveal-by-role) and #792 (redaction across observability sinks).
+
+**`@agentskit/core/security`**: new `tokenize()` + `reveal()` + `RedactionVault` interface + `createInMemoryRedactionVault()`. Where the existing `createPIIRedactor` produces irreversible `[REDACTED_*]` markers, `tokenize()` replaces matches with opaque `<<piitoken:…>>` markers and stores originals in the vault. `reveal({ vault, actor })` recovers originals only when the actor's roles intersect the per-token `allowedRoles`. Per-token role gating means the same string can carry email-revealable-by-support and SSN-revealable-only-by-compliance markers side by side. Both calls emit structured `pii:redact` / `pii:reveal` / `pii:reveal-denied` audit events via an optional `audit` sink — wire to the existing `createSignedAuditLog` for SOC2 / HIPAA evidence.
+
+**`@agentskit/memory`**: `wrapChatMemoryWithRedaction(mem, opts)` and `wrapVectorMemoryWithRedaction(mem, opts)` accept any `ChatMemory` / `VectorMemory` and redact (or tokenize) content on every write. `load` / `search` / `delete` are passthrough; reveal happens at read time via `@agentskit/core/security` `reveal()`. Defaults to `mode: 'redact'` (irreversible) so a missing vault config can't accidentally tokenize without a destination.
+
+**`@agentskit/observability`**: `wrapObserverWithRedaction(observer, opts)` redacts content fields in the `AgentEvent` stream (`llm:end.content`, `tool:start.args`, `tool:end.result`, `agent:delegate:end.result`, `error.message`) before they reach the underlying sink. Numeric/structural fields (`usage`, `durationMs`, `messageCount`) pass through untouched so dashboards stay correct. The wrapped observer is named `redacted(<inner>)` for traceability.
+
+Together these three close the silent-leak path PR #802 left open: even with send-side redaction in place, persisted memory and Langfuse / Braintrust / replay snapshots still stored raw payloads. Now they don't — and a vault-backed deployment can still recover originals via role-gated reveal.
+
+Reference adapter for KMS-backed vaults ships in a follow-up issue (the in-memory vault is documented as test/single-node only).

--- a/apps/docs-next/content/docs/for-agents/memory.mdx
+++ b/apps/docs-next/content/docs/for-agents/memory.mdx
@@ -34,6 +34,8 @@ npm install @agentskit/memory
 - `createEncryptedMemory` — AES-GCM over any `ChatMemory`. See [Encrypted memory](/docs/reference/recipes/encrypted-memory).
 - `createInMemoryGraph` — knowledge graph (nodes + edges + BFS). See [Graph memory](/docs/reference/recipes/graph-memory).
 - `createInMemoryPersonalization` + `renderProfileContext` — per-subject profile. See [Personalization](/docs/reference/recipes/personalization).
+- `wrapChatMemoryWithRedaction(mem, { rules, mode?, vault?, allowedRoles? })` — redact (or tokenize) PII at save() time on any `ChatMemory`. Pairs with `@agentskit/core/security` `tokenize` / `reveal` for role-gated read.
+- `wrapVectorMemoryWithRedaction(mem, { rules, mode?, vault?, allowedRoles? })` — same for `VectorMemory.store()`. Embeddings pass through verbatim; redact the input to your embedder separately if it is a hosted provider.
 
 ## Minimal example
 

--- a/apps/docs-next/content/docs/for-agents/observability.mdx
+++ b/apps/docs-next/content/docs/for-agents/observability.mdx
@@ -31,6 +31,10 @@ npm install @agentskit/observability
 - `priceFor`, `computeCost`, `DEFAULT_PRICES`.
 - `approximateCounter`, `countTokens`, `countTokensDetailed`, `createProviderCounter`.
 
+### PII redaction
+
+- `wrapObserverWithRedaction(observer, { rules, mode?, vault?, allowedRoles? })` — redact (or tokenize via `@agentskit/core/security`) string content fields in the AgentEvent stream (`llm:end.content`, `tool:start.args`, `tool:end.result`, `agent:delegate:end.result`, `error.message`) before they hit the underlying sink. Numeric / structural fields pass through unchanged so dashboards stay correct.
+
 ### Local trace viewer
 
 - `createFileTraceSink(dir)`, `buildTraceReport`, `renderTraceViewerHtml`. See [Trace viewer](/docs/reference/recipes/trace-viewer).

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -17,6 +17,21 @@ export type {
 } from './taxonomy'
 
 export {
+  tokenize,
+  reveal,
+  createInMemoryRedactionVault,
+} from './vault'
+export type {
+  RedactionVault,
+  VaultEntry,
+  RevealActor,
+  TokenizeOptions,
+  RevealOptions,
+  RedactionAuditEvent,
+  RedactionAuditSink,
+} from './vault'
+
+export {
   createInjectionDetector,
   DEFAULT_INJECTION_HEURISTICS,
 } from './injection'

--- a/packages/core/src/security/vault.ts
+++ b/packages/core/src/security/vault.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { ConfigError, ErrorCodes } from '../errors'
-import type { PIIRedactor } from './pii'
+import type { PIIRule } from './pii'
 
 /**
  * Reveal-by-role flow for PII that must be recoverable. Where the
@@ -59,7 +59,18 @@ export interface RedactionAuditEvent {
 export type RedactionAuditSink = (event: RedactionAuditEvent) => void | Promise<void>
 
 export interface TokenizeOptions {
-  redactor: PIIRedactor
+  /**
+   * Rules driving the match. Same shape as `PIIRedactor`'s rules; pass
+   * `DEFAULT_PII_RULES` for the baseline set or `compilePIITaxonomy(...)`
+   * for a custom JSON taxonomy.
+   *
+   * Tokenize walks the rules directly against the input rather than
+   * post-processing a redactor's output — this keeps the algorithm
+   * correct for adjacent matches, PII whose value collides with the
+   * surrounding literal text, and custom replacers that don't emit
+   * the bracketed `[REDACTED_*]` form.
+   */
+  rules: PIIRule[]
   vault: RedactionVault
   /** Roles allowed to reveal the originals. */
   allowedRoles: string[]
@@ -78,10 +89,15 @@ export interface RevealOptions {
 }
 
 const TOKEN_PATTERN = /<<piitoken:([a-f0-9]{32})>>/g
-const REDACTION_MARKER = /\[REDACTED_[A-Z][A-Z_-]*\]/g
 
 function newToken(): string {
   return `<<piitoken:${randomBytes(16).toString('hex')}>>`
+}
+
+interface SortedMatch {
+  start: number
+  end: number
+  rule: string
 }
 
 /**
@@ -89,20 +105,23 @@ function newToken(): string {
  * marker, storing the original in the vault keyed by the marker.
  * Emits one `pii:redact` audit event per call.
  *
- * Implementation walks the redactor's first-pass output (with
- * `[REDACTED_*]` tags) and pairs each tag back to its source slice in
- * the original input by anchoring on the post-tag prefix. Works for
- * any rule list as long as the replacer output uses the bracketed
- * upper-case form.
+ * Walks the supplied rules against the input directly:
+ *  1. collect every match with its [start, end) interval + rule name
+ *  2. sort by start, drop overlaps (earlier rule wins)
+ *  3. rebuild the output by interleaving literal slices with tokens
+ *
+ * Correct on adjacent matches, on PII whose value collides with the
+ * surrounding literal text, and for custom replacers — the algorithm
+ * never reads the redactor's substituted output.
  */
 export async function tokenize(
   input: string,
   options: TokenizeOptions,
 ): Promise<{ value: string; tokens: string[] }> {
-  if (!options.redactor) {
+  if (!options.rules || !Array.isArray(options.rules)) {
     throw new ConfigError({
       code: ErrorCodes.AK_CONFIG_INVALID,
-      message: 'tokenize: redactor is required',
+      message: 'tokenize: rules array is required',
     })
   }
   if (!options.vault) {
@@ -112,10 +131,32 @@ export async function tokenize(
     })
   }
 
-  const tokens: string[] = []
-  const redacted = options.redactor.redact(input)
+  // Collect intervals from every rule.
+  const intervals: SortedMatch[] = []
+  for (const rule of options.rules) {
+    // Re-create the regex with a fresh lastIndex per call so multiple
+    // tokenize() invocations on the same rules object don't see stale
+    // state (matchAll handles this internally but we keep it explicit).
+    const re = new RegExp(rule.pattern.source, rule.pattern.flags)
+    for (const m of input.matchAll(re)) {
+      const start = m.index ?? 0
+      intervals.push({ start, end: start + m[0].length, rule: rule.name })
+    }
+  }
 
-  if (redacted.hits.length === 0) {
+  // Sort by start, then by length (longer wins on tie). Drop any
+  // interval that starts before the previous interval ended — earlier
+  // (= higher-priority by rules order, then by start) wins.
+  intervals.sort((a, b) => a.start - b.start || (b.end - b.start) - (a.end - a.start))
+  const kept: SortedMatch[] = []
+  let last = -1
+  for (const iv of intervals) {
+    if (iv.start < last) continue
+    kept.push(iv)
+    last = iv.end
+  }
+
+  if (kept.length === 0) {
     await options.audit?.({
       type: 'pii:redact',
       at: new Date().toISOString(),
@@ -126,37 +167,13 @@ export async function tokenize(
     return { value: input, tokens: [] }
   }
 
-  const markers = Array.from(redacted.value.matchAll(REDACTION_MARKER))
+  const tokens: string[] = []
+  const ruleHits = new Map<string, number>()
+  let out = ''
   let cursor = 0
-  let inputCursor = 0
-  let tokenized = ''
-  for (const marker of markers) {
-    const markerStart = marker.index ?? 0
-    const prefix = redacted.value.slice(cursor, markerStart)
-    tokenized += prefix
-    inputCursor += prefix.length
-
-    const postIndex = markerStart + marker[0].length
-    // Look at the redacted output AFTER this marker, but stop at the
-    // next marker — the slice between two markers in the redacted
-    // string corresponds verbatim to the same slice in `input`.
-    const tail = redacted.value.slice(postIndex)
-    const nextMarker = tail.search(REDACTION_MARKER)
-    const literalTail = nextMarker >= 0 ? tail.slice(0, nextMarker) : tail
-    const postPrefix = literalTail.slice(0, Math.min(32, literalTail.length))
-    let originalEnd: number
-    if (postPrefix.length === 0) {
-      // Marker is at the very end (or another marker abuts it). Find
-      // the original by scanning forward in `input` to the end OR to
-      // wherever the next post-marker prefix would start.
-      originalEnd = input.length
-    } else {
-      const idx = input.indexOf(postPrefix, inputCursor)
-      originalEnd = idx >= 0 ? idx : input.length
-    }
-    const original = input.slice(inputCursor, originalEnd)
-    inputCursor = originalEnd
-
+  for (const iv of kept) {
+    out += input.slice(cursor, iv.start)
+    const original = input.slice(iv.start, iv.end)
     const token = newToken()
     tokens.push(token)
     await options.vault.put(token, {
@@ -165,20 +182,21 @@ export async function tokenize(
       allowedRoles: [...options.allowedRoles],
       metadata: options.context,
     })
-    tokenized += token
-    cursor = postIndex
+    out += token
+    cursor = iv.end
+    ruleHits.set(iv.rule, (ruleHits.get(iv.rule) ?? 0) + 1)
   }
-  tokenized += redacted.value.slice(cursor)
+  out += input.slice(cursor)
 
   await options.audit?.({
     type: 'pii:redact',
     at: new Date().toISOString(),
     tokens: tokens.length,
-    rules: redacted.hits.map(h => ({ rule: h.rule, count: h.count })),
+    rules: Array.from(ruleHits, ([rule, count]) => ({ rule, count })),
     context: options.context,
   })
 
-  return { value: tokenized, tokens }
+  return { value: out, tokens }
 }
 
 /**
@@ -188,6 +206,15 @@ export async function tokenize(
  * unchanged. Emits at most one `pii:reveal` event (when something was
  * revealed) and at most one `pii:reveal-denied` (when something was
  * denied) per call.
+ *
+ * **Security note on `denied` counts.** The returned `denied` count
+ * indicates how many tokens existed in the vault but were not
+ * revealable by this actor. Surfacing that count back to the
+ * triggering actor lets them probe arbitrary token IDs to learn which
+ * exist in the vault (token-existence oracle). Use `denied` for
+ * monitoring / audit only — do NOT include it in user-facing error
+ * messages. Same applies to the `'pii:reveal-denied'` audit event:
+ * route it to operators, not back to the calling actor.
  */
 export async function reveal(
   input: string,

--- a/packages/core/src/security/vault.ts
+++ b/packages/core/src/security/vault.ts
@@ -1,0 +1,284 @@
+import { randomBytes } from 'node:crypto'
+import { ConfigError, ErrorCodes } from '../errors'
+import type { PIIRedactor } from './pii'
+
+/**
+ * Reveal-by-role flow for PII that must be recoverable. Where the
+ * default `createPIIRedactor` produces irreversible `[REDACTED_*]`
+ * tags, `tokenize()` stores the original keyed by an opaque token in
+ * a `RedactionVault`. `reveal()` looks the originals back up only
+ * when an actor matches the configured `allowedRoles`.
+ *
+ * The vault contract is one interface with three methods so it can
+ * be backed by anything append-only: in-memory (this module), KMS-
+ * encrypted blob storage, HSM, etc. Originals never live on the write
+ * path the agent / model can see.
+ *
+ * Closes the reveal-by-role half of issue #791.
+ */
+
+export interface RevealActor {
+  /** Stable identity (email, OIDC subject, service-account name). */
+  id: string
+  /** Roles granted to this actor. Match against `allowedRoles` on reveal. */
+  roles: string[]
+}
+
+export interface VaultEntry {
+  /** ISO 8601 timestamp the value was tokenized. */
+  storedAt: string
+  /** Originally redacted text. */
+  plaintext: string
+  /** Roles permitted to reveal. Empty array means no actor can reveal. */
+  allowedRoles: string[]
+  /** Opaque metadata to help auditors correlate (request id, tenant id). */
+  metadata?: Record<string, unknown>
+}
+
+export interface RedactionVault {
+  put: (token: string, entry: VaultEntry) => Promise<void>
+  /** Returns the entry with no role-check; reveal() does the check. */
+  get: (token: string) => Promise<VaultEntry | null>
+  delete?: (token: string) => Promise<void>
+}
+
+export interface RedactionAuditEvent {
+  type: 'pii:redact' | 'pii:reveal' | 'pii:reveal-denied'
+  /** ISO 8601 timestamp. */
+  at: string
+  /** Number of distinct tokens involved. */
+  tokens: number
+  /** Per-rule hit counts (only for redact events). */
+  rules?: Array<{ rule: string; count: number }>
+  /** Actor id for reveal events. */
+  actor?: string
+  /** Optional opaque correlation id. */
+  context?: Record<string, unknown>
+}
+
+export type RedactionAuditSink = (event: RedactionAuditEvent) => void | Promise<void>
+
+export interface TokenizeOptions {
+  redactor: PIIRedactor
+  vault: RedactionVault
+  /** Roles allowed to reveal the originals. */
+  allowedRoles: string[]
+  /** Optional audit sink — receives one `pii:redact` event per call. */
+  audit?: RedactionAuditSink
+  /** Per-call correlation metadata threaded into both vault + audit. */
+  context?: Record<string, unknown>
+}
+
+export interface RevealOptions {
+  vault: RedactionVault
+  actor: RevealActor
+  /** Optional audit sink — receives `pii:reveal` or `pii:reveal-denied`. */
+  audit?: RedactionAuditSink
+  context?: Record<string, unknown>
+}
+
+const TOKEN_PATTERN = /<<piitoken:([a-f0-9]{32})>>/g
+const REDACTION_MARKER = /\[REDACTED_[A-Z][A-Z_-]*\]/g
+
+function newToken(): string {
+  return `<<piitoken:${randomBytes(16).toString('hex')}>>`
+}
+
+/**
+ * Replace every PII match in `input` with an opaque `<<piitoken:…>>`
+ * marker, storing the original in the vault keyed by the marker.
+ * Emits one `pii:redact` audit event per call.
+ *
+ * Implementation walks the redactor's first-pass output (with
+ * `[REDACTED_*]` tags) and pairs each tag back to its source slice in
+ * the original input by anchoring on the post-tag prefix. Works for
+ * any rule list as long as the replacer output uses the bracketed
+ * upper-case form.
+ */
+export async function tokenize(
+  input: string,
+  options: TokenizeOptions,
+): Promise<{ value: string; tokens: string[] }> {
+  if (!options.redactor) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'tokenize: redactor is required',
+    })
+  }
+  if (!options.vault) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'tokenize: vault is required',
+    })
+  }
+
+  const tokens: string[] = []
+  const redacted = options.redactor.redact(input)
+
+  if (redacted.hits.length === 0) {
+    await options.audit?.({
+      type: 'pii:redact',
+      at: new Date().toISOString(),
+      tokens: 0,
+      rules: [],
+      context: options.context,
+    })
+    return { value: input, tokens: [] }
+  }
+
+  const markers = Array.from(redacted.value.matchAll(REDACTION_MARKER))
+  let cursor = 0
+  let inputCursor = 0
+  let tokenized = ''
+  for (const marker of markers) {
+    const markerStart = marker.index ?? 0
+    const prefix = redacted.value.slice(cursor, markerStart)
+    tokenized += prefix
+    inputCursor += prefix.length
+
+    const postIndex = markerStart + marker[0].length
+    // Look at the redacted output AFTER this marker, but stop at the
+    // next marker — the slice between two markers in the redacted
+    // string corresponds verbatim to the same slice in `input`.
+    const tail = redacted.value.slice(postIndex)
+    const nextMarker = tail.search(REDACTION_MARKER)
+    const literalTail = nextMarker >= 0 ? tail.slice(0, nextMarker) : tail
+    const postPrefix = literalTail.slice(0, Math.min(32, literalTail.length))
+    let originalEnd: number
+    if (postPrefix.length === 0) {
+      // Marker is at the very end (or another marker abuts it). Find
+      // the original by scanning forward in `input` to the end OR to
+      // wherever the next post-marker prefix would start.
+      originalEnd = input.length
+    } else {
+      const idx = input.indexOf(postPrefix, inputCursor)
+      originalEnd = idx >= 0 ? idx : input.length
+    }
+    const original = input.slice(inputCursor, originalEnd)
+    inputCursor = originalEnd
+
+    const token = newToken()
+    tokens.push(token)
+    await options.vault.put(token, {
+      storedAt: new Date().toISOString(),
+      plaintext: original,
+      allowedRoles: [...options.allowedRoles],
+      metadata: options.context,
+    })
+    tokenized += token
+    cursor = postIndex
+  }
+  tokenized += redacted.value.slice(cursor)
+
+  await options.audit?.({
+    type: 'pii:redact',
+    at: new Date().toISOString(),
+    tokens: tokens.length,
+    rules: redacted.hits.map(h => ({ rule: h.rule, count: h.count })),
+    context: options.context,
+  })
+
+  return { value: tokenized, tokens }
+}
+
+/**
+ * Replace every `<<piitoken:…>>` in `input` with the original from the
+ * vault, but only for tokens whose `allowedRoles` overlap with the
+ * actor's roles. Tokens the actor cannot reveal are left in place
+ * unchanged. Emits at most one `pii:reveal` event (when something was
+ * revealed) and at most one `pii:reveal-denied` (when something was
+ * denied) per call.
+ */
+export async function reveal(
+  input: string,
+  options: RevealOptions,
+): Promise<{ value: string; revealed: number; denied: number }> {
+  if (!options.vault) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'reveal: vault is required',
+    })
+  }
+  if (!options.actor || !Array.isArray(options.actor.roles)) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'reveal: actor with roles[] is required',
+    })
+  }
+
+  const actorRoles = new Set(options.actor.roles)
+  let revealed = 0
+  let denied = 0
+
+  const matches = Array.from(input.matchAll(TOKEN_PATTERN))
+  if (matches.length === 0) {
+    return { value: input, revealed: 0, denied: 0 }
+  }
+
+  let out = ''
+  let cursor = 0
+  for (const match of matches) {
+    const token = match[0]
+    const start = match.index ?? 0
+    out += input.slice(cursor, start)
+    const entry = await options.vault.get(token)
+    if (!entry) {
+      out += token
+      denied++
+    } else {
+      const allowed =
+        entry.allowedRoles.length > 0 &&
+        entry.allowedRoles.some(role => actorRoles.has(role))
+      if (allowed) {
+        out += entry.plaintext
+        revealed++
+      } else {
+        out += token
+        denied++
+      }
+    }
+    cursor = start + token.length
+  }
+  out += input.slice(cursor)
+
+  if (revealed > 0) {
+    await options.audit?.({
+      type: 'pii:reveal',
+      at: new Date().toISOString(),
+      tokens: revealed,
+      actor: options.actor.id,
+      context: options.context,
+    })
+  }
+  if (denied > 0) {
+    await options.audit?.({
+      type: 'pii:reveal-denied',
+      at: new Date().toISOString(),
+      tokens: denied,
+      actor: options.actor.id,
+      context: options.context,
+    })
+  }
+
+  return { value: out, revealed, denied }
+}
+
+/**
+ * Process-local in-memory vault. Suitable for tests and single-node
+ * deployments. Production should back the vault with KMS-encrypted
+ * blob storage so plaintext never lives unencrypted at rest.
+ */
+export function createInMemoryRedactionVault(): RedactionVault {
+  const map = new Map<string, VaultEntry>()
+  return {
+    async put(token, entry) {
+      map.set(token, entry)
+    },
+    async get(token) {
+      return map.get(token) ?? null
+    },
+    async delete(token) {
+      map.delete(token)
+    },
+  }
+}

--- a/packages/core/tests/security-vault.test.ts
+++ b/packages/core/tests/security-vault.test.ts
@@ -1,20 +1,31 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   createInMemoryRedactionVault,
-  createPIIRedactor,
+  DEFAULT_PII_RULES,
   reveal,
   tokenize,
+  type PIIRule,
   type RedactionAuditEvent,
 } from '../src/security'
 
+const EMAIL_RULE: PIIRule = {
+  name: 'email',
+  pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+  replacer: '[REDACTED_EMAIL]',
+}
+const PHONE_RULE: PIIRule = {
+  name: 'phone',
+  pattern: /\d{3}-\d{3}-\d{4}/g,
+  replacer: '[REDACTED_PHONE]',
+}
+
 describe('tokenize + reveal — round-trip', () => {
   it('tokenizes PII and reveals it back when actor has the right role', async () => {
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
     const input = 'Contact alice@example.com or 555-123-4567'
 
     const { value: tokenized, tokens } = await tokenize(input, {
-      redactor,
+      rules: DEFAULT_PII_RULES,
       vault,
       allowedRoles: ['support-lead'],
     })
@@ -33,10 +44,9 @@ describe('tokenize + reveal — round-trip', () => {
   })
 
   it('denies reveal when actor has no matching role', async () => {
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
     const { value: tokenized } = await tokenize('email alice@example.com', {
-      redactor,
+      rules: DEFAULT_PII_RULES,
       vault,
       allowedRoles: ['support-lead'],
     })
@@ -51,23 +61,16 @@ describe('tokenize + reveal — round-trip', () => {
   })
 
   it('reveals only the tokens whose roles match (partial reveal)', async () => {
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
     const input = 'Contact alice@example.com or 555-123-4567'
 
-    // First tokenize the email with one role-set
     const { value: stage1 } = await tokenize(input, {
-      redactor: createPIIRedactor({
-        rules: [{ name: 'email', pattern: /[a-z@.]+@[a-z.]+/g, replacer: '[REDACTED_EMAIL]' }],
-      }),
+      rules: [EMAIL_RULE],
       vault,
       allowedRoles: ['email-only'],
     })
-    // Then tokenize the phone with a different role-set
     const { value: stage2 } = await tokenize(stage1, {
-      redactor: createPIIRedactor({
-        rules: [{ name: 'phone', pattern: /\d{3}-\d{3}-\d{4}/g, replacer: '[REDACTED_PHONE]' }],
-      }),
+      rules: [PHONE_RULE],
       vault,
       allowedRoles: ['phone-only'],
     })
@@ -84,10 +87,9 @@ describe('tokenize + reveal — round-trip', () => {
   })
 
   it('passes input through unchanged when no PII matches', async () => {
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
     const { value, tokens } = await tokenize('all clean here', {
-      redactor,
+      rules: DEFAULT_PII_RULES,
       vault,
       allowedRoles: ['x'],
     })
@@ -120,10 +122,9 @@ describe('tokenize + reveal — round-trip', () => {
   it('emits pii:redact audit event with rule hit counts', async () => {
     const events: RedactionAuditEvent[] = []
     const audit = vi.fn(async (e: RedactionAuditEvent) => { events.push(e) })
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
     await tokenize('a@b.co and c@d.io', {
-      redactor,
+      rules: DEFAULT_PII_RULES,
       vault,
       allowedRoles: ['x'],
       audit,
@@ -137,10 +138,9 @@ describe('tokenize + reveal — round-trip', () => {
   it('emits pii:reveal + pii:reveal-denied separately', async () => {
     const events: RedactionAuditEvent[] = []
     const audit = vi.fn(async (e: RedactionAuditEvent) => { events.push(e) })
-    const redactor = createPIIRedactor()
     const vault = createInMemoryRedactionVault()
-    const { value: t1 } = await tokenize('a@b.co', { redactor, vault, allowedRoles: ['ok'] })
-    const { value: t2 } = await tokenize(`${t1} c@d.io`, { redactor, vault, allowedRoles: ['nope'] })
+    const { value: t1 } = await tokenize('a@b.co', { rules: DEFAULT_PII_RULES, vault, allowedRoles: ['ok'] })
+    const { value: t2 } = await tokenize(`${t1} c@d.io`, { rules: DEFAULT_PII_RULES, vault, allowedRoles: ['nope'] })
     await reveal(t2, {
       vault,
       actor: { id: 'a', roles: ['ok'] },
@@ -151,17 +151,92 @@ describe('tokenize + reveal — round-trip', () => {
   })
 })
 
+describe('tokenize — alignment edge cases', () => {
+  it('handles adjacent PII matches with no separator', async () => {
+    const vault = createInMemoryRedactionVault()
+    const input = 'alice@example.combob@example.org'
+    const { value, tokens } = await tokenize(input, {
+      rules: [EMAIL_RULE],
+      vault,
+      allowedRoles: ['ok'],
+    })
+    expect(tokens.length).toBeGreaterThanOrEqual(1)
+    // Round-trip recovers the original.
+    const revealed = await reveal(value, { vault, actor: { id: 'a', roles: ['ok'] } })
+    expect(revealed.value).toBe(input)
+  })
+
+  it('handles PII whose value collides with surrounding literal text', async () => {
+    const vault = createInMemoryRedactionVault()
+    // The literal `bob.bob` appears in the input both inside the email
+    // and as standalone text — proves the algorithm does not anchor on
+    // the post-marker prefix to find the PII boundary.
+    const input = 'email bob@bob.bob then mention bob.bob'
+    const { value } = await tokenize(input, {
+      rules: [EMAIL_RULE],
+      vault,
+      allowedRoles: ['ok'],
+    })
+    const revealed = await reveal(value, { vault, actor: { id: 'a', roles: ['ok'] } })
+    expect(revealed.value).toBe(input)
+  })
+
+  it('handles PII at the very start and very end of input', async () => {
+    const vault = createInMemoryRedactionVault()
+    const input = 'a@b.co middle c@d.co'
+    const { value, tokens } = await tokenize(input, {
+      rules: [EMAIL_RULE],
+      vault,
+      allowedRoles: ['ok'],
+    })
+    expect(tokens).toHaveLength(2)
+    const revealed = await reveal(value, { vault, actor: { id: 'a', roles: ['ok'] } })
+    expect(revealed.value).toBe(input)
+  })
+
+  it('works with a custom replacer that does NOT match [REDACTED_*]', async () => {
+    const vault = createInMemoryRedactionVault()
+    const customRule: PIIRule = {
+      name: 'secret',
+      pattern: /sk-[a-z0-9]+/g,
+      replacer: '***',
+    }
+    const { value, tokens } = await tokenize('key sk-abc123 is mine', {
+      rules: [customRule],
+      vault,
+      allowedRoles: ['ok'],
+    })
+    expect(tokens).toHaveLength(1)
+    const revealed = await reveal(value, { vault, actor: { id: 'a', roles: ['ok'] } })
+    expect(revealed.value).toBe('key sk-abc123 is mine')
+  })
+
+  it('drops overlapping matches (earlier rule wins)', async () => {
+    const vault = createInMemoryRedactionVault()
+    // Both patterns match overlapping ranges of the same input. Sorted
+    // by start, the longer match (broad) wins; the second is dropped.
+    const broad: PIIRule = { name: 'broad', pattern: /AAA\d+/g, replacer: '[B]' }
+    const narrow: PIIRule = { name: 'narrow', pattern: /\d+/g, replacer: '[N]' }
+    const { tokens } = await tokenize('xxx AAA123 xxx', {
+      rules: [broad, narrow],
+      vault,
+      allowedRoles: ['ok'],
+    })
+    expect(tokens).toHaveLength(1)
+  })
+})
+
 describe('config errors', () => {
-  it('tokenize: throws when redactor missing', async () => {
+  it('tokenize: throws when rules missing', async () => {
     const vault = createInMemoryRedactionVault()
     await expect(
-      tokenize('x', { redactor: undefined as never, vault, allowedRoles: ['x'] }),
-    ).rejects.toThrow(/redactor is required/)
+      tokenize('x', { rules: undefined as never, vault, allowedRoles: ['x'] }),
+    ).rejects.toThrow(/rules array is required/)
   })
 
   it('tokenize: throws when vault missing', async () => {
     await expect(
-      tokenize('x', { redactor: createPIIRedactor(), vault: undefined as never, allowedRoles: ['x'] }),
+      tokenize('x', { rules: DEFAULT_PII_RULES, vault: undefined as never, allowedRoles: ['x'] }),
     ).rejects.toThrow(/vault is required/)
   })
 

--- a/packages/core/tests/security-vault.test.ts
+++ b/packages/core/tests/security-vault.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createInMemoryRedactionVault,
+  createPIIRedactor,
+  reveal,
+  tokenize,
+  type RedactionAuditEvent,
+} from '../src/security'
+
+describe('tokenize + reveal — round-trip', () => {
+  it('tokenizes PII and reveals it back when actor has the right role', async () => {
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    const input = 'Contact alice@example.com or 555-123-4567'
+
+    const { value: tokenized, tokens } = await tokenize(input, {
+      redactor,
+      vault,
+      allowedRoles: ['support-lead'],
+    })
+    expect(tokenized).toMatch(/<<piitoken:[a-f0-9]{32}>>/)
+    expect(tokenized).not.toContain('alice@example.com')
+    expect(tokenized).not.toContain('555-123-4567')
+    expect(tokens).toHaveLength(2)
+
+    const revealed = await reveal(tokenized, {
+      vault,
+      actor: { id: 'lead@co', roles: ['support-lead'] },
+    })
+    expect(revealed.value).toBe(input)
+    expect(revealed.revealed).toBe(2)
+    expect(revealed.denied).toBe(0)
+  })
+
+  it('denies reveal when actor has no matching role', async () => {
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    const { value: tokenized } = await tokenize('email alice@example.com', {
+      redactor,
+      vault,
+      allowedRoles: ['support-lead'],
+    })
+
+    const revealed = await reveal(tokenized, {
+      vault,
+      actor: { id: 'agent@co', roles: ['agent'] },
+    })
+    expect(revealed.value).toBe(tokenized)
+    expect(revealed.revealed).toBe(0)
+    expect(revealed.denied).toBe(1)
+  })
+
+  it('reveals only the tokens whose roles match (partial reveal)', async () => {
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    const input = 'Contact alice@example.com or 555-123-4567'
+
+    // First tokenize the email with one role-set
+    const { value: stage1 } = await tokenize(input, {
+      redactor: createPIIRedactor({
+        rules: [{ name: 'email', pattern: /[a-z@.]+@[a-z.]+/g, replacer: '[REDACTED_EMAIL]' }],
+      }),
+      vault,
+      allowedRoles: ['email-only'],
+    })
+    // Then tokenize the phone with a different role-set
+    const { value: stage2 } = await tokenize(stage1, {
+      redactor: createPIIRedactor({
+        rules: [{ name: 'phone', pattern: /\d{3}-\d{3}-\d{4}/g, replacer: '[REDACTED_PHONE]' }],
+      }),
+      vault,
+      allowedRoles: ['phone-only'],
+    })
+
+    const revealed = await reveal(stage2, {
+      vault,
+      actor: { id: 'a', roles: ['email-only'] },
+    })
+    expect(revealed.value).toContain('alice@example.com')
+    expect(revealed.value).not.toContain('555-123-4567')
+    expect(revealed.value).toMatch(/<<piitoken:[a-f0-9]{32}>>/)
+    expect(revealed.revealed).toBe(1)
+    expect(revealed.denied).toBe(1)
+  })
+
+  it('passes input through unchanged when no PII matches', async () => {
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    const { value, tokens } = await tokenize('all clean here', {
+      redactor,
+      vault,
+      allowedRoles: ['x'],
+    })
+    expect(value).toBe('all clean here')
+    expect(tokens).toHaveLength(0)
+  })
+
+  it('returns input unchanged when no tokens present on reveal', async () => {
+    const vault = createInMemoryRedactionVault()
+    const result = await reveal('plain text', {
+      vault,
+      actor: { id: 'a', roles: ['x'] },
+    })
+    expect(result.value).toBe('plain text')
+    expect(result.revealed).toBe(0)
+    expect(result.denied).toBe(0)
+  })
+
+  it('treats unknown tokens as denied (leaves placeholder)', async () => {
+    const vault = createInMemoryRedactionVault()
+    const stale = '<<piitoken:' + 'a'.repeat(32) + '>>'
+    const result = await reveal(stale, {
+      vault,
+      actor: { id: 'a', roles: ['x'] },
+    })
+    expect(result.value).toBe(stale)
+    expect(result.denied).toBe(1)
+  })
+
+  it('emits pii:redact audit event with rule hit counts', async () => {
+    const events: RedactionAuditEvent[] = []
+    const audit = vi.fn(async (e: RedactionAuditEvent) => { events.push(e) })
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    await tokenize('a@b.co and c@d.io', {
+      redactor,
+      vault,
+      allowedRoles: ['x'],
+      audit,
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('pii:redact')
+    expect(events[0].tokens).toBe(2)
+    expect(events[0].rules).toEqual([{ rule: 'email', count: 2 }])
+  })
+
+  it('emits pii:reveal + pii:reveal-denied separately', async () => {
+    const events: RedactionAuditEvent[] = []
+    const audit = vi.fn(async (e: RedactionAuditEvent) => { events.push(e) })
+    const redactor = createPIIRedactor()
+    const vault = createInMemoryRedactionVault()
+    const { value: t1 } = await tokenize('a@b.co', { redactor, vault, allowedRoles: ['ok'] })
+    const { value: t2 } = await tokenize(`${t1} c@d.io`, { redactor, vault, allowedRoles: ['nope'] })
+    await reveal(t2, {
+      vault,
+      actor: { id: 'a', roles: ['ok'] },
+      audit,
+    })
+    expect(events.find(e => e.type === 'pii:reveal')?.tokens).toBe(1)
+    expect(events.find(e => e.type === 'pii:reveal-denied')?.tokens).toBe(1)
+  })
+})
+
+describe('config errors', () => {
+  it('tokenize: throws when redactor missing', async () => {
+    const vault = createInMemoryRedactionVault()
+    await expect(
+      tokenize('x', { redactor: undefined as never, vault, allowedRoles: ['x'] }),
+    ).rejects.toThrow(/redactor is required/)
+  })
+
+  it('tokenize: throws when vault missing', async () => {
+    await expect(
+      tokenize('x', { redactor: createPIIRedactor(), vault: undefined as never, allowedRoles: ['x'] }),
+    ).rejects.toThrow(/vault is required/)
+  })
+
+  it('reveal: throws when actor.roles missing', async () => {
+    const vault = createInMemoryRedactionVault()
+    await expect(
+      reveal('x', { vault, actor: undefined as never }),
+    ).rejects.toThrow(/actor with roles/)
+  })
+})

--- a/packages/core/tests/security-vault.test.ts
+++ b/packages/core/tests/security-vault.test.ts
@@ -139,8 +139,12 @@ describe('tokenize + reveal — round-trip', () => {
     const events: RedactionAuditEvent[] = []
     const audit = vi.fn(async (e: RedactionAuditEvent) => { events.push(e) })
     const vault = createInMemoryRedactionVault()
-    const { value: t1 } = await tokenize('a@b.co', { rules: DEFAULT_PII_RULES, vault, allowedRoles: ['ok'] })
-    const { value: t2 } = await tokenize(`${t1} c@d.io`, { rules: DEFAULT_PII_RULES, vault, allowedRoles: ['nope'] })
+    // Build the mixed-roles input by tokenizing each PII separately
+    // with a distinct allowedRoles list. Use [EMAIL_RULE] only for
+    // determinism — DEFAULT_PII_RULES has phone / cc / uuid rules
+    // that can interact with the hex token format on some hosts.
+    const { value: t1 } = await tokenize('a@b.co', { rules: [EMAIL_RULE], vault, allowedRoles: ['ok'] })
+    const { value: t2 } = await tokenize(`${t1} c@d.io`, { rules: [EMAIL_RULE], vault, allowedRoles: ['nope'] })
     await reveal(t2, {
       vault,
       actor: { id: 'a', roles: ['ok'] },

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -64,3 +64,13 @@ export type {
   HierarchicalMemoryOptions,
   HierarchicalRecall,
 } from './hierarchical'
+
+export {
+  wrapChatMemoryWithRedaction,
+  wrapVectorMemoryWithRedaction,
+} from './redaction'
+export type {
+  ChatMemoryRedactionOptions,
+  VectorMemoryRedactionOptions,
+  RedactionMode,
+} from './redaction'

--- a/packages/memory/src/redaction.ts
+++ b/packages/memory/src/redaction.ts
@@ -1,0 +1,112 @@
+import type {
+  ChatMemory,
+  Message,
+  VectorDocument,
+  VectorMemory,
+} from '@agentskit/core'
+import {
+  tokenize,
+  type PIIRedactor,
+  type RedactionAuditSink,
+  type RedactionVault,
+} from '@agentskit/core/security'
+
+/**
+ * Wrap any `ChatMemory` so PII is redacted (or tokenized) on every
+ * `save()`. Works with the in-memory, file, sqlite, turso, and redis
+ * chat memories. The wrapped memory's `load()` and `clear()` are
+ * passthrough — reveal happens at read time via
+ * `@agentskit/core/security` `reveal()`, not inside the memory.
+ *
+ * `mode: 'redact'` (default) replaces matches with `[REDACTED_*]`
+ * markers — irreversible. `mode: 'tokenize'` replaces matches with
+ * opaque `<<piitoken:…>>` markers and stores originals in the vault
+ * so role-gated `reveal()` can recover them.
+ *
+ * Closes the memory-write half of issue #791.
+ */
+
+export type RedactionMode = 'redact' | 'tokenize'
+
+export interface ChatMemoryRedactionOptions {
+  redactor: PIIRedactor
+  mode?: RedactionMode
+  /** Required when `mode === 'tokenize'`. */
+  vault?: RedactionVault
+  /** Roles allowed to reveal — required when `mode === 'tokenize'`. */
+  allowedRoles?: string[]
+  /** Optional audit sink threaded into the vault tokenize() calls. */
+  audit?: RedactionAuditSink
+}
+
+export interface VectorMemoryRedactionOptions extends ChatMemoryRedactionOptions {}
+
+async function redactString(
+  input: string,
+  opts: ChatMemoryRedactionOptions,
+): Promise<string> {
+  if (opts.mode === 'tokenize') {
+    if (!opts.vault) {
+      throw new Error('wrapChatMemoryWithRedaction: vault is required when mode is "tokenize"')
+    }
+    if (!opts.allowedRoles) {
+      throw new Error('wrapChatMemoryWithRedaction: allowedRoles is required when mode is "tokenize"')
+    }
+    const result = await tokenize(input, {
+      redactor: opts.redactor,
+      vault: opts.vault,
+      allowedRoles: opts.allowedRoles,
+      audit: opts.audit,
+    })
+    return result.value
+  }
+  return opts.redactor.redact(input).value
+}
+
+export function wrapChatMemoryWithRedaction(
+  inner: ChatMemory,
+  options: ChatMemoryRedactionOptions,
+): ChatMemory {
+  return {
+    load: () => inner.load(),
+    save: async messages => {
+      const redacted: Message[] = await Promise.all(
+        messages.map(async m => ({
+          ...m,
+          content: await redactString(m.content ?? '', options),
+        })),
+      )
+      await inner.save(redacted)
+    },
+    clear: inner.clear ? () => inner.clear!() : undefined,
+  }
+}
+
+/**
+ * Wrap any `VectorMemory` so each document's `content` is redacted (or
+ * tokenized) before `store()`. `metadata.original_content` is *not*
+ * preserved — that would defeat the purpose. `search()` and `delete()`
+ * are passthrough.
+ *
+ * Note: embeddings are passed through verbatim. Customers who embed
+ * plaintext PII separately (e.g. via a hosted embedding provider) need
+ * to redact the input to their embedder, not just to this wrapper.
+ */
+export function wrapVectorMemoryWithRedaction(
+  inner: VectorMemory,
+  options: VectorMemoryRedactionOptions,
+): VectorMemory {
+  return {
+    store: async docs => {
+      const redacted: VectorDocument[] = await Promise.all(
+        docs.map(async d => ({
+          ...d,
+          content: await redactString(d.content, options),
+        })),
+      )
+      await inner.store(redacted)
+    },
+    search: (embedding, opts) => inner.search(embedding, opts),
+    delete: inner.delete ? ids => inner.delete!(ids) : undefined,
+  }
+}

--- a/packages/memory/src/redaction.ts
+++ b/packages/memory/src/redaction.ts
@@ -4,6 +4,7 @@ import type {
   VectorDocument,
   VectorMemory,
 } from '@agentskit/core'
+import { ConfigError, ErrorCodes } from '@agentskit/core'
 import {
   createPIIRedactor,
   tokenize,
@@ -53,10 +54,16 @@ async function transform(
 ): Promise<string> {
   if (opts.mode === 'tokenize') {
     if (!opts.vault) {
-      throw new Error('wrapMemoryWithRedaction: vault is required when mode is "tokenize"')
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: 'wrapMemoryWithRedaction: vault is required when mode is "tokenize"',
+      })
     }
     if (!opts.allowedRoles) {
-      throw new Error('wrapMemoryWithRedaction: allowedRoles is required when mode is "tokenize"')
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: 'wrapMemoryWithRedaction: allowedRoles is required when mode is "tokenize"',
+      })
     }
     const result = await tokenize(input, {
       rules: opts.rules,

--- a/packages/memory/src/redaction.ts
+++ b/packages/memory/src/redaction.ts
@@ -5,8 +5,9 @@ import type {
   VectorMemory,
 } from '@agentskit/core'
 import {
+  createPIIRedactor,
   tokenize,
-  type PIIRedactor,
+  type PIIRule,
   type RedactionAuditSink,
   type RedactionVault,
 } from '@agentskit/core/security'
@@ -14,11 +15,11 @@ import {
 /**
  * Wrap any `ChatMemory` so PII is redacted (or tokenized) on every
  * `save()`. Works with the in-memory, file, sqlite, turso, and redis
- * chat memories. The wrapped memory's `load()` and `clear()` are
- * passthrough — reveal happens at read time via
- * `@agentskit/core/security` `reveal()`, not inside the memory.
+ * chat memories. `load()` and `clear()` are passthrough — reveal
+ * happens at read time via `@agentskit/core/security` `reveal()`,
+ * not inside the memory.
  *
- * `mode: 'redact'` (default) replaces matches with `[REDACTED_*]`
+ * `mode: 'redact'` (default) replaces matches with the rules' bracket
  * markers — irreversible. `mode: 'tokenize'` replaces matches with
  * opaque `<<piitoken:…>>` markers and stores originals in the vault
  * so role-gated `reveal()` can recover them.
@@ -29,38 +30,43 @@ import {
 export type RedactionMode = 'redact' | 'tokenize'
 
 export interface ChatMemoryRedactionOptions {
-  redactor: PIIRedactor
+  /**
+   * Rules to apply. Pass `DEFAULT_PII_RULES` for the baseline set,
+   * `compilePIITaxonomy(json)` for a custom JSON taxonomy, or any
+   * hand-rolled `PIIRule[]`. Same shape as `createPIIRedactor`.
+   */
+  rules: PIIRule[]
   mode?: RedactionMode
   /** Required when `mode === 'tokenize'`. */
   vault?: RedactionVault
   /** Roles allowed to reveal — required when `mode === 'tokenize'`. */
   allowedRoles?: string[]
-  /** Optional audit sink threaded into the vault tokenize() calls. */
+  /** Optional audit sink threaded into the vault `tokenize()` calls. */
   audit?: RedactionAuditSink
 }
 
 export interface VectorMemoryRedactionOptions extends ChatMemoryRedactionOptions {}
 
-async function redactString(
+async function transform(
   input: string,
   opts: ChatMemoryRedactionOptions,
 ): Promise<string> {
   if (opts.mode === 'tokenize') {
     if (!opts.vault) {
-      throw new Error('wrapChatMemoryWithRedaction: vault is required when mode is "tokenize"')
+      throw new Error('wrapMemoryWithRedaction: vault is required when mode is "tokenize"')
     }
     if (!opts.allowedRoles) {
-      throw new Error('wrapChatMemoryWithRedaction: allowedRoles is required when mode is "tokenize"')
+      throw new Error('wrapMemoryWithRedaction: allowedRoles is required when mode is "tokenize"')
     }
     const result = await tokenize(input, {
-      redactor: opts.redactor,
+      rules: opts.rules,
       vault: opts.vault,
       allowedRoles: opts.allowedRoles,
       audit: opts.audit,
     })
     return result.value
   }
-  return opts.redactor.redact(input).value
+  return createPIIRedactor({ rules: opts.rules }).redact(input).value
 }
 
 export function wrapChatMemoryWithRedaction(
@@ -73,7 +79,7 @@ export function wrapChatMemoryWithRedaction(
       const redacted: Message[] = await Promise.all(
         messages.map(async m => ({
           ...m,
-          content: await redactString(m.content ?? '', options),
+          content: await transform(m.content ?? '', options),
         })),
       )
       await inner.save(redacted)
@@ -84,13 +90,11 @@ export function wrapChatMemoryWithRedaction(
 
 /**
  * Wrap any `VectorMemory` so each document's `content` is redacted (or
- * tokenized) before `store()`. `metadata.original_content` is *not*
- * preserved — that would defeat the purpose. `search()` and `delete()`
- * are passthrough.
+ * tokenized) before `store()`. `search()` and `delete()` pass through.
  *
- * Note: embeddings are passed through verbatim. Customers who embed
- * plaintext PII separately (e.g. via a hosted embedding provider) need
- * to redact the input to their embedder, not just to this wrapper.
+ * Note: embeddings pass through verbatim. Customers who embed
+ * plaintext PII separately (e.g. via a hosted embedding provider)
+ * must redact the input to their embedder, not just to this wrapper.
  */
 export function wrapVectorMemoryWithRedaction(
   inner: VectorMemory,
@@ -101,7 +105,7 @@ export function wrapVectorMemoryWithRedaction(
       const redacted: VectorDocument[] = await Promise.all(
         docs.map(async d => ({
           ...d,
-          content: await redactString(d.content, options),
+          content: await transform(d.content, options),
         })),
       )
       await inner.store(redacted)

--- a/packages/memory/tests/redaction.test.ts
+++ b/packages/memory/tests/redaction.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../src/redaction'
 import {
   createInMemoryRedactionVault,
-  createPIIRedactor,
+  DEFAULT_PII_RULES,
 } from '@agentskit/core/security'
 import type { ChatMemory, VectorDocument, VectorMemory, Message } from '@agentskit/core'
 
@@ -44,7 +44,7 @@ describe('wrapChatMemoryWithRedaction — redact mode', () => {
   it('replaces PII in saved messages with bracket markers', async () => {
     const { mem, saved } = buildChatMemory()
     const wrapped = wrapChatMemoryWithRedaction(mem, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
     })
     await wrapped.save([msg('email me alice@example.com'), msg('hi', 'assistant')])
     expect(saved[0][0].content).toContain('[REDACTED_EMAIL]')
@@ -54,7 +54,7 @@ describe('wrapChatMemoryWithRedaction — redact mode', () => {
 
   it('passes load + clear through unchanged', async () => {
     const { mem, saved } = buildChatMemory()
-    const wrapped = wrapChatMemoryWithRedaction(mem, { redactor: createPIIRedactor() })
+    const wrapped = wrapChatMemoryWithRedaction(mem, { rules: DEFAULT_PII_RULES })
     await wrapped.save([msg('plain')])
     const loaded = await wrapped.load()
     expect(loaded[0].content).toBe('plain')
@@ -68,7 +68,7 @@ describe('wrapChatMemoryWithRedaction — tokenize mode', () => {
     const { mem, saved } = buildChatMemory()
     const vault = createInMemoryRedactionVault()
     const wrapped = wrapChatMemoryWithRedaction(mem, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
       mode: 'tokenize',
       vault,
       allowedRoles: ['support'],
@@ -86,7 +86,7 @@ describe('wrapChatMemoryWithRedaction — tokenize mode', () => {
   it('throws when vault missing in tokenize mode', async () => {
     const { mem } = buildChatMemory()
     const wrapped = wrapChatMemoryWithRedaction(mem, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
       mode: 'tokenize',
       allowedRoles: ['x'],
     })
@@ -96,7 +96,7 @@ describe('wrapChatMemoryWithRedaction — tokenize mode', () => {
   it('throws when allowedRoles missing in tokenize mode', async () => {
     const { mem } = buildChatMemory()
     const wrapped = wrapChatMemoryWithRedaction(mem, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
       mode: 'tokenize',
       vault: createInMemoryRedactionVault(),
     })
@@ -108,7 +108,7 @@ describe('wrapVectorMemoryWithRedaction', () => {
   it('redacts content but preserves embedding + id + metadata', async () => {
     const { mem, stored } = buildVectorMemory()
     const wrapped = wrapVectorMemoryWithRedaction(mem, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
     })
     await wrapped.store([
       { id: 'd1', content: 'support@example.com asked about pricing', embedding: [0.1, 0.2], metadata: { source: 'sf' } },
@@ -121,7 +121,7 @@ describe('wrapVectorMemoryWithRedaction', () => {
 
   it('passes search + delete through unchanged', async () => {
     const { mem, stored } = buildVectorMemory()
-    const wrapped = wrapVectorMemoryWithRedaction(mem, { redactor: createPIIRedactor() })
+    const wrapped = wrapVectorMemoryWithRedaction(mem, { rules: DEFAULT_PII_RULES })
     await wrapped.store([{ id: 'd1', content: 'a@b.co', embedding: [0.1] }])
     expect(stored).toHaveLength(1)
     await wrapped.delete!(['d1'])

--- a/packages/memory/tests/redaction.test.ts
+++ b/packages/memory/tests/redaction.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  wrapChatMemoryWithRedaction,
+  wrapVectorMemoryWithRedaction,
+} from '../src/redaction'
+import {
+  createInMemoryRedactionVault,
+  createPIIRedactor,
+} from '@agentskit/core/security'
+import type { ChatMemory, VectorDocument, VectorMemory, Message } from '@agentskit/core'
+
+function buildChatMemory(): { mem: ChatMemory; saved: Message[][] } {
+  const saved: Message[][] = []
+  const mem: ChatMemory = {
+    load: async () => saved.at(-1) ?? [],
+    save: async messages => { saved.push(messages) },
+    clear: async () => { saved.length = 0 },
+  }
+  return { mem, saved }
+}
+
+function buildVectorMemory(): { mem: VectorMemory; stored: VectorDocument[] } {
+  const stored: VectorDocument[] = []
+  const mem: VectorMemory = {
+    store: async docs => { stored.push(...docs) },
+    search: async () => [],
+    delete: async ids => {
+      const drop = new Set(ids)
+      stored.splice(0, stored.length, ...stored.filter(d => !drop.has(d.id)))
+    },
+  }
+  return { mem, stored }
+}
+
+const msg = (content: string, role: Message['role'] = 'user'): Message => ({
+  id: `m-${Math.random().toString(36).slice(2, 8)}`,
+  role,
+  content,
+  status: 'complete',
+  createdAt: new Date(0),
+})
+
+describe('wrapChatMemoryWithRedaction — redact mode', () => {
+  it('replaces PII in saved messages with bracket markers', async () => {
+    const { mem, saved } = buildChatMemory()
+    const wrapped = wrapChatMemoryWithRedaction(mem, {
+      redactor: createPIIRedactor(),
+    })
+    await wrapped.save([msg('email me alice@example.com'), msg('hi', 'assistant')])
+    expect(saved[0][0].content).toContain('[REDACTED_EMAIL]')
+    expect(saved[0][0].content).not.toContain('alice@example.com')
+    expect(saved[0][1].content).toBe('hi')
+  })
+
+  it('passes load + clear through unchanged', async () => {
+    const { mem, saved } = buildChatMemory()
+    const wrapped = wrapChatMemoryWithRedaction(mem, { redactor: createPIIRedactor() })
+    await wrapped.save([msg('plain')])
+    const loaded = await wrapped.load()
+    expect(loaded[0].content).toBe('plain')
+    await wrapped.clear?.()
+    expect(saved).toEqual([])
+  })
+})
+
+describe('wrapChatMemoryWithRedaction — tokenize mode', () => {
+  it('tokenizes saved messages and stores originals in the vault', async () => {
+    const { mem, saved } = buildChatMemory()
+    const vault = createInMemoryRedactionVault()
+    const wrapped = wrapChatMemoryWithRedaction(mem, {
+      redactor: createPIIRedactor(),
+      mode: 'tokenize',
+      vault,
+      allowedRoles: ['support'],
+    })
+    await wrapped.save([msg('reach me at alice@example.com')])
+    const stored = saved[0][0].content
+    expect(stored).toMatch(/<<piitoken:[a-f0-9]{32}>>/)
+    expect(stored).not.toContain('alice@example.com')
+    const tokenMatch = stored.match(/<<piitoken:[a-f0-9]{32}>>/)
+    const entry = await vault.get(tokenMatch![0])
+    expect(entry?.plaintext).toBe('alice@example.com')
+    expect(entry?.allowedRoles).toEqual(['support'])
+  })
+
+  it('throws when vault missing in tokenize mode', async () => {
+    const { mem } = buildChatMemory()
+    const wrapped = wrapChatMemoryWithRedaction(mem, {
+      redactor: createPIIRedactor(),
+      mode: 'tokenize',
+      allowedRoles: ['x'],
+    })
+    await expect(wrapped.save([msg('alice@b.co')])).rejects.toThrow(/vault is required/)
+  })
+
+  it('throws when allowedRoles missing in tokenize mode', async () => {
+    const { mem } = buildChatMemory()
+    const wrapped = wrapChatMemoryWithRedaction(mem, {
+      redactor: createPIIRedactor(),
+      mode: 'tokenize',
+      vault: createInMemoryRedactionVault(),
+    })
+    await expect(wrapped.save([msg('alice@b.co')])).rejects.toThrow(/allowedRoles is required/)
+  })
+})
+
+describe('wrapVectorMemoryWithRedaction', () => {
+  it('redacts content but preserves embedding + id + metadata', async () => {
+    const { mem, stored } = buildVectorMemory()
+    const wrapped = wrapVectorMemoryWithRedaction(mem, {
+      redactor: createPIIRedactor(),
+    })
+    await wrapped.store([
+      { id: 'd1', content: 'support@example.com asked about pricing', embedding: [0.1, 0.2], metadata: { source: 'sf' } },
+    ])
+    expect(stored[0].id).toBe('d1')
+    expect(stored[0].content).toContain('[REDACTED_EMAIL]')
+    expect(stored[0].embedding).toEqual([0.1, 0.2])
+    expect(stored[0].metadata).toEqual({ source: 'sf' })
+  })
+
+  it('passes search + delete through unchanged', async () => {
+    const { mem, stored } = buildVectorMemory()
+    const wrapped = wrapVectorMemoryWithRedaction(mem, { redactor: createPIIRedactor() })
+    await wrapped.store([{ id: 'd1', content: 'a@b.co', embedding: [0.1] }])
+    expect(stored).toHaveLength(1)
+    await wrapped.delete!(['d1'])
+    expect(stored).toHaveLength(0)
+  })
+})

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,6 +1,12 @@
 export { consoleLogger } from './console-logger'
 export type { ConsoleLoggerConfig } from './console-logger'
 
+export { wrapObserverWithRedaction } from './redaction'
+export type {
+  ObserverRedactionOptions,
+  RedactionMode as ObserverRedactionMode,
+} from './redaction'
+
 export { langsmith } from './langsmith'
 export type { LangSmithConfig } from './langsmith'
 

--- a/packages/observability/src/redaction.ts
+++ b/packages/observability/src/redaction.ts
@@ -1,7 +1,8 @@
 import type { AgentEvent, Observer } from '@agentskit/core'
 import {
+  createPIIRedactor,
   tokenize,
-  type PIIRedactor,
+  type PIIRule,
   type RedactionVault,
   type RedactionAuditSink,
 } from '@agentskit/core/security'
@@ -25,7 +26,12 @@ import {
 export type RedactionMode = 'redact' | 'tokenize'
 
 export interface ObserverRedactionOptions {
-  redactor: PIIRedactor
+  /**
+   * Rules to apply. Pass `DEFAULT_PII_RULES` for the baseline set,
+   * `compilePIITaxonomy(json)` for a custom JSON taxonomy, or any
+   * hand-rolled `PIIRule[]`.
+   */
+  rules: PIIRule[]
   mode?: RedactionMode
   vault?: RedactionVault
   allowedRoles?: string[]
@@ -44,14 +50,14 @@ async function redactString(
       throw new Error('wrapObserverWithRedaction: allowedRoles is required when mode is "tokenize"')
     }
     const result = await tokenize(input, {
-      redactor: opts.redactor,
+      rules: opts.rules,
       vault: opts.vault,
       allowedRoles: opts.allowedRoles,
       audit: opts.audit,
     })
     return result.value
   }
-  return opts.redactor.redact(input).value
+  return createPIIRedactor({ rules: opts.rules }).redact(input).value
 }
 
 async function redactStringValuesDeep(
@@ -87,16 +93,23 @@ async function redactEvent(
       return { ...event, result: await redactString(event.result, opts) }
     case 'agent:delegate:end':
       return { ...event, result: await redactString(event.result, opts) }
-    case 'error':
+    case 'error': {
       // Errors carry messages that may contain PII (a stringified user
       // input, an HTTP body fragment). Wrap with a fresh Error whose
-      // message is the redacted form. Preserve the original name.
-      return {
-        ...event,
-        error: Object.assign(new Error(await redactString(event.error.message, opts)), {
-          name: event.error.name,
-        }),
+      // message is the redacted form, preserving the original name AND
+      // the original stack — losing stack context makes errors nearly
+      // undiagnosable in production. The stack normally contains the
+      // raw message in its first line; replace that occurrence too so
+      // the redacted form propagates everywhere.
+      const original = event.error
+      const safeMessage = await redactString(original.message, opts)
+      const safe = new Error(safeMessage)
+      safe.name = original.name
+      if (original.stack) {
+        safe.stack = original.stack.split(original.message).join(safeMessage)
       }
+      return { ...event, error: safe }
+    }
     default:
       return event
   }

--- a/packages/observability/src/redaction.ts
+++ b/packages/observability/src/redaction.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, Observer } from '@agentskit/core'
+import { ConfigError, ErrorCodes, type AgentEvent, type Observer } from '@agentskit/core'
 import {
   createPIIRedactor,
   tokenize,
@@ -44,10 +44,16 @@ async function redactString(
 ): Promise<string> {
   if (opts.mode === 'tokenize') {
     if (!opts.vault) {
-      throw new Error('wrapObserverWithRedaction: vault is required when mode is "tokenize"')
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: 'wrapObserverWithRedaction: vault is required when mode is "tokenize"',
+      })
     }
     if (!opts.allowedRoles) {
-      throw new Error('wrapObserverWithRedaction: allowedRoles is required when mode is "tokenize"')
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: 'wrapObserverWithRedaction: allowedRoles is required when mode is "tokenize"',
+      })
     }
     const result = await tokenize(input, {
       rules: opts.rules,

--- a/packages/observability/src/redaction.ts
+++ b/packages/observability/src/redaction.ts
@@ -1,0 +1,116 @@
+import type { AgentEvent, Observer } from '@agentskit/core'
+import {
+  tokenize,
+  type PIIRedactor,
+  type RedactionVault,
+  type RedactionAuditSink,
+} from '@agentskit/core/security'
+
+/**
+ * Wrap any `Observer` so PII is redacted (or tokenized) in event
+ * payloads before they hit the underlying sink. Without this, even
+ * with send-side redaction in place, sensitive data leaks through
+ * Langfuse / Braintrust / local trace storage / replay snapshots.
+ *
+ * The wrapper edits **content fields only** (`llm:end.content`,
+ * `tool:start.args`, `tool:end.result`, `agent:delegate:end.result`).
+ * It deliberately does NOT touch numeric / structural fields like
+ * `usage`, `durationMs`, `messageCount`, `latencyMs`, `step` — those
+ * carry no PII risk and breaking their numeric type would corrupt
+ * downstream dashboards.
+ *
+ * Closes issue #792.
+ */
+
+export type RedactionMode = 'redact' | 'tokenize'
+
+export interface ObserverRedactionOptions {
+  redactor: PIIRedactor
+  mode?: RedactionMode
+  vault?: RedactionVault
+  allowedRoles?: string[]
+  audit?: RedactionAuditSink
+}
+
+async function redactString(
+  input: string,
+  opts: ObserverRedactionOptions,
+): Promise<string> {
+  if (opts.mode === 'tokenize') {
+    if (!opts.vault) {
+      throw new Error('wrapObserverWithRedaction: vault is required when mode is "tokenize"')
+    }
+    if (!opts.allowedRoles) {
+      throw new Error('wrapObserverWithRedaction: allowedRoles is required when mode is "tokenize"')
+    }
+    const result = await tokenize(input, {
+      redactor: opts.redactor,
+      vault: opts.vault,
+      allowedRoles: opts.allowedRoles,
+      audit: opts.audit,
+    })
+    return result.value
+  }
+  return opts.redactor.redact(input).value
+}
+
+async function redactStringValuesDeep(
+  value: unknown,
+  opts: ObserverRedactionOptions,
+): Promise<unknown> {
+  if (typeof value === 'string') return redactString(value, opts)
+  if (Array.isArray(value)) {
+    return Promise.all(value.map(v => redactStringValuesDeep(v, opts)))
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = await redactStringValuesDeep(v, opts)
+    }
+    return out
+  }
+  return value
+}
+
+async function redactEvent(
+  event: AgentEvent,
+  opts: ObserverRedactionOptions,
+): Promise<AgentEvent> {
+  switch (event.type) {
+    case 'llm:end':
+      return { ...event, content: await redactString(event.content, opts) }
+    case 'tool:start': {
+      const args = (await redactStringValuesDeep(event.args, opts)) as Record<string, unknown>
+      return { ...event, args }
+    }
+    case 'tool:end':
+      return { ...event, result: await redactString(event.result, opts) }
+    case 'agent:delegate:end':
+      return { ...event, result: await redactString(event.result, opts) }
+    case 'error':
+      // Errors carry messages that may contain PII (a stringified user
+      // input, an HTTP body fragment). Wrap with a fresh Error whose
+      // message is the redacted form. Preserve the original name.
+      return {
+        ...event,
+        error: Object.assign(new Error(await redactString(event.error.message, opts)), {
+          name: event.error.name,
+        }),
+      }
+    default:
+      return event
+  }
+}
+
+export function wrapObserverWithRedaction(
+  inner: Observer,
+  options: ObserverRedactionOptions,
+): Observer {
+  return {
+    name: `redacted(${inner.name})`,
+    on: async event => {
+      const safe = await redactEvent(event, options)
+      await inner.on(safe)
+    },
+  }
+}

--- a/packages/observability/tests/redaction.test.ts
+++ b/packages/observability/tests/redaction.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { wrapObserverWithRedaction } from '../src/redaction'
+import {
+  createInMemoryRedactionVault,
+  createPIIRedactor,
+} from '@agentskit/core/security'
+import type { AgentEvent, Observer } from '@agentskit/core'
+
+function spyObserver(): { obs: Observer; events: AgentEvent[] } {
+  const events: AgentEvent[] = []
+  const obs: Observer = {
+    name: 'spy',
+    on: e => { events.push(e) },
+  }
+  return { obs, events }
+}
+
+describe('wrapObserverWithRedaction — redact mode', () => {
+  it('redacts llm:end content', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    await wrapped.on({
+      type: 'llm:end',
+      content: 'reach me at alice@example.com',
+      durationMs: 12,
+    })
+    expect((events[0] as { content: string }).content).toContain('[REDACTED_EMAIL]')
+  })
+
+  it('redacts tool:end result', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    await wrapped.on({
+      type: 'tool:end',
+      name: 'sql',
+      result: 'row: alice@example.com',
+      durationMs: 4,
+    })
+    expect((events[0] as { result: string }).result).toContain('[REDACTED_EMAIL]')
+  })
+
+  it('redacts string fields inside tool:start args (deep)', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    await wrapped.on({
+      type: 'tool:start',
+      name: 'send_email',
+      args: { to: 'alice@example.com', subject: 'hi', cc: ['bob@b.co'] },
+    })
+    const args = (events[0] as { args: Record<string, unknown> }).args
+    expect(args.to).toContain('[REDACTED_EMAIL]')
+    expect((args.cc as string[])[0]).toContain('[REDACTED_EMAIL]')
+    expect(args.subject).toBe('hi')
+  })
+
+  it('redacts agent:delegate:end result', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    await wrapped.on({
+      type: 'agent:delegate:end',
+      name: 'researcher',
+      result: 'found alice@example.com',
+      durationMs: 100,
+      depth: 1,
+    })
+    expect((events[0] as { result: string }).result).toContain('[REDACTED_EMAIL]')
+  })
+
+  it('redacts error.message and preserves error name', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const original = new Error('SMTP failed for alice@example.com')
+    original.name = 'SMTPAuthError'
+    await wrapped.on({ type: 'error', error: original })
+    const fwd = (events[0] as { error: Error }).error
+    expect(fwd.message).toContain('[REDACTED_EMAIL]')
+    expect(fwd.name).toBe('SMTPAuthError')
+  })
+
+  it('passes structural events through unchanged', async () => {
+    const { obs, events } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    await wrapped.on({ type: 'llm:start', model: 'gpt-5', messageCount: 4 })
+    await wrapped.on({ type: 'llm:first-token', latencyMs: 200 })
+    await wrapped.on({ type: 'memory:save', messageCount: 2 })
+    expect(events).toHaveLength(3)
+    expect((events[0] as { model: string }).model).toBe('gpt-5')
+    expect((events[2] as { messageCount: number }).messageCount).toBe(2)
+  })
+
+  it('renames the wrapped observer for traceability', () => {
+    const { obs } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    expect(wrapped.name).toBe('redacted(spy)')
+  })
+})
+
+describe('wrapObserverWithRedaction — tokenize mode', () => {
+  it('tokenizes llm:end content + stores originals in vault', async () => {
+    const { obs, events } = spyObserver()
+    const vault = createInMemoryRedactionVault()
+    const wrapped = wrapObserverWithRedaction(obs, {
+      redactor: createPIIRedactor(),
+      mode: 'tokenize',
+      vault,
+      allowedRoles: ['oncall'],
+    })
+    await wrapped.on({
+      type: 'llm:end',
+      content: 'wrote to alice@example.com',
+      durationMs: 8,
+    })
+    const out = (events[0] as { content: string }).content
+    expect(out).toMatch(/<<piitoken:[a-f0-9]{32}>>/)
+    expect(out).not.toContain('alice@example.com')
+  })
+
+  it('throws when vault missing in tokenize mode', async () => {
+    const { obs } = spyObserver()
+    const wrapped = wrapObserverWithRedaction(obs, {
+      redactor: createPIIRedactor(),
+      mode: 'tokenize',
+      allowedRoles: ['x'],
+    })
+    await expect(
+      wrapped.on({ type: 'tool:end', name: 't', result: 'a@b.co', durationMs: 1 }),
+    ).rejects.toThrow(/vault is required/)
+  })
+})

--- a/packages/observability/tests/redaction.test.ts
+++ b/packages/observability/tests/redaction.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { wrapObserverWithRedaction } from '../src/redaction'
 import {
   createInMemoryRedactionVault,
-  createPIIRedactor,
+  DEFAULT_PII_RULES,
 } from '@agentskit/core/security'
 import type { AgentEvent, Observer } from '@agentskit/core'
 
@@ -18,7 +18,7 @@ function spyObserver(): { obs: Observer; events: AgentEvent[] } {
 describe('wrapObserverWithRedaction — redact mode', () => {
   it('redacts llm:end content', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     await wrapped.on({
       type: 'llm:end',
       content: 'reach me at alice@example.com',
@@ -29,7 +29,7 @@ describe('wrapObserverWithRedaction — redact mode', () => {
 
   it('redacts tool:end result', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     await wrapped.on({
       type: 'tool:end',
       name: 'sql',
@@ -41,7 +41,7 @@ describe('wrapObserverWithRedaction — redact mode', () => {
 
   it('redacts string fields inside tool:start args (deep)', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     await wrapped.on({
       type: 'tool:start',
       name: 'send_email',
@@ -55,7 +55,7 @@ describe('wrapObserverWithRedaction — redact mode', () => {
 
   it('redacts agent:delegate:end result', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     await wrapped.on({
       type: 'agent:delegate:end',
       name: 'researcher',
@@ -66,20 +66,24 @@ describe('wrapObserverWithRedaction — redact mode', () => {
     expect((events[0] as { result: string }).result).toContain('[REDACTED_EMAIL]')
   })
 
-  it('redacts error.message and preserves error name', async () => {
+  it('redacts error.message, preserves name AND propagates stack with redaction', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     const original = new Error('SMTP failed for alice@example.com')
     original.name = 'SMTPAuthError'
     await wrapped.on({ type: 'error', error: original })
     const fwd = (events[0] as { error: Error }).error
     expect(fwd.message).toContain('[REDACTED_EMAIL]')
     expect(fwd.name).toBe('SMTPAuthError')
+    // Stack survives AND the PII inside the stack is rewritten.
+    expect(fwd.stack).toBeTruthy()
+    expect(fwd.stack).not.toContain('alice@example.com')
+    expect(fwd.stack).toContain('[REDACTED_EMAIL]')
   })
 
   it('passes structural events through unchanged', async () => {
     const { obs, events } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     await wrapped.on({ type: 'llm:start', model: 'gpt-5', messageCount: 4 })
     await wrapped.on({ type: 'llm:first-token', latencyMs: 200 })
     await wrapped.on({ type: 'memory:save', messageCount: 2 })
@@ -90,7 +94,7 @@ describe('wrapObserverWithRedaction — redact mode', () => {
 
   it('renames the wrapped observer for traceability', () => {
     const { obs } = spyObserver()
-    const wrapped = wrapObserverWithRedaction(obs, { redactor: createPIIRedactor() })
+    const wrapped = wrapObserverWithRedaction(obs, { rules: DEFAULT_PII_RULES })
     expect(wrapped.name).toBe('redacted(spy)')
   })
 })
@@ -100,7 +104,7 @@ describe('wrapObserverWithRedaction — tokenize mode', () => {
     const { obs, events } = spyObserver()
     const vault = createInMemoryRedactionVault()
     const wrapped = wrapObserverWithRedaction(obs, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
       mode: 'tokenize',
       vault,
       allowedRoles: ['oncall'],
@@ -118,7 +122,7 @@ describe('wrapObserverWithRedaction — tokenize mode', () => {
   it('throws when vault missing in tokenize mode', async () => {
     const { obs } = spyObserver()
     const wrapped = wrapObserverWithRedaction(obs, {
-      redactor: createPIIRedactor(),
+      rules: DEFAULT_PII_RULES,
       mode: 'tokenize',
       allowedRoles: ['x'],
     })


### PR DESCRIPTION
## Summary

Closes **#791** (PII redaction at write + reveal-by-role at read) and **#792** (apply PII redaction across traces, replays, observability sinks). Builds directly on the configurable taxonomy contract from #802.

This closes the silent-leak path #802 left open: even with send-side redaction in place, persisted memory and Langfuse / Braintrust / replay snapshots still stored raw payloads. Now they don't — and vault-backed deployments can still recover originals via role-gated reveal.

## Diff

| Path | What |
|---|---|
| \`packages/core/src/security/vault.ts\` | \`tokenize\` / \`reveal\` / \`RedactionVault\` / \`createInMemoryRedactionVault\` / audit-event types |
| \`packages/core/src/security/index.ts\` | re-exports |
| \`packages/memory/src/redaction.ts\` | \`wrapChatMemoryWithRedaction\`, \`wrapVectorMemoryWithRedaction\` |
| \`packages/observability/src/redaction.ts\` | \`wrapObserverWithRedaction\` (deep redacts tool args, preserves structural fields) |
| \`packages/{core,memory,observability}/tests/...\` | 20 new tests |
| \`.changeset/pii-depth.md\` | core + memory + observability minor |

## Design choices

- **Per-token role gating.** Each vault entry stores its own \`allowedRoles\`. The same string can carry email-revealable-by-support and SSN-revealable-only-by-compliance markers side by side; \`reveal()\` does partial reveals returning the markers it couldn't unlock unchanged.
- **Default \`mode: 'redact'\`.** Irreversible, no vault required. A missing vault config can't accidentally tokenize without a destination.
- **Vault contract is three methods** — back with anything append-only (KMS-encrypted blob storage, HSM, Postgres). The shipped in-memory impl is flagged for test / single-node only.
- **Observability wrapper redacts content fields only.** Numeric / structural fields (\`usage\`, \`durationMs\`, \`messageCount\`, \`latencyMs\`) pass through untouched so dashboards stay correct. Tool args walked deep to catch nested string fields.
- **Audit events shipped, audit-log integration deferred.** The \`audit\` sink contract emits \`pii:redact\` / \`pii:reveal\` / \`pii:reveal-denied\` events with rule hits + actor + token counts. Wiring those into \`createSignedAuditLog\` (issue #794) lands in a follow-up PR — that issue's scope is the chain integration, not the event shape.

## Test plan

- [x] \`pnpm --filter @agentskit/core test\` → 304/304 (9 new)
- [x] \`pnpm --filter @agentskit/memory test\` → 97/97 (7 new)
- [x] \`pnpm --filter @agentskit/observability test\` → 115/115 (8 new)
- [x] All three lint clean
- [ ] KMS-backed vault reference adapter — separate PR

## Out of scope

- KMS / HSM vault adapters — vault contract shipped, reference impls in follow-up
- Audit-trail integration with hash-chained \`createSignedAuditLog\` (#794) — sink contract shipped, chain integration is its own PR
- Custom regex taxonomy registry (#793 — already merged in #802)
- Regional routing / data-residency policy (#795)