### PR TITLE
docs(audit): fill gaps for vertical skills, examples, runtime guarantees, SSO, devtools

### DIFF
--- a/apps/docs-next/content/docs/agents/guarantees.mdx
+++ b/apps/docs-next/content/docs/agents/guarantees.mdx
@@ -1,0 +1,79 @@
+---
+title: Guarantees (validator + quota)
+description: Runtime safety primitives — validator guard wraps regenerable output with a validator chain; per-tool quotas hard-cap blast radius.
+---
+
+Two production-grade safety primitives ship in `@agentskit/runtime`:
+
+- **Validator guard** — wraps any regenerable agent output with a validator chain. Retry, block, or fall back on failure.
+- **Per-tool quota** — hard caps on tool calls per run and per sliding window. Survives runaway loops.
+
+Both are auditable and adapter-agnostic.
+
+## Validator guard
+
+```ts
+import { createValidatorGuard, isJson, denyPattern } from '@agentskit/runtime'
+
+const guard = createValidatorGuard({
+  validators: [
+    { name: 'json-shape', check: ({ output }) => isJson(output), onFail: 'retry', maxRetries: 2 },
+    { name: 'no-pii', check: ({ output }) => denyPattern(/\b\d{3}-\d{2}-\d{4}\b/)({ output, attempt: 0 }), onFail: 'fallback' },
+  ],
+  fallback: '{"error":"redacted"}',
+  audit: (event) => myAuditSink.write(event),
+})
+
+const result = await guard.run({
+  regenerate: (repair) => runtime.run(prompt + (repair ?? '')).then(r => r.content),
+})
+// result.output, result.accepted, result.attempts, result.failures
+```
+
+Each validator gets its own retry budget, so a flaky JSON gate does not burn the budget that a strict PII gate also needs. Three failure actions:
+
+| Action | Behaviour |
+|---|---|
+| `retry` | Regenerate with optional `repairPrompt`. Cap via `maxRetries` (default 1). |
+| `block` | Return empty output, `accepted: false`. |
+| `fallback` | Return the configured `fallback` string, `accepted: false`. |
+
+Built-ins: `isJson`, `denyPattern(re)`, `lengthRange(min, max)`. Bring your own for RAG citation, eval LLM-judge, or domain rules.
+
+Use cases: JSON-shape contracts, "never emit PII" final gate, "must cite a source from the corpus", SOX / HIPAA / fair-housing rails.
+
+## Per-tool quota
+
+```ts
+import { createQuotaTracker, withQuotas, createRuntime } from '@agentskit/runtime'
+
+const tracker = createQuotaTracker({
+  env: process.env.NODE_ENV,
+  quotas: {
+    send_email: { perRun: 50, perWindow: { count: 500, windowMs: 60_000 } },
+    drop_table: { dryRunRequiredIn: ['production'] },
+  },
+  onExceeded: (event) => alert.fire(event),
+})
+
+const runtime = createRuntime({
+  adapter,
+  tools: withQuotas([sendEmail, dropTable], tracker),
+})
+```
+
+Two limits per tool:
+
+- `perRun` — counter resets on every `runtime.run()`.
+- `perWindow` — sliding window shared across runs.
+
+Plus `dryRunRequiredIn: [...envTags]` — destructive tools throw before `execute` runs in matching environments.
+
+Quota breaches raise `ToolError(AK_TOOL_QUOTA_EXCEEDED)` and emit a `tool:quota:exceeded` event so observers and cost-guards can react.
+
+## Related
+
+- [Runtime](./runtime)
+- [Cost guard](/docs/production/observability/cost-guard)
+- [Audit log](/docs/production/observability/audit-log)
+- [Rate limiting](/docs/production/security/rate-limiting)

--- a/apps/docs-next/content/docs/agents/meta.json
+++ b/apps/docs-next/content/docs/agents/meta.json
@@ -13,6 +13,7 @@
     "speculate",
     "hitl",
     "self-debug",
