### PR TITLE
feat(security): add PII audit trail and regional routing

### DIFF
--- a/.changeset/pii-audit-regional-routing.md
+++ b/.changeset/pii-audit-regional-routing.md
@@ -1,0 +1,7 @@
+---
+"@agentskit/core": patch
+"@agentskit/observability": minor
+"@agentskit/adapters": minor
+---
+
+Add PII redaction audit helpers backed by the signed audit log and data-residency-aware adapter routing. PII redaction hits now include offsets and lengths for evidence, observability can append `pii:redact` / `pii:reveal` / `pii:reveal-denied` events into the hash chain, and adapter routers can require `eu`, `us`, or `apac` candidates. Closes #794 #795

--- a/apps/docs-next/content/docs/for-agents/observability.mdx
+++ b/apps/docs-next/content/docs/for-agents/observability.mdx
@@ -49,6 +49,7 @@ npm install @agentskit/observability
 ### Signed audit log
 
 - `createSignedAuditLog`, `createInMemoryAuditStore`. Hash-chain + HMAC. See [Audit log](/docs/reference/recipes/audit-log).
+- `appendPiiAuditEvents(log, { actor, action, hits, subjectId?, reason? })` — append one signed entry per PII redaction hit to an existing `SignedAuditLog`. `action` is `pii:redact`, `pii:reveal`, or `pii:reveal-denied`; each payload records rule id, counts, and match `offset`/`length` only (no raw spans), for tamper-evident audit evidence alongside the hash chain.
 
 ## Minimal example
 

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -59,6 +59,7 @@ export { fetchWithRetry, simulateStream, chunkText } from './utils'
 export type { RetryOptions } from './utils'
 
 export { createRouter } from './router'
+export type { DataRegion } from '@agentskit/core'
 export type { RouterCandidate, RouterOptions, RouterPolicy } from './router'
 
 export { createEnsembleAdapter } from './ensemble'

--- a/packages/adapters/src/router.ts
+++ b/packages/adapters/src/router.ts
@@ -1,9 +1,17 @@
 import { AdapterError, ConfigError, ErrorCodes } from '@agentskit/core'
