### PR TITLE
feat(adapters): carbon-aware + cost-aware routing

### DIFF
--- a/packages/adapters/src/carbon.ts
+++ b/packages/adapters/src/carbon.ts
@@ -1,0 +1,122 @@
+import type { RouterCandidate } from './router'
+
+/**
+ * Carbon-aware routing data. Estimated grid CO2 intensity (gCO2eq per
+ * 1k tokens) per provider+region. Numbers are best-effort approximations
+ * derived from public grid-mix data and provider PUE disclosures — they
+ * are good enough to differentiate "very dirty" from "very clean" but
+ * are not audited.
+ *
+ * Sources:
+ *   - Electricity Maps (electricitymaps.com) for grid carbon intensity.
+ *   - Provider PUE / efficiency reports (Anthropic, Google, AWS).
+ *   - LLMCarbon (Faiz et al., 2024) for tok→J coefficients.
+ *
+ * Pull-requests welcome to refine. The table is community-updateable
+ * and ships at compile time; a runtime table can be passed via
+ * `applyCarbonTable(candidates, customTable)`.
+ *
+ * Closes part of issue #209.
+ */
+
+export type ProviderRegionKey = `${string}:${string}`
+
+export type CarbonTable = Record<ProviderRegionKey, number>
+
+/**
+ * Default carbon table. Keys are `provider:region`; values are
+ * estimated gCO2eq per 1k tokens of typical mixed input/output. Lower
+ * is greener.
+ */
+export const DEFAULT_CARBON_TABLE: CarbonTable = {
+  // Anthropic — primarily AWS us-east-* / eu-west-* via Bedrock-style fronts.
+  'anthropic:us-east-1': 0.42,
+  'anthropic:us-west-2': 0.18,
+  'anthropic:eu-central-1': 0.32,
+  'anthropic:eu-west-1': 0.27,
+
+  // OpenAI — Azure East US / West Europe / Sweden Central.
+  'openai:eastus': 0.40,
+  'openai:westus3': 0.19,
+  'openai:swedencentral': 0.04,
+  'openai:westeurope': 0.28,
+
+  // Google (Vertex / Gemini) — typically reports lowest PUE.
+  'google:us-central1': 0.34,
+  'google:us-west1': 0.16,
+  'google:europe-west1': 0.21,
+  'google:europe-north1': 0.05,
+
+  // AWS Bedrock direct.
+  'aws:us-east-1': 0.42,
+  'aws:us-west-2': 0.18,
+  'aws:eu-west-1': 0.27,
+
+  // Local / on-device — only the device's grid matters.
+  'ollama:local': 0.30,
+  'webllm:browser': 0.30,
+  'lmstudio:local': 0.30,
+
+  // Self-hosted / community.
+  'groq:us-east-1': 0.40,
+  'fireworks:us-west-2': 0.18,
+  'together:us-east-1': 0.42,
+  'cerebras:us-west-2': 0.18,
+}
+
+export interface ApplyCarbonOptions {
+  /** Override the default table. */
+  table?: CarbonTable
+  /**
+   * How to derive the lookup key for a candidate. Defaults to
+   * `${provider}:${region}` where `provider` is the candidate id
+   * before the first `-` and `region` is `candidate.region`.
+   */
+  keyFor?: (candidate: RouterCandidate) => ProviderRegionKey | undefined
+  /** Fallback gCO2eq per 1k tokens when no table entry is found. */
+  fallback?: number
+}
+
+function defaultKey(candidate: RouterCandidate): ProviderRegionKey | undefined {
+  if (!candidate.region) return undefined
+  const provider = candidate.id.split(/[-:]/)[0]
+  return `${provider}:${candidate.region}` as ProviderRegionKey
+}
+
+/**
+ * Decorate a list of router candidates with `gCO2PerKtok` from a
+ * carbon table. Returns a new list — does not mutate the input.
+ *
+ * ```ts
+ * const candidates = applyCarbonTable([
+ *   { id: 'openai-eu',   adapter: openai({...}), region: 'swedencentral', cost: 0.6 },
+ *   { id: 'anthropic-us', adapter: anthropic({...}), region: 'us-east-1',   cost: 0.5 },
+ * ])
+ *
+ * const router = createRouter({ candidates, policy: 'green-cost' })
+ * ```
+ */
+export function applyCarbonTable(
+  candidates: RouterCandidate[],
+  options: ApplyCarbonOptions = {},
+): RouterCandidate[] {
+  const table = options.table ?? DEFAULT_CARBON_TABLE
+  const keyFor = options.keyFor ?? defaultKey
+  return candidates.map(c => {
+    if (c.gCO2PerKtok != null) return c
+    const key = keyFor(c)
+    const value = key ? table[key] : undefined
+    return { ...c, gCO2PerKtok: value ?? options.fallback }
+  })
+}
+
+/**
+ * Estimated CO2 emitted by a single completion (grams). Multiply
+ * `gCO2PerKtok` by `tokens / 1000`. Provided as a convenience for
+ * dashboards / chargeback reports — runtimes typically derive this
+ * from token usage events.
+ */
+export function estimateCO2Grams(gCO2PerKtok: number | undefined, tokens: number): number {
+  if (gCO2PerKtok == null) return 0
+  return (tokens / 1000) * gCO2PerKtok
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -62,6 +62,9 @@ export { createRouter } from './router'
 export type { DataRegion } from '@agentskit/core'
 export type { RouterCandidate, RouterOptions, RouterPolicy } from './router'
 
+export { applyCarbonTable, estimateCO2Grams, DEFAULT_CARBON_TABLE } from './carbon'
+export type { CarbonTable, ProviderRegionKey, ApplyCarbonOptions } from './carbon'
+
 export { createEnsembleAdapter } from './ensemble'
 export type {
   EnsembleCandidate,

--- a/packages/adapters/src/router.ts
+++ b/packages/adapters/src/router.ts
@@ -27,11 +27,20 @@ export interface RouterCandidate {
   capabilities?: AdapterCapabilities
   /** Free-form tags used by classifier routing (e.g. 'fast', 'coding'). */
   tags?: string[]
+  /**
+   * Estimated grid CO2 intensity (gCO2eq per 1k tokens) for this
+   * adapter+region. Lower wins for `policy='greenest'`. Use
+   * `applyCarbonTable()` to populate from `DEFAULT_CARBON_TABLE` or
+   * a custom table.
+   */
+  gCO2PerKtok?: number
 }
 
 export type RouterPolicy =
   | 'cheapest'
   | 'fastest'
+  | 'greenest'
+  | 'green-cost'
   | 'capability-match'
   | ((input: { request: AdapterRequest; candidates: RouterCandidate[] }) => string | Promise<string>)
 
@@ -78,6 +87,25 @@ function pickSyncPolicy(
   if (policy === 'fastest') {
     const c = pool.reduce((best, x) => ((x.latencyMs ?? Infinity) < (best.latencyMs ?? Infinity) ? x : best), pool[0]!)
     return { c, reason: 'fastest' }
+  }
+  if (policy === 'greenest') {
+    const c = pool.reduce((best, x) => ((x.gCO2PerKtok ?? Infinity) < (best.gCO2PerKtok ?? Infinity) ? x : best), pool[0]!)
+    return { c, reason: 'greenest' }
+  }
+  if (policy === 'green-cost') {
+    // Composite score: normalised carbon × normalised cost. Lower wins.
+    // A candidate missing either signal is treated as median (neutral).
+    const carbonValues = pool.map(p => p.gCO2PerKtok).filter((v): v is number => v != null)
+    const costValues = pool.map(p => p.cost).filter((v): v is number => v != null)
+    const maxC = Math.max(1, ...carbonValues)
+    const maxCost = Math.max(1, ...costValues)
+    const score = (x: RouterCandidate): number => {
+      const carbon = (x.gCO2PerKtok ?? maxC / 2) / maxC
+      const cost = (x.cost ?? maxCost / 2) / maxCost
+      return carbon + cost
+    }
+    const c = pool.reduce((best, x) => (score(x) < score(best) ? x : best), pool[0]!)
+    return { c, reason: 'green-cost' }
   }
   return { c: pool[0]!, reason: 'capability-match' }
 }

--- a/packages/adapters/tests/carbon.test.ts
+++ b/packages/adapters/tests/carbon.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { applyCarbonTable, estimateCO2Grams, DEFAULT_CARBON_TABLE } from '../src/carbon'
+import type { RouterCandidate } from '../src/router'
+import { createRouter } from '../src/router'
+
+const fakeAdapter = {
+  createSource: () => ({
+    abort: () => {},
+    stream: async function* () {
+      yield { type: 'token' as const, content: 'x' }
+    },
+  }),
+}
+
+describe('applyCarbonTable', () => {
+  it('looks up gCO2PerKtok by provider:region', () => {
+    const out = applyCarbonTable([
+      { id: 'openai-eu', adapter: fakeAdapter, region: 'swedencentral', cost: 0.6 },
+      { id: 'anthropic-us', adapter: fakeAdapter, region: 'us-east-1', cost: 0.5 },
+    ])
+    expect(out[0]!.gCO2PerKtok).toBe(0.04)
+    expect(out[1]!.gCO2PerKtok).toBe(0.42)
+  })
+
+  it('preserves explicit gCO2PerKtok', () => {
+    const out = applyCarbonTable([{ id: 'x', adapter: fakeAdapter, region: 'us-east-1', gCO2PerKtok: 99 }])
+    expect(out[0]!.gCO2PerKtok).toBe(99)
+  })
+
+  it('falls back when no entry is found', () => {
+    const out = applyCarbonTable(
+      [{ id: 'unknown', adapter: fakeAdapter, region: 'mars-1' as never }],
+      { fallback: 0.5 },
+    )
+    expect(out[0]!.gCO2PerKtok).toBe(0.5)
+  })
+})
+
+describe('estimateCO2Grams', () => {
+  it('scales linearly with tokens', () => {
+    expect(estimateCO2Grams(0.4, 2_000)).toBeCloseTo(0.8, 6)
+  })
+
+  it('returns 0 when no signal', () => {
+    expect(estimateCO2Grams(undefined, 1_000)).toBe(0)
+  })
+})
+
+describe('createRouter — carbon-aware policies', () => {
+  const candidates: RouterCandidate[] = [
+    { id: 'dirty-cheap', adapter: fakeAdapter, cost: 0.1, gCO2PerKtok: 1.0 },
+    { id: 'clean-pricey', adapter: fakeAdapter, cost: 1.0, gCO2PerKtok: 0.05 },
+    { id: 'mid', adapter: fakeAdapter, cost: 0.5, gCO2PerKtok: 0.3 },
+  ]
+
+  it('greenest picks lowest gCO2PerKtok', () => {
+    let chosen = ''
+    const router = createRouter({
+      candidates,
+      policy: 'greenest',
+      onRoute: d => {
+        chosen = d.id
+      },
+    })
+    router.createSource({ messages: [] })
+    expect(chosen).toBe('clean-pricey')
+  })
+
+  it('green-cost balances both signals', () => {
+    let chosen = ''
+    const router = createRouter({
+      candidates,
+      policy: 'green-cost',
+      onRoute: d => {
+        chosen = d.id
+      },
+    })
+    router.createSource({ messages: [] })
+    expect(chosen).toBe('mid')
+  })
+})
+
+describe('DEFAULT_CARBON_TABLE', () => {
+  it('has entries for the major providers', () => {
+    expect(DEFAULT_CARBON_TABLE['openai:swedencentral']).toBeDefined()
+    expect(DEFAULT_CARBON_TABLE['anthropic:us-east-1']).toBeDefined()
+    expect(DEFAULT_CARBON_TABLE['google:europe-north1']).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

```ts
import { createRouter, applyCarbonTable } from '@agentskit/adapters'

const candidates = applyCarbonTable([
  { id: 'openai-eu',    adapter: openai({...}),    region: 'swedencentral', cost: 0.6 },
  { id: 'anthropic-us', adapter: anthropic({...}), region: 'us-west-2',     cost: 0.5 },
  { id: 'google-eu',    adapter: gemini({...}),    region: 'europe-north1', cost: 0.4 },
])

const router = createRouter({ candidates, policy: 'green-cost' })
```

### What this ships

- `gCO2PerKtok` field on `RouterCandidate`.
- New policies: `'greenest'` (carbon only) and `'green-cost'` (normalised composite).
- `DEFAULT_CARBON_TABLE` — provider:region → gCO2eq per 1k tokens. Estimates from Electricity Maps + provider PUE disclosures.
- `applyCarbonTable(candidates, options?)` — non-mutating decorator.
- `estimateCO2Grams(gCO2PerKtok, tokens)` for dashboards / chargeback exports.

### Acceptance

- [x] Carbon-aware routing ships with default policies.
- [x] Default table covers major provider+region combos.
- [ ] Green-badge UI — out of scope for this PR; emit via `onRoute(decision)` for now.

## Test plan
- [x] `pnpm --filter @agentskit/adapters exec vitest run tests/carbon.test.ts` — 8 passed.
- [x] `pnpm --filter @agentskit/adapters lint` — clean.

Closes #209.