+    "guarantees",
     "---Tools---",
     "tools",
     "---Skills---",

--- a/apps/docs-next/content/docs/agents/skills/contract-reviewer.mdx
+++ b/apps/docs-next/content/docs/agents/skills/contract-reviewer.mdx
@@ -1,0 +1,17 @@
+---
+title: contractReviewer
+description: Reviews contract drafts for missing clauses, risk flags, and unclear terms. Always defers final sign-off to a licensed attorney.
+---
+
+```ts
+import { contractReviewer } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [contractReviewer] })
+```
+
+Three-section output per review: plain-English summary, risk flags (🚩 / 🟡 / ✅ with verbatim clause text), open questions for counsel. Never says "fine to sign" — always ends with attorney-review disclaimer.
+
+## Related
+
+- [legalAssistant](./legal-assistant)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/curriculum-designer.mdx
+++ b/apps/docs-next/content/docs/agents/skills/curriculum-designer.mdx
@@ -1,0 +1,17 @@
+---
+title: curriculumDesigner
+description: Designs lesson plans and assessment rubrics for a topic at a target grade level. Bloom-taxonomy aware, accessibility-aware.
+---
+
+```ts
+import { curriculumDesigner } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [curriculumDesigner] })
+```
+
+Outputs structured lesson plans aligned to Bloom levels, with accessibility accommodations (UDL principles) and assessment rubrics keyed to learning objectives.
+
+## Related
+
+- [tutor](./tutor)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/legal-assistant.mdx
+++ b/apps/docs-next/content/docs/agents/skills/legal-assistant.mdx
@@ -1,0 +1,17 @@
+---
+title: legalAssistant
+description: Information-only legal assistant. Refuses jurisdiction-specific advice; always recommends a licensed attorney for binding decisions.
+---
+
+```ts
+import { legalAssistant } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [legalAssistant] })
+```
+
+Hard rails: information not advice, jurisdiction-aware, no attorney-client privilege, plain language with statute citations. Every substantive answer ends with the "general information, not legal advice" disclaimer.
+
+## Related
+
+- [contractReviewer](./contract-reviewer)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/listing-concierge.mdx
+++ b/apps/docs-next/content/docs/agents/skills/listing-concierge.mdx
@@ -1,0 +1,17 @@
+---
+title: listingConcierge
+description: Helps buyers / renters narrow listings by criteria, schedule tours, and request more info. Hard fair-housing rails.
+---
+
+```ts
+import { listingConcierge } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [listingConcierge] })
+```
+
+Fair-housing rails: never filters or steers based on protected characteristics (race, religion, familial status, disability, national origin, sex). Refuses requests phrased that way and explains why.
+
+## Related
+
+- [marketAnalyst](./market-analyst)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/market-analyst.mdx
+++ b/apps/docs-next/content/docs/agents/skills/market-analyst.mdx
@@ -1,0 +1,17 @@
+---
+title: marketAnalyst
+description: Pulls comps, computes price-per-sqft, and produces buyer / seller market briefs for a named area. Describes only — no predictions.
+---
+
+```ts
+import { marketAnalyst } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [marketAnalyst] })
+```
+
+Exported as `marketAnalyst` (skill name `real-estate-market-analyst`). Strict no-prediction rule: describes the current and historical market, never forecasts price direction.
+
+## Related
+
+- [listingConcierge](./listing-concierge)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/merchandising-analyst.mdx
+++ b/apps/docs-next/content/docs/agents/skills/merchandising-analyst.mdx
@@ -1,0 +1,18 @@
+---
+title: merchandisingAnalyst
+description: Analyses sales / inventory data to surface restock priorities, slow-moving SKUs, and bundle opportunities. Outputs CSV-friendly tables.
+---
+
+```ts
+import { merchandisingAnalyst } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [merchandisingAnalyst] })
+```
+
+Designed to consume sales + inventory feeds and emit deterministic, CSV-friendly tables. Pairs with `sql-analyst` for warehouse queries.
+
+## Related
+
+- [storefrontConcierge](./storefront-concierge)
+- [sqlAnalyst](./sql-analyst)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/meta.json
+++ b/apps/docs-next/content/docs/agents/skills/meta.json
@@ -25,6 +25,14 @@
     "healthcare-assistant",
     "clinical-note-summarizer",
     "financial-advisor",
