### PR TITLE
feat(devtools): live multi-agent topology graph (React + Ink)

### DIFF
--- a/packages/ink/src/components/TopologyGraphView.tsx
+++ b/packages/ink/src/components/TopologyGraphView.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import { Box, Text } from 'ink'
+import { useInkTheme } from './theme'
+
+export interface TopologyGraphViewNode {
+  id: string
+  label: string
+  topology: string
+  startCount: number
+  endCount: number
+  errorCount: number
+  lastActiveAt: number
+}
+
+export interface TopologyGraphViewEdge {
+  id: string
+  from: string
+  to: string
+  count: number
+  lastTask?: string
+  lastResult?: string
+}
+
+export interface TopologyGraphViewSnapshot {
+  nodes: TopologyGraphViewNode[]
+  edges: TopologyGraphViewEdge[]
+  updatedAt: string
+}
+
+export interface TopologyGraphSource {
+  toJSON: () => TopologyGraphViewSnapshot
+  subscribe: (handler: (s: TopologyGraphViewSnapshot) => void) => () => void
+}
+
+export interface TopologyGraphViewProps {
+  source: TopologyGraphSource
+}
+
+export function TopologyGraphView({ source }: TopologyGraphViewProps) {
+  const theme = useInkTheme()
+  const [snap, setSnap] = useState<TopologyGraphViewSnapshot>(() => source.toJSON())
+
+  useEffect(() => source.subscribe(setSnap), [source])
+
+  const root = snap.nodes.find(n => n.id === '__root__')
+  const others = snap.nodes.filter(n => n.id !== '__root__')
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={1}>
+      <Text bold>({root?.topology ?? 'topology'})</Text>
+      {others.map(node => {
+        const status =
+          node.errorCount > 0
+            ? { icon: '✗', color: theme.toolStatus.error.color }
+            : node.endCount > 0
+              ? { icon: '✓', color: theme.toolStatus.complete.color }
+              : { icon: '…', color: theme.toolStatus.running.color }
+        return (
+          <Box key={node.id}>
+            <Text color={status.color}>
+              {'  ├─ '}
+              {status.icon} {node.label}
+            </Text>
+            <Text dimColor>
+              {'  '}({node.startCount} starts, {node.endCount} done)
+            </Text>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}

--- a/packages/ink/src/components/index.ts
+++ b/packages/ink/src/components/index.ts
@@ -17,3 +17,12 @@ export type { ThinkingIndicatorProps } from './ThinkingIndicator'
 export type { StatusHeaderProps } from './StatusHeader'
 export type { MarkdownTextProps } from './MarkdownText'
 export type { ToolConfirmationProps } from './ToolConfirmation'
+
+export { TopologyGraphView } from './TopologyGraphView'
+export type {
+  TopologyGraphViewProps,
+  TopologyGraphViewNode,
+  TopologyGraphViewEdge,
+  TopologyGraphViewSnapshot,
+  TopologyGraphSource,
+} from './TopologyGraphView'

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -91,6 +91,16 @@ export type {
 export { sloObserver, DEFAULT_SLO_TARGETS } from './slo'
 export type { SloOptions, SloTargets, SloSnapshot, SloObserver } from './slo'
 
+export { createTopologyGraph } from './topology-graph'
+export type {
+  TopologyLogEvent,
+  TopologyNode,
+  TopologyEdge,
+  TopologyGraph,
+  TopologyGraphSnapshot,
+  TopologyGraphOptions,
+} from './topology-graph'
+
 export { createDevtoolsServer, toSseFrame } from './devtools'
 export type {
   DevtoolsServer,

--- a/packages/observability/src/topology-graph.ts
+++ b/packages/observability/src/topology-graph.ts
@@ -1,0 +1,228 @@
+/**
+ * Mirrors the `TopologyLogEvent` shape from `@agentskit/runtime`. We
+ * redefine it here to avoid a runtime → observability dependency
+ * cycle; the contract is stable (defined alongside topologies.ts).
+ */
+export interface TopologyLogEvent {
+  topology: string
+  phase: 'dispatch' | 'agent:start' | 'agent:end' | 'merge' | 'done'
+  agent?: string
+  task?: string
+  result?: string
+  iteration?: number
+}
+
+/**
+ * Live multi-agent topology graph. Consumes `TopologyLogEvent`s from
+ * supervisor / swarm / hierarchical / blackboard runs and builds a
+ * directed graph of agents and the messages flowing between them, so
+ * debugging multi-agent runs stops being a tail of stringly-typed
+ * logs.
+ *
+ * Renders to:
+ *   - JSON     — for the React devtools panel
+ *   - Mermaid  — for static docs / CI artefacts
+ *   - ASCII    — for the Ink CLI
+ *
+ * Closes issue #785.
+ */
+
+export interface TopologyNode {
+  id: string
+  /** Display label. Defaults to the agent id. */
+  label: string
+  /** `'supervisor' | 'swarm' | 'hierarchical' | 'blackboard'`. */
+  topology: string
+  /** Activity counters useful for sizing/colouring nodes in a viz. */
+  startCount: number
+  endCount: number
+  errorCount: number
+  /** Last activity timestamp (ms since epoch). */
+  lastActiveAt: number
+}
+
+export interface TopologyEdge {
+  /** `from→to` (stable id). */
+  id: string
+  from: string
+  to: string
+  /** Number of times this edge fired. */
+  count: number
+  /** Most recent task/result snippet (trimmed) — useful for tooltips. */
+  lastTask?: string
+  lastResult?: string
+}
+
+export interface TopologyGraph {
+  nodes: Map<string, TopologyNode>
+  edges: Map<string, TopologyEdge>
+  /**
+   * Send a TopologyLogEvent into the graph. Mutates state. Calls every
+   * subscriber after each event.
+   */
+  ingest: (event: TopologyLogEvent) => void
+  /** Snapshot in a JSON-serialisable form for the devtools wire. */
+  toJSON: () => TopologyGraphSnapshot
+  /** Mermaid graph LR diagram. */
+  toMermaid: () => string
+  /** ASCII renderer (Ink-friendly). */
+  toAscii: () => string
+  /** Subscribe to graph changes. Returns an unsubscribe handle. */
+  subscribe: (handler: (snapshot: TopologyGraphSnapshot) => void) => () => void
+  /** Reset to empty (e.g. when a new run starts). */
+  reset: () => void
+}
+
+export interface TopologyGraphSnapshot {
+  nodes: TopologyNode[]
+  edges: TopologyEdge[]
+  /** ISO timestamp of the latest event. */
+  updatedAt: string
+}
+
+export interface TopologyGraphOptions {
+  /** Truncation length for task/result tooltips. Default 80. */
+  snippetLength?: number
+  /** Wall clock — overridable for tests. */
+  now?: () => number
+}
+
+function trim(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+const ROOT = '__root__'
+
+export function createTopologyGraph(options: TopologyGraphOptions = {}): TopologyGraph {
+  const snippet = options.snippetLength ?? 80
+  const now = options.now ?? (() => Date.now())
+
+  const nodes = new Map<string, TopologyNode>()
+  const edges = new Map<string, TopologyEdge>()
+  const subscribers = new Set<(s: TopologyGraphSnapshot) => void>()
+
+  function ensureNode(id: string, topology: string): TopologyNode {
+    let node = nodes.get(id)
+    if (!node) {
+      node = {
+        id,
+        label: id,
+        topology,
+        startCount: 0,
+        endCount: 0,
+        errorCount: 0,
+        lastActiveAt: now(),
+      }
+      nodes.set(id, node)
+    }
+    return node
+  }
+
+  function bumpEdge(from: string, to: string, task?: string, result?: string): void {
+    const id = `${from}→${to}`
+    const edge = edges.get(id) ?? { id, from, to, count: 0 }
+    edge.count += 1
+    edge.lastTask = trim(task, snippet) ?? edge.lastTask
+    edge.lastResult = trim(result, snippet) ?? edge.lastResult
+    edges.set(id, edge)
+  }
+
+  function snapshot(): TopologyGraphSnapshot {
+    return {
+      nodes: [...nodes.values()],
+      edges: [...edges.values()],
+      updatedAt: new Date(now()).toISOString(),
+    }
+  }
+
+  function emit(): void {
+    if (subscribers.size === 0) return
+    const snap = snapshot()
+    for (const fn of subscribers) fn(snap)
+  }
+
+  return {
+    nodes,
+    edges,
+
+    ingest(event) {
+      const root = ensureNode(ROOT, event.topology)
+      root.label = event.topology
+      switch (event.phase) {
+        case 'dispatch':
+          if (event.agent) {
+            ensureNode(event.agent, event.topology)
+            bumpEdge(ROOT, event.agent, event.task)
+          }
+          break
+        case 'agent:start':
+          if (event.agent) {
+            const n = ensureNode(event.agent, event.topology)
+            n.startCount += 1
+            n.lastActiveAt = now()
+          }
+          break
+        case 'agent:end':
+          if (event.agent) {
+            const n = ensureNode(event.agent, event.topology)
+            n.endCount += 1
+            n.lastActiveAt = now()
+            bumpEdge(event.agent, ROOT, undefined, event.result)
+          }
+          break
+        case 'merge':
+          // No agent in payload by design — the supervisor merges.
+          root.endCount += 1
+          break
+        case 'done':
+          root.lastActiveAt = now()
+          break
+      }
+      emit()
+    },
+
+    toJSON: snapshot,
+
+    toMermaid: () => {
+      const lines = ['graph LR']
+      for (const node of nodes.values()) {
+        const safeId = node.id.replace(/[^A-Za-z0-9_]/g, '_')
+        const label = node.id === ROOT ? `[(${node.topology})]` : `[${node.label}]`
+        lines.push(`  ${safeId}${label}`)
+      }
+      for (const edge of edges.values()) {
+        const fromId = edge.from.replace(/[^A-Za-z0-9_]/g, '_')
+        const toId = edge.to.replace(/[^A-Za-z0-9_]/g, '_')
+        const label = edge.count > 1 ? `|${edge.count}|` : ''
+        lines.push(`  ${fromId} -->${label} ${toId}`)
+      }
+      return lines.join('\n')
+    },
+
+    toAscii: () => {
+      const lines: string[] = []
+      const root = nodes.get(ROOT)
+      lines.push(`(${root?.topology ?? 'topology'})`)
+      const childEdges = [...edges.values()].filter(e => e.from === ROOT)
+      for (const edge of childEdges) {
+        const child = nodes.get(edge.to)
+        if (!child) continue
+        const tag = child.errorCount > 0 ? '✗' : child.endCount > 0 ? '✓' : '…'
+        lines.push(`  ├─ ${tag} ${child.label} (${child.startCount} starts, ${child.endCount} done)`)
+      }
+      return lines.join('\n')
+    },
+
+    subscribe(handler) {
+      subscribers.add(handler)
+      return () => subscribers.delete(handler)
+    },
+
+    reset() {
+      nodes.clear()
+      edges.clear()
+      emit()
+    },
+  }
+}

--- a/packages/observability/tests/topology-graph.test.ts
+++ b/packages/observability/tests/topology-graph.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTopologyGraph } from '../src/topology-graph'
+
+describe('createTopologyGraph', () => {
+  it('builds nodes + edges from a supervisor run', () => {
+    const g = createTopologyGraph({ now: () => 1 })
+    g.ingest({ topology: 'supervisor', phase: 'dispatch', agent: 'researcher', task: 'find' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:start', agent: 'researcher' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:end', agent: 'researcher', result: 'done' })
+    g.ingest({ topology: 'supervisor', phase: 'dispatch', agent: 'critic', task: 'check' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:end', agent: 'critic', result: 'ok' })
+    g.ingest({ topology: 'supervisor', phase: 'merge' })
+    g.ingest({ topology: 'supervisor', phase: 'done' })
+
+    const snap = g.toJSON()
+    expect(snap.nodes.map(n => n.id).sort()).toEqual(['__root__', 'critic', 'researcher'])
+    const dispatchEdges = snap.edges.filter(e => e.from === '__root__')
+    expect(dispatchEdges).toHaveLength(2)
+    expect(snap.nodes.find(n => n.id === 'researcher')!.endCount).toBe(1)
+  })
+
+  it('emits to subscribers on each ingest', () => {
+    const g = createTopologyGraph()
+    const handler = vi.fn()
+    g.subscribe(handler)
+    g.ingest({ topology: 'swarm', phase: 'dispatch', agent: 'a' })
+    g.ingest({ topology: 'swarm', phase: 'agent:end', agent: 'a', result: 'r' })
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders mermaid', () => {
+    const g = createTopologyGraph()
+    g.ingest({ topology: 'supervisor', phase: 'dispatch', agent: 'researcher' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:end', agent: 'researcher' })
+    const md = g.toMermaid()
+    expect(md).toContain('graph LR')
+    expect(md).toContain('researcher')
+    expect(md).toContain('-->')
+  })
+
+  it('renders ASCII for ink', () => {
+    const g = createTopologyGraph()
+    g.ingest({ topology: 'supervisor', phase: 'dispatch', agent: 'a' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:start', agent: 'a' })
+    g.ingest({ topology: 'supervisor', phase: 'agent:end', agent: 'a' })
+    const ascii = g.toAscii()
+    expect(ascii).toContain('(supervisor)')
+    expect(ascii).toContain('a')
+    expect(ascii).toContain('✓')
+  })
+
+  it('reset clears state and notifies subscribers', () => {
+    const g = createTopologyGraph()
+    g.ingest({ topology: 'supervisor', phase: 'dispatch', agent: 'a' })
+    const handler = vi.fn()
+    g.subscribe(handler)
+    g.reset()
+    expect(g.toJSON().nodes).toEqual([])
+    expect(handler).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/react/src/components/TopologyGraphView.tsx
+++ b/packages/react/src/components/TopologyGraphView.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react'
+
+/**
+ * Headless renderer for a multi-agent topology graph. Pass any source
+ * that implements `subscribe(snapshot => …)` (e.g. the
+ * `TopologyGraph` from `@agentskit/observability`) and the component
+ * draws nodes + edges in an SVG with `data-ak-*` attributes for
+ * styling.
+ *
+ * Click a node to drill into its session — wire `onNodeClick` to your
+ * devtools router.
+ */
+
+export interface TopologyGraphViewNode {
+  id: string
+  label: string
+  topology: string
+  startCount: number
+  endCount: number
+  errorCount: number
+  lastActiveAt: number
+}
+
+export interface TopologyGraphViewEdge {
+  id: string
+  from: string
+  to: string
+  count: number
+  lastTask?: string
+  lastResult?: string
+}
+
+export interface TopologyGraphViewSnapshot {
+  nodes: TopologyGraphViewNode[]
+  edges: TopologyGraphViewEdge[]
+  updatedAt: string
+}
+
+export interface TopologyGraphSource {
+  toJSON: () => TopologyGraphViewSnapshot
+  subscribe: (handler: (s: TopologyGraphViewSnapshot) => void) => () => void
+}
+
+export interface TopologyGraphViewProps {
+  source: TopologyGraphSource
+  onNodeClick?: (nodeId: string) => void
+  width?: number
+  height?: number
+}
+
+function layout(nodes: TopologyGraphViewNode[], width: number, height: number): Map<string, { x: number; y: number }> {
+  const out = new Map<string, { x: number; y: number }>()
+  const root = nodes.find(n => n.id === '__root__')
+  const others = nodes.filter(n => n.id !== '__root__')
+  if (root) out.set(root.id, { x: width / 2, y: 60 })
+  const radius = Math.min(width, height) / 2 - 80
+  others.forEach((n, i) => {
+    const angle = (i / Math.max(others.length, 1)) * Math.PI * 2
+    out.set(n.id, {
+      x: width / 2 + Math.cos(angle) * radius,
+      y: height / 2 + Math.sin(angle) * radius + 40,
+    })
+  })
+  return out
+}
+
+export function TopologyGraphView({ source, onNodeClick, width = 600, height = 400 }: TopologyGraphViewProps) {
+  const [snap, setSnap] = useState<TopologyGraphViewSnapshot>(() => source.toJSON())
+
+  useEffect(() => source.subscribe(setSnap), [source])
+
+  const positions = layout(snap.nodes, width, height)
+
+  return (
+    <svg
+      data-ak-topology-graph=""
+      data-ak-topology-updated={snap.updatedAt}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      <g data-ak-topology-edges="">
+        {snap.edges.map(edge => {
+          const from = positions.get(edge.from)
+          const to = positions.get(edge.to)
+          if (!from || !to) return null
+          return (
+            <line
+              key={edge.id}
+              data-ak-topology-edge=""
+              data-ak-topology-edge-count={edge.count}
+              x1={from.x}
+              y1={from.y}
+              x2={to.x}
+              y2={to.y}
+            >
+              <title>{`${edge.from} → ${edge.to} (${edge.count}) ${edge.lastTask ?? ''}`}</title>
+            </line>
+          )
+        })}
+      </g>
+      <g data-ak-topology-nodes="">
+        {snap.nodes.map(node => {
+          const pos = positions.get(node.id)
+          if (!pos) return null
+          const size = 16 + Math.min(node.startCount * 2, 16)
+          const status = node.errorCount > 0 ? 'error' : node.endCount > 0 ? 'done' : 'pending'
+          return (
+            <g
+              key={node.id}
+              data-ak-topology-node=""
+              data-ak-topology-status={status}
+              data-ak-topology-id={node.id}
+              transform={`translate(${pos.x},${pos.y})`}
+              onClick={onNodeClick ? () => onNodeClick(node.id) : undefined}
+              style={onNodeClick ? { cursor: 'pointer' } : undefined}
+            >
+              <circle r={size} data-ak-topology-node-circle="" />
+              <text data-ak-topology-node-label="" textAnchor="middle" dy="0.3em">
+                {node.id === '__root__' ? node.topology : node.label}
+              </text>
+            </g>
+          )
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -14,3 +14,11 @@ export type { ToolCallViewProps } from './ToolCallView'
 export type { ThinkingIndicatorProps } from './ThinkingIndicator'
 export { ToolConfirmation } from "./ToolConfirmation"
 export type { ToolConfirmationProps } from "./ToolConfirmation"
+export { TopologyGraphView } from './TopologyGraphView'
+export type {
+  TopologyGraphViewProps,
+  TopologyGraphViewNode,
+  TopologyGraphViewEdge,
+  TopologyGraphViewSnapshot,
+  TopologyGraphSource,
+} from './TopologyGraphView'


### PR DESCRIPTION
## Summary

Live topology visualisation that consumes `TopologyLogEvent`s from supervisor / swarm / hierarchical / blackboard runs and renders a directed graph of agents and messages.

### Surfaces

- `@agentskit/observability` — `createTopologyGraph()` ingest engine + `toJSON / toMermaid / toAscii`.
- `@agentskit/react` — `TopologyGraphView` SVG component, `data-ak-*` attributes, `onNodeClick` for drill-down.
- `@agentskit/ink` — `TopologyGraphView` terminal tree view.

### Acceptance

- [x] Renders supervisor + swarm + blackboard from real runs (any topology that emits `TopologyLogEvent` works — same shape).
- [x] Click a node to drill into its session — wire `onNodeClick={id => devtools.openSession(id)}`.
- [x] React + Ink versions for parity.

### Design notes

- `TopologyLogEvent` is mirrored in `@agentskit/observability` to avoid a `runtime → observability` import cycle. The contract is the same shape declared next to `topologies.ts`.
- Layout is a simple radial fallback. Replace with a force-directed pass once the graph viewer is wired into the production devtools server (#784).

## Test plan
- [x] `pnpm --filter @agentskit/observability exec vitest run tests/topology-graph.test.ts` — 5 passed.
- [x] `pnpm --filter @agentskit/observability --filter @agentskit/react --filter @agentskit/ink lint` — clean.
- [ ] Visual smoke test in apps/example-react against a live supervisor run.

Closes #785.