-import type { AdapterCapabilities, AdapterFactory, AdapterRequest, StreamSource } from '@agentskit/core'
+import type {
+  AdapterCapabilities,
+  AdapterFactory,
+  AdapterRequest,
+  DataRegion,
+  StreamSource,
+} from '@agentskit/core'
 
 export interface RouterCandidate {
   id: string
   adapter: AdapterFactory
+  /** Data residency region for this adapter endpoint. */
+  region?: DataRegion
   /**
    * Relative cost hint (lower wins for policy='cheapest'). Only
    * relative values matter — use $/1M tokens or any consistent unit.
@@ -29,6 +37,10 @@ export type RouterPolicy =
 
 export interface RouterOptions {
   candidates: RouterCandidate[]
+  /** Require all selected adapters to match this data-residency region. */
+  region?: DataRegion
+  /** Dynamic region selector. Takes precedence over `region`. */
+  regionOf?: (request: AdapterRequest) => DataRegion | undefined
   /** Policy when `classify` doesn't pick a candidate. Default 'cheapest'. */
   policy?: RouterPolicy
   /**
@@ -70,6 +82,10 @@ function pickSyncPolicy(
   return { c: pool[0]!, reason: 'capability-match' }
 }
 
+function matchesRegion(candidate: RouterCandidate, region: DataRegion | undefined): boolean {
+  return region === undefined || candidate.region === region
+}
+
 /**
  * Build an AdapterFactory that picks one of N candidates per request.
  *
@@ -92,24 +108,34 @@ export function createRouter(options: RouterOptions): AdapterFactory {
   return {
     createSource: (request: AdapterRequest): StreamSource => {
       const need = requireCapabilities(request)
+      const region = options.regionOf?.(request) ?? options.region
       const capable = candidates.filter(c => matchesCapabilities(need, c.capabilities ?? c.adapter.capabilities))
+      const eligible = capable.filter(c => matchesRegion(c, region))
+
+      if (capable.length > 0 && eligible.length === 0 && region !== undefined) {
+        throw new ConfigError({
+          code: ErrorCodes.AK_CONFIG_INVALID,
+          message: `no candidate satisfies required region: ${region}`,
+          hint: 'Set candidate.region to the requested data-residency region, or remove the router region requirement.',
+        })
+      }
 
       const classified = options.classify?.(request)
       if (typeof classified === 'string') {
-        const c = capable.find(x => x.id === classified)
+        const c = eligible.find(x => x.id === classified)
         if (c) {
-          options.onRoute?.({ id: c.id, reason: 'classify:id', request })
+          options.onRoute?.({ id: c.id, reason: region ? `classify:id:${region}` : 'classify:id', request })
           return c.adapter.createSource(request)
         }
       }
 
-      let pool = capable
+      let pool = eligible
       let pickedBy: string | undefined
       if (Array.isArray(classified) && classified.length > 0) {
-        const filtered = capable.filter(c => c.tags && classified.every(t => c.tags!.includes(t)))
+        const filtered = eligible.filter(c => c.tags && classified.every(t => c.tags!.includes(t)))
         if (filtered.length > 0) {
           pool = filtered
-          pickedBy = 'classify:tags'
+          pickedBy = region ? `classify:tags:${region}` : 'classify:tags'
         }
       }
 

--- a/packages/adapters/tests/router.test.ts
+++ b/packages/adapters/tests/router.test.ts
@@ -181,4 +181,39 @@ describe('createRouter', () => {
     })
     expect(await collect(router, req('x', { tools: true }))).toEqual(['a'])
   })
+
+  it('filters candidates by required data region', async () => {
+    const router = createRouter({
+      region: 'eu',
+      candidates: [
+        { id: 'us-openai', adapter: fake('us-openai'), region: 'us', cost: 1 },
+        { id: 'eu-azure', adapter: fake('eu-azure'), region: 'eu', cost: 5 },
+      ],
+    })
+    expect(await collect(router, req('x'))).toEqual(['eu-azure'])
+  })
+
+  it('rejects startup routing when no candidate matches region', () => {
+    const router = createRouter({
+      region: 'eu',
+      candidates: [{ id: 'us-openai', adapter: fake('us-openai'), region: 'us' }],
+    })
+    expect(() => router.createSource(req('x'))).toThrow(/required region: eu/)
+  })
+
+  it('supports dynamic region selection per request', async () => {
+    const router = createRouter({
+      regionOf: request => request.context?.metadata?.region as 'eu' | 'us' | undefined,
+      candidates: [
+        { id: 'us-openai', adapter: fake('us-openai'), region: 'us', cost: 1 },
+        { id: 'eu-azure', adapter: fake('eu-azure'), region: 'eu', cost: 1 },
+      ],
+    })
+    expect(
+      await collect(router, {
+        ...req('x'),
+        context: { metadata: { region: 'eu' } },
+      }),
+    ).toEqual(['eu-azure'])
+  })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export type { ConsumeStreamHandlers } from './primitives'
 export { buildToolMap, activateSkills, executeSafeTool } from './agent-loop'
 export type { ActivateSkillsResult, ToolExecResult, ExecuteSafeToolOptions } from './agent-loop'
 export type {
+  DataRegion,
   MaybePromise,
   StreamStatus,
   MessageRole,

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -2,7 +2,13 @@ export {
   createPIIRedactor,
   DEFAULT_PII_RULES,
 } from './pii'
-export type { PIIRule, PIIRedactor, PIIRedactionResult } from './pii'
+export type {
+  PIIRule,
+  PIIRedactionHit,
+  PIIRedactionMatch,
+  PIIRedactor,
+  PIIRedactionResult,
+} from './pii'
 
 export {
   createInjectionDetector,

--- a/packages/core/src/security/pii.ts
+++ b/packages/core/src/security/pii.ts
@@ -11,9 +11,20 @@ export interface PIIRule {
   replacer?: string | ((match: string) => string)
 }
 
+export interface PIIRedactionMatch {
+  offset: number
+  length: number
+}
+
+export interface PIIRedactionHit {
+  rule: string
+  count: number
+  matches: PIIRedactionMatch[]
+}
+
 export interface PIIRedactionResult<TPayload = string> {
   value: TPayload
-  hits: Array<{ rule: string; count: number }>
+  hits: PIIRedactionHit[]
 }
 
 export interface PIIRedactor {
@@ -57,16 +68,19 @@ export function createPIIRedactor(options: { rules?: PIIRule[] } = {}): PIIRedac
   const rules = options.rules ?? DEFAULT_PII_RULES
 
   const redactString = (input: string): PIIRedactionResult<string> => {
-    const hits: Array<{ rule: string; count: number }> = []
+    const hits: PIIRedactionHit[] = []
     let current = input
     for (const rule of rules) {
       let count = 0
+      const matches: PIIRedactionMatch[] = []
       const replacer = rule.replacer ?? `[REDACTED_${rule.name.toUpperCase()}]`
-      current = current.replace(rule.pattern, match => {
+      current = current.replace(rule.pattern, (match, ...args: unknown[]) => {
         count++
+        const offset = args.find((arg): arg is number => typeof arg === 'number') ?? -1
+        matches.push({ offset, length: match.length })
         return typeof replacer === 'function' ? replacer(match) : replacer
       })
-      if (count > 0) hits.push({ rule: rule.name, count })
+      if (count > 0) hits.push({ rule: rule.name, count, matches })
     }
     return { value: current, hits }
   }
@@ -74,15 +88,23 @@ export function createPIIRedactor(options: { rules?: PIIRule[] } = {}): PIIRedac
   return {
     redact: redactString,
     redactMessages(messages) {
-      const hits = new Map<string, number>()
+      const hits = new Map<string, PIIRedactionHit>()
       const redacted = messages.map(m => {
         const { value, hits: msgHits } = redactString(m.content ?? '')
-        for (const h of msgHits) hits.set(h.rule, (hits.get(h.rule) ?? 0) + h.count)
+        for (const h of msgHits) {
+          const current = hits.get(h.rule)
+          if (!current) {
+            hits.set(h.rule, { rule: h.rule, count: h.count, matches: [...h.matches] })
+          } else {
+            current.count += h.count
+            current.matches.push(...h.matches)
+          }
+        }
         return { ...m, content: value }
       })
       return {
         value: redacted,
-        hits: Array.from(hits, ([rule, count]) => ({ rule, count })),
+        hits: Array.from(hits.values()),
       }
     },
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,7 @@
 
 export type {
   MaybePromise,
+  DataRegion,
   StreamStatus, StreamToolCallPayload, StreamChunk, StreamSource, UseStreamOptions, UseStreamReturn,
   MessageRole, MessageStatus, Message, MemoryRecord,
   ToolCallStatus, ToolCall, ToolExecutionContext, ToolDefinition, ToolCallHandlerContext, InferSchemaType, DefineToolConfig,

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -1,1 +1,3 @@
 export type MaybePromise<T> = T | Promise<T>
+
+export type DataRegion = 'eu' | 'us' | 'apac'

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { MaybePromise } from './common'
+export type { DataRegion, MaybePromise } from './common'
 export type { StreamStatus, StreamToolCallPayload, StreamChunk, StreamSource, TokenUsage, UseStreamOptions, UseStreamReturn } from './stream'
 export type { MessageRole, MessageStatus, Message, MemoryRecord } from './message'
 export type { ToolCallStatus, ToolCall, ToolExecutionContext, ToolDefinition, ToolCallHandlerContext, InferSchemaType, DefineToolConfig } from './tool'

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -1,8 +1,10 @@
-import type { MaybePromise } from './common'
+import type { DataRegion, MaybePromise } from './common'
 import type { Message } from './message'
 import type { RetrievedDocument } from './retrieval'
 
 export interface ChatMemory {
+  /** Data-residency region for this memory backend, when known. */
+  region?: DataRegion
   load: () => MaybePromise<Message[]>
   save: (messages: Message[]) => MaybePromise<void>
   clear?: () => MaybePromise<void>
@@ -60,6 +62,8 @@ export interface VectorSearchOptions {
 }
 
 export interface VectorMemory {
+  /** Data-residency region for this vector backend, when known. */
+  region?: DataRegion
   store: (docs: VectorDocument[]) => MaybePromise<void>
   search: (
     embedding: number[],

--- a/packages/core/tests/security.test.ts
+++ b/packages/core/tests/security.test.ts
@@ -27,6 +27,13 @@ describe('createPIIRedactor', () => {
     expect(hits.find(h => h.rule === 'email')?.count).toBe(2)
   })
 
+  it('records offsets for audit evidence', () => {
+    const r = createPIIRedactor()
+    const { hits } = r.redact('email: a@b.co')
+    const email = hits.find(h => h.rule === 'email')
+    expect(email?.matches[0]).toEqual({ offset: 7, length: 6 })
+  })
+
   it('redactMessages preserves message shape', () => {
     const r = createPIIRedactor()
     const { value, hits } = r.redactMessages([msg('user', 'email: x@y.zz'), msg('assistant', 'ack')])

--- a/packages/observability-langfuse/src/langfuse.ts
+++ b/packages/observability-langfuse/src/langfuse.ts
@@ -1,4 +1,4 @@
-import type { Observer } from '@agentskit/core'
+import { AdapterError, ErrorCodes, type Observer } from '@agentskit/core'
 import { createTraceTracker, type TraceSpan } from '@agentskit/observability'
 
 export interface LangfuseConfig {
@@ -64,9 +64,11 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
           | (new (c: Record<string, unknown>) => LangfuseClient)
           | undefined
         if (typeof Ctor !== 'function') {
-          throw new Error(
-            'langfuse package is missing or invalid: no `Langfuse` export. Add the peer dependency: pnpm add langfuse',
-          )
+          throw new AdapterError({
+            code: ErrorCodes.AK_ADAPTER_MISSING,
+            message: 'langfuse package is missing or invalid: no `Langfuse` export.',
+            hint: 'Add the optional peer dependency: pnpm add langfuse',
+          })
         }
         return new Ctor({
           publicKey,
@@ -82,7 +84,14 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
           '[@agentskit/observability-langfuse] Optional peer `langfuse` failed to load; spans will not be sent.',
           cause,
         )
-        throw cause instanceof Error ? cause : new Error(String(cause))
+        throw cause instanceof AdapterError
+          ? cause
+          : new AdapterError({
+              code: ErrorCodes.AK_ADAPTER_MISSING,
+              message: cause instanceof Error ? cause.message : String(cause),
+              hint: 'Add the optional peer dependency: pnpm add langfuse',
+              cause,
+            })
       }
     })()
     return clientPromise

--- a/packages/observability-langfuse/src/langfuse.ts
+++ b/packages/observability-langfuse/src/langfuse.ts
@@ -58,19 +58,32 @@ export function langfuse(config: LangfuseConfig = {}): Observer {
   const getClient = (): Promise<LangfuseClient> => {
     if (clientPromise) return clientPromise
     clientPromise = (async () => {
-      const mod = await import('langfuse')
-      const Ctor = (mod.Langfuse ?? (mod as { default?: unknown }).default) as unknown as new (
-        c: Record<string, unknown>,
-      ) => LangfuseClient
-      return new Ctor({
-        publicKey,
-        secretKey,
-        baseUrl,
-        release,
-        environment,
-        flushAt: config.flushAt ?? 15,
-        flushInterval: config.flushInterval ?? 1_000,
-      })
+      try {
+        const mod = await import('langfuse')
+        const Ctor = (mod.Langfuse ?? (mod as { default?: unknown }).default) as unknown as
+          | (new (c: Record<string, unknown>) => LangfuseClient)
+          | undefined
+        if (typeof Ctor !== 'function') {
+          throw new Error(
+            'langfuse package is missing or invalid: no `Langfuse` export. Add the peer dependency: pnpm add langfuse',
+          )
+        }
+        return new Ctor({
+          publicKey,
+          secretKey,
+          baseUrl,
+          release,
+          environment,
+          flushAt: config.flushAt ?? 15,
+          flushInterval: config.flushInterval ?? 1_000,
+        })
+      } catch (cause) {
+        console.warn(
+          '[@agentskit/observability-langfuse] Optional peer `langfuse` failed to load; spans will not be sent.',
+          cause,
+        )
+        throw cause instanceof Error ? cause : new Error(String(cause))
+      }
     })()
     return clientPromise
   }

--- a/packages/observability-langfuse/tests/langfuse.test.ts
+++ b/packages/observability-langfuse/tests/langfuse.test.ts
@@ -153,15 +153,19 @@ describe('langfuse observer', () => {
     await flush()
   })
 
-  it('throws helpful message if langfuse package is missing', async () => {
-    vi.doMock('langfuse', () => {
-      throw new Error('not found')
-    })
+  it('does not emit traces and warns when langfuse package is missing', async () => {
+    // A mock factory that throws leaves Vitest on the previous mock (FakeLangfuse).
+    // Simulate a missing / broken install: module loads but exports no Langfuse client.
+    vi.doMock('langfuse', () => ({}))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { langfuse } = await import('../src/langfuse')
     const sink = langfuse({ publicKey: 'pk', secretKey: 'sk' })
     sink.on({ type: 'llm:start', model: 'm', messageCount: 1 })
     await flush()
     expect(captured.traces.length).toBe(0)
+    expect(warn).toHaveBeenCalled()
+    expect(String(warn.mock.calls[0]?.[0] ?? '')).toContain('observability-langfuse')
+    warn.mockRestore()
   })
 
   it('reads config from env when not provided', async () => {

--- a/packages/observability/src/audit-log.ts
+++ b/packages/observability/src/audit-log.ts
@@ -1,4 +1,5 @@
 import { createHash, createHmac } from 'node:crypto'
+import type { PIIRedactionHit } from '@agentskit/core/security'
 
 export interface AuditEntry<TPayload = unknown> {
   /** Monotonic sequence within a log. Starts at 1. */
@@ -45,6 +46,24 @@ export interface SignedAuditLog {
   append: <TPayload>(input: AppendAuditInput<TPayload>) => Promise<AuditEntry<TPayload>>
   verify: () => Promise<AuditVerifyResult>
   list: () => Promise<AuditEntry[]>
+}
+
+export type PiiAuditAction = 'pii:redact' | 'pii:reveal' | 'pii:reveal-denied'
+
+export interface PiiAuditInput {
+  actor: string
+  action: PiiAuditAction
+  subjectId?: string
+  hits: readonly PIIRedactionHit[]
+  reason?: string
+}
+
+export interface PiiAuditPayload {
+  subjectId?: string
+  rule: string
+  count: number
+  matches: Array<{ offset: number; length: number }>
+  reason?: string
 }
 
 function canonical<TPayload>(entry: Omit<AuditEntry<TPayload>, 'signature'>): string {
@@ -123,6 +142,32 @@ export function createSignedAuditLog(options: AuditLogOptions): SignedAuditLog {
       return options.store.list()
     },
   }
+}
+
+export async function appendPiiAuditEvents(
+  log: SignedAuditLog,
+  input: PiiAuditInput,
+): Promise<Array<AuditEntry<PiiAuditPayload>>> {
+  const entries: Array<AuditEntry<PiiAuditPayload>> = []
+  for (const hit of input.hits) {
+    entries.push(
+      await log.append<PiiAuditPayload>({
+        actor: input.actor,
+        action: input.action,
+        payload: {
+          subjectId: input.subjectId,
+          rule: hit.rule,
+          count: hit.count,
+          matches: hit.matches.map(match => ({
+            offset: match.offset,
+            length: match.length,
+          })),
+          reason: input.reason,
+        },
+      }),
+    )
+  }
+  return entries
 }
 
 /** In-memory `AuditLogStore` — tests, demos, transient deployments. */

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -36,6 +36,7 @@ export {
 export type { TraceReport, FileTraceSink } from './trace-viewer'
 
 export {
+  appendPiiAuditEvents,
   createSignedAuditLog,
   createInMemoryAuditStore,
 } from './audit-log'
@@ -46,6 +47,9 @@ export type {
   SignedAuditLog,
   AppendAuditInput,
   AuditVerifyResult,
+  PiiAuditAction,
+  PiiAuditInput,
+  PiiAuditPayload,
 } from './audit-log'
 
 export { createDevtoolsServer, toSseFrame } from './devtools'

--- a/packages/observability/tests/audit-log.test.ts
+++ b/packages/observability/tests/audit-log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  appendPiiAuditEvents,
   createInMemoryAuditStore,
   createSignedAuditLog,
   type AuditEntry,
@@ -88,6 +89,28 @@ describe('createSignedAuditLog', () => {
     await log.append({ actor: 'a', action: 'x', payload: 1 })
     await log.append({ actor: 'b', action: 'y', payload: 2 })
     expect(await log.list()).toHaveLength(2)
+  })
+
+  it('appends PII audit events into the signed hash chain', async () => {
+    const log = createSignedAuditLog({
+      secret: 'k',
+      store: createInMemoryAuditStore(),
+      now: () => new Date(0),
+    })
+    const entries = await appendPiiAuditEvents(log, {
+      actor: 'redactor',
+      action: 'pii:redact',
+      subjectId: 'case-1',
+      hits: [{ rule: 'email', count: 1, matches: [{ offset: 9, length: 11 }] }],
+    })
+    expect(entries[0]?.action).toBe('pii:redact')
+    expect(entries[0]?.payload).toEqual({
+      subjectId: 'case-1',
+      rule: 'email',
+      count: 1,
+      matches: [{ offset: 9, length: 11 }],
+    })
+    expect((await log.verify()).ok).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- add PII redaction hit offsets/lengths for audit evidence
- append pii:redact, pii:reveal, and pii:reveal-denied events into the signed audit log hash chain
- add data residency region routing for adapter candidates and memory types

Closes #794
Closes #795

## Validation
- pnpm --filter @agentskit/core build
- pnpm --filter @agentskit/core lint
- pnpm --filter @agentskit/core test -- --run tests/security.test.ts
- pnpm --filter @agentskit/observability build
- pnpm --filter @agentskit/observability lint
- pnpm --filter @agentskit/observability test -- --run tests/audit-log.test.ts
- pnpm --filter @agentskit/adapters build
- pnpm --filter @agentskit/adapters lint
- pnpm --filter @agentskit/adapters test -- --run tests/router.test.ts