-    "transaction-triage"
+    "transaction-triage",
+    "legal-assistant",
+    "contract-reviewer",
+    "tutor",
+    "curriculum-designer",
+    "storefront-concierge",
+    "merchandising-analyst",
+    "listing-concierge",
+    "market-analyst"
   ]
 }

--- a/apps/docs-next/content/docs/agents/skills/storefront-concierge.mdx
+++ b/apps/docs-next/content/docs/agents/skills/storefront-concierge.mdx
@@ -1,0 +1,18 @@
+---
+title: storefrontConcierge
+description: Customer-facing storefront agent. Recommends products, looks up order status, and escalates returns/refunds to a human.
+---
+
+```ts
+import { storefrontConcierge } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [storefrontConcierge] })
+```
+
+Pairs with the `shopify` and `stripe` integrations for order lookup. Hard escalation rules for refunds, chargebacks, and complaints — never autonomously issues credit.
+
+## Related
+
+- [merchandisingAnalyst](./merchandising-analyst)
+- [`shopify` integration](../tools/integrations/shopify)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/skills/tutor.mdx
+++ b/apps/docs-next/content/docs/agents/skills/tutor.mdx
@@ -1,0 +1,17 @@
+---
+title: tutor
+description: Socratic tutor. Defaults to questions and hints; only gives direct answers when the user explicitly asks for them.
+---
+
+```ts
+import { tutor } from '@agentskit/skills'
+
+const runtime = createRuntime({ adapter, skills: [tutor] })
+```
+
+Default mode: ask diagnostic questions, give graduated hints, withhold the answer. Switches to direct-answer mode only when the user explicitly opts out.
+
+## Related
+
+- [curriculumDesigner](./curriculum-designer)
+- [Skills overview](./)

