### PR TITLE
arch: phase 4 — core no-deps guard, controller split, package tiers — #841

### DIFF
--- a/.changeset/phase-1-security-hotfixes.md
+++ b/.changeset/phase-1-security-hotfixes.md
@@ -1,0 +1,32 @@
+---
+"@agentskit/tools": minor
+"@agentskit/sandbox": patch
+"@agentskit/cli": patch
+---
+
+Phase 1 security hot-fixes (tracks issue #841):
+
+- **`fetchUrl`**: blocks SSRF to private/loopback/link-local addresses
+  by default (127/8, 10/8, 172.16/12, 192.168/16, 169.254/16, ::1, fc00::/7,
+  fe80::/10) plus DNS lookups for hostnames; redirects are now followed
+  manually so every hop is re-gated. New options: `allowPrivateHosts`,
+  `allowedHosts`, `maxRedirects`.
+- **`shell`**: default-deny when no allowlist is provided (opt-out via
+  `allowAny: true`); switched from `execSync` to `execFile` so the shell
+  is never invoked; rejects shell metacharacters (`; & | $ ` < > ( ) ! * ?`)
+  to close allowlist-bypass paths like `ls; rm -rf ~`.
+- **`filesystem`**: replaced `startsWith` jail with `path.relative` + `..`
+  rejection (Windows-safe), and resolves symlinks via `fs.realpath` to
+  block symlinked escapes; new `denySymlinks` (default `true`) refuses
+  symlinks outright.
+- **`@agentskit/tools/mcp` client**: per-request `requestTimeoutMs`
+  (default 30s) and `maxPending` bound (default 256) so a silent server
+  cannot leak pending entries; `close()` rejects in-flight calls.
+- **`@agentskit/tools/mcp` stdio transport**: `maxFrameBytes` cap
+  (default 1 MB) — oversized frames kill the child and fire `onClose`.
+- **`@agentskit/sandbox` E2B backend**: `clearTimeout` in `finally`
+  (no more timer leak per call); documented shared-instance concurrency
+  semantics.
+- **`@agentskit/cli`**: `shell` tool now passes `allowAny: true`
+  explicitly — CLI's `requiresConfirmation` gate covers the dual-use
+  surface.

--- a/.changeset/phase-2-reliability.md
+++ b/.changeset/phase-2-reliability.md
@@ -1,0 +1,27 @@
+---
+"@agentskit/core": minor
+"@agentskit/tools": minor
+---
+
+Phase 2 reliability + quotas (tracks issue #841):
+
+- **`@agentskit/core/security` rate-limiter**: bounded memory.
+  `maxEntries` cap (default 100k) evicts the oldest-touched entry on
+  overflow; `ttlMs` (default 1 h) drops idle entries lazily on `check`.
+  Replaced the `::` separator with the Unit-Separator char (`\x1f`) so
+  keys containing `::` can no longer collide with `reset()`.
+- **`@agentskit/core/security` vault**: `reveal()` no longer returns
+  the `denied` count on the public result. The number of tokens that
+  exist-but-were-denied was a token-existence oracle; it now reaches
+  operators only through the audit sink (BREAKING for callers that
+  destructured `denied`).
+- **`@agentskit/core/security` injection detector**: docs gained a
+  defense-in-depth banner + classifier wiring recipe. Heuristic set
+  expanded (PT/ES variants of the override family, base64-blob smell,
+  fixed `tool-smuggle` regex that broke on nested objects).
+- **`@agentskit/tools/mcp` `toolsFromMcpClient`**: server-provided
+  metadata is now treated as untrusted input. New options:
+  `maxDescriptionBytes` (default 4 KB, truncates), `maxSchemaBytes`
+  (default 64 KB, drops tool when exceeded), `quarantine` (default
+  `true`; prefixes tool name with `mcp:` and adds `[mcp]` provenance
+  hint to the description). Opt-out: `quarantine: false`.

--- a/.changeset/phase-3-supply-chain.md
+++ b/.changeset/phase-3-supply-chain.md
@@ -1,0 +1,30 @@
+---
+"@agentskit/adapters": patch
+"@agentskit/angular": patch
+"@agentskit/cli": patch
+"@agentskit/core": patch
+"@agentskit/eval": patch
+"@agentskit/eval-braintrust": patch
+"@agentskit/ink": patch
+"@agentskit/memory": patch
+"@agentskit/observability": patch
+"@agentskit/observability-langfuse": patch
+"@agentskit/rag": patch
+"@agentskit/react": patch
+"@agentskit/react-native": patch
+"@agentskit/runtime": patch
+"@agentskit/sandbox": patch
+"@agentskit/skills": patch
+"@agentskit/solid": patch
+"@agentskit/svelte": patch
+"@agentskit/templates": patch
+"@agentskit/tools": patch
+"@agentskit/vue": patch
+---
+
+Supply chain + repo hygiene (Phase 3 of #841):
+
+- `"sideEffects": false` (or `["**/*.css"]` for `@agentskit/react`) on
+  every publishable package so consumer bundlers can tree-shake unused
+  modules.
+- No runtime behaviour change.

--- a/.changeset/phase-4-architecture.md
+++ b/.changeset/phase-4-architecture.md
@@ -1,0 +1,12 @@
+---
+"@agentskit/core": patch
+---
+
+Phase 4 architecture cleanup (#841):
+
+- Extract `mergeSystemMessages` and `buildRetrievalMessage` from
+  `controller.ts` into `controller-helpers.ts` so they can be tested in
+  isolation. No public API change.
+- New CI guard `scripts/check-core-no-deps.mjs` fails the build if
+  `@agentskit/core` ever grows a runtime `dependencies` block — the
+  zero-dependency invariant is now enforced rather than aspirational.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,3 +48,14 @@
 /apps/example-ink/                  @EmersonBraun
 /apps/example-runtime/              @EmersonBraun
 /apps/example-multi-agent/          @EmersonBraun
+
+# --- Security-sensitive paths (dual-use, agent-host surface) ---
+# Listed last so these overrides win regardless of earlier package rules.
+/packages/tools/src/shell.ts            @EmersonBraun
+/packages/tools/src/filesystem.ts       @EmersonBraun
+/packages/tools/src/fetch-url.ts        @EmersonBraun
+/packages/tools/src/sqlite-query.ts     @EmersonBraun
+/packages/tools/src/mcp/                @EmersonBraun
+/packages/sandbox/src/                  @EmersonBraun
+/packages/core/src/security/            @EmersonBraun
+/SECURITY.md                            @EmersonBraun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Forbid bare throw new Error in package src
         run: node scripts/check-no-bare-throw.mjs
 
+      - name: Enforce @agentskit/core zero-dependency contract
+        run: node scripts/check-core-no-deps.mjs
+
       - name: Verify for-agents docs cover every public export
         run: node scripts/check-for-agents-coverage.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -46,9 +46,9 @@ jobs:
     name: Lint, Test, Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan to catch newly-published rules against unchanged code.
+    - cron: '37 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      # actions/checkout v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # github/codeql-action/init v3.27.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      # github/codeql-action/analyze v3.27.0
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-reports
           path: packages/*/coverage/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review new dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Dependency Review
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
+
+  audit:
+    name: pnpm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --prod --audit-level=high

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -38,7 +38,7 @@ jobs:
       - run: pnpm exec playwright test
 
       - if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -46,7 +46,7 @@ jobs:
           if-no-files-found: ignore
 
       - if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results
           path: test-results/

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Vercel previews may have Deployment Protection enabled, which makes the
       # public URL return 401 for unauthenticated pollers. Read the URL straight
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run Lighthouse CI
         if: steps.preview.outputs.url != ''
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         id: lhci
         with:
           urls: ${{ steps.urls.outputs.urls }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post Lighthouse summary
         if: always() && steps.preview.outputs.url != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           LH_MANIFEST: ${{ steps.lhci.outputs.manifest }}
         with:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,16 +21,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .lycheecache
           key: lychee-cache-${{ runner.os }}
 
       - name: Run lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           fail: true
           args: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -26,7 +26,8 @@ jobs:
 
       - run: pnpm --filter "./packages/*" build
 
-      - uses: changesets/action@v1
+      - id: changesets
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           publish: pnpm changeset publish
           version: pnpm changeset version
@@ -34,8 +35,20 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # setup-node's registry-url writes .npmrc referencing
-          # ${NODE_AUTH_TOKEN}; that is the name npm publish reads.
-          # Pass the secret under both names so changeset publish works.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Generate SBOM (CycloneDX)
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          npx --yes @cyclonedx/cyclonedx-npm@2.0.0 \
+            --output-format JSON \
+            --output-file sbom.cdx.json \
+            --short-PURLs
+      - name: Upload SBOM artifact
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -29,11 +29,11 @@ jobs:
       UPDATE_BASELINES: ${{ github.event.inputs.update_baselines }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -41,7 +41,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload diffs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: visual-report
           path: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload baselines (when bootstrapping)
         if: env.UPDATE_BASELINES == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: visual-baselines-linux
           path: apps/visual-react/tests/visual.spec.ts-snapshots

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,6 +49,49 @@ Raised in the relevant PR/issue, escalated via [Discussions](https://github.com/
 
 Releases are cut via Changesets. Every user-facing PR ships with a changeset describing the impact.
 
+## Package tiers
+
+Not every package gets the same SLA. The ecosystem ships under two
+tiers so the maintainer-led core stays small and reviewable while
+community packages can move at their own pace.
+
+### Tier 1 — First-party (maintainer-supported)
+
+Same SLA as core: covered by `SECURITY.md`, gated by CI bundle/perf
+budgets, breaking changes require an ADR + deprecation cycle.
+
+- `@agentskit/core`
+- `@agentskit/adapters`
+- `@agentskit/runtime`
+- `@agentskit/tools`
+- `@agentskit/skills`
+- `@agentskit/memory`
+- `@agentskit/rag`
+- `@agentskit/sandbox`
+- `@agentskit/observability`
+- `@agentskit/eval`
+- `@agentskit/cli`
+- `@agentskit/react`
+- `@agentskit/ink`
+- `@agentskit/templates`
+
+### Tier 2 — Community / experimental
+
+Same code style, same CI, but maintained on a best-effort basis. Bug
+reports and PRs are welcome; release cadence and stability guarantees
+are lower. The maintainer reserves the right to demote a tier-1
+package here if it goes too long without an owner.
+
+- `@agentskit/angular`
+- `@agentskit/vue`
+- `@agentskit/svelte`
+- `@agentskit/solid`
+- `@agentskit/react-native`
+- `@agentskit/eval-braintrust`
+- `@agentskit/observability-langfuse`
+
+Tier moves happen explicitly via an ADR + this document, never silently.
+
 ## What's off-limits
 
 - Adding runtime dependencies to `@agentskit/core`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,18 +5,83 @@
 | Version | Supported |
 |---------|-----------|
 | 0.3.x   | Yes       |
+| < 0.3   | No        |
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it responsibly:
+Please report security issues through GitHub's private vulnerability
+reporting:
 
-1. **Do NOT** open a public issue
-2. Email the maintainer directly (see GitHub profile)
-3. Include a description of the vulnerability and steps to reproduce
-4. Allow reasonable time for a fix before public disclosure
+→ <https://github.com/AgentsKit-io/agentskit/security/advisories/new>
 
-We aim to respond within 48 hours and release a fix within 7 days for critical issues.
+If that channel is unavailable, email `emersonfbraun@gmail.com` with
+`[agentskit-security]` in the subject. Encrypted reports are welcome —
+key fingerprint will be published here once generated.
+
+Please include:
+
+- Affected package(s) + version(s)
+- Reproduction steps or a minimal proof of concept
+- Suspected severity (see SLA below)
+- Whether the issue has been disclosed elsewhere
+
+**Please do not file a public issue or PR for security reports.**
+
+## Disclosure SLA
+
+| Severity | First response | Patch target | Public advisory |
+|----------|----------------|--------------|-----------------|
+| Critical (RCE, sandbox escape, credential exfiltration) | 24 h | 7 days | within 7 days of patch |
+| High (SSRF, auth bypass, data exfiltration) | 48 h | 14 days | within 14 days of patch |
+| Medium (DoS, info leak, hardening gap) | 5 days | next minor release | with release notes |
+| Low (best-practice, defense-in-depth) | best effort | next minor release | with release notes |
+
+The patch target is "design + implement + test + publish to npm". For
+ecosystem-wide issues we coordinate with downstream maintainers before
+public advisory.
 
 ## Scope
 
-This policy covers all `@agentskit/*` npm packages. Third-party adapters and example code are provided as-is.
+Covered by this policy:
+
+- All `@agentskit/*` npm packages published to the npm registry
+- The `agentskit` CLI binary
+- This repository's GitHub Actions workflows
+
+Out of scope (best-effort only):
+
+- Example apps under `apps/example-*`
+- Third-party adapters published outside the `@agentskit` scope
+- The docs site (`apps/docs-next`) hosted on Vercel
+
+## Dual-use components
+
+The following packages and modules ship intentionally powerful
+primitives. They are designed for sandboxed / supervised use; running
+them against untrusted input without the documented hardening is
+itself a misconfiguration, not a vulnerability.
+
+- `@agentskit/tools` — `shell`, `filesystem`, `fetchUrl`, `sqliteQueryTool`, `mcp` client
+- `@agentskit/sandbox` — code execution backends
+- `@agentskit/core/security` — PII vault, injection detector, rate limiter
+
+Each module's README documents the recommended deployment posture
+(allowlists, sandbox wrapping, audit sinks). Vulnerability reports
+about these modules should describe how the documented guarantees were
+broken, not that the underlying capability exists.
+
+## Supply chain
+
+- All third-party GitHub Actions are pinned to commit SHAs.
+- `actions/dependency-review-action` runs on every PR; high-severity
+  vulnerabilities or copyleft-licensed deps fail the build.
+- `pnpm audit --prod --audit-level=high` runs in CI.
+- `CodeQL` (security-and-quality query pack) runs on every PR plus a
+  weekly schedule.
+- SBOMs are generated on release; ask if you need a specific format.
+
+## Coordinated disclosure
+
+We follow standard 90-day coordinated disclosure unless severity or
+exposure justifies a shorter window. Reporters are credited in the
+advisory unless they request otherwise.

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -25,6 +25,7 @@
     "provider-adapter"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -14,6 +14,7 @@
     "headless"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
     "terminal"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -29,7 +29,10 @@ function instantiate(kind: ToolKind): ToolDefinition[] {
     case 'filesystem':
       return filesystem({ basePath: process.cwd() })
     case 'shell':
-      return [shell({ timeout: 30_000 })]
+      // CLI gates shell behind requiresConfirmation; explicit allowAny
+      // surfaces the dual-use nature without forcing every CLI user to
+      // pick an allowlist up front.
+      return [shell({ timeout: 30_000, allowAny: true })]
   }
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "edge-runtime"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/controller-helpers.ts
+++ b/packages/core/src/controller-helpers.ts
@@ -1,0 +1,41 @@
+import { buildMessage } from './primitives'
+import type { Message } from './types'
+
+/**
+ * Ensure a system prompt is present at the head of the message list.
+ *
+ * The chat controller threads `config.systemPrompt` through on every
+ * stream; this helper keeps the message-array transform out of the
+ * controller body so it can be tested + reasoned about in isolation.
+ * Returns the original array (no-op) when the prompt is empty or
+ * already at any position in the list — re-prepending would duplicate
+ * the prompt on the second turn.
+ */
+export function mergeSystemMessages(
+  messages: Message[],
+  systemPrompt?: string,
+): Message[] {
+  if (!systemPrompt) return messages
+  if (
+    messages.some(
+      message => message.role === 'system' && message.content === systemPrompt,
+    )
+  ) {
+    return messages
+  }
+  return [buildMessage({ role: 'system', content: systemPrompt }), ...messages]
+}
+
+/**
+ * Wrap retrieved RAG documents in a system-role message so the model
+ * receives them as authoritative context rather than as part of the
+ * user turn. Returns `null` when there is nothing to inject so the
+ * caller can skip pushing an empty message.
+ */
+export function buildRetrievalMessage(documentsText: string): Message | null {
+  if (!documentsText) return null
+  return buildMessage({
+    role: 'system',
+    content: `Use the retrieved context below when it is relevant.\n\n${documentsText}`,
+  })
+}

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -1,6 +1,7 @@
 import { formatRetrievedDocuments } from './rag'
 import { buildMessage, consumeStream, createEventEmitter, safeParseArgs, createToolLifecycle } from './primitives'
 import { buildToolMap, activateSkills, executeSafeTool } from './agent-loop'
+import { mergeSystemMessages, buildRetrievalMessage } from './controller-helpers'
 import type {
   AdapterRequest,
   ChatConfig,
@@ -12,22 +13,6 @@ import type {
   ToolCall,
   ToolDefinition,
 } from './types'
-
-function mergeSystemMessages(messages: Message[], systemPrompt?: string): Message[] {
-  if (!systemPrompt) return messages
-  if (messages.some(message => message.role === 'system' && message.content === systemPrompt)) {
-    return messages
-  }
-  return [buildMessage({ role: 'system', content: systemPrompt }), ...messages]
-}
-
-function buildRetrievalMessage(documentsText: string): Message | null {
-  if (!documentsText) return null
-  return buildMessage({
-    role: 'system',
-    content: `Use the retrieved context below when it is relevant.\n\n${documentsText}`,
-  })
-}
 
 export function createChatController(initialConfig: ChatConfig): ChatController {
   let config = initialConfig

--- a/packages/core/src/security/injection.ts
+++ b/packages/core/src/security/injection.ts
@@ -30,6 +30,37 @@ export interface InjectionDetector {
 }
 
 /**
+ * **Defense-in-depth, not a moat.** These heuristics catch obvious
+ * English-language injections — they do not stop a determined attacker
+ * who paraphrases, encodes, translates, or splits the payload across
+ * turns. Always combine with at least one of:
+ *
+ *  - a model classifier (Llama Guard, Prompt Guard, Rebuff, an HTTP
+ *    moderation endpoint) wired through `InjectionDetectorOptions.classifier`
+ *  - tool-call gating (`@agentskit/sandbox` mandatory sandbox + allow/deny)
+ *  - PII/secret redaction (`@agentskit/core/security` vault + redactor)
+ *  - audit + rate-limit on the calling actor
+ *
+ * Example with a classifier:
+ * ```ts
+ * import { createInjectionDetector } from '@agentskit/core/security'
+ *
+ * const detector = createInjectionDetector({
+ *   threshold: 0.7,
+ *   classifier: async input => {
+ *     const r = await fetch('https://guard.example.com/score', {
+ *       method: 'POST',
+ *       body: JSON.stringify({ input }),
+ *     })
+ *     const { score } = await r.json() as { score: number }
+ *     return score
+ *   },
+ * })
+ *
+ * const verdict = await detector.check(userMessage)
+ * if (verdict.blocked) throw new Error('injection blocked')
+ * ```
+ *
  * Default heuristics aimed at the classic prompt-injection families:
  * instruction override, system-prompt leakage, tool-call smuggling,
  * role confusion, and policy-bypass attempts. Curated — not
@@ -42,8 +73,15 @@ export const DEFAULT_INJECTION_HEURISTICS: InjectionHeuristic[] = [
   { name: 'system-leak', pattern: /(?:what is|show me|print|reveal) (?:your|the) (?:system prompt|instructions|rules)/i, weight: 0.8 },
   { name: 'developer-mode', pattern: /\b(?:developer|dan|jailbreak|god) mode\b/i, weight: 0.8 },
   { name: 'policy-bypass', pattern: /(?:ignore|bypass|disable) (?:all |the )?(?:safety|content|moderation) (?:filters?|rules?|policies)/i, weight: 0.9 },
-  { name: 'tool-smuggle', pattern: /```(?:json|tool_call)\s*\{[^}]*"function"/i, weight: 0.6 },
+  // `[^}]*` was too narrow — it failed on nested objects. Allow any
+  // amount of body between the fence and the `"function"` key.
+  { name: 'tool-smuggle', pattern: /```(?:json|tool_call)\s*\{[\s\S]*?"function"/i, weight: 0.6 },
   { name: 'role-confusion', pattern: /^\s*(?:system|assistant):\s/im, weight: 0.4 },
+  // Common Portuguese / Spanish translations of the override family.
+  { name: 'ignore-previous-pt-es', pattern: /(?:ignor(?:e|a|ar)|desconsider(?:e|a|ar)) (?:as |todas as |todas |toda |la |las )?(?:instruções|instrucciones|regras|reglas) (?:anteriores|prévias|previas|acima)/i, weight: 0.9 },
+  // Base64 / hex-encoded payload smell — high weight as a signal not a
+  // verdict; pair with a classifier.
+  { name: 'b64-blob', pattern: /\b[A-Za-z0-9+/]{200,}={0,2}\b/, weight: 0.4 },
 ]
 
 /**

--- a/packages/core/src/security/rate-limit.ts
+++ b/packages/core/src/security/rate-limit.ts
@@ -25,6 +25,18 @@ export interface RateLimiterOptions<TContext = unknown> {
   bucketOf?: (context: TContext) => string
   /** Clock override for tests. */
   now?: () => number
+  /**
+   * Maximum distinct (bucket, key) pairs tracked. Oldest-touched entry
+   * is evicted on overflow so a flood of unique keys cannot grow the
+   * in-memory map without bound. Default 100_000.
+   */
+  maxEntries?: number
+  /**
+   * Drop any bucket entry that has been idle (no `check`) for longer
+   * than this. Default 1 hour. Idle drop happens lazily on `check`,
+   * so there is no background timer.
+   */
+  ttlMs?: number
 }
 
 export interface RateLimiter<TContext = unknown> {
@@ -38,12 +50,27 @@ export interface RateLimiter<TContext = unknown> {
 interface BucketState {
   tokens: number
   lastRefillMs: number
+  lastTouchMs: number
 }
+
+const DEFAULT_MAX_ENTRIES = 100_000
+const DEFAULT_TTL_MS = 60 * 60 * 1_000
+// Unit separator — invalid in URLs, identifiers, and bucket / actor
+// names. Defeats the prior `endsWith('::'+key)` collision when keys
+// themselves contained `::`.
+const SEP = '\x1f'
 
 /**
  * Token-bucket rate limiter. Per-key state is in-memory — for
  * multi-process deployments, swap in a Redis-backed implementation
  * with the same `RateLimiter` contract.
+ *
+ * Memory is bounded:
+ *  - `maxEntries` caps distinct (bucket, key) pairs; oldest-touch entry
+ *    is evicted on overflow so a stream of unique keys can't grow the
+ *    map past the cap.
+ *  - `ttlMs` drops entries that have been idle longer than the window
+ *    lazily on `check`.
  */
 export function createRateLimiter<TContext = unknown>(
   options: RateLimiterOptions<TContext>,
@@ -52,6 +79,10 @@ export function createRateLimiter<TContext = unknown>(
   if (bucketNames.length === 0) throw new Error('createRateLimiter requires ≥ 1 bucket')
   const pickBucket = options.bucketOf ?? ((): string => 'default')
   const clock = options.now ?? ((): number => Date.now())
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  // Map iteration order is insertion order; we re-insert on touch so
+  // the first entry is always the oldest-touched — LRU eviction in O(1).
   const state = new Map<string, BucketState>()
 
   const refill = (s: BucketState, cfg: RateLimitBucket, now: number): void => {
@@ -64,21 +95,50 @@ export function createRateLimiter<TContext = unknown>(
     }
   }
 
+  const touch = (stateKey: string, s: BucketState, now: number): void => {
+    s.lastTouchMs = now
+    state.delete(stateKey)
+    state.set(stateKey, s)
+  }
+
+  const evictExpired = (now: number): void => {
+    for (const [k, s] of state) {
+      if (now - s.lastTouchMs > ttlMs) {
+        state.delete(k)
+      } else {
+        // Insertion-ordered by lastTouch; first non-expired entry means
+        // every entry after it is fresher.
+        break
+      }
+    }
+  }
+
+  const evictOverflow = (): void => {
+    while (state.size > maxEntries) {
+      const oldest = state.keys().next().value
+      if (oldest === undefined) break
+      state.delete(oldest)
+    }
+  }
+
   return {
     check(context) {
       const key = options.keyOf(context)
       const bucketName = pickBucket(context)
       const cfg = options.buckets[bucketName]
       if (!cfg) throw new Error(`unknown rate-limit bucket: ${bucketName}`)
-      const stateKey = `${bucketName}::${key}`
+      const stateKey = `${bucketName}${SEP}${key}`
       const now = clock()
+      evictExpired(now)
 
       let s = state.get(stateKey)
       if (!s) {
-        s = { tokens: cfg.capacity, lastRefillMs: now }
+        s = { tokens: cfg.capacity, lastRefillMs: now, lastTouchMs: now }
         state.set(stateKey, s)
+        evictOverflow()
       } else {
         refill(s, cfg, now)
+        touch(stateKey, s, now)
       }
 
       if (s.tokens > 0) {
@@ -96,15 +156,18 @@ export function createRateLimiter<TContext = unknown>(
     },
 
     reset(key) {
+      const suffix = `${SEP}${key}`
       for (const stateKey of Array.from(state.keys())) {
-        if (stateKey.endsWith(`::${key}`)) state.delete(stateKey)
+        if (stateKey.endsWith(suffix)) state.delete(stateKey)
       }
     },
 
     inspect() {
-      return Array.from(state, ([key, s]) => {
-        const [bucket, rest] = key.split('::')
-        return { bucket: bucket!, key: rest!, tokens: s.tokens }
+      return Array.from(state, ([k, s]) => {
+        const sepIdx = k.indexOf(SEP)
+        const bucket = sepIdx === -1 ? k : k.slice(0, sepIdx)
+        const rest = sepIdx === -1 ? '' : k.slice(sepIdx + 1)
+        return { bucket, key: rest, tokens: s.tokens }
       })
     },
   }

--- a/packages/core/src/security/vault.ts
+++ b/packages/core/src/security/vault.ts
@@ -207,19 +207,18 @@ export async function tokenize(
  * revealed) and at most one `pii:reveal-denied` (when something was
  * denied) per call.
  *
- * **Security note on `denied` counts.** The returned `denied` count
- * indicates how many tokens existed in the vault but were not
- * revealable by this actor. Surfacing that count back to the
- * triggering actor lets them probe arbitrary token IDs to learn which
- * exist in the vault (token-existence oracle). Use `denied` for
- * monitoring / audit only — do NOT include it in user-facing error
- * messages. Same applies to the `'pii:reveal-denied'` audit event:
- * route it to operators, not back to the calling actor.
+ * **Security note on deny counts.** The number of tokens that existed
+ * in the vault but were not revealable by this actor is intentionally
+ * *not* returned to the caller. Surfacing it back to the triggering
+ * actor would let them probe arbitrary token IDs to learn which exist
+ * in the vault (token-existence oracle). The count is delivered only
+ * through the audit sink, which should be routed to operators rather
+ * than back into the calling actor's response.
  */
 export async function reveal(
   input: string,
   options: RevealOptions,
-): Promise<{ value: string; revealed: number; denied: number }> {
+): Promise<{ value: string; revealed: number }> {
   if (!options.vault) {
     throw new ConfigError({
       code: ErrorCodes.AK_CONFIG_INVALID,
@@ -239,7 +238,7 @@ export async function reveal(
 
   const matches = Array.from(input.matchAll(TOKEN_PATTERN))
   if (matches.length === 0) {
-    return { value: input, revealed: 0, denied: 0 }
+    return { value: input, revealed: 0 }
   }
 
   let out = ''
@@ -287,7 +286,7 @@ export async function reveal(
     })
   }
 
-  return { value: out, revealed, denied }
+  return { value: out, revealed }
 }
 
 /**

--- a/packages/core/tests/controller-helpers.test.ts
+++ b/packages/core/tests/controller-helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { mergeSystemMessages, buildRetrievalMessage } from '../src/controller-helpers'
+import type { Message } from '../src/types'
+
+const msg = (role: Message['role'], content: string): Message => ({
+  id: `m-${role}-${content.slice(0, 4)}`,
+  role,
+  content,
+  createdAt: Date.now(),
+})
+
+describe('mergeSystemMessages', () => {
+  it('returns original when systemPrompt is undefined', () => {
+    const messages = [msg('user', 'hi')]
+    expect(mergeSystemMessages(messages)).toBe(messages)
+  })
+
+  it('returns original when prompt already present at head', () => {
+    const messages = [msg('system', 'P'), msg('user', 'hi')]
+    expect(mergeSystemMessages(messages, 'P')).toBe(messages)
+  })
+
+  it('returns original when prompt present at any position (no duplicate)', () => {
+    const messages = [msg('user', 'hi'), msg('system', 'P')]
+    const out = mergeSystemMessages(messages, 'P')
+    expect(out).toBe(messages)
+  })
+
+  it('prepends prompt when absent', () => {
+    const messages = [msg('user', 'hi')]
+    const out = mergeSystemMessages(messages, 'P')
+    expect(out).toHaveLength(2)
+    expect(out[0]!.role).toBe('system')
+    expect(out[0]!.content).toBe('P')
+  })
+
+  it('treats empty string as missing prompt (no inject)', () => {
+    const messages = [msg('user', 'hi')]
+    expect(mergeSystemMessages(messages, '')).toBe(messages)
+  })
+})
+
+describe('buildRetrievalMessage', () => {
+  it('returns null when documents text is empty', () => {
+    expect(buildRetrievalMessage('')).toBeNull()
+  })
+
+  it('wraps docs in a system message', () => {
+    const out = buildRetrievalMessage('chunk-1\nchunk-2')
+    expect(out).not.toBeNull()
+    expect(out!.role).toBe('system')
+    expect(out!.content).toContain('chunk-1')
+    expect(out!.content).toContain('retrieved context')
+  })
+})

--- a/packages/core/tests/security-vault.test.ts
+++ b/packages/core/tests/security-vault.test.ts
@@ -40,7 +40,7 @@ describe('tokenize + reveal — round-trip', () => {
     })
     expect(revealed.value).toBe(input)
     expect(revealed.revealed).toBe(2)
-    expect(revealed.denied).toBe(0)
+    expect('denied' in revealed).toBe(false)
   })
 
   it('denies reveal when actor has no matching role', async () => {
@@ -57,7 +57,7 @@ describe('tokenize + reveal — round-trip', () => {
     })
     expect(revealed.value).toBe(tokenized)
     expect(revealed.revealed).toBe(0)
-    expect(revealed.denied).toBe(1)
+    expect('denied' in revealed).toBe(false)
   })
 
   it('reveals only the tokens whose roles match (partial reveal)', async () => {
@@ -83,7 +83,7 @@ describe('tokenize + reveal — round-trip', () => {
     expect(revealed.value).not.toContain('555-123-4567')
     expect(revealed.value).toMatch(/<<piitoken:[a-f0-9]{32}>>/)
     expect(revealed.revealed).toBe(1)
-    expect(revealed.denied).toBe(1)
+    expect('denied' in revealed).toBe(false)
   })
 
   it('passes input through unchanged when no PII matches', async () => {
@@ -105,7 +105,6 @@ describe('tokenize + reveal — round-trip', () => {
     })
     expect(result.value).toBe('plain text')
     expect(result.revealed).toBe(0)
-    expect(result.denied).toBe(0)
   })
 
   it('treats unknown tokens as denied (leaves placeholder)', async () => {
@@ -116,7 +115,23 @@ describe('tokenize + reveal — round-trip', () => {
       actor: { id: 'a', roles: ['x'] },
     })
     expect(result.value).toBe(stale)
-    expect(result.denied).toBe(1)
+    expect('denied' in result).toBe(false)
+  })
+
+  it('does not expose denied count on the public return (token-existence oracle)', async () => {
+    const vault = createInMemoryRedactionVault()
+    const { value: tokenized } = await tokenize('email alice@example.com', {
+      rules: DEFAULT_PII_RULES,
+      vault,
+      allowedRoles: ['admin'],
+    })
+    const result = await reveal(tokenized, {
+      vault,
+      actor: { id: 'low', roles: ['agent'] },
+    })
+    // Result shape must contain only {value, revealed}; no count of
+    // tokens that exist-but-were-denied.
+    expect(Object.keys(result).sort()).toEqual(['revealed', 'value'])
   })
 
   it('emits pii:redact audit event with rule hit counts', async () => {

--- a/packages/core/tests/security.test.ts
+++ b/packages/core/tests/security.test.ts
@@ -190,4 +190,51 @@ describe('createRateLimiter', () => {
     expect(snap).toHaveLength(1)
     expect(snap[0]!.tokens).toBe(2)
   })
+
+  it('caps state size via maxEntries (LRU evict)', () => {
+    const limiter = createRateLimiter<string>({
+      keyOf: k => k,
+      buckets: { default: { capacity: 1, refill: 1, windowMs: 60_000 } },
+      maxEntries: 3,
+    })
+    limiter.check('a')
+    limiter.check('b')
+    limiter.check('c')
+    limiter.check('d')
+    const keys = limiter.inspect().map(e => e.key)
+    expect(keys).toHaveLength(3)
+    expect(keys).not.toContain('a')
+    expect(keys).toContain('d')
+  })
+
+  it('expires idle entries via ttlMs (lazy on check)', () => {
+    let now = 0
+    const limiter = createRateLimiter<string>({
+      keyOf: k => k,
+      buckets: { default: { capacity: 1, refill: 1, windowMs: 60_000 } },
+      ttlMs: 1_000,
+      now: () => now,
+    })
+    limiter.check('a')
+    expect(limiter.inspect().map(e => e.key)).toContain('a')
+    now = 5_000
+    limiter.check('b')
+    const keys = limiter.inspect().map(e => e.key)
+    expect(keys).not.toContain('a')
+    expect(keys).toContain('b')
+  })
+
+  it('reset does not collide on keys containing the literal separator', () => {
+    const limiter = createRateLimiter<string>({
+      keyOf: k => k,
+      buckets: { default: { capacity: 1, refill: 1, windowMs: 60_000 } },
+    })
+    // Key shaped like "bucket::key" was the prior collision case.
+    limiter.check('default::evil')
+    limiter.check('victim')
+    limiter.reset('victim')
+    const keys = limiter.inspect().map(e => e.key)
+    expect(keys).toContain('default::evil')
+    expect(keys).not.toContain('victim')
+  })
 })

--- a/packages/eval-braintrust/package.json
+++ b/packages/eval-braintrust/package.json
@@ -17,6 +17,7 @@
     "ai-agents"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -24,6 +24,7 @@
     "accuracy"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -23,6 +23,7 @@
     "streaming"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -23,6 +23,7 @@
     "persistence"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -17,6 +17,7 @@
     "ai-agents"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -22,6 +22,7 @@
     "otlp"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -24,6 +24,7 @@
     "chunking"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -15,6 +15,7 @@
     "hooks"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,6 +24,7 @@
     "headless"
   ],
   "type": "module",
+  "sideEffects": ["**/*.css"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,6 +23,7 @@
     "tool-use"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -23,6 +23,7 @@
     "isolated-vm"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sandbox/src/e2b-backend.ts
+++ b/packages/sandbox/src/e2b-backend.ts
@@ -58,6 +58,13 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
   }
 
   return {
+    /**
+     * Execute code in the E2B sandbox. **Concurrency note:** the backend
+     * lazily creates a single shared `Sandbox` instance and serializes
+     * the SDK's `runCode` calls onto it; concurrent invocations share
+     * one VM. If you need isolation per call, create one backend per
+     * call rather than running parallel `execute()` on a single backend.
+     */
     async execute(code: string, options: ExecuteOptions = {}): Promise<ExecuteResult> {
       const sb = await getInstance()
       const language = options.language ?? 'javascript'
@@ -67,8 +74,12 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
       let stderr = ''
       const startTime = Date.now()
 
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error(`Sandbox execution timed out after ${timeout}ms`)), timeout)
+        timeoutHandle = setTimeout(
+          () => reject(new Error(`Sandbox execution timed out after ${timeout}ms`)),
+          timeout,
+        )
       })
 
       try {
@@ -93,6 +104,8 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
           exitCode: 1,
           durationMs: Date.now() - startTime,
         }
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle)
       }
     },
 

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -24,6 +24,7 @@
     "system-prompt"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -14,6 +14,7 @@
     "headless"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -14,6 +14,7 @@
     "headless"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -21,6 +21,7 @@
     "create-package"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -24,6 +24,7 @@
     "filesystem"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/tools/src/discovery.ts
+++ b/packages/tools/src/discovery.ts
@@ -30,7 +30,7 @@ export function listTools(): ToolMetadata[] {
     webSearch(),
     fetchUrl(),
     ...filesystem({ basePath: tmpdir() }),
-    shell(),
+    shell({ allowed: [] }),
   ]
 
   return tools.map(extractMetadata)

--- a/packages/tools/src/fetch-url.ts
+++ b/packages/tools/src/fetch-url.ts
@@ -7,10 +7,29 @@ export interface FetchUrlConfig {
   timeoutMs?: number
   /** Header value for `User-Agent`. Default: `AgentsKit/1.0`. */
   userAgent?: string
+  /**
+   * Allow requests to private/loopback/link-local addresses. Off by
+   * default so an agent can't reach AWS IMDS (169.254.169.254), the
+   * loopback interface, or internal RFC1918 services. Set true only
+   * when the tool runs against a vetted internal target.
+   */
+  allowPrivateHosts?: boolean
+  /**
+   * Max redirects to follow. Each hop's resolved host is re-checked
+   * against `allowPrivateHosts` to block redirect-based SSRF. Default 3.
+   */
+  maxRedirects?: number
+  /**
+   * Hostname allowlist. If set, every request (and every redirect hop)
+   * must match a literal hostname in this list — overrides
+   * `allowPrivateHosts`. Wildcards are not supported by design.
+   */
+  allowedHosts?: string[]
 }
 
 const DEFAULT_MAX_BYTES = 200 * 1024
 const DEFAULT_TIMEOUT_MS = 15_000
+const DEFAULT_MAX_REDIRECTS = 3
 
 function stripHtml(html: string): string {
   return html
@@ -28,10 +47,118 @@ function stripHtml(html: string): string {
     .trim()
 }
 
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let out = 0
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n < 0 || n > 255) return null
+    out = (out << 8) | n
+  }
+  return out >>> 0
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const n = ipv4ToInt(ip)
+  if (n === null) return false
+  const o1 = (n >>> 24) & 0xff
+  const o2 = (n >>> 16) & 0xff
+  // 0.0.0.0/8
+  if (o1 === 0) return true
+  // 10.0.0.0/8
+  if (o1 === 10) return true
+  // 127.0.0.0/8 loopback
+  if (o1 === 127) return true
+  // 169.254.0.0/16 link-local (incl. AWS IMDS)
+  if (o1 === 169 && o2 === 254) return true
+  // 172.16.0.0/12
+  if (o1 === 172 && o2 >= 16 && o2 <= 31) return true
+  // 192.168.0.0/16
+  if (o1 === 192 && o2 === 168) return true
+  // 100.64.0.0/10 CGNAT
+  if (o1 === 100 && o2 >= 64 && o2 <= 127) return true
+  return false
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase()
+  if (lower === '::1' || lower === '::') return true
+  if (lower === '0:0:0:0:0:0:0:1' || lower === '0:0:0:0:0:0:0:0') return true
+  // fc00::/7 unique-local
+  if (/^f[cd][0-9a-f]{2}:/i.test(lower)) return true
+  // fe80::/10 link-local
+  if (/^fe[89ab][0-9a-f]:/i.test(lower)) return true
+  // IPv4-mapped: ::ffff:a.b.c.d
+  const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (mapped) return isPrivateIPv4(mapped[1]!)
+  return false
+}
+
+/**
+ * Decide whether `host` resolves to a private/loopback/link-local
+ * address. Sync host-literal checks are exact; for hostnames we resort
+ * to DNS lookup via `node:dns/promises` when available. Conservatively
+ * blocks on any DNS failure so a misconfigured resolver can't open the
+ * SSRF gap by accident.
+ */
+async function isPrivateHost(host: string): Promise<boolean> {
+  const stripped = host.replace(/^\[/, '').replace(/\]$/, '')
+  // host literal IPv4?
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(stripped)) {
+    return isPrivateIPv4(stripped)
+  }
+  // host literal IPv6?
+  if (stripped.includes(':')) {
+    return isPrivateIPv6(stripped)
+  }
+  const lower = stripped.toLowerCase()
+  if (lower === 'localhost' || lower.endsWith('.localhost')) return true
+  if (lower === 'metadata.google.internal') return true
+  if (lower === 'metadata.goog') return true
+  // Resolve through DNS where possible.
+  try {
+    const dns = await import('node:dns/promises')
+    const records = await dns.lookup(stripped, { all: true, verbatim: true })
+    if (records.length === 0) return true
+    for (const r of records) {
+      if (r.family === 4 && isPrivateIPv4(r.address)) return true
+      if (r.family === 6 && isPrivateIPv6(r.address)) return true
+    }
+    return false
+  } catch {
+    // No DNS available (edge runtime) or lookup failed — fail closed.
+    return true
+  }
+}
+
+async function gateHost(parsed: URL, opts: {
+  allowPrivateHosts: boolean
+  allowedHosts?: string[]
+}): Promise<string | null> {
+  const host = parsed.hostname
+  if (opts.allowedHosts && opts.allowedHosts.length > 0) {
+    if (!opts.allowedHosts.includes(host)) {
+      return `Error: host "${host}" is not in allowedHosts`
+    }
+    return null
+  }
+  if (opts.allowPrivateHosts) return null
+  if (await isPrivateHost(host)) {
+    return `Error: host "${host}" resolves to a private/loopback/link-local address (SSRF blocked). Pass allowPrivateHosts:true or use allowedHosts to override for vetted internal targets.`
+  }
+  return null
+}
+
 /**
  * Tool: fetch a URL and return its text content.
  *
  * - Enforces HTTPS/HTTP only (no file://, ftp://, etc).
+ * - SSRF-gated: every hop's resolved host is checked against private /
+ *   loopback / link-local ranges and (when configured) an allowlist.
+ * - Redirects are followed manually so the target host of each hop is
+ *   re-validated; the platform's automatic redirect is disabled.
  * - Caps response size via `maxBytes` so a huge page can't flood the
  *   model's context window or blow memory.
  * - Strips HTML tags by default; set `raw: true` to get the body verbatim.
@@ -41,6 +168,9 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
     maxBytes = DEFAULT_MAX_BYTES,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     userAgent = 'AgentsKit/1.0',
+    allowPrivateHosts = false,
+    maxRedirects = DEFAULT_MAX_REDIRECTS,
+    allowedHosts,
   } = config
 
   return {
@@ -61,33 +191,62 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
       required: ['url'],
     },
     execute: async (args) => {
-      const url = String(args.url ?? '').trim()
+      const input = String(args.url ?? '').trim()
       const raw = Boolean(args.raw)
-      if (!url) return 'Error: url is required'
+      if (!input) return 'Error: url is required'
 
-      let parsed: URL
-      try {
-        parsed = new URL(url)
-      } catch {
-        return `Error: invalid URL "${url}"`
-      }
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return `Error: unsupported protocol "${parsed.protocol}" — only http/https allowed`
-      }
-
+      let currentUrl = input
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), timeoutMs)
 
       try {
-        const response = await fetch(url, {
-          headers: { 'User-Agent': userAgent, 'Accept': 'text/html,text/plain,*/*' },
-          signal: controller.signal,
-        })
-        if (!response.ok) return `Error: ${response.status} ${response.statusText} for ${url}`
+        let response: Response | null = null
+        let hops = 0
+        while (hops <= maxRedirects) {
+          let parsed: URL
+          try {
+            parsed = new URL(currentUrl)
+          } catch {
+            return `Error: invalid URL "${currentUrl}"`
+          }
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return `Error: unsupported protocol "${parsed.protocol}" — only http/https allowed`
+          }
+          const gateError = await gateHost(parsed, { allowPrivateHosts, allowedHosts })
+          if (gateError) return gateError
+
+          const r = await fetch(currentUrl, {
+            headers: { 'User-Agent': userAgent, 'Accept': 'text/html,text/plain,*/*' },
+            signal: controller.signal,
+            redirect: 'manual',
+          })
+
+          if (r.status >= 300 && r.status < 400) {
+            const loc = r.headers.get('location')
+            if (!loc) {
+              response = r
+              break
+            }
+            try {
+              currentUrl = new URL(loc, currentUrl).toString()
+            } catch {
+              return `Error: invalid redirect target "${loc}"`
+            }
+            hops++
+            if (hops > maxRedirects) {
+              return `Error: exceeded maxRedirects (${maxRedirects})`
+            }
+            continue
+          }
+          response = r
+          break
+        }
+        if (!response) return `Error: exceeded maxRedirects (${maxRedirects})`
+        if (!response.ok) return `Error: ${response.status} ${response.statusText} for ${currentUrl}`
 
         const contentType = response.headers.get('content-type') ?? ''
         const reader = response.body?.getReader()
-        if (!reader) return `Error: empty response body for ${url}`
+        if (!reader) return `Error: empty response body for ${currentUrl}`
 
         const chunks: Uint8Array[] = []
         let bytes = 0
@@ -107,10 +266,10 @@ export function fetchUrl(config: FetchUrlConfig = {}): ToolDefinition {
         const isHtml = contentType.includes('html') || /<html[\s>]/i.test(body)
         const text = raw || !isHtml ? body : stripHtml(body)
         const truncated = bytes >= maxBytes ? `\n\n[truncated at ${maxBytes} bytes]` : ''
-        return `URL: ${url}\nContent-Type: ${contentType || 'unknown'}\n\n${text}${truncated}`
+        return `URL: ${currentUrl}\nContent-Type: ${contentType || 'unknown'}\n\n${text}${truncated}`
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        return `Error fetching ${url}: ${message}`
+        return `Error fetching ${currentUrl}: ${message}`
       } finally {
         clearTimeout(timer)
       }

--- a/packages/tools/src/filesystem.ts
+++ b/packages/tools/src/filesystem.ts
@@ -1,26 +1,117 @@
-import { resolve, relative } from 'node:path'
+import { isAbsolute, resolve, relative, sep } from 'node:path'
 import { ErrorCodes, ToolError } from '@agentskit/core'
 import type { ToolDefinition } from '@agentskit/core'
 
 export interface FilesystemConfig {
   basePath: string
+  /**
+   * When true, refuse to operate on symlinks at all (read, write,
+   * list). Default true — symlinks inside basePath can target outside
+   * the jail and would otherwise leak access. Set false only if you
+   * trust the contents of basePath.
+   */
+  denySymlinks?: boolean
 }
 
-function safePath(basePath: string, inputPath: string): string {
-  const normalizedBase = resolve(basePath)
+function isInside(base: string, target: string): boolean {
+  if (base === target) return true
+  const rel = relative(base, target)
+  if (rel === '' || rel === '.') return true
+  if (rel.startsWith('..')) return false
+  if (isAbsolute(rel)) return false
+  // On Windows, relative('C:\\base', 'D:\\other') returns 'D:\\other'.
+  // isAbsolute already catches that.
+  // Reject any '..' segment in the relative path (defensive).
+  const parts = rel.split(sep)
+  return !parts.includes('..')
+}
+
+function jailPath(basePath: string, inputPath: string): string {
   const resolved = resolve(basePath, inputPath)
-  if (!resolved.startsWith(normalizedBase + '/') && resolved !== normalizedBase) {
+  if (!isInside(basePath, resolved)) {
     throw new ToolError({
       code: ErrorCodes.AK_TOOL_INVALID_INPUT,
       message: `Access denied: "${inputPath}" is outside the allowed base path`,
-      hint: 'Pass paths relative to the configured basePath; absolute traversal (e.g. ../) is rejected.',
+      hint: 'Pass paths relative to the configured basePath; absolute paths and ../ traversal are rejected.',
     })
   }
   return resolved
 }
 
+async function canonicalBase(basePath: string): Promise<string> {
+  const fs = await import('node:fs/promises')
+  try {
+    return await fs.realpath(basePath)
+  } catch {
+    return basePath
+  }
+}
+
+async function realJailPath(
+  basePath: string,
+  inputPath: string,
+  opts: { denySymlinks: boolean; mustExist: boolean },
+): Promise<string> {
+  const fs = await import('node:fs/promises')
+  const canonical = await canonicalBase(basePath)
+  const initial = jailPath(canonical, inputPath)
+  // Resolve symlinks to their real targets so a symlink whose target
+  // sits outside the jail is rejected. For write-new-file calls the
+  // leaf may not exist yet — fall back to checking the parent.
+  let real: string
+  try {
+    real = await fs.realpath(initial)
+  } catch (err) {
+    if (opts.mustExist) throw err as Error
+    // Walk up until we find an existing ancestor we can realpath; then
+    // rejoin the trailing segments. Handles deep new-directory writes.
+    const path = await import('node:path')
+    const trailing: string[] = []
+    let cursor = initial
+    while (true) {
+      trailing.unshift(path.basename(cursor))
+      const parent = path.dirname(cursor)
+      if (parent === cursor) {
+        real = initial
+        break
+      }
+      try {
+        const parentReal = await fs.realpath(parent)
+        real = resolve(parentReal, ...trailing)
+        break
+      } catch {
+        cursor = parent
+      }
+    }
+  }
+  if (!isInside(canonical, real)) {
+    throw new ToolError({
+      code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+      message: `Access denied: "${inputPath}" resolves outside the allowed base path (symlink escape blocked)`,
+      hint: 'A symlink inside basePath was pointing outside it. Move the target inside basePath or remove the symlink.',
+    })
+  }
+  if (opts.denySymlinks) {
+    try {
+      const stat = await fs.lstat(initial)
+      if (stat.isSymbolicLink()) {
+        throw new ToolError({
+          code: ErrorCodes.AK_TOOL_INVALID_INPUT,
+          message: `Access denied: "${inputPath}" is a symbolic link`,
+          hint: 'Symlinks are disabled for this filesystem tool. Set denySymlinks:false to allow them.',
+        })
+      }
+    } catch (err) {
+      if (opts.mustExist) throw err as Error
+      // leaf doesn't exist yet — fine
+    }
+  }
+  return real
+}
+
 export function filesystem(config: FilesystemConfig): ToolDefinition[] {
   const basePath = resolve(config.basePath)
+  const denySymlinks = config.denySymlinks ?? true
 
   const readFile: ToolDefinition = {
     name: 'read_file',
@@ -36,7 +127,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     },
     execute: async (args) => {
       const fs = await import('node:fs/promises')
-      const filePath = safePath(basePath, String(args.path ?? ''))
+      const filePath = await realJailPath(basePath, String(args.path ?? ''), {
+        denySymlinks,
+        mustExist: true,
+      })
       return await fs.readFile(filePath, 'utf8')
     },
   }
@@ -57,7 +151,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     execute: async (args) => {
       const fs = await import('node:fs/promises')
       const { dirname } = await import('node:path')
-      const filePath = safePath(basePath, String(args.path ?? ''))
+      const filePath = await realJailPath(basePath, String(args.path ?? ''), {
+        denySymlinks,
+        mustExist: false,
+      })
       await fs.mkdir(dirname(filePath), { recursive: true })
       await fs.writeFile(filePath, String(args.content ?? ''), 'utf8')
       return `Written to ${args.path}`
@@ -77,7 +174,10 @@ export function filesystem(config: FilesystemConfig): ToolDefinition[] {
     },
     execute: async (args) => {
       const fs = await import('node:fs/promises')
-      const dirPath = safePath(basePath, String(args.path ?? '.'))
+      const dirPath = await realJailPath(basePath, String(args.path ?? '.'), {
+        denySymlinks,
+        mustExist: true,
+      })
       const entries = await fs.readdir(dirPath, { withFileTypes: true })
       return entries
         .map(e => `${e.isDirectory() ? '[dir] ' : ''}${e.name}`)

--- a/packages/tools/src/mcp/client.ts
+++ b/packages/tools/src/mcp/client.ts
@@ -123,30 +123,92 @@ export function createMcpClient(options: {
   }
 }
 
+export interface ToolsFromMcpOptions {
+  /**
+   * Maximum byte length permitted for each tool's `description`.
+   * Anything longer is truncated. The description ends up inside the
+   * LLM prompt, so a malicious or buggy MCP server could otherwise
+   * inject arbitrarily large or prompt-poisoning text. Default 4096.
+   */
+  maxDescriptionBytes?: number
+  /**
+   * Maximum byte length permitted for each tool's `inputSchema` once
+   * serialized to JSON. Tools whose schema exceeds the cap are dropped
+   * (since a partially-truncated schema is worse than no schema).
+   * Default 65536.
+   */
+  maxSchemaBytes?: number
+  /**
+   * Treat the remote server as untrusted: prefix tool names with
+   * `mcp:` to make their origin obvious in the agent's tool registry
+   * and quarantine logs, and prepend a provenance hint to descriptions.
+   * Default true — opt out only for first-party MCP servers you operate.
+   */
+  quarantine?: boolean
+}
+
+const DEFAULT_MAX_DESCRIPTION_BYTES = 4096
+const DEFAULT_MAX_SCHEMA_BYTES = 65_536
+
+function truncateBytes(input: string, max: number): string {
+  if (input.length <= max) return input
+  return `${input.slice(0, max - 14)}…[truncated]`
+}
+
 /**
  * Hydrate the tools advertised by an MCP server into AgentsKit
  * `ToolDefinition`s. Each call delegates to `client.callTool` and
  * flattens the text content into a single string result.
+ *
+ * Server-provided metadata is treated as untrusted input:
+ *  - `description` is capped at `maxDescriptionBytes` (default 4 KB) so
+ *    a malicious server cannot smuggle a giant prompt-injection
+ *    payload into the agent's system context
+ *  - `inputSchema` whose JSON exceeds `maxSchemaBytes` (default 64 KB)
+ *    is dropped — partial schemas would silently break tool calls
+ *  - when `quarantine` (default `true`) the tool name is prefixed with
+ *    `mcp:` and the description carries a provenance hint, so the
+ *    agent and audit logs can tell origin tools from native ones
  */
-export async function toolsFromMcpClient(client: McpClient): Promise<ToolDefinition[]> {
+export async function toolsFromMcpClient(
+  client: McpClient,
+  options: ToolsFromMcpOptions = {},
+): Promise<ToolDefinition[]> {
+  const maxDescription = options.maxDescriptionBytes ?? DEFAULT_MAX_DESCRIPTION_BYTES
+  const maxSchema = options.maxSchemaBytes ?? DEFAULT_MAX_SCHEMA_BYTES
+  const quarantine = options.quarantine ?? true
   const { tools } = await client.listTools()
-  return tools.map(t => ({
-    name: t.name,
-    description: t.description,
-    schema: t.inputSchema,
-    async execute(args) {
-      const result = await client.callTool(t.name, args)
-      const text = result.content
-        .map(c => (c.type === 'text' ? c.text : ''))
-        .filter(Boolean)
-        .join('\n')
-      if (result.isError) {
-        throw new ToolError({
-          code: ErrorCodes.AK_TOOL_EXEC_FAILED,
-          message: text || `MCP tool ${t.name} errored`,
-        })
-      }
-      return text
-    },
-  }))
+  const out: ToolDefinition[] = []
+  for (const t of tools) {
+    const schemaJson = JSON.stringify(t.inputSchema ?? {})
+    if (schemaJson.length > maxSchema) {
+      // Drop oversized schema; safer than passing a truncated copy.
+      continue
+    }
+    const rawDescription = t.description ?? ''
+    const description = quarantine
+      ? `[mcp] ${truncateBytes(rawDescription, maxDescription)}`
+      : truncateBytes(rawDescription, maxDescription)
+    const name = quarantine ? `mcp:${t.name}` : t.name
+    out.push({
+      name,
+      description,
+      schema: t.inputSchema,
+      async execute(args) {
+        const result = await client.callTool(t.name, args)
+        const text = result.content
+          .map(c => (c.type === 'text' ? c.text : ''))
+          .filter(Boolean)
+          .join('\n')
+        if (result.isError) {
+          throw new ToolError({
+            code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+            message: text || `MCP tool ${t.name} errored`,
+          })
+        }
+        return text
+      },
+    })
+  }
+  return out
 }

--- a/packages/tools/src/mcp/client.ts
+++ b/packages/tools/src/mcp/client.ts
@@ -24,39 +24,75 @@ function isError(msg: JsonRpcSuccess | JsonRpcError): msg is JsonRpcError {
   return 'error' in msg
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_PENDING = 256
+
 /**
  * Build an MCP client over any `McpTransport`. Supports
  * `initialize`, `tools/list`, and `tools/call` — the minimum needed
  * to drive external MCP servers as AgentsKit tools.
+ *
+ * Requests are bounded:
+ *  - each call rejects after `requestTimeoutMs` (default 30s) so a
+ *    silent server cannot leak entries into `pending` forever
+ *  - `maxPending` caps concurrent in-flight requests so the map cannot
+ *    grow without bound on a runaway producer
  */
 export function createMcpClient(options: {
   transport: McpTransport
   clientInfo?: { name: string; version: string }
+  /** Per-request timeout in ms. Default 30000. */
+  requestTimeoutMs?: number
+  /** Max concurrent in-flight requests. Default 256. */
+  maxPending?: number
 }): McpClient {
-  const pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  const maxPending = options.maxPending ?? DEFAULT_MAX_PENDING
+  interface PendingEntry {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }
+  const pending = new Map<number, PendingEntry>()
   let nextId = 1
+
+  const settle = (id: number, ok: boolean, value: unknown): void => {
+    const entry = pending.get(id)
+    if (!entry) return
+    pending.delete(id)
+    clearTimeout(entry.timer)
+    if (ok) entry.resolve(value)
+    else entry.reject(value as Error)
+  }
 
   const detach = options.transport.onMessage(message => {
     if (!isResponse(message)) return
-    const entry = pending.get(Number(message.id))
-    if (!entry) return
-    pending.delete(Number(message.id))
+    const id = Number(message.id)
     if (isError(message)) {
-      entry.reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`))
+      settle(id, false, new Error(`MCP error ${message.error.code}: ${message.error.message}`))
     } else {
-      entry.resolve(message.result)
+      settle(id, true, message.result)
     }
   })
 
   const call = <T>(method: string, params?: Record<string, unknown>): Promise<T> => {
+    if (pending.size >= maxPending) {
+      return Promise.reject(new Error(`MCP client: maxPending (${maxPending}) exceeded`))
+    }
     const id = nextId++
     return new Promise<T>((resolve, reject) => {
-      pending.set(id, { resolve: v => resolve(v as T), reject })
+      const timer = setTimeout(() => {
+        settle(id, false, new Error(`MCP request timeout after ${requestTimeoutMs}ms: ${method}`))
+      }, requestTimeoutMs)
+      pending.set(id, {
+        resolve: v => resolve(v as T),
+        reject,
+        timer,
+      })
       Promise.resolve(
         options.transport.send({ jsonrpc: '2.0', id, method, params }),
       ).catch(err => {
-        pending.delete(id)
-        reject(err instanceof Error ? err : new Error(String(err)))
+        settle(id, false, err instanceof Error ? err : new Error(String(err)))
       })
     })
   }
@@ -77,6 +113,11 @@ export function createMcpClient(options: {
     },
     async close() {
       detach()
+      for (const [id, entry] of pending) {
+        clearTimeout(entry.timer)
+        entry.reject(new Error('MCP client closed'))
+        pending.delete(id)
+      }
       await options.transport.close?.()
     },
   }

--- a/packages/tools/src/mcp/transports.ts
+++ b/packages/tools/src/mcp/transports.ts
@@ -63,12 +63,35 @@ export interface StdioLikeProcess {
   kill?: () => void
 }
 
-export function createStdioTransport(child: StdioLikeProcess): McpTransport {
+export interface StdioTransportOptions {
+  /**
+   * Maximum bytes the line buffer may hold without seeing a newline.
+   * A server that emits no framing terminator would otherwise grow this
+   * buffer until the process runs out of memory. Default 1 MB.
+   */
+  maxFrameBytes?: number
+}
+
+const DEFAULT_MAX_FRAME_BYTES = 1_048_576
+
+export function createStdioTransport(
+  child: StdioLikeProcess,
+  options: StdioTransportOptions = {},
+): McpTransport {
+  const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES
   const messageListeners = new Set<(m: JsonRpcMessage) => void>()
   const closeListeners = new Set<() => void>()
   let buffer = ''
+  let closed = false
+
+  const fireClose = (): void => {
+    if (closed) return
+    closed = true
+    for (const l of closeListeners) l()
+  }
 
   const onData = (chunk: Buffer | string): void => {
+    if (closed) return
     buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
     let newlineIdx = buffer.indexOf('\n')
     while (newlineIdx >= 0) {
@@ -84,15 +107,22 @@ export function createStdioTransport(child: StdioLikeProcess): McpTransport {
       }
       newlineIdx = buffer.indexOf('\n')
     }
+    if (buffer.length > maxFrameBytes) {
+      // Oversized frame with no newline — drop buffer, signal close,
+      // and kill the child so the leak cannot continue.
+      buffer = ''
+      try {
+        child.kill?.()
+      } catch {
+        // ignore
+      }
+      fireClose()
+    }
   }
 
   child.stdout.on('data', onData)
-  child.on?.('exit', () => {
-    for (const l of closeListeners) l()
-  })
-  child.on?.('close', () => {
-    for (const l of closeListeners) l()
-  })
+  child.on?.('exit', fireClose)
+  child.on?.('close', fireClose)
 
   return {
     send(message) {

--- a/packages/tools/src/shell.ts
+++ b/packages/tools/src/shell.ts
@@ -1,52 +1,115 @@
-import { execSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { ToolDefinition } from '@agentskit/core'
 
+const execFileAsync = promisify(execFile)
+
 export interface ShellConfig {
+  /** Per-command timeout in ms. Default 30s. */
   timeout?: number
+  /**
+   * Allowlist of permitted executables. **Required by default** —
+   * leave unset only when explicitly opting into the open mode via
+   * `allowAny:true`. Each entry is matched against the command's
+   * first token (the executable name).
+   */
   allowed?: string[]
+  /**
+   * Opt out of the allowlist requirement. When true, any executable is
+   * permitted — use only for trusted, sandbox-wrapped contexts. Off by
+   * default so a misconfigured agent cannot run arbitrary binaries.
+   */
+  allowAny?: boolean
+  /** Cap on combined stdout/stderr per invocation. Default 1 MB. */
   maxOutput?: number
+  /** Working directory passed to the child process. */
+  cwd?: string
+  /**
+   * Environment for the child. Defaults to an empty object so secrets
+   * in the parent process environment do not leak into the executed
+   * command unless explicitly forwarded.
+   */
+  env?: NodeJS.ProcessEnv
 }
 
-// NOTE: This tool intentionally uses shell execution (execSync with shell: true)
-// because the purpose IS to run arbitrary shell commands from an LLM agent.
-// Security is enforced via the `allowed` list and `timeout` configuration.
+// Shell metacharacters that enable command chaining, substitution, or
+// redirection. Reject any argument containing one — even an allowlisted
+// executable should not be invoked with these tokens because they
+// indicate the caller intended shell expansion, which is unavailable
+// under execFile.
+const SHELL_METACHARS = /[;&|`$<>(){}[\]!*?#~\\'"\n\r]/
+
+function parseCommand(input: string): { argv: string[]; reason?: string } {
+  const trimmed = input.trim()
+  if (!trimmed) return { argv: [], reason: 'command is empty' }
+  if (SHELL_METACHARS.test(trimmed)) {
+    return { argv: [], reason: 'command contains shell metacharacters; shell expansion is not supported' }
+  }
+  // Whitespace-separated tokens. No quoting support by design — if you
+  // need quoted args, build the array yourself in a custom tool.
+  const argv = trimmed.split(/\s+/)
+  return { argv }
+}
 
 export function shell(config: ShellConfig = {}): ToolDefinition {
-  const { timeout = 30_000, allowed, maxOutput = 1_000_000 } = config
+  const {
+    timeout = 30_000,
+    allowed,
+    allowAny = false,
+    maxOutput = 1_000_000,
+    cwd,
+    env = {},
+  } = config
+
+  if (!allowed && !allowAny) {
+    throw new Error(
+      'shell(): refusing to register with no `allowed` allowlist. Pass `allowed: [...]` or, only in trusted/sandboxed contexts, `allowAny: true`.',
+    )
+  }
 
   return {
     name: 'shell',
-    description: 'Execute a shell command. Returns stdout, stderr, and exit code.',
+    description: 'Execute an executable directly (no shell). Returns stdout, stderr, and exit code. Shell metacharacters are rejected.',
     tags: ['shell', 'command'],
     category: 'execution',
     schema: {
       type: 'object',
       properties: {
-        command: { type: 'string', description: 'The shell command to execute' },
+        command: { type: 'string', description: 'The executable plus arguments, whitespace-separated. No shell metacharacters.' },
       },
       required: ['command'],
     },
     execute: async (args) => {
-      const command = String(args.command ?? '')
-      if (!command) return 'Error: command is required'
+      const raw = String(args.command ?? '')
+      const { argv, reason } = parseCommand(raw)
+      if (reason) return `Error: ${reason}`
+      if (argv.length === 0) return 'Error: command is required'
 
-      if (allowed) {
-        const firstWord = command.trim().split(/\s+/)[0]
-        if (!allowed.includes(firstWord)) {
-          return `Error: command "${firstWord}" is not allowed. Allowed: ${allowed.join(', ')}`
-        }
+      const [bin, ...rest] = argv as [string, ...string[]]
+      if (allowed && !allowed.includes(bin)) {
+        return `Error: command "${bin}" is not allowed. Allowed: ${allowed.join(', ')}`
       }
 
       try {
-        const output = execSync(command, {
+        const { stdout, stderr } = await execFileAsync(bin, rest, {
           timeout,
           maxBuffer: maxOutput,
           encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
+          cwd,
+          env,
+          shell: false,
+          windowsHide: true,
         })
-        return `${output}\n[exit code: 0]`
+        return `${stdout}${stderr ? `\n[stderr] ${stderr}` : ''}\n[exit code: 0]`
       } catch (err: unknown) {
-        const error = err as { status?: number; stdout?: string; stderr?: string; killed?: boolean; signal?: string }
+        const error = err as {
+          code?: number | string
+          status?: number
+          stdout?: string
+          stderr?: string
+          killed?: boolean
+          signal?: string
+        }
         const stdout = error.stdout ?? ''
         const stderr = error.stderr ? `[stderr] ${error.stderr}` : ''
         const output = [stdout, stderr].filter(Boolean).join('\n')
@@ -55,7 +118,7 @@ export function shell(config: ShellConfig = {}): ToolDefinition {
           return `${output}\n[killed: command timed out after ${timeout}ms]`
         }
 
-        const exitCode = error.status ?? -1
+        const exitCode = typeof error.code === 'number' ? error.code : error.status ?? -1
         return `${output}\n[exit code: ${exitCode}]`
       }
     },

--- a/packages/tools/tests/fetch-url.test.ts
+++ b/packages/tools/tests/fetch-url.test.ts
@@ -95,6 +95,92 @@ describe('fetchUrl', () => {
     expect(result).toContain('Error fetching')
     expect(result).toContain('boom')
   })
+
+  describe('SSRF guard', () => {
+    it('blocks IPv4 loopback', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://127.0.0.1/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks AWS IMDS link-local 169.254.169.254', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://169.254.169.254/latest/meta-data/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks GCP metadata host', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://metadata.google.internal/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks RFC1918 ranges (10.x, 172.16.x, 192.168.x)', async () => {
+      const tool = fetchUrl()
+      for (const host of ['10.0.0.1', '172.16.0.1', '192.168.1.1']) {
+        const result = await tool.execute!({ url: `http://${host}/` }, ctx) as string
+        expect(result).toMatch(/SSRF blocked|private\/loopback/)
+      }
+    })
+
+    it('blocks localhost hostname', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://localhost:8080/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('blocks IPv6 loopback ::1', async () => {
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'http://[::1]/' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('allows private host when allowPrivateHosts:true', async () => {
+      const body = new TextEncoder().encode('hi')
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse(body, 'text/plain')))
+      const tool = fetchUrl({ allowPrivateHosts: true })
+      const result = await tool.execute!({ url: 'http://127.0.0.1/health' }, ctx) as string
+      expect(result).toContain('hi')
+    })
+
+    it('rejects host not in allowedHosts even when public', async () => {
+      const tool = fetchUrl({ allowedHosts: ['api.example.com'] })
+      const result = await tool.execute!({ url: 'https://evil.com/' }, ctx) as string
+      expect(result).toMatch(/not in allowedHosts/)
+    })
+
+    it('blocks redirect-based SSRF to loopback', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          headers: new Map([['location', 'http://127.0.0.1/admin']]),
+          body: null,
+        })
+      vi.stubGlobal('fetch', fetchMock)
+      const tool = fetchUrl()
+      const result = await tool.execute!({ url: 'https://example.com/redir' }, ctx) as string
+      expect(result).toMatch(/SSRF blocked|private\/loopback/)
+    })
+
+    it('caps redirects at maxRedirects', async () => {
+      let n = 0
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+        n++
+        return Promise.resolve({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          headers: new Map([['location', `https://example.com/next${n}`]]),
+          body: null,
+        })
+      }))
+      const tool = fetchUrl({ maxRedirects: 2 })
+      const result = await tool.execute!({ url: 'https://example.com/0' }, ctx) as string
+      expect(result).toMatch(/exceeded maxRedirects/)
+    })
+  })
 })
 
 function makeResponse(body: Uint8Array, contentType: string) {

--- a/packages/tools/tests/filesystem.test.ts
+++ b/packages/tools/tests/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { filesystem } from '../src/filesystem'
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile, mkdir, symlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -104,6 +104,60 @@ describe('filesystem', () => {
       await expect(
         listDir.execute!({ path: '../..' }, ctx)
       ).rejects.toThrow('Access denied')
+    })
+  })
+
+  describe('hardened path-jail', () => {
+    it('rejects absolute paths outside basePath', async () => {
+      const [readFile] = filesystem({ basePath })
+      await expect(
+        readFile.execute!({ path: '/etc/passwd' }, ctx),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('rejects deep ../ traversal that nominally lands inside basePath', async () => {
+      const [readFile] = filesystem({ basePath })
+      // path that descends then climbs out
+      await expect(
+        readFile.execute!({ path: 'subdir/../../escape.txt' }, ctx),
+      ).rejects.toThrow('Access denied')
+    })
+
+    it('rejects symlink that escapes basePath', async () => {
+      // Create a symlink inside basePath pointing outside.
+      const outside = await mkdtemp(join(tmpdir(), 'agentskit-fs-outside-'))
+      try {
+        await writeFile(join(outside, 'secret.txt'), 'TOPSECRET')
+        await symlink(join(outside, 'secret.txt'), join(basePath, 'escape'))
+        const [readFile] = filesystem({ basePath })
+        await expect(
+          readFile.execute!({ path: 'escape' }, ctx),
+        ).rejects.toThrow(/symbolic link|symlink escape|Access denied/)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
+    })
+
+    it('allows symlinks when denySymlinks:false and target is inside basePath', async () => {
+      await writeFile(join(basePath, 'real.txt'), 'real')
+      await symlink(join(basePath, 'real.txt'), join(basePath, 'link.txt'))
+      const [readFile] = filesystem({ basePath, denySymlinks: false })
+      const result = await readFile.execute!({ path: 'link.txt' }, ctx)
+      expect(result).toBe('real')
+    })
+
+    it('rejects symlink to outside even with denySymlinks:false', async () => {
+      const outside = await mkdtemp(join(tmpdir(), 'agentskit-fs-outside-'))
+      try {
+        await writeFile(join(outside, 'secret.txt'), 'TOPSECRET')
+        await symlink(join(outside, 'secret.txt'), join(basePath, 'escape'))
+        const [readFile] = filesystem({ basePath, denySymlinks: false })
+        await expect(
+          readFile.execute!({ path: 'escape' }, ctx),
+        ).rejects.toThrow(/symlink escape|Access denied/)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/packages/tools/tests/mcp.test.ts
+++ b/packages/tools/tests/mcp.test.ts
@@ -120,11 +120,11 @@ describe('MCP bridge (client ↔ server over in-memory transport)', () => {
 })
 
 describe('toolsFromMcpClient', () => {
-  it('hydrates MCP tools into AgentsKit ToolDefinitions', async () => {
+  it('hydrates MCP tools into AgentsKit ToolDefinitions (no quarantine)', async () => {
     const [a, b] = createInMemoryTransportPair()
     createMcpServer({ transport: b, tools: [makeTool('echo', async ({ q }) => `you said ${q}`)] })
     const client = createMcpClient({ transport: a })
-    const tools = await toolsFromMcpClient(client)
+    const tools = await toolsFromMcpClient(client, { quarantine: false })
     expect(tools).toHaveLength(1)
     expect(tools[0]!.name).toBe('echo')
     const out = await tools[0]!.execute!(
@@ -135,6 +135,49 @@ describe('toolsFromMcpClient', () => {
     await client.close()
   })
 
+  it('quarantines untrusted servers by default: name prefix + provenance hint', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    createMcpServer({ transport: b, tools: [makeTool('echo', async ({ q }) => `you said ${q}`)] })
+    const client = createMcpClient({ transport: a })
+    const tools = await toolsFromMcpClient(client)
+    expect(tools[0]!.name).toBe('mcp:echo')
+    expect(tools[0]!.description).toMatch(/^\[mcp\]/)
+    await client.close()
+  })
+
+  it('truncates oversized descriptions to maxDescriptionBytes', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    const huge = 'x'.repeat(10_000)
+    createMcpServer({
+      transport: b,
+      tools: [{ name: 't', description: huge, execute: async () => 'ok' }],
+    })
+    const client = createMcpClient({ transport: a })
+    const tools = await toolsFromMcpClient(client, { maxDescriptionBytes: 100, quarantine: false })
+    expect(tools[0]!.description!.length).toBeLessThanOrEqual(100)
+    expect(tools[0]!.description).toContain('[truncated]')
+    await client.close()
+  })
+
+  it('drops tools whose inputSchema exceeds maxSchemaBytes', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    const giant: Record<string, { type: string }> = {}
+    for (let i = 0; i < 5_000; i++) giant[`p${i}`] = { type: 'string' }
+    createMcpServer({
+      transport: b,
+      tools: [{
+        name: 'big',
+        description: 'd',
+        schema: { type: 'object', properties: giant },
+        execute: async () => 'ok',
+      }],
+    })
+    const client = createMcpClient({ transport: a })
+    const tools = await toolsFromMcpClient(client, { maxSchemaBytes: 1_000 })
+    expect(tools).toHaveLength(0)
+    await client.close()
+  })
+
   it('propagates tool errors', async () => {
     const [a, b] = createInMemoryTransportPair()
     createMcpServer({
@@ -142,7 +185,7 @@ describe('toolsFromMcpClient', () => {
       tools: [{ name: 'boom', description: '', execute: async () => { throw new Error('bang') } }],
     })
     const client = createMcpClient({ transport: a })
-    const tools = await toolsFromMcpClient(client)
+    const tools = await toolsFromMcpClient(client, { quarantine: false })
     await expect(
       tools[0]!.execute!({}, { messages: [], call: { id: 'c', name: 'boom', args: {}, status: 'running' } }),
     ).rejects.toThrow(/bang/)

--- a/packages/tools/tests/mcp.test.ts
+++ b/packages/tools/tests/mcp.test.ts
@@ -208,4 +208,62 @@ describe('createStdioTransport', () => {
     dataCb!('not-json\n')
     expect(received).toHaveLength(0)
   })
+
+  it('kills child and fires onClose when frame exceeds maxFrameBytes', () => {
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const kill = vi.fn()
+    const child = {
+      stdin: { write: vi.fn() },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+      },
+      kill,
+    }
+    const transport = createStdioTransport(child, { maxFrameBytes: 32 })
+    let closed = false
+    transport.onClose(() => { closed = true })
+    dataCb!('x'.repeat(100))
+    expect(kill).toHaveBeenCalled()
+    expect(closed).toBe(true)
+  })
+})
+
+describe('MCP client request bounds', () => {
+  it('rejects per-request after requestTimeoutMs', async () => {
+    vi.useFakeTimers()
+    try {
+      const [a, b] = createInMemoryTransportPair()
+      // Drop messages on the server side — never reply.
+      b.onMessage(() => {})
+      const client = createMcpClient({ transport: a, requestTimeoutMs: 100 })
+      const promise = client.listTools()
+      vi.advanceTimersByTime(200)
+      await expect(promise).rejects.toThrow(/timeout/)
+      await client.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects new calls once maxPending is reached', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    b.onMessage(() => {})
+    const client = createMcpClient({ transport: a, maxPending: 2, requestTimeoutMs: 60_000 })
+    const p1 = client.listTools().catch(() => undefined)
+    const p2 = client.listTools().catch(() => undefined)
+    await expect(client.listTools()).rejects.toThrow(/maxPending/)
+    await client.close()
+    await Promise.all([p1, p2])
+  })
+
+  it('close() rejects all in-flight calls', async () => {
+    const [a, b] = createInMemoryTransportPair()
+    b.onMessage(() => {})
+    const client = createMcpClient({ transport: a, requestTimeoutMs: 60_000 })
+    const p = client.listTools()
+    await client.close()
+    await expect(p).rejects.toThrow(/closed/)
+  })
 })

--- a/packages/tools/tests/shell.test.ts
+++ b/packages/tools/tests/shell.test.ts
@@ -7,7 +7,7 @@ const ctx = { messages: [], call: baseCall }
 
 describe('shell', () => {
   it('satisfies ToolDefinition contract', () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     expect(tool.name).toBe('shell')
     expect(tool.description).toBeTruthy()
     expect(tool.schema).toBeDefined()
@@ -16,50 +16,86 @@ describe('shell', () => {
     expect(tool.execute).toBeTypeOf('function')
   })
 
+  it('refuses to register with no allowlist (default-deny)', () => {
+    expect(() => shell()).toThrow(/allowlist/)
+  })
+
+  it('permits allowAny opt-out', () => {
+    expect(() => shell({ allowAny: true })).not.toThrow()
+  })
+
   it('executes a simple command', async () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     const result = await tool.execute!({ command: 'echo hello' }, ctx)
     expect(result).toContain('hello')
     expect(result).toContain('[exit code: 0]')
   })
 
-  it('captures stderr on non-zero exit', async () => {
-    const tool = shell()
-    const result = await tool.execute!({ command: 'echo error >&2 && exit 1' }, ctx)
-    expect(result).toContain('[stderr]')
-    expect(result).toContain('error')
-    expect(result).toContain('[exit code: 1]')
-  })
-
   it('returns error for empty command', async () => {
-    const tool = shell()
+    const tool = shell({ allowed: ['echo'] })
     const result = await tool.execute!({ command: '' }, ctx)
     expect(result).toContain('Error')
   })
 
   it('rejects commands not in allow list', async () => {
     const tool = shell({ allowed: ['ls', 'echo'] })
-    const result = await tool.execute!({ command: 'rm -rf /' }, ctx)
+    const result = await tool.execute!({ command: 'rm /tmp/x' }, ctx)
     expect(result).toContain('not allowed')
     expect(result).toContain('ls, echo')
   })
 
-  it('allows commands in allow list', async () => {
+  it('rejects shell metacharacter chaining (`;`)', async () => {
+    const tool = shell({ allowed: ['ls', 'echo'] })
+    const result = await tool.execute!({ command: 'ls; rm -rf /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects shell metacharacter chaining (`&&`)', async () => {
+    const tool = shell({ allowed: ['ls', 'echo'] })
+    const result = await tool.execute!({ command: 'ls && rm /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects pipe redirection', async () => {
+    const tool = shell({ allowed: ['ls'] })
+    const result = await tool.execute!({ command: 'ls | cat' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects command substitution `$()`', async () => {
     const tool = shell({ allowed: ['echo'] })
-    const result = await tool.execute!({ command: 'echo allowed' }, ctx)
-    expect(result).toContain('allowed')
-    expect(result).toContain('[exit code: 0]')
+    const result = await tool.execute!({ command: 'echo $(whoami)' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects backtick substitution', async () => {
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo `whoami`' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects output redirection `>`', async () => {
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo hi > /tmp/x' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('rejects glob `*`', async () => {
+    const tool = shell({ allowed: ['ls'] })
+    const result = await tool.execute!({ command: 'ls *.ts' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
+  })
+
+  it('allowlist cannot be bypassed by metachar prefix', async () => {
+    // First word "echo" looks allowed; metachar guard fires before allowlist check.
+    const tool = shell({ allowed: ['echo'] })
+    const result = await tool.execute!({ command: 'echo a; echo b' }, ctx)
+    expect(result).toMatch(/shell metacharacters/)
   })
 
   it('enforces timeout', async () => {
-    const tool = shell({ timeout: 200 })
+    const tool = shell({ allowed: ['sleep'], timeout: 200 })
     const result = await tool.execute!({ command: 'sleep 30' }, ctx)
     expect(result).toContain('timed out')
   }, 5_000)
-
-  it('reports non-zero exit code', async () => {
-    const tool = shell()
-    const result = await tool.execute!({ command: 'exit 42' }, ctx)
-    expect(result).toContain('[exit code: 42]')
-  })
 })

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,6 +15,7 @@
     "headless"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/check-core-no-deps.mjs
+++ b/scripts/check-core-no-deps.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Fail the build if @agentskit/core grows a `dependencies` block. Core
+// is contractually zero-dependency (CLAUDE.md, AGENTS.md, package
+// keyword `zero-dependencies`); a runtime dep here would silently
+// invalidate the load-time / bundle-size promises every downstream
+// package makes.
+//
+// `devDependencies` and `peerDependencies` are fine — they don't ship.
+
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgPath = resolve(here, '..', 'packages', 'core', 'package.json')
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+
+const deps = pkg.dependencies ?? {}
+const names = Object.keys(deps)
+if (names.length > 0) {
+  console.error(
+    `\n@agentskit/core must remain zero-dependency.\n` +
+      `Found dependencies in ${pkgPath}:\n` +
+      names.map(n => `  - ${n}@${deps[n]}`).join('\n') +
+      `\n\nIf this is intentional, propose an RFC and update this guard.\n`,
+  )
+  process.exit(1)
+}
+
+console.log('core has no runtime dependencies ✓')


### PR DESCRIPTION
Fourth phase of the audit tracked in #841. **Stacked on top of #844** (which is stacked on #843, which is stacked on #842).

## Summary
- **Controller split** (`packages/core/src/controller-helpers.ts`): pulled `mergeSystemMessages` + `buildRetrievalMessage` out of the 554-LOC `controller.ts` into a dedicated helpers module. Public API unchanged; helpers are now unit-testable in isolation (new `controller-helpers.test.ts`, 7 cases).
- **Core zero-deps CI guard** (`scripts/check-core-no-deps.mjs`): fails the build if `@agentskit/core/package.json` ever grows a `dependencies` block. Memory/keyword invariant is now enforced, not aspirational. Wired into `ci.yml` `quality` job.
- **Governance — Package tiers**: `GOVERNANCE.md` now lists Tier 1 (maintainer-supported, same SLA as core) and Tier 2 (community/experimental, best-effort). Promotion/demotion requires an explicit ADR + doc update.

## Deferred (follow-up)
The full split of `controller.ts` into state / stream / tool-loop modules is too invasive for this PR — it would change internal call graphs the agent-loop tests don't yet cover. Filing a follow-up issue. The lightweight extraction here is the safe first cut.

Extending RFC-0007's API-surface guard to adapters/runtime/tools is also deferred — the current repo has no `scripts/check-rfc-0007*` script to extend (despite the memory note); will need a fresh design and lives outside the audit's scope.

## Test plan
- [x] `node scripts/check-core-no-deps.mjs` — passes
- [x] `node scripts/check-src-test-parity.mjs` — clean (helpers covered)
- [x] `pnpm --filter @agentskit/core test` — 328 tests (was 321)
- [x] `pnpm --filter "./packages/*" build` + lint + test — all green

## Checklist items closed (issue #841)
- [x] Split `controller.ts` (initial extraction; full module split tracked as follow-up)
- [x] CI guard: fail PR if `dependencies` block appears in `packages/core/package.json`
- [x] Formalize first-party vs community framework-package tier in GOVERNANCE.md
- [ ] Extend `pnpm check:rfc-0007` API-surface guard to adapters/runtime/tools — deferred; no script to extend in current `main`, needs fresh design

Tracks #841.