### PR TITLE
ci(visual-react): Playwright workflow + baseline-bootstrap path

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,0 +1,81 @@
+name: Visual (React)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/react/**'
+      - 'apps/visual-react/**'
+      - '.github/workflows/visual.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/react/**'
+      - 'apps/visual-react/**'
+      - '.github/workflows/visual.yml'
+  workflow_dispatch:
+    inputs:
+      update_baselines:
+        description: 'Run with --update-snapshots and upload new baselines as an artifact (run once to bootstrap, then commit the artifact via a PR).'
+        required: false
+        default: 'false'
+
+jobs:
+  visual:
+    name: Visual regression
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      UPDATE_BASELINES: ${{ github.event.inputs.update_baselines }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @agentskit/visual-react test:visual:install
+
+      - name: Build harness
+        run: pnpm --filter @agentskit/visual-react build
+
+      - name: Run visual tests
+        if: env.UPDATE_BASELINES != 'true'
+        run: pnpm --filter @agentskit/visual-react test:visual
+
+      - name: Update baselines (manual bootstrap)
+        if: env.UPDATE_BASELINES == 'true'
+        run: pnpm --filter @agentskit/visual-react test:visual:update
+
+      - name: Upload diffs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-report
+          path: |
+            apps/visual-react/test-results
+            apps/visual-react/playwright-report
+          retention-days: 14
+
+      - name: Upload baselines (when bootstrapping)
+        if: env.UPDATE_BASELINES == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-baselines-linux
+          path: apps/visual-react/tests/visual.spec.ts-snapshots
+          retention-days: 30

--- a/apps/visual-react/README.md
+++ b/apps/visual-react/README.md
@@ -51,12 +51,15 @@ If a snapshot drifts without a real visual change, look for a missed source of n
 
 ## CI
 
-Not wired into the default workflow yet. To enable, run:
+Wired in via [`.github/workflows/visual.yml`](../../.github/workflows/visual.yml). Runs on every push / PR that touches `packages/react/**` or `apps/visual-react/**`.
 
-```yaml
-- run: pnpm --filter @agentskit/visual-react test:visual:install
-- run: pnpm --filter @agentskit/visual-react build
-- run: pnpm --filter @agentskit/visual-react test:visual
-```
+### Bootstrapping baselines
 
-Cache the Playwright browser bundle at `~/.cache/ms-playwright`.
+Baselines must be generated on the same Linux x86_64 image the workflow runs on (`ubuntu-22.04`); local macOS / Linux builds will produce subpixel-different PNGs. To bootstrap:
+
+1. Trigger the **Visual (React)** workflow via the Actions tab → **Run workflow** → set `update_baselines: true`.
+2. The job runs `playwright test --update-snapshots` and uploads `visual-baselines-linux` as an artifact.
+3. Download the artifact, drop the contents into `apps/visual-react/tests/visual.spec.ts-snapshots/`, and open a PR. Review every PNG visually before merging.
+4. Once baselines are in `main`, the default `update_baselines: false` runs gate every PR.
+
+Re-run the bootstrap when components intentionally change visually. Use a probe PR with a one-off colour tweak to confirm the suite catches a real regression.


### PR DESCRIPTION
## Summary

Wires the React visual harness into CI and ships the baseline-bootstrap path. Issue #770 needs (a) committed baselines for the 14 cases and (b) a CI job that catches regressions; baselines must be generated on the same Linux x86_64 image CI runs on, otherwise subpixel rendering differs and every PR fails.

### What this ships

- `.github/workflows/visual.yml` — runs on push / PR touching `packages/react/**` or `apps/visual-react/**`. Caches `~/.cache/ms-playwright`. Uploads `test-results` + `playwright-report` as an artifact on failure.
- `workflow_dispatch` input `update_baselines: true` runs `--update-snapshots` and uploads the resulting PNGs as a `visual-baselines-linux` artifact so a maintainer can download and open the bootstrap PR.
- `apps/visual-react/README.md` updated with the bootstrap procedure.

### What this does NOT ship

- The baseline PNGs themselves. They must be generated on the workflow runner (ubuntu-22.04) — generating them locally on macOS produces subpixel-different images that fail every CI run.

### Bootstrap procedure (post-merge)

1. After this merges, go to **Actions → Visual (React) → Run workflow** and set `update_baselines: true`.
2. Download the `visual-baselines-linux` artifact.
3. Drop the contents into `apps/visual-react/tests/visual.spec.ts-snapshots/` and open a PR.
4. Review every PNG visually before merging.
5. Once on main, future PRs run with `update_baselines: false` (default) and gate visual regressions.

### Acceptance

- [x] CI workflow added with Playwright cache + diff upload on failure.
- [x] README updated with the actual update workflow.
- [ ] Baselines committed for all 14 cases — follow-up bootstrap PR (this needs a CI run, not a local commit).
- [ ] Verify regression detection with a one-off colour-tweak probe PR.

Refs #770.