--- a/apps/docs-next/content/docs/agents/tools/integrations/postgres-cdc.mdx
+++ b/apps/docs-next/content/docs/agents/tools/integrations/postgres-cdc.mdx
@@ -85,7 +85,7 @@ for await (const change of stream) {
 ## Safety
 
 - CDC payloads can include sensitive columns. Filter with a column allowlist before feeding to the model.
-- Consider [redaction](/docs/production/observability/pii-redaction) for any sink that persists events.
+- Consider [redaction](/docs/production/security/pii-redaction) for any sink that persists events.
 
 ## Related
 

--- a/apps/docs-next/content/docs/agents/tools/integrations/teams.mdx
+++ b/apps/docs-next/content/docs/agents/tools/integrations/teams.mdx
@@ -79,5 +79,5 @@ package only exposes outbound tool primitives.
 ## Related
 
 - [Integrations overview](./) · [slack](./slack) · [discord](./discord).
-- Recipe: [teams-bot](/docs/reference/recipes/teams-bot).
+- Example: [teams-bot](/docs/reference/examples/teams-bot).
 - Issue [#727](https://github.com/AgentsKit-io/agentskit/issues/727), [#813](https://github.com/AgentsKit-io/agentskit/issues/813).

--- a/apps/docs-next/content/docs/agents/tools/mcp.mdx
+++ b/apps/docs-next/content/docs/agents/tools/mcp.mdx
@@ -38,7 +38,28 @@ await server.listen({ transport: 'stdio' })
 - `http` — HTTP/SSE
 - `ws` — WebSocket
 
+## Devtools over MCP
+
+`@agentskit/tools/mcp-devtools` exposes a running runtime as MCP tools — any MCP-aware client (Claude Code, Cursor, Codex) can list sessions, inspect messages, pause / step, replay, and run evals.
+
+```ts
+import { createMcpServer } from '@agentskit/tools'
+import { devtoolsTools } from '@agentskit/tools/mcp-devtools'
+
+const server = createMcpServer({
+  name: 'agentskit-devtools',
+  version: '0.1.0',
+  tools: devtoolsTools({ inspector: myRuntimeInspector }),
+})
+
+await server.listen({ transport: 'stdio' })
+```
+
+The inspector is a capability bag — only methods you implement get exposed. Read-only consumers pass `listSessions` + `inspectSession` and never expose `pause` / `step` / `replay`. Auth lives at the transport (bearer header on HTTP/WS, file perms on stdio).
+
 ## Related
 
 - [Recipe: MCP bridge](/docs/reference/recipes/mcp-bridge)
+- [Devtools server recipe](/docs/reference/recipes/devtools-server)
+- [Production → Devtools](/docs/production/observability/devtools)
 - [Specs → A2A](/docs/reference/specs/a2a)

--- a/apps/docs-next/content/docs/production/observability/devtools.mdx
+++ b/apps/docs-next/content/docs/production/observability/devtools.mdx
@@ -28,7 +28,48 @@ export const GET = () =>
 
 Connect any web UI with `EventSource('/devtools')`.
 
+## Production control surface (pause / step / replay)
+
+`createDevtoolsServer` is dev-only — read-only event tap. The auth-gated production counterpart is `createControlSurface`, which lets ops pause an agent loop, step it one iteration, override the next tool call's result, and replay a finished run.
+
+```ts
+import { createControlSurface } from '@agentskit/observability'
+
+const control = createControlSurface({
+  authorize: (req) => verifyOpsToken(req.headers.get('authorization')),
+  audit: (entry) => auditSink.write(entry),
+})
+
+const runtime = createRuntime({ adapter, observers: [control.observer] })
+
+control.pause(runId)            // freeze loop at next checkpoint
+control.step(runId)             // advance one iteration
+control.overrideTool(runId, { name: 'send_email', result: { stubbed: true } })
+control.snapshot(runId)         // structured RunSnapshot
+control.replay(runId)           // re-execute from the recorded transcript
+```
+
+Every action passes through `authorize` and emits a `ControlAuditEntry` — pair with [audit log](/docs/production/observability/audit-log).
+
+## Live multi-agent topology graph
+
+`createTopologyGraph` consumes the same observer stream and renders a live DAG of agents, delegates, and tool edges. Pre-built views in `@agentskit/react` and `@agentskit/ink`:
+
+```tsx
+import { createTopologyGraph } from '@agentskit/observability'
+import { TopologyGraphView } from '@agentskit/react'
+
+const graph = createTopologyGraph()
+const runtime = createRuntime({ adapter, observers: [graph.observer] })
+
+<TopologyGraphView snapshot={graph.snapshot()} />
+```
+
+Snapshot shape is JSON-serialisable — pipe through SSE for a remote dashboard, or render in Ink for terminal observability.
+
 ## Related
 
 - [Recipe: devtools server](/docs/reference/recipes/devtools-server)
 - [Trace viewer](./trace-viewer)
+- [Audit log](./audit-log)
+- [Devtools over MCP](/docs/agents/tools/mcp#devtools-over-mcp)

--- a/apps/docs-next/content/docs/production/security/meta.json
+++ b/apps/docs-next/content/docs/production/security/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Security",
   "description": "PII redaction, prompt injection detection, rate limits, audit, sandbox policy.",
-  "pages": ["index", "pii-redaction", "prompt-injection", "rate-limiting", "mandatory-sandbox", "sandbox"]
+  "pages": ["index", "pii-redaction", "prompt-injection", "rate-limiting", "sso", "mandatory-sandbox", "sandbox"]
 }

--- a/apps/docs-next/content/docs/production/security/sso.mdx
+++ b/apps/docs-next/content/docs/production/security/sso.mdx
@@ -1,0 +1,49 @@
+---
+title: SSO (OIDC + SAML)
+description: Verify OIDC ID tokens and SAML assertions to map an inbound request to a tenant. Pure, dependency-free, WebCrypto-only.
+---
+
+`@agentskit/core/security` ships two helpers for plugging an enterprise IdP (Okta, Auth0, Azure AD, Keycloak, Cognito) into a runtime so each request resolves to a tenant.
+
+Pure, dependency-free. Signature verification uses WebCrypto (`crypto.subtle`) — Node 18+, every modern browser, every edge runtime.
+
+## OIDC ID tokens (RS256 / ES256)
+
+```ts
+import { createOidcVerifier } from '@agentskit/core/security'
+
+const verifier = createOidcVerifier({
+  issuer: 'https://example.okta.com',
+  audience: 'agentskit-api',
+  // jwksUrl defaults to `${issuer}/.well-known/jwks.json`
+  // jwksTtlMs defaults to 1h, clockSkewSeconds to 30
+})
+
+const claims = await verifier.verify(bearerToken)
+// claims.sub, claims.iss, claims.aud, claims.exp, plus any tenant claim
+```
+
+Use the IdP-specific tenant claim (`tid`, `org_id`, `tenant`) to scope downstream cost-guard, rate-limit, and audit-log lookups.
+
+If the IdP rotates a key out-of-band, call `verifier.refreshJwks()` to bypass the cache.
+
+## SAML assertions
+
+SAML requires an XML / XML-DSig validator — bring your own. The helper provides a typed contract for the parsed assertion shape so the rest of the pipeline can stay generic.
+
+```ts
+import { createSamlVerifier } from '@agentskit/core/security'
+
+const verifier = createSamlVerifier({
+  validator: async (xml) => myXmlDsigValidator(xml),
+})
+
+const assertion = await verifier.verify(samlResponseXml)
+// assertion.subject, assertion.attributes (typed bag)
+```
+
+## Related
+
+- [Audit log](/docs/production/observability/audit-log)
+- [Cost guard](/docs/production/observability/cost-guard) — pair with the tenant claim
+- [Rate limiting](/docs/production/security/rate-limiting)

--- a/apps/docs-next/content/docs/reference/examples/discord-bot.mdx
+++ b/apps/docs-next/content/docs/reference/examples/discord-bot.mdx
@@ -1,0 +1,26 @@
+---
+title: Discord Bot
+description: Reference Discord bot wrapping createChatTrigger from @agentskit/runtime. Verifies inbound interactions with Ed25519 public key. No discord.js dependency.
+---
+
+Driver-light Discord bot using Discord's Interactions HTTP endpoint. No gateway, no `discord.js`. Verifies inbound interactions with the application's Ed25519 public key.
+
+For richer setups (presence, voice, gateway events), wrap `discord.js` — this template covers the slash-command + message-component path.
+
+## Setup
+
+1. Create a Discord application at [discord.com/developers/applications](https://discord.com/developers/applications).
+2. Copy **Public Key** (General Information) and bot **Token** (Bot tab).
+3. Set **Interactions Endpoint URL** to `https://<your-host>/discord/interactions`.
+
+```bash
+export DISCORD_BOT_TOKEN=...
+export DISCORD_PUBLIC_KEY=<hex>
+pnpm --filter @agentskit/example-discord-bot dev
+```
+
+## Related
+
+- [Recipe: discord-bot](/docs/reference/recipes/discord-bot)
+- [`discord` integration](/docs/agents/tools/integrations/discord)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-discord-bot)

--- a/apps/docs-next/content/docs/reference/examples/dspy.mdx
+++ b/apps/docs-next/content/docs/reference/examples/dspy.mdx
@@ -1,0 +1,24 @@
+---
+title: DSPy
+description: Baseline prompt vs DSPy-optimized prompt, scored side-by-side against the AgentsKit eval pipeline.
+---
+
+Side-by-side scoring of a baseline ReAct prompt vs a DSPy-optimized variant, run through the 8 bundled scorers (4 quality + 4 robustness).
+
+```sh
+pnpm --filter @agentskit/example-dspy start
+```
+
+Output: a markdown table comparing both prompts across every scorer.
+
+## What it shows
+
+- Baseline ReAct prompt at `prompts/baseline.txt` — short, cheap, day-one prompt.
+- DSPy-optimized variant produced via `BootstrapFewShot`.
+- AgentsKit eval pipeline scoring both with the same harness.
+
+## Related
+
+- [`@agentskit/eval`](/docs/for-agents/eval)
+- [Recipe: eval-suite](/docs/reference/recipes/eval-suite)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-dspy)

--- a/apps/docs-next/content/docs/reference/examples/edge.mdx
+++ b/apps/docs-next/content/docs/reference/examples/edge.mdx
@@ -1,0 +1,20 @@
+---
+title: Edge (Cloudflare Workers)
+description: AgentsKit running on Cloudflare Workers. Demonstrates the sub-50 KB hot path — adapter + ReadableStream, no runtime, no memory, no tools.
+---
+
+AgentsKit on Cloudflare Workers. Single-file Worker, one adapter, one `ReadableStream`. The bundle that runs per request is `openai()` plus the streaming bridge — measured well under the 50 KB target.
+
+## What ships
+
+- `src/worker.ts` — single-file Worker.
+- `wrangler.jsonc` — `nodejs_compat` enabled so `@agentskit/adapters` can use `fetch` + `AbortController` from the Workers runtime.
+
+```bash
+pnpm --filter @agentskit/example-edge dev
+```
+
+## Related
+
+- [Production → Edge](/docs/production/edge)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-edge)

