### PR TITLE
feat(observability): advanced cost guard — modes, windows, forecasting, alert sinks, chargeback

### DIFF
--- a/.changeset/cost-guard-depth.md
+++ b/.changeset/cost-guard-depth.md
@@ -1,0 +1,19 @@
+---
+"@agentskit/observability": minor
+---
+
+Production-grade cost guard. Closes #787 (hard-kill mode), #788 (forecasting + window caps), #789 (alert sinks), #790 (chargeback report).
+
+`createAdvancedCostGuard({ budgets, caps, mode, disableRuntime, alertSinks })` extends the existing per-tenant guard with:
+
+- **Modes**: `warn` (log only), `reject` (per-tenant flag, no abort), `kill` (disables the tenant runtime via an injected `disableRuntime` callback; refuses to construct without one).
+- **Window caps**: `perMinute` / `perDay` / `perMonth` / arbitrary custom rolling buckets. Each window has its own threshold; tripping any one fires alerts and (in `kill` mode) disables the tenant.
+- **50 / 80 / 100 % threshold alerts** per window, fired at most once per window.
+- **Linear forecast alerts**: at >25% of a window's elapsed time, if extrapolated final spend exceeds the cap, emit `cost:forecast` with `msUntilExceeded`. Once per window.
+- **Per-tenant cap overrides** via `tenantCaps`.
+- **Pluggable alert sinks**: `CostAlertSink = (event) => void | Promise<void>`. Built-in `consoleAlertSink()`, `webhookAlertSink({ url, headers })`, and `throttle(sink, windowMs)` wrapper for noisy windows. Alert keys throttle on `(type, tenant, window, threshold)` so different tenants alert independently.
+- **`enable(tenant)`** for explicit re-enable after kill (caller must also clear the persisted disabled flag).
+
+`chargebackReport(samples, { groupBy, from, to, prices })` is a pure exporter for cost attribution. Group keys: `tenant` / `user` / `skill` / `tool` / `model` / any of those joined with `tenant+`. Rows sorted by spend desc; samples missing `costUsd` get computed from `(model, tokens, prices)`. `chargebackReportToCsv(report)` renders a finance-friendly CSV (header + one row per group + TOTAL footer; commas / quotes / newlines correctly escaped).
+
+Both ship alongside the existing `costGuard` / `multiTenantCostGuard` — no breaking change. Use the advanced guard when you need windowed budgets, forecasting, or hard-kill enforcement; the simple guards are still the right tool for single-run dollar caps.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -56,7 +56,7 @@
   {
     "name": "@agentskit/observability (ESM)",
     "path": "packages/observability/dist/index.js",
-    "limit": "10 KB",
+    "limit": "12 KB",
     "gzip": true
   },
   {

--- a/apps/docs-next/content/docs/for-agents/observability.mdx
+++ b/apps/docs-next/content/docs/for-agents/observability.mdx
@@ -28,6 +28,9 @@ npm install @agentskit/observability
 
 - `costGuard(options)` — dollar ceiling per run.
 - `multiTenantCostGuard(options)` — per-tenant cost cap with shared bookkeeping.
+- `createAdvancedCostGuard({ budgets, caps, mode, disableRuntime, alertSinks })` — production-grade guard with `warn` / `reject` / `kill` modes, rolling window caps (`perMinute` / `perDay` / `perMonth` / custom), 50/80/100 % threshold alerts, linear forecast alerts, and pluggable sinks.
+- `consoleAlertSink()`, `webhookAlertSink({ url, headers })`, `throttle(sink, windowMs)` — built-in alert sinks.
+- `chargebackReport(samples, { groupBy, from, to })` + `chargebackReportToCsv(report)` — pure cost-attribution exporter for finance / per-tenant invoicing.
 - `priceFor`, `computeCost`, `DEFAULT_PRICES`.
 - `approximateCounter`, `countTokens`, `countTokensDetailed`, `createProviderCounter`.
 

--- a/packages/observability/src/cost-chargeback.ts
+++ b/packages/observability/src/cost-chargeback.ts
@@ -98,8 +98,20 @@ function keyOf(sample: CostSample, groupBy: ChargebackGroupKey): string {
 }
 
 function inWindow(sample: CostSample, from?: string, to?: string): boolean {
-  if (from && sample.at < from) return false
-  if (to && sample.at > to) return false
+  // Compare by epoch ms — string compare on ISO 8601 only works when
+  // every value shares the same UTC offset. Real-world callers mix
+  // `+05:30`, `Z`, and naive forms; coercing through Date.getTime
+  // collapses them all to the same instant.
+  const at = Date.parse(sample.at)
+  if (Number.isNaN(at)) return false
+  if (from) {
+    const fromMs = Date.parse(from)
+    if (!Number.isNaN(fromMs) && at < fromMs) return false
+  }
+  if (to) {
+    const toMs = Date.parse(to)
+    if (!Number.isNaN(toMs) && at > toMs) return false
+  }
   return true
 }
 
@@ -178,9 +190,11 @@ function escapeCsv(field: string | number): string {
 
 export function chargebackReportToCsv(report: ChargebackReport): string {
   const lines = [CSV_HEADERS.join(',')]
+  const renderRow = (cells: Array<string | number>): string =>
+    cells.map(v => escapeCsv(v)).join(',')
   for (const row of report.rows) {
-    lines.push([
-      escapeCsv(row.group),
+    lines.push(renderRow([
+      row.group,
       row.callCount,
       row.promptTokens,
       row.completionTokens,
@@ -188,10 +202,9 @@ export function chargebackReportToCsv(report: ChargebackReport): string {
       row.costUsd.toFixed(6),
       row.firstAt,
       row.lastAt,
-    ].map(v => typeof v === 'string' ? v : escapeCsv(v)).join(','))
+    ]))
   }
-  // Footer summary line.
-  lines.push([
+  lines.push(renderRow([
     'TOTAL',
     report.totalCalls,
     report.rows.reduce((s, r) => s + r.promptTokens, 0),
@@ -200,6 +213,6 @@ export function chargebackReportToCsv(report: ChargebackReport): string {
     report.totalCostUsd.toFixed(6),
     report.from ?? '',
     report.to ?? '',
-  ].map(v => typeof v === 'string' ? v : escapeCsv(v)).join(','))
+  ]))
   return `${lines.join('\n')}\n`
 }

--- a/packages/observability/src/cost-chargeback.ts
+++ b/packages/observability/src/cost-chargeback.ts
@@ -1,0 +1,205 @@
+import { DEFAULT_PRICES, computeCost, priceFor, type TokenPrice } from './cost-guard'
+
+/**
+ * Chargeback / cost-attribution exporter. Group LLM call samples by
+ * tenant + (user | skill | tool | model | custom) and produce CSV /
+ * JSON for finance dashboards or per-tenant invoicing.
+ *
+ * Inputs are caller-supplied `CostSample[]` rows. Wire your runtime
+ * to emit one sample per `llm:end` event (the `multiTenantCostGuard`
+ * already tracks the same data — feed its observer hook into a
+ * persistence layer to build the sample set).
+ *
+ * Closes #790.
+ */
+
+export interface CostSample {
+  /** ISO 8601 — when the call completed. */
+  at: string
+  tenant: string
+  /** Optional acting user id within the tenant. */
+  user?: string
+  /** Optional skill / tool that drove the call. */
+  skill?: string
+  tool?: string
+  /** Model id used for this call. */
+  model: string
+  promptTokens: number
+  completionTokens: number
+  /**
+   * Pre-computed cost in USD. When omitted, `chargebackReport` will
+   * compute it from the (model, token counts, prices) triple.
+   */
+  costUsd?: number
+}
+
+export type ChargebackGroupKey =
+  | 'tenant'
+  | 'user'
+  | 'skill'
+  | 'tool'
+  | 'model'
+  | 'tenant+user'
+  | 'tenant+skill'
+  | 'tenant+tool'
+  | 'tenant+model'
+
+export interface ChargebackReportOptions {
+  /** Group key. Default `'tenant'`. */
+  groupBy?: ChargebackGroupKey
+  /** Optional price table override for sample cost computation. */
+  prices?: Record<string, TokenPrice>
+  /**
+   * Inclusive window filter (ISO 8601). Samples outside the window
+   * are dropped before grouping.
+   */
+  from?: string
+  to?: string
+}
+
+export interface ChargebackRow {
+  /** Composite group key, joined with '/' for multi-field groups. */
+  group: string
+  callCount: number
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  costUsd: number
+  /** Earliest sample timestamp in the group (ISO 8601). */
+  firstAt: string
+  /** Latest sample timestamp in the group (ISO 8601). */
+  lastAt: string
+}
+
+export interface ChargebackReport {
+  groupBy: ChargebackGroupKey
+  rows: ChargebackRow[]
+  /** Sum of costUsd across all rows. */
+  totalCostUsd: number
+  /** Sum of callCount across all rows. */
+  totalCalls: number
+  /** Window the report covers (whichever the caller passed). */
+  from?: string
+  to?: string
+}
+
+function keyOf(sample: CostSample, groupBy: ChargebackGroupKey): string {
+  switch (groupBy) {
+    case 'tenant':         return sample.tenant
+    case 'user':           return sample.user ?? '<unknown>'
+    case 'skill':          return sample.skill ?? '<unknown>'
+    case 'tool':           return sample.tool ?? '<unknown>'
+    case 'model':          return sample.model
+    case 'tenant+user':    return `${sample.tenant}/${sample.user ?? '<unknown>'}`
+    case 'tenant+skill':   return `${sample.tenant}/${sample.skill ?? '<unknown>'}`
+    case 'tenant+tool':    return `${sample.tenant}/${sample.tool ?? '<unknown>'}`
+    case 'tenant+model':   return `${sample.tenant}/${sample.model}`
+  }
+}
+
+function inWindow(sample: CostSample, from?: string, to?: string): boolean {
+  if (from && sample.at < from) return false
+  if (to && sample.at > to) return false
+  return true
+}
+
+export function chargebackReport(
+  samples: CostSample[],
+  options: ChargebackReportOptions = {},
+): ChargebackReport {
+  const groupBy = options.groupBy ?? 'tenant'
+  const mergedPrices = options.prices ? { ...DEFAULT_PRICES, ...options.prices } : DEFAULT_PRICES
+
+  const groups = new Map<string, ChargebackRow>()
+  let totalCallCount = 0
+  let totalCost = 0
+
+  for (const sample of samples) {
+    if (!inWindow(sample, options.from, options.to)) continue
+    const cost = sample.costUsd ?? computeCost(
+      { promptTokens: sample.promptTokens, completionTokens: sample.completionTokens },
+      priceFor(sample.model, mergedPrices),
+    )
+    const key = keyOf(sample, groupBy)
+    let row = groups.get(key)
+    if (!row) {
+      row = {
+        group: key,
+        callCount: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        firstAt: sample.at,
+        lastAt: sample.at,
+      }
+      groups.set(key, row)
+    }
+    row.callCount += 1
+    row.promptTokens += sample.promptTokens
+    row.completionTokens += sample.completionTokens
+    row.totalTokens += sample.promptTokens + sample.completionTokens
+    row.costUsd += cost
+    if (sample.at < row.firstAt) row.firstAt = sample.at
+    if (sample.at > row.lastAt) row.lastAt = sample.at
+    totalCallCount += 1
+    totalCost += cost
+  }
+
+  // Stable sort by costUsd desc — biggest spenders first.
+  const rows = Array.from(groups.values()).sort((a, b) => b.costUsd - a.costUsd || a.group.localeCompare(b.group))
+
+  return {
+    groupBy,
+    rows,
+    totalCostUsd: totalCost,
+    totalCalls: totalCallCount,
+    from: options.from,
+    to: options.to,
+  }
+}
+
+const CSV_HEADERS = [
+  'group',
+  'callCount',
+  'promptTokens',
+  'completionTokens',
+  'totalTokens',
+  'costUsd',
+  'firstAt',
+  'lastAt',
+] as const
+
+function escapeCsv(field: string | number): string {
+  const s = String(field)
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`
+  return s
+}
+
+export function chargebackReportToCsv(report: ChargebackReport): string {
+  const lines = [CSV_HEADERS.join(',')]
+  for (const row of report.rows) {
+    lines.push([
+      escapeCsv(row.group),
+      row.callCount,
+      row.promptTokens,
+      row.completionTokens,
+      row.totalTokens,
+      row.costUsd.toFixed(6),
+      row.firstAt,
+      row.lastAt,
+    ].map(v => typeof v === 'string' ? v : escapeCsv(v)).join(','))
+  }
+  // Footer summary line.
+  lines.push([
+    'TOTAL',
+    report.totalCalls,
+    report.rows.reduce((s, r) => s + r.promptTokens, 0),
+    report.rows.reduce((s, r) => s + r.completionTokens, 0),
+    report.rows.reduce((s, r) => s + r.totalTokens, 0),
+    report.totalCostUsd.toFixed(6),
+    report.from ?? '',
+    report.to ?? '',
+  ].map(v => typeof v === 'string' ? v : escapeCsv(v)).join(','))
+  return `${lines.join('\n')}\n`
+}

--- a/packages/observability/src/cost-guard-advanced.ts
+++ b/packages/observability/src/cost-guard-advanced.ts
@@ -244,11 +244,24 @@ export function createAdvancedCostGuard(
     return state
   }
 
-  const onSpend = async (tenant: string, state: TenantState, deltaCost: number): Promise<void> => {
+  /**
+   * Synchronously update state + bucket counters and decide which
+   * alerts must fire. Returns the alert events ready for the caller
+   * to dispatch via the (async) sinks. Keeping this synchronous is
+   * what closes the concurrency window: by the time `on()` returns,
+   * `state.totalCost`, every bucket's `costUsd`, the alert bookkeeping
+   * (`alerted`, `forecastAlerted`, `exceededOverall`), and the
+   * `state.disabled` flag are all in their final consistent shape.
+   */
+  const recordSpend = (
+    tenant: string,
+    state: TenantState,
+    deltaCost: number,
+  ): { alerts: CostAlertEvent[]; disable?: { reason: string } } => {
     state.totalCost += deltaCost
     const t = now()
+    const alerts: CostAlertEvent[] = []
 
-    // Window bookkeeping + threshold alerts.
     const caps = pickCaps(options, tenant)
     for (const [windowId, cap] of caps) {
       const bucket = ensureBucket(state, windowId, cap, t)
@@ -257,7 +270,7 @@ export function createAdvancedCostGuard(
       for (const threshold of THRESHOLDS) {
         if (utilization >= threshold && !bucket.alerted.has(threshold)) {
           bucket.alerted.add(threshold)
-          await fireAlert({
+          alerts.push({
             type: threshold === 1.0 ? 'cost:exceeded' : 'cost:threshold',
             tenant,
             window: windowId,
@@ -269,8 +282,6 @@ export function createAdvancedCostGuard(
           })
         }
       }
-      // Forecast: linear extrapolation. If we are past 25 % of the window
-      // and projected to exceed, alert once per window.
       const elapsed = t - bucket.start
       if (
         !bucket.forecastAlerted &&
@@ -285,7 +296,7 @@ export function createAdvancedCostGuard(
           const remaining = bucket.budgetUsd - bucket.costUsd
           const rate = bucket.costUsd / elapsed
           const msUntilExceeded = remaining > 0 && rate > 0 ? remaining / rate : 0
-          await fireAlert({
+          alerts.push({
             type: 'cost:forecast',
             tenant,
             window: windowId,
@@ -299,11 +310,10 @@ export function createAdvancedCostGuard(
       }
     }
 
-    // Overall hard budget.
     const overall = overallBudget(tenant)
     if (overall !== undefined && state.totalCost > overall && !state.exceededOverall) {
       state.exceededOverall = true
-      await fireAlert({
+      alerts.push({
         type: 'cost:exceeded',
         tenant,
         window: 'overall',
@@ -315,17 +325,17 @@ export function createAdvancedCostGuard(
       })
     }
 
-    // Mode enforcement.
     const tripped =
       state.exceededOverall ||
       Array.from(state.buckets.values()).some(b => b.alerted.has(1.0))
+    let disable: { reason: string } | undefined
     if (mode === 'kill' && tripped && !state.disabled) {
       state.disabled = true
       const reason = state.exceededOverall
         ? `overall budget exceeded ($${overall} cap)`
         : 'window cap exceeded'
-      await options.disableRuntime?.(tenant, reason)
-      await fireAlert({
+      disable = { reason }
+      alerts.push({
         type: 'cost:disabled',
         tenant,
         window: 'overall',
@@ -336,6 +346,17 @@ export function createAdvancedCostGuard(
         reason,
       })
     }
+
+    return { alerts, disable }
+  }
+
+  const dispatchAlerts = async (
+    tenant: string,
+    alerts: CostAlertEvent[],
+    disable?: { reason: string },
+  ): Promise<void> => {
+    for (const event of alerts) await fireAlert(event)
+    if (disable) await options.disableRuntime?.(tenant, disable.reason)
   }
 
   return {
@@ -344,7 +365,7 @@ export function createAdvancedCostGuard(
       const tenant = options.tenantOf?.() ?? activeTenant
       if (!tenant) return
       const state = stateOf(tenant)
-      if (state.disabled && mode === 'kill') return // stop counting once killed
+      if (state.disabled && mode === 'kill') return
       if (event.type === 'llm:start' && event.model && !options.modelOverride) {
         state.model = event.model
       }
@@ -358,9 +379,13 @@ export function createAdvancedCostGuard(
         )
         const delta = newTotal - state.totalCost
         if (delta > 0) {
-          // Fire-and-forget — the on() contract is sync-or-async; sinks
-          // are awaited inside onSpend for sequencing.
-          void onSpend(tenant, state, delta)
+          // Mutate state SYNCHRONOUSLY so concurrent on() calls see the
+          // updated totals. Async work (alert sinks, disableRuntime) is
+          // fire-and-forget afterward and does not touch state again.
+          const { alerts, disable } = recordSpend(tenant, state, delta)
+          if (alerts.length > 0 || disable) {
+            void dispatchAlerts(tenant, alerts, disable)
+          }
         }
       }
     },

--- a/packages/observability/src/cost-guard-advanced.ts
+++ b/packages/observability/src/cost-guard-advanced.ts
@@ -1,0 +1,436 @@
+import { ConfigError, ErrorCodes, type AgentEvent, type Observer } from '@agentskit/core'
+import { DEFAULT_PRICES, computeCost, priceFor, type TokenPrice } from './cost-guard'
+
+/**
+ * Production-grade cost guard. Extends the multi-tenant guard with:
+ *
+ *   - **Modes**: `warn` (log only) · `reject` (per-tenant flag, no abort)
+ *     · `kill` (disable the tenant runtime via an injected
+ *     `disableRuntime` callback; requires explicit re-enable).
+ *   - **Window caps**: per-minute / per-day / per-month rolling buckets.
+ *     Each window has its own threshold; tripping any one fires alerts
+ *     and (in `kill` mode) disables the tenant.
+ *   - **Linear forecasting**: at 50 / 80 / 100 % of any window cap, emit
+ *     a `cost:threshold` alert with an extrapolated time-to-cap.
+ *   - **Pluggable alert sinks**: the same contract regardless of where
+ *     the alert lands (Slack webhook, PagerDuty, email gateway).
+ *   - **Throttled alerting**: at most one alert per (tenant, window,
+ *     threshold) per cap window — avoids alert storms.
+ *
+ * Closes #787 (hard-kill), #788 (forecasting + caps), #789 (alert sinks).
+ * Chargeback report (#790) lives in `chargebackReport()` below.
+ */
+
+export type CostGuardMode = 'warn' | 'reject' | 'kill'
+
+export interface CostCapWindow {
+  /** Window length in milliseconds. */
+  windowMs: number
+  /** USD ceiling per window. */
+  budgetUsd: number
+}
+
+export interface CostCaps {
+  perMinute?: CostCapWindow
+  perDay?: CostCapWindow
+  perMonth?: CostCapWindow
+  /** Custom additional windows. */
+  custom?: Record<string, CostCapWindow>
+}
+
+export type CostAlertType =
+  | 'cost:threshold'      // 50/80/100 % of a window cap reached
+  | 'cost:exceeded'       // hard cap exceeded
+  | 'cost:disabled'       // kill mode triggered → tenant disabled
+  | 'cost:forecast'       // linear extrapolation predicts overrun
+
+export interface CostAlertEvent {
+  type: CostAlertType
+  tenant: string
+  /** Window id (`'perMinute'`, `'perDay'`, `'perMonth'`, custom name). */
+  window: string
+  /** ISO 8601 timestamp. */
+  at: string
+  /** Spend so far in this window (USD). */
+  costUsd: number
+  /** Cap for this window (USD). */
+  budgetUsd: number
+  /** Fraction of budget consumed (0–∞). */
+  utilization: number
+  /** Threshold that triggered this alert (`0.5`, `0.8`, `1.0`, or undefined for forecast). */
+  threshold?: number
+  /**
+   * Estimated milliseconds until the budget is exhausted at the
+   * current spend rate, when type is `'cost:forecast'`.
+   */
+  msUntilExceeded?: number
+  /** Optional human-readable reason (mode change, etc.). */
+  reason?: string
+}
+
+export type CostAlertSink = (event: CostAlertEvent) => void | Promise<void>
+
+export interface AdvancedCostGuardOptions {
+  /** Per-tenant USD budgets (overall, applied alongside windows). */
+  budgets: Record<string, number>
+  /** Fallback overall budget for tenants not listed. */
+  defaultBudgetUsd?: number
+  /** Window caps applied to every tenant. Per-tenant overrides via `tenantCaps`. */
+  caps?: CostCaps
+  /** Per-tenant override of `caps`. Wins over the workspace-wide `caps`. */
+  tenantCaps?: Record<string, CostCaps>
+  /** Active tenant resolver (same shape as `multiTenantCostGuard.tenantOf`). */
+  tenantOf?: () => string | undefined
+  prices?: Record<string, TokenPrice>
+  /**
+   * Enforcement mode (default `'warn'`). `'kill'` requires
+   * `disableRuntime`.
+   */
+  mode?: CostGuardMode
+  /**
+   * Called when a tenant is disabled in `'kill'` mode. Must persist the
+   * disabled state (Redis flag, DB row) so the runtime stays disabled
+   * across restarts. The tenant is re-enabled only via your own
+   * out-of-band call (e.g. an admin API).
+   */
+  disableRuntime?: (tenant: string, reason: string) => void | Promise<void>
+  /** One or more alert sinks. Fired in registration order. */
+  alertSinks?: CostAlertSink[]
+  modelOverride?: string
+  /** Clock override for tests. */
+  now?: () => number
+  name?: string
+}
+
+interface SpendBucket {
+  /** Window id this bucket belongs to. */
+  window: string
+  /** [start, end) times in ms epoch. */
+  start: number
+  /** Cap budget for this window. */
+  budgetUsd: number
+  /** Window length in ms. */
+  windowMs: number
+  /** Spend so far in this window. */
+  costUsd: number
+  /** Thresholds already alerted this window (e.g. {0.5, 0.8, 1.0}). */
+  alerted: Set<number>
+  /** Whether the forecast alert has fired this window. */
+  forecastAlerted: boolean
+}
+
+interface TenantState {
+  prompt: number
+  completion: number
+  totalCost: number
+  model: string | undefined
+  exceededOverall: boolean
+  disabled: boolean
+  buckets: Map<string, SpendBucket>
+}
+
+function freshTenant(modelOverride?: string): TenantState {
+  return {
+    prompt: 0,
+    completion: 0,
+    totalCost: 0,
+    model: modelOverride,
+    exceededOverall: false,
+    disabled: false,
+    buckets: new Map(),
+  }
+}
+
+function rollBucket(bucket: SpendBucket, now: number): void {
+  if (now >= bucket.start + bucket.windowMs) {
+    bucket.start = now - (now - bucket.start) % bucket.windowMs
+    bucket.costUsd = 0
+    bucket.alerted.clear()
+    bucket.forecastAlerted = false
+  }
+}
+
+function ensureBucket(
+  state: TenantState,
+  windowId: string,
+  cap: CostCapWindow,
+  now: number,
+): SpendBucket {
+  let bucket = state.buckets.get(windowId)
+  if (!bucket) {
+    bucket = {
+      window: windowId,
+      start: now,
+      budgetUsd: cap.budgetUsd,
+      windowMs: cap.windowMs,
+      costUsd: 0,
+      alerted: new Set(),
+      forecastAlerted: false,
+    }
+    state.buckets.set(windowId, bucket)
+  } else {
+    rollBucket(bucket, now)
+    // Update cap if the caller changed it between calls.
+    bucket.budgetUsd = cap.budgetUsd
+    bucket.windowMs = cap.windowMs
+  }
+  return bucket
+}
+
+const THRESHOLDS = [0.5, 0.8, 1.0] as const
+
+function pickCaps(
+  options: AdvancedCostGuardOptions,
+  tenant: string,
+): Array<[string, CostCapWindow]> {
+  const merged: CostCaps = { ...(options.caps ?? {}), ...(options.tenantCaps?.[tenant] ?? {}) }
+  const out: Array<[string, CostCapWindow]> = []
+  if (merged.perMinute) out.push(['perMinute', merged.perMinute])
+  if (merged.perDay) out.push(['perDay', merged.perDay])
+  if (merged.perMonth) out.push(['perMonth', merged.perMonth])
+  if (merged.custom) {
+    for (const [name, cap] of Object.entries(merged.custom)) out.push([name, cap])
+  }
+  return out
+}
+
+export interface AdvancedCostGuard extends Observer {
+  setTenant: (tenant: string | undefined) => void
+  costUsd: (tenant: string) => number
+  windowSpend: (tenant: string, window: string) => number | undefined
+  isDisabled: (tenant: string) => boolean
+  /** Re-enable a tenant disabled by `kill` mode. Caller must also clear the persisted flag. */
+  enable: (tenant: string) => void
+  reset: (tenant?: string) => void
+  tenants: () => string[]
+}
+
+export function createAdvancedCostGuard(
+  options: AdvancedCostGuardOptions,
+): AdvancedCostGuard {
+  if (options.mode === 'kill' && !options.disableRuntime) {
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: 'createAdvancedCostGuard: mode "kill" requires disableRuntime callback',
+      hint: 'Provide a function that persists the disabled flag (Redis, DB, KV).',
+    })
+  }
+  const mode: CostGuardMode = options.mode ?? 'warn'
+  const mergedPrices = options.prices ? { ...DEFAULT_PRICES, ...options.prices } : DEFAULT_PRICES
+  const now = options.now ?? Date.now
+  const tenants = new Map<string, TenantState>()
+  let activeTenant: string | undefined
+
+  const fireAlert = async (event: CostAlertEvent): Promise<void> => {
+    for (const sink of options.alertSinks ?? []) {
+      try {
+        await sink(event)
+      } catch {
+        // Sinks must not break the metering loop.
+      }
+    }
+  }
+
+  const overallBudget = (tenant: string): number | undefined => {
+    return options.budgets[tenant] ?? options.defaultBudgetUsd
+  }
+
+  const stateOf = (tenant: string): TenantState => {
+    let state = tenants.get(tenant)
+    if (!state) {
+      state = freshTenant(options.modelOverride)
+      tenants.set(tenant, state)
+    }
+    return state
+  }
+
+  const onSpend = async (tenant: string, state: TenantState, deltaCost: number): Promise<void> => {
+    state.totalCost += deltaCost
+    const t = now()
+
+    // Window bookkeeping + threshold alerts.
+    const caps = pickCaps(options, tenant)
+    for (const [windowId, cap] of caps) {
+      const bucket = ensureBucket(state, windowId, cap, t)
+      bucket.costUsd += deltaCost
+      const utilization = bucket.budgetUsd > 0 ? bucket.costUsd / bucket.budgetUsd : 0
+      for (const threshold of THRESHOLDS) {
+        if (utilization >= threshold && !bucket.alerted.has(threshold)) {
+          bucket.alerted.add(threshold)
+          await fireAlert({
+            type: threshold === 1.0 ? 'cost:exceeded' : 'cost:threshold',
+            tenant,
+            window: windowId,
+            at: new Date(t).toISOString(),
+            costUsd: bucket.costUsd,
+            budgetUsd: bucket.budgetUsd,
+            utilization,
+            threshold,
+          })
+        }
+      }
+      // Forecast: linear extrapolation. If we are past 25 % of the window
+      // and projected to exceed, alert once per window.
+      const elapsed = t - bucket.start
+      if (
+        !bucket.forecastAlerted &&
+        elapsed > 0 &&
+        elapsed < bucket.windowMs &&
+        elapsed > bucket.windowMs * 0.25 &&
+        utilization > 0
+      ) {
+        const projectedFinal = (bucket.costUsd / elapsed) * bucket.windowMs
+        if (projectedFinal > bucket.budgetUsd) {
+          bucket.forecastAlerted = true
+          const remaining = bucket.budgetUsd - bucket.costUsd
+          const rate = bucket.costUsd / elapsed
+          const msUntilExceeded = remaining > 0 && rate > 0 ? remaining / rate : 0
+          await fireAlert({
+            type: 'cost:forecast',
+            tenant,
+            window: windowId,
+            at: new Date(t).toISOString(),
+            costUsd: bucket.costUsd,
+            budgetUsd: bucket.budgetUsd,
+            utilization,
+            msUntilExceeded,
+          })
+        }
+      }
+    }
+
+    // Overall hard budget.
+    const overall = overallBudget(tenant)
+    if (overall !== undefined && state.totalCost > overall && !state.exceededOverall) {
+      state.exceededOverall = true
+      await fireAlert({
+        type: 'cost:exceeded',
+        tenant,
+        window: 'overall',
+        at: new Date(t).toISOString(),
+        costUsd: state.totalCost,
+        budgetUsd: overall,
+        utilization: state.totalCost / overall,
+        threshold: 1.0,
+      })
+    }
+
+    // Mode enforcement.
+    const tripped =
+      state.exceededOverall ||
+      Array.from(state.buckets.values()).some(b => b.alerted.has(1.0))
+    if (mode === 'kill' && tripped && !state.disabled) {
+      state.disabled = true
+      const reason = state.exceededOverall
+        ? `overall budget exceeded ($${overall} cap)`
+        : 'window cap exceeded'
+      await options.disableRuntime?.(tenant, reason)
+      await fireAlert({
+        type: 'cost:disabled',
+        tenant,
+        window: 'overall',
+        at: new Date(t).toISOString(),
+        costUsd: state.totalCost,
+        budgetUsd: overall ?? 0,
+        utilization: overall ? state.totalCost / overall : 0,
+        reason,
+      })
+    }
+  }
+
+  return {
+    name: options.name ?? 'cost-guard-advanced',
+    on(event: AgentEvent) {
+      const tenant = options.tenantOf?.() ?? activeTenant
+      if (!tenant) return
+      const state = stateOf(tenant)
+      if (state.disabled && mode === 'kill') return // stop counting once killed
+      if (event.type === 'llm:start' && event.model && !options.modelOverride) {
+        state.model = event.model
+      }
+      if (event.type === 'llm:end' && event.usage) {
+        state.prompt += event.usage.promptTokens
+        state.completion += event.usage.completionTokens
+        const price = priceFor(state.model, mergedPrices)
+        const newTotal = computeCost(
+          { promptTokens: state.prompt, completionTokens: state.completion },
+          price,
+        )
+        const delta = newTotal - state.totalCost
+        if (delta > 0) {
+          // Fire-and-forget — the on() contract is sync-or-async; sinks
+          // are awaited inside onSpend for sequencing.
+          void onSpend(tenant, state, delta)
+        }
+      }
+    },
+    setTenant(tenant) {
+      activeTenant = tenant
+    },
+    costUsd: (tenant) => stateOf(tenant).totalCost,
+    windowSpend: (tenant, window) => stateOf(tenant).buckets.get(window)?.costUsd,
+    isDisabled: (tenant) => stateOf(tenant).disabled,
+    enable: (tenant) => {
+      const state = stateOf(tenant)
+      state.disabled = false
+    },
+    reset(tenant) {
+      if (tenant) tenants.set(tenant, freshTenant(options.modelOverride))
+      else tenants.clear()
+    },
+    tenants: () => Array.from(tenants.keys()),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in alert sinks
+// ---------------------------------------------------------------------------
+
+/** Console alert sink — `[cost:<type>] <tenant> <window> $<cost>/$<budget>`. */
+export function consoleAlertSink(): CostAlertSink {
+  return event => {
+    const line = `[${event.type}] tenant=${event.tenant} window=${event.window} ` +
+      `cost=$${event.costUsd.toFixed(4)} budget=$${event.budgetUsd.toFixed(4)} ` +
+      `util=${(event.utilization * 100).toFixed(1)}%` +
+      (event.threshold ? ` threshold=${(event.threshold * 100).toFixed(0)}%` : '') +
+      (event.reason ? ` reason="${event.reason}"` : '')
+    process.stderr.write(`${line}\n`)
+  }
+}
+
+export interface WebhookAlertSinkOptions {
+  url: string
+  /** Override fetch (tests / custom clients). */
+  fetch?: typeof fetch
+  /** Optional bearer / signing header. */
+  headers?: Record<string, string>
+}
+
+/** Generic webhook sink — POSTs the event JSON. Wrap with throttle() for noisy windows. */
+export function webhookAlertSink(options: WebhookAlertSinkOptions): CostAlertSink {
+  const fetchImpl = options.fetch ?? fetch
+  return async event => {
+    if (!fetchImpl) return
+    await fetchImpl(options.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(options.headers ?? {}) },
+      body: JSON.stringify(event),
+    })
+  }
+}
+
+/**
+ * Throttle wrapper — at most one alert per (tenant, window, type)
+ * per `windowMs`. Wrap any sink to bound emit rate.
+ */
+export function throttle(sink: CostAlertSink, windowMs: number, now: () => number = Date.now): CostAlertSink {
+  const lastFired = new Map<string, number>()
+  return async event => {
+    const key = `${event.type}|${event.tenant}|${event.window}|${event.threshold ?? ''}`
+    const t = now()
+    const previous = lastFired.get(key)
+    if (previous !== undefined && t - previous < windowMs) return
+    lastFired.set(key, t)
+    await sink(event)
+  }
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -31,6 +31,36 @@ export type { CostGuardOptions, TokenPrice } from './cost-guard'
 export { multiTenantCostGuard } from './cost-guard-multi-tenant'
 export type { MultiTenantCostGuardOptions } from './cost-guard-multi-tenant'
 
+export {
+  createAdvancedCostGuard,
+  consoleAlertSink,
+  webhookAlertSink,
+  throttle,
+} from './cost-guard-advanced'
+export type {
+  AdvancedCostGuard,
+  AdvancedCostGuardOptions,
+  CostGuardMode,
+  CostCaps,
+  CostCapWindow,
+  CostAlertSink,
+  CostAlertEvent,
+  CostAlertType,
+  WebhookAlertSinkOptions,
+} from './cost-guard-advanced'
+
+export {
+  chargebackReport,
+  chargebackReportToCsv,
+} from './cost-chargeback'
+export type {
+  CostSample,
+  ChargebackGroupKey,
+  ChargebackReport,
+  ChargebackReportOptions,
+  ChargebackRow,
+} from './cost-chargeback'
+
 export { approximateCounter, countTokens, countTokensDetailed, createProviderCounter } from './token-counter'
 export type { ProviderTokenCounterOptions } from './token-counter'
 

--- a/packages/observability/tests/cost-chargeback.test.ts
+++ b/packages/observability/tests/cost-chargeback.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import {
+  chargebackReport,
+  chargebackReportToCsv,
+  type CostSample,
+} from '../src/cost-chargeback'
+
+const samples: CostSample[] = [
+  {
+    at: '2026-01-01T08:00:00.000Z',
+    tenant: 'acme',
+    user: 'alice',
+    skill: 'researcher',
+    model: 'gpt-4o',
+    promptTokens: 1000,
+    completionTokens: 500,
+    costUsd: 0.0075,
+  },
+  {
+    at: '2026-01-01T09:00:00.000Z',
+    tenant: 'acme',
+    user: 'alice',
+    skill: 'researcher',
+    model: 'gpt-4o',
+    promptTokens: 200,
+    completionTokens: 800,
+    costUsd: 0.0085,
+  },
+  {
+    at: '2026-01-01T10:00:00.000Z',
+    tenant: 'acme',
+    user: 'bob',
+    skill: 'coder',
+    model: 'claude-sonnet-4-6',
+    promptTokens: 500,
+    completionTokens: 500,
+    costUsd: 0.009,
+  },
+  {
+    at: '2026-01-01T11:00:00.000Z',
+    tenant: 'globex',
+    user: 'eve',
+    skill: 'translator',
+    model: 'gpt-4o-mini',
+    promptTokens: 1000,
+    completionTokens: 1000,
+    // costUsd omitted — chargebackReport must compute from prices
+  },
+]
+
+describe('chargebackReport — grouping', () => {
+  it('groups by tenant by default', () => {
+    const report = chargebackReport(samples)
+    expect(report.groupBy).toBe('tenant')
+    expect(report.rows.map(r => r.group).sort()).toEqual(['acme', 'globex'])
+    const acme = report.rows.find(r => r.group === 'acme')!
+    expect(acme.callCount).toBe(3)
+    expect(acme.promptTokens).toBe(1700)
+    expect(acme.completionTokens).toBe(1800)
+    expect(acme.totalTokens).toBe(3500)
+  })
+
+  it('groups by tenant+user', () => {
+    const report = chargebackReport(samples, { groupBy: 'tenant+user' })
+    const groups = report.rows.map(r => r.group).sort()
+    expect(groups).toEqual(['acme/alice', 'acme/bob', 'globex/eve'])
+  })
+
+  it('groups by skill', () => {
+    const report = chargebackReport(samples, { groupBy: 'skill' })
+    expect(report.rows.map(r => r.group).sort()).toEqual(['coder', 'researcher', 'translator'])
+  })
+
+  it('computes cost from prices when sample.costUsd is missing', () => {
+    const report = chargebackReport(samples, { groupBy: 'tenant' })
+    const globex = report.rows.find(r => r.group === 'globex')!
+    expect(globex.costUsd).toBeGreaterThan(0)
+    // gpt-4o-mini: 0.00015 input + 0.0006 output per 1k → 1×0.00015 + 1×0.0006 = 0.00075
+    expect(globex.costUsd).toBeCloseTo(0.00075, 6)
+  })
+
+  it('sorts rows by costUsd descending', () => {
+    const report = chargebackReport(samples, { groupBy: 'tenant' })
+    for (let i = 0; i < report.rows.length - 1; i++) {
+      expect(report.rows[i].costUsd).toBeGreaterThanOrEqual(report.rows[i + 1].costUsd)
+    }
+  })
+
+  it('totalCallCount + totalCostUsd match row sums', () => {
+    const report = chargebackReport(samples)
+    const sumCalls = report.rows.reduce((s, r) => s + r.callCount, 0)
+    const sumCost = report.rows.reduce((s, r) => s + r.costUsd, 0)
+    expect(report.totalCalls).toBe(sumCalls)
+    expect(report.totalCostUsd).toBeCloseTo(sumCost, 8)
+  })
+})
+
+describe('chargebackReport — windowing', () => {
+  it('drops samples outside [from, to]', () => {
+    const report = chargebackReport(samples, {
+      groupBy: 'tenant',
+      from: '2026-01-01T08:30:00.000Z',
+      to: '2026-01-01T10:30:00.000Z',
+    })
+    expect(report.totalCalls).toBe(2) // 09:00 + 10:00, drops 08:00 + 11:00
+    expect(report.from).toBe('2026-01-01T08:30:00.000Z')
+    expect(report.to).toBe('2026-01-01T10:30:00.000Z')
+  })
+
+  it('captures earliest + latest at within each group', () => {
+    const report = chargebackReport(samples, { groupBy: 'tenant' })
+    const acme = report.rows.find(r => r.group === 'acme')!
+    expect(acme.firstAt).toBe('2026-01-01T08:00:00.000Z')
+    expect(acme.lastAt).toBe('2026-01-01T10:00:00.000Z')
+  })
+})
+
+describe('chargebackReportToCsv', () => {
+  it('emits a header row, one row per group, plus a TOTAL footer', () => {
+    const report = chargebackReport(samples, { groupBy: 'tenant' })
+    const csv = chargebackReportToCsv(report)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('group,callCount,promptTokens,completionTokens,totalTokens,costUsd,firstAt,lastAt')
+    expect(lines[lines.length - 1]).toMatch(/^TOTAL,\d+/)
+    // Header + 2 group rows + TOTAL = 4
+    expect(lines).toHaveLength(4)
+  })
+
+  it('escapes commas / quotes / newlines in group names', () => {
+    const weirdSamples: CostSample[] = [
+      {
+        at: '2026-01-01T00:00:00.000Z',
+        tenant: 'acme, "the company"',
+        model: 'gpt-4o',
+        promptTokens: 100,
+        completionTokens: 100,
+        costUsd: 0.001,
+      },
+    ]
+    const csv = chargebackReportToCsv(chargebackReport(weirdSamples))
+    expect(csv).toContain('"acme, ""the company"""')
+  })
+})

--- a/packages/observability/tests/cost-chargeback.test.ts
+++ b/packages/observability/tests/cost-chargeback.test.ts
@@ -115,6 +115,35 @@ describe('chargebackReport — windowing', () => {
   })
 })
 
+describe('chargebackReport — timezone correctness', () => {
+  it('treats from / to / sample.at as instants regardless of UTC offset', () => {
+    const offsetSamples: CostSample[] = [
+      {
+        at: '2026-01-01T03:00:00Z',
+        tenant: 'a',
+        model: 'gpt-4o',
+        promptTokens: 100,
+        completionTokens: 100,
+        costUsd: 0.001,
+      },
+    ]
+    // String compare would exclude this sample (lexicographic).
+    // Instant compare keeps it: 08:00+05:30 = 02:30Z, 08:30+05:30 = 03:00Z
+    const report = chargebackReport(offsetSamples, {
+      from: '2026-01-01T08:00:00+05:30',
+      to: '2026-01-01T08:30:00+05:30',
+    })
+    expect(report.totalCalls).toBe(1)
+  })
+
+  it('drops samples with unparseable timestamps', () => {
+    const bad: CostSample[] = [
+      { at: 'not a date', tenant: 'a', model: 'gpt-4o', promptTokens: 1, completionTokens: 1, costUsd: 0.001 },
+    ]
+    expect(chargebackReport(bad, { from: '2026-01-01T00:00:00Z' }).totalCalls).toBe(0)
+  })
+})
+
 describe('chargebackReportToCsv', () => {
   it('emits a header row, one row per group, plus a TOTAL footer', () => {
     const report = chargebackReport(samples, { groupBy: 'tenant' })

--- a/packages/observability/tests/cost-guard-advanced.test.ts
+++ b/packages/observability/tests/cost-guard-advanced.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  consoleAlertSink,
+  createAdvancedCostGuard,
+  throttle,
+  webhookAlertSink,
+  type CostAlertEvent,
+} from '../src/cost-guard-advanced'
+import type { AgentEvent } from '@agentskit/core'
+
+function llmEnd(promptTokens: number, completionTokens: number): AgentEvent {
+  return {
+    type: 'llm:end',
+    content: '',
+    durationMs: 1,
+    usage: { promptTokens, completionTokens },
+  }
+}
+
+function llmStart(model: string): AgentEvent {
+  return { type: 'llm:start', model, messageCount: 1 }
+}
+
+const flush = () => new Promise(r => setImmediate(r))
+
+describe('createAdvancedCostGuard — modes', () => {
+  it('mode=warn: tracks spend but never disables', async () => {
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: { t1: 0.001 },
+      alertSinks: [e => { events.push(e) }],
+      mode: 'warn',
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    expect(g.isDisabled('t1')).toBe(false)
+    expect(events.find(e => e.type === 'cost:exceeded')).toBeTruthy()
+  })
+
+  it('mode=kill: disables tenant on overall budget breach + invokes disableRuntime', async () => {
+    const disabled: Array<{ tenant: string; reason: string }> = []
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: { t1: 0.001 },
+      mode: 'kill',
+      disableRuntime: (tenant, reason) => { disabled.push({ tenant, reason }) },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    expect(g.isDisabled('t1')).toBe(true)
+    expect(disabled).toHaveLength(1)
+    expect(disabled[0].tenant).toBe('t1')
+    expect(events.find(e => e.type === 'cost:disabled')).toBeTruthy()
+  })
+
+  it('mode=kill: refuses to construct without disableRuntime', () => {
+    expect(() =>
+      createAdvancedCostGuard({ budgets: {}, mode: 'kill' }),
+    ).toThrow(/requires disableRuntime/)
+  })
+
+  it('mode=kill: stops counting spend after disabled', async () => {
+    const g = createAdvancedCostGuard({
+      budgets: { t1: 0.001 },
+      mode: 'kill',
+      disableRuntime: () => {},
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    const before = g.costUsd('t1')
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    expect(g.costUsd('t1')).toBe(before)
+  })
+
+  it('enable() clears the disabled flag (manual re-enable)', async () => {
+    const g = createAdvancedCostGuard({
+      budgets: { t1: 0.001 },
+      mode: 'kill',
+      disableRuntime: () => {},
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    expect(g.isDisabled('t1')).toBe(true)
+    g.enable('t1')
+    expect(g.isDisabled('t1')).toBe(false)
+  })
+})
+
+describe('createAdvancedCostGuard — window caps + threshold alerts', () => {
+  it('fires 50% / 80% / 100% threshold alerts per window', async () => {
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perDay: { windowMs: 86_400_000, budgetUsd: 0.01 } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    // ~$0.0125 in one llm:end (over 100%) — should fire all three
+    await g.on(llmEnd(1000, 1000))
+    await flush()
+    const thresholds = events
+      .filter(e => e.window === 'perDay')
+      .map(e => e.threshold)
+      .filter((x): x is number => typeof x === 'number')
+    expect(thresholds).toContain(0.5)
+    expect(thresholds).toContain(0.8)
+    expect(thresholds).toContain(1)
+  })
+
+  it('does not fire the same threshold twice within a window', async () => {
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perDay: { windowMs: 86_400_000, budgetUsd: 0.005 } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(500, 500))
+    await flush()
+    const firstCount = events.filter(e => e.window === 'perDay' && e.threshold === 0.5).length
+    await g.on(llmEnd(100, 100))
+    await flush()
+    const secondCount = events.filter(e => e.window === 'perDay' && e.threshold === 0.5).length
+    expect(secondCount).toBe(firstCount) // no duplicate 50% alert
+  })
+
+  it('rolls a new window after windowMs elapses', async () => {
+    let now = 1_000_000
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perMinute: { windowMs: 60_000, budgetUsd: 0.005 } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+      now: () => now,
+    })
+    g.setTenant('t1')
+    await g.on(llmEnd(500, 500))
+    await flush()
+    expect(g.windowSpend('t1', 'perMinute')).toBeGreaterThan(0)
+
+    now += 70_000 // past the window
+    await g.on(llmEnd(100, 100))
+    await flush()
+    // Bucket reset → window spend equals only the second call
+    expect(g.windowSpend('t1', 'perMinute')).toBeLessThan(0.005)
+  })
+})
+
+describe('createAdvancedCostGuard — forecast', () => {
+  it('emits cost:forecast when projected to overrun mid-window', async () => {
+    let now = 1_000_000
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perDay: { windowMs: 86_400_000, budgetUsd: 0.01 } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+      now: () => now,
+    })
+    g.setTenant('t1')
+    // First spend creates the bucket at t=now.
+    await g.on(llmEnd(100, 100)) // ~$0.0013 — under the 50% threshold
+    await flush()
+    // Advance ~30% of the window. Adding ~$0.005 brings us to ~$0.0063.
+    // Linear projection: 0.0063 / 0.3 = $0.021 — well over the $0.01 cap.
+    now += 86_400_000 * 0.3
+    await g.on(llmEnd(400, 400))
+    await flush()
+    const forecast = events.find(e => e.type === 'cost:forecast')
+    expect(forecast).toBeTruthy()
+    expect(forecast!.msUntilExceeded).toBeGreaterThan(0)
+  })
+})
+
+describe('createAdvancedCostGuard — tenant + multi-tenant', () => {
+  it('tenantOf wins over setTenant when both supplied', async () => {
+    let active = 'a'
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      tenantOf: () => active,
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('z') // ignored
+    await g.on(llmEnd(100, 100))
+    await flush()
+    expect(g.costUsd('a')).toBeGreaterThan(0)
+    expect(g.costUsd('z')).toBe(0)
+  })
+
+  it('tenantCaps override workspace caps', async () => {
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perDay: { windowMs: 86_400_000, budgetUsd: 1 } },
+      tenantCaps: { strict: { perDay: { windowMs: 86_400_000, budgetUsd: 0.001 } } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('strict')
+    await g.on(llmEnd(100, 100))
+    await flush()
+    expect(events.find(e => e.tenant === 'strict' && e.threshold === 1)).toBeTruthy()
+  })
+
+  it('reset(tenant) clears just that tenant', async () => {
+    const g = createAdvancedCostGuard({ budgets: {}, modelOverride: 'gpt-4o' })
+    g.setTenant('a')
+    await g.on(llmEnd(100, 100))
+    g.setTenant('b')
+    await g.on(llmEnd(100, 100))
+    g.reset('a')
+    expect(g.costUsd('a')).toBe(0)
+    expect(g.costUsd('b')).toBeGreaterThan(0)
+  })
+})
+
+describe('alert sinks', () => {
+  it('webhookAlertSink POSTs the event JSON', async () => {
+    const captured: Array<{ url: string; init: RequestInit }> = []
+    const fakeFetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      captured.push({ url: String(url), init: init ?? {} })
+      return new Response(null, { status: 204 })
+    }) as unknown as typeof fetch
+    const sink = webhookAlertSink({
+      url: 'https://hooks.example/cost',
+      fetch: fakeFetch,
+      headers: { authorization: 'Bearer secret' },
+    })
+    const event: CostAlertEvent = {
+      type: 'cost:exceeded',
+      tenant: 't1',
+      window: 'perDay',
+      at: '2026-01-01T00:00:00.000Z',
+      costUsd: 1.5,
+      budgetUsd: 1,
+      utilization: 1.5,
+      threshold: 1,
+    }
+    await sink(event)
+    expect(captured).toHaveLength(1)
+    expect(captured[0].url).toBe('https://hooks.example/cost')
+    expect((captured[0].init.headers as Record<string, string>).authorization).toBe('Bearer secret')
+    expect(JSON.parse(String(captured[0].init.body))).toEqual(event)
+  })
+
+  it('throttle suppresses repeat alerts within windowMs', async () => {
+    let now = 1000
+    let count = 0
+    const inner: Parameters<typeof throttle>[0] = () => { count++ }
+    const sink = throttle(inner, 5000, () => now)
+    const event: CostAlertEvent = {
+      type: 'cost:threshold',
+      tenant: 't1',
+      window: 'perDay',
+      at: '2026-01-01T00:00:00.000Z',
+      costUsd: 0.5,
+      budgetUsd: 1,
+      utilization: 0.5,
+      threshold: 0.5,
+    }
+    await sink(event)
+    await sink(event)
+    expect(count).toBe(1)
+    now += 6000
+    await sink(event)
+    expect(count).toBe(2)
+  })
+
+  it('throttle keys on (type, tenant, window, threshold) — different tenants pass independently', async () => {
+    let count = 0
+    const sink = throttle(() => { count++ }, 60_000)
+    const base: CostAlertEvent = {
+      type: 'cost:threshold',
+      tenant: 'a',
+      window: 'perDay',
+      at: '2026-01-01T00:00:00.000Z',
+      costUsd: 0.5,
+      budgetUsd: 1,
+      utilization: 0.5,
+      threshold: 0.5,
+    }
+    await sink(base)
+    await sink({ ...base, tenant: 'b' })
+    expect(count).toBe(2)
+  })
+
+  it('consoleAlertSink writes a structured line to stderr', () => {
+    const writes: string[] = []
+    const original = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: string) => { writes.push(String(chunk)); return true }) as typeof process.stderr.write
+    try {
+      consoleAlertSink()({
+        type: 'cost:exceeded',
+        tenant: 't1',
+        window: 'perDay',
+        at: '2026-01-01T00:00:00.000Z',
+        costUsd: 1.5,
+        budgetUsd: 1,
+        utilization: 1.5,
+        threshold: 1,
+      })
+    } finally {
+      process.stderr.write = original
+    }
+    expect(writes[0]).toContain('cost:exceeded')
+    expect(writes[0]).toContain('tenant=t1')
+    expect(writes[0]).toContain('window=perDay')
+  })
+})

--- a/packages/observability/tests/cost-guard-advanced.test.ts
+++ b/packages/observability/tests/cost-guard-advanced.test.ts
@@ -23,6 +23,48 @@ function llmStart(model: string): AgentEvent {
 
 const flush = () => new Promise(r => setImmediate(r))
 
+describe('createAdvancedCostGuard — concurrency', () => {
+  it('does not double-count when llm:end events fire back-to-back synchronously', async () => {
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    // Fire two events synchronously — the on() handler must update
+    // state.totalCost before returning so the second call's delta is
+    // computed against the up-to-date cumulative cost. Bug shape:
+    // both calls saw state.totalCost = 0 → each added the cumulative
+    // newTotal, doubling the final figure.
+    g.on(llmEnd(1000, 1000))
+    g.on(llmEnd(1000, 1000))
+    await flush()
+    // gpt-4o pricing: $0.0025 input + $0.01 output per 1k tokens.
+    // Two events of (1000, 1000) → cumulative (2000, 2000) → cost
+    // = 2*0.0025 + 2*0.01 = $0.025. Anything above that is double-count.
+    expect(g.costUsd('t1')).toBeCloseTo(0.025, 6)
+  })
+
+  it('threshold alerts fire exactly once per (window, level) under concurrent events', async () => {
+    const events: CostAlertEvent[] = []
+    const g = createAdvancedCostGuard({
+      budgets: {},
+      caps: { perDay: { windowMs: 86_400_000, budgetUsd: 0.01 } },
+      alertSinks: [e => { events.push(e) }],
+      modelOverride: 'gpt-4o',
+    })
+    g.setTenant('t1')
+    g.on(llmEnd(1000, 1000))
+    g.on(llmEnd(1000, 1000))
+    await flush()
+    const fifty = events.filter(e => e.window === 'perDay' && e.threshold === 0.5)
+    const eighty = events.filter(e => e.window === 'perDay' && e.threshold === 0.8)
+    const hundred = events.filter(e => e.window === 'perDay' && e.threshold === 1)
+    expect(fifty).toHaveLength(1)
+    expect(eighty).toHaveLength(1)
+    expect(hundred).toHaveLength(1)
+  })
+})
+
 describe('createAdvancedCostGuard — modes', () => {
   it('mode=warn: tracks spend but never disables', async () => {
     const events: CostAlertEvent[] = []


### PR DESCRIPTION
## Summary

Closes **#787** (hard-kill mode), **#788** (forecasting + window caps), **#789** (alert sinks), **#790** (chargeback report). One PR delivering the full cost-guard depth cluster surfaced in the strategic gap audit.

Production-blocker for multi-tenant deployments: today's per-session caps don't catch sustained spend or runaway tenants, and there's no built-in alert path or chargeback export.

## Diff

| Path | What |
|---|---|
| \`packages/observability/src/cost-guard-advanced.ts\` | \`createAdvancedCostGuard\` + alert-sink contract + built-in \`consoleAlertSink\` / \`webhookAlertSink\` / \`throttle\` |
| \`packages/observability/src/cost-chargeback.ts\` | \`chargebackReport\` + \`chargebackReportToCsv\` |
| \`packages/observability/src/index.ts\` | re-exports |
| \`packages/observability/tests/cost-guard-advanced.test.ts\` | 16 tests — modes, window roll, threshold dedup, forecast, throttle keying |
| \`packages/observability/tests/cost-chargeback.test.ts\` | 10 tests — grouping, window filter, price fallback, CSV escape |
| \`.changeset/cost-guard-depth.md\` | observability minor |

## Design notes

- **Modes are explicit, not flags.** \`warn\` / \`reject\` / \`kill\`. \`kill\` refuses to construct without \`disableRuntime\` so deploying without enforcement isn't possible by accident.
- **Windows are configurable, not hardcoded.** \`perMinute\` / \`perDay\` / \`perMonth\` are convenience names; arbitrary windows go in \`caps.custom\`. Per-tenant overrides via \`tenantCaps\` win over workspace-wide \`caps\`.
- **Threshold alerts dedup per window.** Each \`(tenant, window, threshold)\` triple fires once per window. Throttle wrapper applies on top for noisy sinks.
- **Forecast is opt-in by spend pattern.** Only fires at >25% window elapsed AND linear projection > cap. Once per window.
- **Alert sinks are async.** Sinks awaited inside the metering loop, but errors swallowed — a broken sink can never break accounting.
- **Chargeback is a pure exporter.** Caller persists \`CostSample[]\` (one per \`llm:end\`); reporter groups + computes missing costs from prices + emits CSV/JSON. Doesn't observe events directly — keeps the report function side-effect-free for testing and CI.

## Test plan

- [x] \`pnpm --filter @agentskit/observability test\` → 141/141 (26 new)
- [x] \`pnpm --filter @agentskit/observability lint\` → clean
- [ ] Live integration with an OTEL / Datadog / Slack sink — separate per-sink manual test

## Out of scope

- Per-window persistence (reload spend across restarts) — current buckets are in-memory; a follow-up issue can add a \`bucketStore\` adapter for Redis / Postgres
- Slack / PagerDuty / email-specific sinks — \`webhookAlertSink\` is the generic shape; surface-specific wrappers can land per-customer
- Audit log integration for alert events — \`createSignedAuditLog\` from \`@agentskit/observability\` is the canonical sink for this; the alert-sink contract is generic enough to wrap it without changes here