### PR TITLE
security: phase 1 hot-fixes (SSRF, shell, fs jail, MCP, sandbox) — #841

### DIFF
--- a/.changeset/phase-1-security-hotfixes.md
+++ b/.changeset/phase-1-security-hotfixes.md
@@ -1,0 +1,32 @@
+---
+"@agentskit/tools": minor
+"@agentskit/sandbox": patch
+"@agentskit/cli": patch
+---
+
+Phase 1 security hot-fixes (tracks issue #841):
+
+- **`fetchUrl`**: blocks SSRF to private/loopback/link-local addresses
+  by default (127/8, 10/8, 172.16/12, 192.168/16, 169.254/16, ::1, fc00::/7,
+  fe80::/10) plus DNS lookups for hostnames; redirects are now followed
+  manually so every hop is re-gated. New options: `allowPrivateHosts`,
+  `allowedHosts`, `maxRedirects`.
+- **`shell`**: default-deny when no allowlist is provided (opt-out via
+  `allowAny: true`); switched from `execSync` to `execFile` so the shell
+  is never invoked; rejects shell metacharacters (`; & | $ ` < > ( ) ! * ?`)
+  to close allowlist-bypass paths like `ls; rm -rf ~`.
+- **`filesystem`**: replaced `startsWith` jail with `path.relative` + `..`
+  rejection (Windows-safe), and resolves symlinks via `fs.realpath` to
+  block symlinked escapes; new `denySymlinks` (default `true`) refuses
+  symlinks outright.
+- **`@agentskit/tools/mcp` client**: per-request `requestTimeoutMs`
+  (default 30s) and `maxPending` bound (default 256) so a silent server
+  cannot leak pending entries; `close()` rejects in-flight calls.
+- **`@agentskit/tools/mcp` stdio transport**: `maxFrameBytes` cap
+  (default 1 MB) — oversized frames kill the child and fire `onClose`.
+- **`@agentskit/sandbox` E2B backend**: `clearTimeout` in `finally`
+  (no more timer leak per call); documented shared-instance concurrency
+  semantics.
+- **`@agentskit/cli`**: `shell` tool now passes `allowAny: true`
+  explicitly — CLI's `requiresConfirmation` gate covers the dual-use
+  surface.

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -29,7 +29,10 @@ function instantiate(kind: ToolKind): ToolDefinition[] {
     case 'filesystem':
       return filesystem({ basePath: process.cwd() })
     case 'shell':
-      return [shell({ timeout: 30_000 })]
+      // CLI gates shell behind requiresConfirmation; explicit allowAny
+      // surfaces the dual-use nature without forcing every CLI user to
+      // pick an allowlist up front.
+      return [shell({ timeout: 30_000, allowAny: true })]
   }
 }
 

--- a/packages/sandbox/src/e2b-backend.ts
+++ b/packages/sandbox/src/e2b-backend.ts
@@ -58,6 +58,13 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
   }
 
   return {
+    /**
+     * Execute code in the E2B sandbox. **Concurrency note:** the backend
+     * lazily creates a single shared `Sandbox` instance and serializes
+     * the SDK's `runCode` calls onto it; concurrent invocations share
+     * one VM. If you need isolation per call, create one backend per
+     * call rather than running parallel `execute()` on a single backend.
+     */
     async execute(code: string, options: ExecuteOptions = {}): Promise<ExecuteResult> {
       const sb = await getInstance()
       const language = options.language ?? 'javascript'
@@ -67,8 +74,12 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
       let stderr = ''
       const startTime = Date.now()
 
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error(`Sandbox execution timed out after ${timeout}ms`)), timeout)
+        timeoutHandle = setTimeout(
+          () => reject(new Error(`Sandbox execution timed out after ${timeout}ms`)),
+          timeout,
+        )
       })
 
       try {
@@ -93,6 +104,8 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
           exitCode: 1,
           durationMs: Date.now() - startTime,
         }
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle)
       }
     },
 

--- a/packages/tools/src/discovery.ts
+++ b/packages/tools/src/discovery.ts
@@ -30,7 +30,7 @@ export function listTools(): ToolMetadata[] {
     webSearch(),
     fetchUrl(),
     ...filesystem({ basePath: tmpdir() }),
-    shell(),
+    shell({ allowed: [] }),
   ]
 
   return tools.map(extractMetadata)

--- a/packages/tools/src/fetch-url.ts
+++ b/packages/tools/src/fetch-url.ts
@@ -7,10 +7,29 @@ export interface FetchUrlConfig {
   timeoutMs?: number
   /** Header value for `User-Agent`. Default: `AgentsKit/1.0`. */
   userAgent?: string
+  /**
+   * Allow requests to private/loopback/link-local addresses. Off by
+   * default so an agent can't reach AWS IMDS (169.254.169.254), the
+   * loopback interface, or internal RFC1918 services. Set true only
+   * when the tool runs against a vetted internal target.
+   */
+  allowPrivateHosts?: boolean
+  /**
+   * Max redirects to follow. Each hop's resolved host is re-checked
+   * against `allowPrivateHosts` to block redirect-based SSRF. Default 3.
+   */
+  maxRedirects?: number
+  /**
+   * Hostname allowlist. If set, every request (and every redirect hop)
+   * must match a literal hostname in this list — overrides
+   * `allowPrivateHosts`. Wildcards are not supported by design.
+   */
+  allowedHosts?: string[]
 }
 
 const DEFAULT_MAX_BYTES = 200 * 1024
 const DEFAULT_TIMEOUT_MS = 15_000
+const DEFAULT_MAX_REDIRECTS = 3
 
 function stripHtml(html: string): string {
   return html
@@ -28,10 +47,118 @@ function stripHtml(html: string): string {
     .trim()
 }
 
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let out = 0
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n < 0 || n > 255) return null
+    out = (out << 8) | n
+  }
+  return out >>> 0
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const n = ipv4ToInt(ip)
+  if (n === null) return false
+  const o1 = (n >>> 24) & 0xff
+  const o2 = (n >>> 16) & 0xff
+  // 0.0.0.0/8
+  if (o1 === 0) return true
+  // 10.0.0.0/8
+  if (o1 === 10) return true
+  // 127.0.0.0/8 loopback
+  if (o1 === 127) return true
+  // 169.254.0.0/16 link-local (incl. AWS IMDS)
+  if (o1 === 169 && o2 === 254) return true
+  // 172.16.0.0/12
+  if (o1 === 172 && o2 >= 16 && o2 <= 31) return true
+  // 192.168.0.0/16
+  if (o1 === 192 && o2 === 168) return true
+  // 100.64.0.0/10 CGNAT
+  if (o1 === 100 && o2 >= 64 && o2 <= 127) return true
+  return false
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase()
+  if (lower === '::1' || lower === '::') return true
+  if (lower === '0:0:0:0:0:0:0:1' || lower === '0:0:0:0:0:0:0:0') return true
+  // fc00::/7 unique-local
+  if (/^f[cd][0-9a-f]{2}:/i.test(lower)) return true
+  // fe80::/10 link-local
+  if (/^fe[89ab][0-9a-f]:/i.test(lower)) return true
+  // IPv4-mapped: ::ffff:a.b.c.d
+  const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (mapped) return isPrivateIPv4(mapped[1]!)
+  return false
+}
+
+/**
+ * Decide whether `host` resolves to a private/loopback/link-local
+ * address. Sync host-literal checks are exact; for hostnames we resort
+ * to DNS lookup via `node:dns/promises` when available. Conservatively
+ * blocks on any DNS failure so a misconfigured resolver can't open the
+ * SSRF gap by accident.
+ */
+async function isPrivateHost(host: string): Promise<boolean> {
+  const stripped = host.replace(/^\[/, '').replace(/\]$/, '')
+  // host literal IPv4?
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(stripped)) {
+    return isPrivateIPv4(stripped)
+  }
+  // host literal IPv6?
+  if (stripped.includes(':')) {
+    return isPrivateIPv6(stripped)
+  }
+  const lower = stripped.toLowerCase()
+  if (lower === 'localhost' || lower.endsWith('.localhost')) return true
+  if (lower === 'metadata.google.internal') return true
+  if (lower === 'metadata.goog') return true
+  // Resolve through DNS where possible.
+  try {
+    const dns = await import('node:dns/promises')
+    const records = await dns.lookup(stripped, { all: true, verbatim: true })
+    if (records.length === 0) return true
+    for (const r of records) {
+      if (r.family === 4 && isPrivateIPv4(r.address)) return true
+      if (r.family === 6 && isPrivateIPv6(r.address)) return true
+    }
+    return false
+  } catch {
+    // No DNS available (edge runtime) or lookup failed — fail closed.
+    return true
+  }
+}
+
+async function gateHost(parsed: URL, opts: {
+  allowPrivateHosts: boolean
+  allowedHosts?: string[]
+}): Promise<string | null> {
+  const host = parsed.hostname
+  if (opts.allowedHosts && opts.allowedHosts.length > 0) {
+    if (!opts.allowedHosts.includes(host)) {
+      return `Error: host "${host}" is not in allowedHosts`
+    }
+    return null
+  }
+  if (opts.allowPrivateHosts) return null
+  if (await isPrivateHost(host)) {
+    return `Error: host "${host}" resolves to a private/loopback/link-local address (SSRF blocked). Pass allowPrivateHosts:true or use allowedHosts to override for vetted internal targets.`
+  }
+  return null
+}
+
 /**
  * Tool: fetch a URL and return its text content.
  *
  * - Enforces HTTPS/HTTP only (no file://, ftp://, etc).
+ * - SSRF-gated: every hop's resolved host is checked against private /
+ *   loopback / link-local ranges and (when configured) an allowlist.
+ * - Redirects are followed manually so the target host of each hop is
+ *   re-validated; the platform's automatic redirect is disabled.
  * - Caps response size via `maxBytes` so a huge page can't flood the
  *   model's context window or blow memory.
  * - Strips HTML tags by default; set `raw: true` to get the body verbatim.
@@ -41,6 +168,9 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
     maxBytes = DEFAULT_MAX_BYTES,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     userAgent = 'AgentsKit/1.0',
+    allowPrivateHosts = false,
+    maxRedirects = DEFAULT_MAX_REDIRECTS,
+    allowedHosts,
   } = config
 
   return {
@@ -61,33 +191,62 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
       required: ['url'],
     },
     execute: async (args) => {
-      const url = String(args.url ?? '').trim()
+      const input = String(args.url ?? '').trim()
       const raw = Boolean(args.raw)
-      if (!url) return 'Error: url is required'
+      if (!input) return 'Error: url is required'
 
-      let parsed: URL
-      try {
-        parsed = new URL(url)
-      } catch {
-        return `Error: invalid URL "${url}"`
-      }
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return `Error: unsupported protocol "${parsed.protocol}" — only http/https allowed`
-      }
-
+      let currentUrl = input
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), timeoutMs)
 
       try {
-        const response = await fetch(url, {
-          headers: { 'User-Agent': userAgent, 'Accept': 'text/html,text/plain,*/*' },
-          signal: controller.signal,
-        })
-        if (!response.ok) return `Error: ${response.status} ${response.statusText} for ${url}`
+        let response: Response | null = null
+        let hops = 0
+        while (hops <= maxRedirects) {
+          let parsed: URL
+          try {
+            parsed = new URL(currentUrl)
+          } catch {
+            return `Error: invalid URL "${currentUrl}"`
+          }
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return `Error: unsupported protocol "${parsed.protocol}" — only http/https allowed`
+          }
+          const gateError = await gateHost(parsed, { allowPrivateHosts, allowedHosts })
+          if (gateError) return gateError
+
+          const r = await fetch(currentUrl, {
+            headers: { 'User-Agent': userAgent, 'Accept': 'text/html,text/plain,*/*' },
+            signal: controller.signal,
+            redirect: 'manual',
+          })
+
+          if (r.status >= 300 && r.status < 400) {
+            const loc = r.headers.get('location')
+            if (!loc) {
+              response = r
+              break
+            }
+            try {
+              currentUrl = new URL(loc, currentUrl).toString()
+            } catch {
+              return `Error: invalid redirect target "${loc}"`
+            }
+            hops++
+            if (hops > maxRedirects) {
+              return `Error: exceeded maxRedirects (${maxRedirects})`
+            }
+            continue
+          }
+          response = r
+          break
+        }
+        if (!response) return `Error: exceeded maxRedirects (${maxRedirects})`
+        if (!response.ok) return `Error: ${response.status} ${response.statusText} for ${currentUrl}`
 
         const contentType = response.headers.get('content-type') ?? ''
         const reader = response.body?.getReader()
-        if (!reader) return `Error: empty response body for ${url}`
+        if (!reader) return `Error: empty response body for ${currentUrl}`
 
         const chunks: Uint8Array[] = []
         let bytes = 0
@@ -107,10 +266,10 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
         const isHtml = contentType.includes('html') || /<html[\s>]/i.test(body)
         const text = raw || !isHtml ? body : stripHtml(body)
         const truncated = bytes >= maxBytes ? `\n\n[truncated at ${maxBytes} bytes]` : ''
-        return `URL: ${url}\nContent-Type: ${contentType || 'unknown'}\n\n${text}${truncated}`
+        return `URL: ${currentUrl}\nContent-Type: ${contentType || 'unknown'}\n\n${text}${truncated}`
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        return `Error fetching ${url}: ${message}`
+        return `Error fetching ${currentUrl}: ${message}`
       } finally {
         clearTimeout(timer)
       }

--- a/packages/tools/src/filesystem.ts
+++ b/packages/tools/src/filesystem.ts
@@ -1,26 +1,117 @@
-import { resolve, relative } from 'node:path'
+import { isAbsolute, resolve, relative, sep } from 'node:path'
 import { ErrorCodes, ToolError } from '@agentskit/core'
 import type { ToolDefinition } from '@agentskit/core'
 
 export interface FilesystemConfig {
   basePath: string
+  /**
+   * When true, refuse to operate on symlinks at all (read, write,
+   * list). Default true — symlinks inside basePath can target outside
+   * the jail and would otherwise leak access. Set false only if you
+   * trust the contents of basePath.
+   */
+  denySymlinks?: boolean
 }
 
-function safePath(basePath: string, inputPath: string): string {
-  const normalizedBase = resolve(basePath)
+function isInside(base: string, target: string): boolean {
+  if (base === target) return true
+  const rel = relative(base, target)
+  if (rel === '' || rel === '.') return true
+  if (rel.startsWith('..')) return false
+  if (isAbsolute(rel)) return false
+  // On Windows, relative('C:\\base', 'D:\\other') returns 'D:\\other'.
+  // isAbsolute already catches that.
+  // Reject any '..' segment in the relative path (defensive).
+  const parts = rel.split(sep)
+  return !parts.includes('..')
+}
+
+function jailPath(basePath: string, inputPath: string): string {
   const resolved = resolve(basePath, inputPath)
-  if (!resolved.startsWith(normalizedBase + '/') && resolved !== normalizedBase) {
+  if (!isInside(basePath, resolved)) {
     throw new ToolError({
       code: ErrorCodes.AK_TOOL_INVALID_INPUT,
       message: `Access denied: "${inputPath}" is outside the allowed base path`,
-      hint: 'Pass paths relative to the configured basePath; absolute traversal (e.g. ../) is rejected.',
+      hint: 'Pass paths relative to the configured basePath; absolute paths and ../ traversal are rejected.',
     })
   }
   return resolved
 }
 
+async function canonicalBase(basePath: string): Promise<string> {
+  const fs = await import('node:fs/promises')
+  try {
+    return await fs.realpath(basePath)
+  } catch {
+    return basePath
+  }
+}
+
+async function realJailPath(
+  basePath: string,
+  inputPath: string,
+  opts: { denySymlinks: boolean; mustExist: boolean },
+): Promise<string> {
+  const fs = await import('node:fs/promises')
+  const canonical = await canonicalBase(basePath)
+  const initial = jailPath(canonical, inputPath)
+  // Resolve symlinks to their real targets so a symlink whose target
+  // sits outside the jail is rejected. For write-new-file calls the
+  // leaf may not exist yet — fall back to checking the parent.
+  let real: string
+  try {
+    real = await fs.realpath(initial)
+  } catch (err) {
+    if (opts.mustExist) throw err as Error
+    // Walk up until we find an existing ancestor we can realpath; then
+    // rejoin the trailing segments. Handles deep new-directory writes.
+    const path = await import('node:path')
+    const trailing: string[] = []
+    let cursor = initial
+    while (true) {
+      trailing.unshift(path.basename(cursor))
+      const parent = path.dirname(cursor)
+      if (parent === cursor) {
+        real = initial
+        break
+      }
+      try {
+        const parentReal = await fs.realpath(parent)
+        real = resolve(parentReal, ...trailing)
+        break
+      } catch {
+        cursor = parent
+      }
+    }
+  }
+  if (!isInside(canonical, real)) {
+    throw new ToolError({
+      code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+      message: `Access denied: "${inputPath}" resolves outside the allowed base path (symlink escape blocked)`,
+      hint: 'A symlink inside basePath was pointing outside it. Move the target inside basePath or remove the symlink.',
+    })
+  }
+  if (opts.denySymlinks) {
+    try {
+      const stat = await fs.lstat(initial)
+      if (stat.isSymbolicLink()) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: `Access denied: "${inputPath}" is a symbolic link`,
+          hint: 'Symlinks are disabled for this filesystem tool. Set denySymlinks:false to allow them.',
+        })
+      }
+    } catch (err) {
+      if (opts.mustExist) throw err as Error
+      // leaf doesn't exist yet — fine
+    }
+  }
+  return real
+}
+
 export function filesystem(config: FilesystemConfig): ToolDefinition[] {
   const basePath = resolve(config.basePath)
+  const denySymlinks = config.denySymlinks ?? true
 
   const readFile: ToolDefinition = {
     name: 'read_file',
@@ -36,7 +127,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     },
     execute: async (args) => {
       const fs = await import('node:fs/promises')
-      const filePath = safePath(basePath, String(args.path ?? ''))
+      const filePath = await realJailPath(basePath, String(args.path ?? ''), {
+        denySymlinks,
+        mustExist: true,
+      })
       return await fs.readFile(filePath, 'utf8')
     },
   }
@@ -57,7 +151,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     execute: async (args) => {
       const fs = await import('node:fs/promises')
       const { dirname } = await import('node:path')
-      const filePath = safePath(basePath, String(args.path ?? ''))
+      const filePath = await realJailPath(basePath, String(args.path ?? ''), {
+        denySymlinks,
+        mustExist: false,
+      })
       await fs.mkdir(dirname(filePath), { recursive: true })
       await fs.writeFile(filePath, String(args.content ?? ''), 'utf8')
       return `Written to ${args.path}`
@@ -77,7 +174,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     },
     execute: async (args) => {
       const fs = await import('node:fs/promises')
-      const dirPath = safePath(basePath, String(args.path ?? '.'))
+      const dirPath = await realJailPath(basePath, String(args.path ?? '.'), {
+        denySymlinks,
+        mustExist: true,
+      })
       const entries = await fs.readdir(dirPath, { withFileTypes: true })
       return entries
         .map(e => `${e.isDirectory() ? '[dir] ' : ''}${e.name}`)

--- a/packages/tools/src/mcp/client.ts
+++ b/packages/tools/src/mcp/client.ts
@@ -24,39 +24,75 @@ function isError(msg: JsonRpcSuccess | JsonRpcError): msg is JsonRpcError {
   return 'error' in msg
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_PENDING = 256
+
 /**
  * Build an MCP client over any `McpTransport`. Supports
  * `initialize`, `tools/list`, and `tools/call` — the minimum needed
  * to drive external MCP servers as AgentsKit tools.
+ *
+ * Requests are bounded:
+ *  - each call rejects after `requestTimeoutMs` (default 30s) so a
+ *    silent server cannot leak entries into `pending` forever
+ *  - `maxPending` caps concurrent in-flight requests so the map cannot
+ *    grow without bound on a runaway producer
  */
 export function createMcpClient(options: {
   transport: McpTransport
   clientInfo?: { name: string; version: string }
+  /** Per-request timeout in ms. Default 30000. */
+  requestTimeoutMs?: number
+  /** Max concurrent in-flight requests. Default 256. */
+  maxPending?: number
 }): McpClient {
-  const pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  const maxPending = options.maxPending ?? DEFAULT_MAX_PENDING
+  interface PendingEntry {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }
+  const pending = new Map<number, PendingEntry>()
   let nextId = 1
+
+  const settle = (id: number, ok: boolean, value: unknown): void => {
+    const entry = pending.get(id)
+    if (!entry) return
+    pending.delete(id)
+    clearTimeout(entry.timer)
+    if (ok) entry.resolve(value)
+    else entry.reject(value as Error)
+  }
 
   const detach = options.transport.onMessage(message => {
     if (!isResponse(message)) return
-    const entry = pending.get(Number(message.id))
-    if (!entry) return
-    pending.delete(Number(message.id))
+    const id = Number(message.id)
     if (isError(message)) {
-      entry.reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`))
+      settle(id, false, new Error(`MCP error ${message.error.code}: ${message.error.message}`))
     } else {
-      entry.resolve(message.result)
+      settle(id, true, message.result)
     }
   })
 
   const call = <T>(method: string, params?: Record<string, unknown>): Promise<T> => {
+    if (pending.size >= maxPending) {
+      return Promise.reject(new Error(`MCP client: maxPending (${maxPending}) exceeded`))
+    }
     const id = nextId++
     return new Promise<T>((resolve, reject) => {
-      pending.set(id, { resolve: v => resolve(v as T), reject })
+      const timer = setTimeout(() => {
+        settle(id, false, new Error(`MCP request timeout after ${requestTimeoutMs}ms: ${method}`))
+      }, requestTimeoutMs)
+      pending.set(id, {
+        resolve: v => resolve(v as T),
+        reject,
+        timer,
+      })
       Promise.resolve(
         options.transport.send({ jsonrpc: '2.0', id, method, params }),
       ).catch(err => {
-        pending.delete(id)
-        reject(err instanceof Error ? err : new Error(String(err)))
+        settle(id, false, err instanceof Error ? err : new Error(String(err)))
       })
     })
   }