--- a/apps/docs-next/content/docs/reference/examples/embedded.mdx
+++ b/apps/docs-next/content/docs/reference/examples/embedded.mdx
@@ -1,0 +1,19 @@
+---
+title: Embedded (CLI / Raycast / VS Code)
+description: Same agent runs from anywhere. Three host integrations of the identical runtime — Node CLI, Raycast script command, VS Code task.
+---
+
+Same `createRuntime({ adapter })` shape, three hosts:
+
+| Host | Wrapper | Try it |
+|---|---|---|
+| Node CLI | `src/index.ts` | `pnpm --filter @agentskit/example-embedded dev "Why is the sky blue?"` |
+| Raycast Script Command | `raycast/agentskit-ask.ts` | Copy into `~/.config/raycast/scripts/agentskit/`, install, type "Ask AgentsKit". |
+| VS Code Task | `vscode/tasks.json` | Copy into `.vscode/tasks.json`, then `Cmd+Shift+P → Tasks: Run Task → AgentsKit · Ask`. |
+
+The runtime is identical across hosts — only invocation glue differs.
+
+## Related
+
+- [Production → Embedded](/docs/production/embedded)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-embedded)

--- a/apps/docs-next/content/docs/reference/examples/flow.mdx
+++ b/apps/docs-next/content/docs/reference/examples/flow.mdx
@@ -1,0 +1,24 @@
+---
+title: Flow (compileFlow)
+description: Live demo of compileFlow — YAML FlowDefinition compiled into a durable DAG, executed with a JSONL step log.
+---
+
+`compileFlow` from `@agentskit/runtime` turns a YAML `FlowDefinition` into a durable DAG. This example fetches stargazer counts for two GitHub repos in parallel, sums them, and renders a markdown digest.
+
+```
+▸ flow=octo-stars-digest runId=demo-run
+  order=fetch-react → fetch-vue → total → render
+▸ fetch-react start
+  ★ facebook/react → 235,492
+✓ fetch-react done
+```
+
+```bash
+pnpm --filter @agentskit/example-flow dev
+```
+
+## Related
+
+- [Agents → Flow](/docs/agents/flow)
+- [Agents → Durable execution](/docs/agents/durable)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-flow)

--- a/apps/docs-next/content/docs/reference/examples/meta.json
+++ b/apps/docs-next/content/docs/reference/examples/meta.json
@@ -15,6 +15,16 @@
     "multi-agent",
     "shadcn-chat",
     "rag-pipeline",
-    "eval-runner"
+    "eval-runner",
+    "---Bots---",
+    "discord-bot",
+    "slack-bot",
+    "teams-bot",
+    "---Runtime---",
+    "edge",
+    "embedded",
+    "flow",
+    "dspy",
+    "webllm"
   ]
 }

--- a/apps/docs-next/content/docs/reference/examples/slack-bot.mdx
+++ b/apps/docs-next/content/docs/reference/examples/slack-bot.mdx
@@ -1,0 +1,26 @@
+---
+title: Slack Bot
+description: Reference Slack bot wrapping createChatTrigger from @agentskit/runtime. Uses Events API + chat.postMessage REST. No Bolt dependency.
+---
+
+Driver-light Slack bot using Slack's Events API webhook + `chat.postMessage` REST endpoint via `fetch`. No Bolt dependency.
+
+For production, swap the reply body to wrap Bolt's `app.client.chat.postMessage` so retries, rate-limit handling, and pagination come for free.
+
+## Setup
+
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps).
+2. Enable **Event Subscriptions** with bot events: `app_mention`, `message.channels`, `message.im`.
+3. Set request URL to `https://<your-host>/slack/events`.
+4. Install the app; copy **Bot User OAuth Token** (`xoxb-…`) and **Signing Secret**.
+
+```bash
+export SLACK_BOT_TOKEN=xoxb-...
+export SLACK_SIGNING_SECRET=...
+pnpm --filter @agentskit/example-slack-bot dev
+```
+
+## Related
+
+- [`slack` integration](/docs/agents/tools/integrations/slack)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-slack-bot)