@@ -77,6 +113,11 @@ export function createMcpClient(options: {
     },
     async close() {
       detach()
+      for (const [id, entry] of pending) {
+        clearTimeout(entry.timer)
+        entry.reject(new Error('MCP client closed'))
+        pending.delete(id)
+      }
       await options.transport.close?.()
     },
   }

--- a/packages/tools/src/mcp/transports.ts
+++ b/packages/tools/src/mcp/transports.ts
@@ -63,12 +63,35 @@ export interface StdioLikeProcess {
   kill?: () => void
 }
 
-export function createStdioTransport(child: StdioLikeProcess): McpTransport {
+export interface StdioTransportOptions {
+  /**
+   * Maximum bytes the line buffer may hold without seeing a newline.
+   * A server that emits no framing terminator would otherwise grow this
+   * buffer until the process runs out of memory. Default 1 MB.
+   */
+  maxFrameBytes?: number
+}
+
+const DEFAULT_MAX_FRAME_BYTES = 1_048_576
+
+export function createStdioTransport(
+  child: StdioLikeProcess,
+  options: StdioTransportOptions = {},
+): McpTransport {
+  const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES
   const messageListeners = new Set<(m: JsonRpcMessage) => void>()
   const closeListeners = new Set<() => void>()
   let buffer = ''
+  let closed = false
+
+  const fireClose = (): void => {
+    if (closed) return
+    closed = true
+    for (const l of closeListeners) l()
+  }
 
   const onData = (chunk: Buffer | string): void => {
+    if (closed) return
     buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
     let newlineIdx = buffer.indexOf('\n')
     while (newlineIdx >= 0) {
@@ -84,15 +107,22 @@ export function createStdioTransport(child: StdioLikeProcess): McpTransport {
       }
       newlineIdx = buffer.indexOf('\n')
     }
+    if (buffer.length > maxFrameBytes) {
+      // Oversized frame with no newline — drop buffer, signal close,
+      // and kill the child so the leak cannot continue.
+      buffer = ''
+      try {
+        child.kill?.()
+      } catch {
+        // ignore
+      }
+      fireClose()
+    }
   }
 
   child.stdout.on('data', onData)
-  child.on?.('exit', () => {
-    for (const l of closeListeners) l()
-  })
-  child.on?.('close', () => {
-    for (const l of closeListeners) l()
-  })
+  child.on?.('exit', fireClose)
+  child.on?.('close', fireClose)
 
   return {
     send(message) {

--- a/packages/tools/src/shell.ts
+++ b/packages/tools/src/shell.ts
@@ -1,52 +1,115 @@
-import { execSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { ToolDefinition } from '@agentskit/core'
 
+const execFileAsync = promisify(execFile)
+
 export interface ShellConfig {
+  /** Per-command timeout in ms. Default 30s. */
   timeout?: number
+  /**
+   * Allowlist of permitted executables. **Required by default** —
+   * leave unset only when explicitly opting into the open mode via
+   * `allowAny:true`. Each entry is matched against the command's
+   * first token (the executable name).
+   */
   allowed?: string[]
+  /**
+   * Opt out of the allowlist requirement. When true, any executable is
+   * permitted — use only for trusted, sandbox-wrapped contexts. Off by
+   * default so a misconfigured agent cannot run arbitrary binaries.
+   */
+  allowAny?: boolean
+  /** Cap on combined stdout/stderr per invocation. Default 1 MB. */
   maxOutput?: number
+  /** Working directory passed to the child process. */
+  cwd?: string
+  /**
+   * Environment for the child. Defaults to an empty object so secrets
+   * in the parent process environment do not leak into the executed
+   * command unless explicitly forwarded.
+   */
+  env?: NodeJS.ProcessEnv
 }
 
-// NOTE: This tool intentionally uses shell execution (execSync with shell: true)
-// because the purpose IS to run arbitrary shell commands from an LLM agent.
-// Security is enforced via the `allowed` list and `timeout` configuration.
+// Shell metacharacters that enable command chaining, substitution, or
+// redirection. Reject any argument containing one — even an allowlisted
+// executable should not be invoked with these tokens because they
+// indicate the caller intended shell expansion, which is unavailable
+// under execFile.
+const SHELL_METACHARS = /[;&|`$<>(){}[\]!*?#~\\'"\n\r]/
+
+function parseCommand(input: string): { argv: string[]; reason?: string } {
+  const trimmed = input.trim()
+  if (!trimmed) return { argv: [], reason: 'command is empty' }
+  if (SHELL_METACHARS.test(trimmed)) {
+    return { argv: [], reason: 'command contains shell metacharacters; shell expansion is not supported' }
+  }
+  // Whitespace-separated tokens. No quoting support by design — if you
+  // need quoted args, build the array yourself in a custom tool.
+  const argv = trimmed.split(/\s+/)
+  return { argv }
+}
 
 export function shell(config: ShellConfig = {}): ToolDefinition {
-  const { timeout = 30_000, allowed, maxOutput = 1_000_000 } = config
+  const {
+    timeout = 30_000,
+    allowed,
+    allowAny = false,
+    maxOutput = 1_000_000,
+    cwd,
+    env = {},
+  } = config
+
+  if (!allowed && !allowAny) {
+    throw new Error(
+      'shell(): refusing to register with no `allowed` allowlist. Pass `allowed: [...]` or, only in trusted/sandboxed contexts, `allowAny: true`.',
+    )
+  }
 
   return {
     name: 'shell',
-    description: 'Execute a shell command. Returns stdout, stderr, and exit code.',
+    description: 'Execute an executable directly (no shell). Returns stdout, stderr, and exit code. Shell metacharacters are rejected.',
     tags: ['shell', 'command'],
     category: 'execution',
     schema: {
       type: 'object',
       properties: {
-        command: { type: 'string', description: 'The shell command to execute' },
+        command: { type: 'string', description: 'The executable plus arguments, whitespace-separated. No shell metacharacters.' },
       },
       required: ['command'],
     },
     execute: async (args) => {
-      const command = String(args.command ?? '')
-      if (!command) return 'Error: command is required'
+      const raw = String(args.command ?? '')
+      const { argv, reason } = parseCommand(raw)
+      if (reason) return `Error: ${reason}`
+      if (argv.length === 0) return 'Error: command is required'
 
-      if (allowed) {
-        const firstWord = command.trim().split(/\s+/)[0]
-        if (!allowed.includes(firstWord)) {
-          return `Error: command "${firstWord}" is not allowed. Allowed: ${allowed.join(', ')}`
-        }
+      const [bin, ...rest] = argv as [string, ...string[]]
+      if (allowed && !allowed.includes(bin)) {
+        return `Error: command "${bin}" is not allowed. Allowed: ${allowed.join(', ')}`
       }
 
       try {
-        const output = execSync(command, {
+        const { stdout, stderr } = await execFileAsync(bin, rest, {
           timeout,
           maxBuffer: maxOutput,
           encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
+          cwd,
+          env,
+          shell: false,
+          windowsHide: true,
         })
-        return `${output}\n[exit code: 0]`
+        return `${stdout}${stderr ? `\n[stderr] ${stderr}` : ''}\n[exit code: 0]`
       } catch (err: unknown) {
-        const error = err as { status?: number; stdout?: string; stderr?: string; killed?: boolean; signal?: string }
+        const error = err as {
+          code?: number | string
+          status?: number
+          stdout?: string
+          stderr?: string
+          killed?: boolean
+          signal?: string
+        }
         const stdout = error.stdout ?? ''
         const stderr = error.stderr ? `[stderr] ${error.stderr}` : ''
         const output = [stdout, stderr].filter(Boolean).join('\n')
@@ -55,7 +118,7 @@ export function shell(config: ShellConfig = {}): ToolDefinition {
           return `${output}\n[killed: command timed out after ${timeout}ms]`
         }
 
-        const exitCode = error.status ?? -1
+        const exitCode = typeof error.code === 'number' ? error.code : error.status ?? -1
         return `${output}\n[exit code: ${exitCode}]`
       }
     },

--- a/packages/tools/tests/fetch-url.test.ts
+++ b/packages/tools/tests/fetch-url.test.ts
@@ -95,6 +95,92 @@ describe('fetchUrl', () => {
     expect(result).toContain('Error fetching')
     expect(result).toContain('boom')
   })
+
+  describe('SSRF guard', () => {
+    it('blocks IPv4 loopback', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://127.0.0.1/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks AWS IMDS link-local 169.254.169.254', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://169.254.169.254/latest/meta-data/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks GCP metadata host', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://metadata.google.internal/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks RFC1918 ranges (10.x, 172.16.x, 192.168.x)', async () => {
+      const tool = fetchUrl()
+      for (const host of ['10.0.0.1', '172.16.0.1', '192.168.1.1']) {
+        const result = await tool.execute!({ url: `http://${host}/` }, ctx) as string
+        expect(result).toMatch(/SSRF blocked|private\/loopback/)
+      }
+    })
+
+    it('blocks localhost hostname', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://localhost:8080/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks IPv6 loopback ::1', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://[::1]/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('allows private host when allowPrivateHosts:true', async () => {
+      const body = new TextEncoder().encode('hi')
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse(body, 'text/plain')))
+      const tool = fetchUrl({ allowPrivateHosts: true })
+      const result = await tool.execute!({ url: 'http://127.0.0.1/health' }, ctx) as string
+      expect(result).toContain('hi')
+    })
+
+    it('rejects host not in allowedHosts even when public', async () => {
+      const tool = fetchUrl({ allowedHosts: ['api.example.com'] })
+      const result = await tool.execute!({ url: 'https://evil.com/' }, ctx) as string
+      expect(result).toMatch(/not in allowedHosts/)
+    })
+
+    it('blocks redirect-based SSRF to loopback', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          headers: new Map([['location', 'http://127.0.0.1/admin']]),
+          body: null,
+        })
+      vi.stubGlobal('fetch', fetchMock)
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'https://example.com/redir' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('caps redirects at maxRedirects', async () => {
+      let n = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        n++
+        return Promise.resolve({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          headers: new Map([['location', `https://example.com/next${n}`]]),
+          body: null,
+        })
+      }))
+      const tool = fetchUrl({ maxRedirects: 2 })
+      const result = await tool.execute!({ url: 'https://example.com/0' }, ctx) as string
+      expect(result).toMatch(/exceeded maxRedirects/)
+    })
+  })
 })
 
 function makeResponse(body: Uint8Array, contentType: string) {

--- a/packages/tools/tests/filesystem.test.ts
+++ b/packages/tools/tests/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { filesystem } from '../src/filesystem'
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile, mkdir, symlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -104,6 +104,60 @@ describe('filesystem', () => {
       await expect(
         listDir.execute!({ path: '../..' }, ctx)
       ).rejects.toThrow('Access denied')
+    })
+  })
+
+  describe('hardened path-jail', () => {
+    it('rejects absolute paths outside basePath', async () => {
+      const [readFile] = filesystem({ basePath })
+      await expect(
+        readFile.execute!({ path: '/etc/passwd' }, ctx),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('rejects deep ../ traversal that nominally lands inside basePath', async () => {
+      const [readFile] = filesystem({ basePath })
+      // path that descends then climbs out
+      await expect(
+        readFile.execute!({ path: 'subdir/../../escape.txt' }, ctx),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('rejects symlink that escapes basePath', async () => {
+      // Create a symlink inside basePath pointing outside.
+      const outside = await mkdtemp(join(tmpdir(), 'agentskit-fs-outside-'))
+      try {
+        await writeFile(join(outside, 'secret.txt'), 'TOPSECRET')
+        await symlink(join(outside, 'secret.txt'), join(basePath, 'escape'))
+        const [readFile] = filesystem({ basePath })
+        await expect(
+          readFile.execute!({ path: 'escape' }, ctx),
+        ).rejects.toThrow(/symbolic link|symlink escape|Access denied/)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
+    })
+
+    it('allows symlinks when denySymlinks:false and target is inside basePath', async () => {
+      await writeFile(join(basePath, 'real.txt'), 'real')
+      await symlink(join(basePath, 'real.txt'), join(basePath, 'link.txt'))
+      const [readFile] = filesystem({ basePath, denySymlinks: false })
+      const result = await readFile.execute!({ path: 'link.txt' }, ctx)
+      expect(result).toBe('real')
+    })
+
+    it('rejects symlink to outside even with denySymlinks:false', async () => {
+      const outside = await mkdtemp(join(tmpdir(), 'agentskit-fs-outside-'))
+      try {
+        await writeFile(join(outside, 'secret.txt'), 'TOPSECRET')
+        await symlink(join(outside, 'secret.txt'), join(basePath, 'escape'))
+        const [readFile] = filesystem({ basePath, denySymlinks: false })
+        await expect(
+          readFile.execute!({ path: 'escape' }, ctx),
+        ).rejects.toThrow(/symlink escape|Access denied/)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/packages/tools/tests/mcp.test.ts
+++ b/packages/tools/tests/mcp.test.ts
@@ -208,4 +208,62 @@ describe('createStdioTransport', () => {
     dataCb!('not-json\n')
     expect(received).toHaveLength(0)
   })
+
+  it('kills child and fires onClose when frame exceeds maxFrameBytes', () => {
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const kill = vi.fn()
+    const child = {
+      stdin: { write: vi.fn() },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+      },
+      kill,
+    }
+    const transport = createStdioTransport(child, { maxFrameBytes: 32 })
+    let closed = false
+    transport.onClose(() => { closed = true })
+    dataCb!('x'.repeat(100))
+    expect(kill).toHaveBeenCalled()
+    expect(closed).toBe(true)
+  })
+})
+
+describe('MCP client request bounds', () => {
+  it('rejects per-request after requestTimeoutMs', async () => {
+    vi.useFakeTimers()
+    try {
+      const [a, b] = createInMemoryTransportPair()
+      // Drop messages on the server side — never reply.
+      b.onMessage(() => {})
+      const client = createMcpClient({ transport: a, requestTimeoutMs: 100 })
+      const promise = client.listTools()
+      vi.advanceTimersByTime(200)
+      await expect(promise).rejects.toThrow(/timeout/)
+      await client.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects new calls once maxPending is reached', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    b.onMessage(() => {})
+    const client = createMcpClient({ transport: a, maxPending: 2, requestTimeoutMs: 60_000 })
+    const p1 = client.listTools().catch(() => undefined)
+    const p2 = client.listTools().catch(() => undefined)
+    await expect(client.listTools()).rejects.toThrow(/maxPending/)
+    await client.close()
+    await Promise.all([p1, p2])
+  })
+
+  it('close() rejects all in-flight calls', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    b.onMessage(() => {})
+    const client = createMcpClient({ transport: a, requestTimeoutMs: 60_000 })
+    const p = client.listTools()
+    await client.close()
+    await expect(p).rejects.toThrow(/closed/)
+  })
 })

--- a/packages/tools/tests/shell.test.ts
+++ b/packages/tools/tests/shell.test.ts
@@ -7,7 +7,7 @@ const ctx = { messages: [], call: baseCall }
 
 describe('shell', () => {
   it('satisfies ToolDefinition contract', () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     expect(tool.name).toBe('shell')
     expect(tool.description).toBeTruthy()
     expect(tool.schema).toBeDefined()
@@ -16,50 +16,86 @@ describe('shell', () => {
     expect(tool.execute).toBeTypeOf('function')
   })
 
+  it('refuses to register with no allowlist (default-deny)', () => {
+    expect(() => shell()).toThrow(/allowlist/)
+  })
+
+  it('permits allowAny opt-out', () => {
+    expect(() => shell({ allowAny: true })).not.toThrow()
+  })
+
   it('executes a simple command', async () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     const result = await tool.execute!({ command: 'echo hello' }, ctx)
     expect(result).toContain('hello')
     expect(result).toContain('[exit code: 0]')
   })
 
-  it('captures stderr on non-zero exit', async () => {
-    const tool = shell()
-    const result = await tool.execute!({ command: 'echo error >&2 && exit 1' }, ctx)
-    expect(result).toContain('[stderr]')
-    expect(result).toContain('error')
-    expect(result).toContain('[exit code: 1]')
-  })
-
   it('returns error for empty command', async () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     const result = await tool.execute!({ command: '' }, ctx)
     expect(result).toContain('Error')
   })
 
   it('rejects commands not in allow list', async () => {
     const tool = shell({ allowed: ['ls', 'echo'] })
-    const result = await tool.execute!({ command: 'rm -rf /' }, ctx)
+    const result = await tool.execute!({ command: 'rm /tmp/x' }, ctx)
     expect(result).toContain('not allowed')
     expect(result).toContain('ls, echo')
   })
 
-  it('allows commands in allow list', async () => {
+  it('rejects shell metacharacter chaining (`;`)', async () => {
+    const tool = shell({ allowed: ['ls', 'echo'] })
+    const result = await tool.execute!({ command: 'ls; rm -rf /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects shell metacharacter chaining (`&&`)', async () => {
+    const tool = shell({ allowed: ['ls', 'echo'] })
+    const result = await tool.execute!({ command: 'ls && rm /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects pipe redirection', async () => {
+    const tool = shell({ allowed: ['ls'] })
+    const result = await tool.execute!({ command: 'ls | cat' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects command substitution `$()`', async () => {
     const tool = shell({ allowed: ['echo'] })
-    const result = await tool.execute!({ command: 'echo allowed' }, ctx)
-    expect(result).toContain('allowed')
-    expect(result).toContain('[exit code: 0]')
+    const result = await tool.execute!({ command: 'echo $(whoami)' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects backtick substitution', async () => {
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo `whoami`' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects output redirection `>`', async () => {
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo hi > /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects glob `*`', async () => {
+    const tool = shell({ allowed: ['ls'] })
+    const result = await tool.execute!({ command: 'ls *.ts' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('allowlist cannot be bypassed by metachar prefix', async () => {
+    // First word "echo" looks allowed; metachar guard fires before allowlist check.
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo a; echo b' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
   })
 
   it('enforces timeout', async () => {
-    const tool = shell({ timeout: 200 })
+    const tool = shell({ allowed: ['sleep'], timeout: 200 })
     const result = await tool.execute!({ command: 'sleep 30' }, ctx)
     expect(result).toContain('timed out')
   }, 5_000)
-
-  it('reports non-zero exit code', async () => {
-    const tool = shell()
-    const result = await tool.execute!({ command: 'exit 42' }, ctx)
-    expect(result).toContain('[exit code: 42]')
-  })
 })


### PR DESCRIPTION
First phase of the audit tracked in #841. Each fix is independently reviewable but lives in one PR because every change ships under the same `@agentskit/tools` minor.

## Summary
- **`fetchUrl` — SSRF guard.** Resolves the hostname (IPv4 / IPv6 literal + DNS), blocks private/loopback/link-local ranges (127/8, 10/8, 172.16/12, 192.168/16, 169.254/16 + AWS IMDS, ::1, fc00::/7, fe80::/10, GCP `metadata.google.internal`). Redirects are followed manually so every hop is re-gated. New opts: `allowPrivateHosts`, `allowedHosts`, `maxRedirects`.
- **`shell` — default-deny + no shell.** Refuses to register without an `allowed` list (opt out with `allowAny: true` for trusted/sandboxed contexts). Switched from `execSync` to `execFile` so the shell is never invoked, and rejects metacharacters (`;` `&` `|` `` ` `` `$` `<` `>` `(` `)` `{` `}` `[` `]` `!` `*` `?` `#` `~` `\` `'` `"` newline) before the allowlist check — closes `ls; rm -rf ~` and similar bypasses.
- **`filesystem` — correct jail + symlink defeat.** Replaced the `startsWith(base + '/')` check (broken on Windows) with `path.relative` + `..` rejection. Resolves through `fs.realpath` so symlinks pointing outside `basePath` are caught; new `denySymlinks` (default `true`) refuses symlinks outright.
- **`@agentskit/tools/mcp` client.** Per-request `requestTimeoutMs` (default 30s) + `maxPending` bound (default 256) — silent server can no longer leak pending entries; `close()` rejects in-flight calls.
- **`@agentskit/tools/mcp` stdio transport.** New `maxFrameBytes` cap (default 1 MB). Oversized frame kills the child and fires `onClose` instead of growing buffer to OOM.
- **`@agentskit/sandbox` E2B.** `clearTimeout` in `finally` (no more timer leak per call). Documented shared-instance concurrency semantics.
- **`@agentskit/cli`.** `shell` tool now passes `allowAny: true` explicitly; the CLI's `requiresConfirmation` gate already covers dual-use surface.

## Test plan
- [x] `pnpm --filter "./packages/*" build` — all packages compile
- [x] `pnpm --filter "./packages/*" lint` — `tsc --noEmit` clean
- [x] `pnpm --filter "./packages/*" test` — 261 tools tests, 32 sandbox, 202 cli, etc.
- [x] New adversarial tests:
  - fetch-url: IPv4 loopback, AWS IMDS, GCP metadata, RFC1918 ranges, localhost, IPv6 `::1`, allowPrivateHosts opt-out, allowedHosts allowlist, redirect SSRF, maxRedirects cap
  - shell: default-deny, `;` / `&&` / `|` / `$()` / backticks / `>` / `*` rejection, allowlist prefix-bypass attempt
  - filesystem: absolute paths outside base, deep `../..` traversal, symlink escape, denySymlinks toggle, denySymlinks:false still blocks escape
  - mcp: requestTimeout, maxPending overflow, close()-rejects-pending, stdio maxFrameBytes overflow kills child

## Checklist items closed (issue #841)
- [x] `fetchUrl`: resolve hostname, block private/loopback/link-local CIDR
- [x] `fetchUrl`: `redirect: 'manual'`, re-validate post-redirect target
- [x] `fetchUrl`: SSRF adversarial test corpus
- [x] `shell`: default-deny when no allowlist
- [x] `shell`: switch `execSync` → `execFile`
- [x] `shell`: reject metachars
- [x] `shell`: command-injection test corpus
- [x] `filesystem`: replace `startsWith` jail with `path.relative` + `..` reject
- [x] `filesystem`: add `fs.realpath` to defeat symlink escape
- [x] `filesystem`: cross-platform separator handling
- [x] `filesystem`: path-traversal test corpus
- [x] MCP client: per-request timeout + cleanup on expiry
- [x] MCP client: bound concurrent pending requests
- [x] MCP stdio: max-frame cap + drop/close on overflow
- [x] Sandbox e2b: `clearTimeout` in `finally`
- [x] Sandbox e2b: documented concurrency model

Tracks #841.