--- a/apps/docs-next/content/docs/reference/examples/teams-bot.mdx
+++ b/apps/docs-next/content/docs/reference/examples/teams-bot.mdx
@@ -1,0 +1,27 @@
+---
+title: Teams Bot
+description: Reference Microsoft Teams bot wrapping createChatTrigger from @agentskit/runtime. Consumes Bot Framework activities at /api/messages with injectable JWT verifier.
+---
+
+Driver-light Microsoft Teams bot. Consumes Bot Framework activity payloads at `/api/messages` and verifies the inbound JWT via an injected `verifyToken` callback.
+
+No `botbuilder` / `microsoft-graph-client` dependency in the template. In production, wire `botbuilder`'s `JwtTokenValidation.authenticateRequest` (or any JWT lib against Microsoft's OpenID config).
+
+## Setup
+
+1. Register a bot in **Azure Bot Service** + create an Azure AD app. Copy App ID + secret.
+2. Set messaging endpoint to `https://<your-host>/api/messages`.
+3. Sideload the Teams app manifest into a Teams tenant.
+
+```bash
+export TEAMS_APP_ID=...
+export TEAMS_APP_SECRET=...
+pnpm --filter @agentskit/example-teams-bot dev
+```
+
+`TEAMS_DISABLE_AUTH=1` skips JWT verification for local testing.
+
+## Related
+
+- [`teams` integration](/docs/agents/tools/integrations/teams)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-teams-bot)

--- a/apps/docs-next/content/docs/reference/examples/webllm.mdx
+++ b/apps/docs-next/content/docs/reference/examples/webllm.mdx
@@ -1,0 +1,20 @@
+---
+title: WebLLM (browser-only)
+description: Browser-only chat — the LLM runs 100% in the browser via WebGPU + @mlc-ai/web-llm. No API key, no server-side inference, no telemetry.
+---
+
+The LLM runs **100% in the browser** via WebGPU + [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm). No API key, no server-side inference, no telemetry.
+
+Demonstrates the [`webllm`](/docs/data/providers/webllm) adapter from `@agentskit/adapters` driving the standard [`useChat`](/docs/for-agents/react) hook from `@agentskit/react`.
+
+```bash
+pnpm --filter @agentskit/example-webllm dev
+```
+
+Persistent memory survives page reload via `localStorage`.
+
+## Related
+
+- [Recipe: browser-only-webllm](/docs/reference/recipes/browser-only-webllm)
+- [`webllm` provider](/docs/data/providers/webllm)
+- [Source](https://github.com/AgentsKit-io/agentskit/tree/main/apps/example-webllm)

--- a/apps/docs-next/content/docs/reference/recipes/adapter-router.mdx
+++ b/apps/docs-next/content/docs/reference/recipes/adapter-router.mdx
@@ -38,8 +38,30 @@ and then ranked by the `policy`.
 |--------|----------|
 | `'cheapest'` *(default)* | Minimum `cost` |
 | `'fastest'` | Minimum `latencyMs` |
+| `'greenest'` | Minimum `gCO2PerKtok` (carbon intensity) |
+| `'green-cost'` | Composite normalised carbon × cost score |
 | `'capability-match'` | First candidate that satisfies requirements |
 | `(input) => id` | Custom function, sync or async |
+
+## Carbon-aware + cost-aware routing
+
+Each candidate can carry a `gCO2PerKtok` (grams CO2eq per 1k tokens) signal — populate manually or via `applyCarbonTable()` against `DEFAULT_CARBON_TABLE` (or a custom regional table).
+
+```ts
+import { createRouter, applyCarbonTable, DEFAULT_CARBON_TABLE, anthropic, openai } from '@agentskit/adapters'
+
+const candidates = applyCarbonTable(
+  [
+    { id: 'haiku', adapter: anthropic({ model: 'claude-haiku-4-5' }), cost: 0.25, region: 'us-east' },
+    { id: 'gpt-mini', adapter: openai({ model: 'gpt-4o-mini' }), cost: 0.15, region: 'eu-west' },
+  ],
+  DEFAULT_CARBON_TABLE,
+)
+
+const router = createRouter({ candidates, policy: 'green-cost' })
+```
+
+`'greenest'` minimises grid carbon intensity. `'green-cost'` normalises both signals and minimises the sum — picks the model that's cheap *and* on a clean grid. Candidates missing either signal are treated as median (neutral) so partial telemetry doesn't bias the ranking.
 
 ## Classify-then-route
 

--- a/apps/docs-next/content/docs/reference/recipes/templates-cookbook.mdx
+++ b/apps/docs-next/content/docs/reference/recipes/templates-cookbook.mdx
@@ -129,4 +129,3 @@ its own test that compiles + runs.
 
 - [`agentskit init`](/docs/production/cli/init) — the CLI counterpart.
 - [`@agentskit/templates` package reference](/docs/reference/packages/templates).
-- [`scaffold-creator` recipe](/docs/reference/recipes/scaffold-creator) — the AI-assisted path.


### PR DESCRIPTION
## Summary

Docs audit pass — covers recently-shipped features and missing relationships across the docs site.

### New pages (18)

- **8 vertical skills**: legal-assistant, contract-reviewer, tutor, curriculum-designer, storefront-concierge, merchandising-analyst, listing-concierge, market-analyst
- **8 examples**: discord-bot, slack-bot, teams-bot, edge, embedded, flow, dspy, webllm
- `agents/guarantees.mdx` — validator guard (#210) + per-tool quota (#801)
- `production/security/sso.mdx` — OIDC + SAML verifiers (#203)

### Updated content

- `agents/tools/mcp.mdx` — devtools-over-MCP section (`@agentskit/tools/mcp-devtools`)
- `production/observability/devtools.mdx` — production control surface (pause/step/replay, #828) + live topology graph (#829)
- `reference/recipes/adapter-router.mdx` — `greenest` + `green-cost` policies (#831)

### Broken links fixed

- `postgres-cdc` → `security/pii-redaction` (was `observability/`)
- `teams` → `examples/teams-bot` (recipe didn't exist)
- `templates-cookbook` → drop dead `scaffold-creator` link

## Test plan

- [x] `pnpm --filter @agentskit/docs-next build` passes
- [ ] Sidebar nav renders new entries under expected sections
- [ ] No new broken links from lychee CI