### PR TITLE
test: phase 5 — security-critical coverage gates ≥90% — #841

### DIFF
--- a/.changeset/phase-5-coverage.md
+++ b/.changeset/phase-5-coverage.md
@@ -1,0 +1,18 @@
+---
+"@agentskit/core": patch
+"@agentskit/tools": patch
+"@agentskit/sandbox": patch
+---
+
+Phase 5 coverage gates (#841):
+
+- `vitest.shared.ts` gains `criticalFiles` opt — a per-file lines%
+  override on top of the package-level threshold.
+- Apply 90% gate to security-critical surfaces:
+  - `@agentskit/tools`: `shell.ts`, `filesystem.ts`, `fetch-url.ts`,
+    `sqlite-query.ts`, `mcp/client.ts`, `mcp/transports.ts`
+  - `@agentskit/core`: `security/vault.ts`, `security/rate-limit.ts`,
+    `security/pii.ts`, `security/injection.ts`
+  - `@agentskit/sandbox`: `policy.ts` (`sandbox.ts` held at 80 because
+    its dynamic-import branch is integration-only)
+- Tests-only: no runtime behaviour change.

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,4 +2,14 @@ import { createTestConfig } from '../../vitest.shared'
 import { defineConfig } from 'vitest/config'
 
 // @agentskit/core — lines threshold: 80 (CLAUDE.md sacred target, current ≈ 92%).
-export default defineConfig(createTestConfig({ linesThreshold: 80 }))
+export default defineConfig(
+  createTestConfig({
+    linesThreshold: 80,
+    criticalFiles: {
+      'src/security/vault.ts': 90,
+      'src/security/rate-limit.ts': 90,
+      'src/security/pii.ts': 90,
+      'src/security/injection.ts': 90,
+    },
+  }),
+)

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -2,4 +2,15 @@ import { createTestConfig } from '../../vitest.shared'
 import { defineConfig } from 'vitest/config'
 
 // @agentskit/sandbox — lines threshold: 60 (current ≈ 92%).
-export default defineConfig(createTestConfig({ linesThreshold: 60 }))
+export default defineConfig(
+  createTestConfig({
+    linesThreshold: 60,
+    criticalFiles: {
+      'src/policy.ts': 90,
+      // sandbox.ts lazy-imports e2b-backend; the dynamic-import branch
+      // is exercised only in integration, not unit tests. Hold the
+      // package's existing achieved bar (80) instead of demanding 90.
+      'src/sandbox.ts': 80,
+    },
+  }),
+)

--- a/packages/tools/tests/mcp.test.ts
+++ b/packages/tools/tests/mcp.test.ts
@@ -252,6 +252,50 @@ describe('createStdioTransport', () => {
     expect(received).toHaveLength(0)
   })
 
+  it('exposes detach functions for onMessage / onClose and supports close()', () => {
+    let dataCb: ((chunk: Buffer | string) => void) | undefined
+    const off = vi.fn()
+    const kill = vi.fn()
+    const child = {
+      stdin: { write: vi.fn() },
+      stdout: {
+        on: (_event: 'data', cb: (chunk: Buffer | string) => void) => {
+          dataCb = cb
+        },
+        off,
+      },
+      kill,
+    }
+    const transport = createStdioTransport(child)
+    const msgs: JsonRpcMessage[] = []
+    const detachMsg = transport.onMessage(m => msgs.push(m))
+    let closed = false
+    const detachClose = transport.onClose(() => { closed = true })
+    detachMsg()
+    detachClose()
+    // After detach, no further callbacks fire.
+    dataCb!('{"jsonrpc":"2.0","id":1,"result":1}\n')
+    expect(msgs).toHaveLength(0)
+    transport.close()
+    expect(off).toHaveBeenCalledWith('data', expect.any(Function))
+    expect(kill).toHaveBeenCalled()
+    expect(closed).toBe(false)
+  })
+
+  it('in-memory transport detach removes message + close listeners', () => {
+    const [a, b] = createInMemoryTransportPair()
+    const msgs: JsonRpcMessage[] = []
+    let closed = false
+    const offMsg = a.onMessage(m => msgs.push(m))
+    const offClose = a.onClose(() => { closed = true })
+    offMsg()
+    offClose()
+    b.send({ jsonrpc: '2.0', id: 1, method: 'x' })
+    expect(msgs).toHaveLength(0)
+    b.close?.()
+    expect(closed).toBe(false)
+  })
+
   it('kills child and fires onClose when frame exceeds maxFrameBytes', () => {
     let dataCb: ((chunk: Buffer | string) => void) | undefined
     const kill = vi.fn()

--- a/packages/tools/vitest.config.ts
+++ b/packages/tools/vitest.config.ts
@@ -2,4 +2,17 @@ import { createTestConfig } from '../../vitest.shared'
 import { defineConfig } from 'vitest/config'
 
 // @agentskit/tools — lines threshold: 70
-export default defineConfig(createTestConfig({ linesThreshold: 70 }))
+export default defineConfig(
+  createTestConfig({
+    linesThreshold: 70,
+    // Security-critical surfaces — agent-host boundary.
+    criticalFiles: {
+      'src/shell.ts': 90,
+      'src/filesystem.ts': 90,
+      'src/fetch-url.ts': 90,
+      'src/sqlite-query.ts': 90,
+      'src/mcp/client.ts': 90,
+      'src/mcp/transports.ts': 90,
+    },
+  }),
+)

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -12,6 +12,11 @@ import type { ViteUserConfig } from 'vitest/config'
  *
  * To raise a threshold: write the tests, raise the number in the package's
  * vitest.config.ts, ship the PR. CI will hold the new line.
+ *
+ * `criticalFiles` allows individual files (security-sensitive paths) to
+ * carry a tighter gate than the package-level default. Each entry is a
+ * vitest threshold-glob — see
+ * https://vitest.dev/config/#coverage-thresholds for the syntax.
  */
 export interface PackageTestConfig {
   /** Lines coverage threshold (percentage 0-100). Default: 60. */
@@ -20,9 +25,24 @@ export interface PackageTestConfig {
   environment?: 'node' | 'jsdom' | 'happy-dom'
   /** Setup files to run before tests (relative to package root). */
   setupFiles?: string[]
+  /**
+   * Files that must be held to a higher coverage bar than the package
+   * default. Map of glob → required lines%. Use for security-critical
+   * surfaces (shell, filesystem, fetch-url, vault, sandbox, mcp client).
+   */
+  criticalFiles?: Record<string, number>
 }
 
 export function createTestConfig(opts: PackageTestConfig = {}): ViteUserConfig {
+  const baseThresholds: Record<string, unknown> = {
+    lines: opts.linesThreshold ?? 60,
+  }
+  if (opts.criticalFiles) {
+    for (const [pattern, lines] of Object.entries(opts.criticalFiles)) {
+      baseThresholds[pattern] = { lines }
+    }
+  }
+
   return {
     test: {
       environment: opts.environment ?? 'node',
@@ -39,9 +59,7 @@ export function createTestConfig(opts: PackageTestConfig = {}): ViteUserConfig {
           'src/**/index.ts',
           'src/**/__tests__/**',
         ],
-        thresholds: {
-          lines: opts.linesThreshold ?? 60,
-        },
+        thresholds: baseThresholds,
       },
     },
   }


### PR DESCRIPTION
Final phase of the audit tracked in #841. **Stacked on top of #845** (#842 → #843 → #844 → #845 → this).

## Summary
- **`vitest.shared.ts`**: new `criticalFiles` option on `createTestConfig`. Each entry is `{ glob: lines% }` and translates to vitest's per-file threshold map. Lets a package keep its default bar (60/70/80) while gating individual security-critical files higher.
- **`@agentskit/tools`** — 90% lines gate on `shell.ts`, `filesystem.ts`, `fetch-url.ts`, `sqlite-query.ts`, `mcp/client.ts`, `mcp/transports.ts`. Added detach + close micro-tests so `mcp/transports.ts` cleared 90.
- **`@agentskit/core`** — 90% lines gate on `security/vault.ts`, `security/rate-limit.ts`, `security/pii.ts`, `security/injection.ts`. All already pass.
- **`@agentskit/sandbox`** — 90% on `policy.ts`; `sandbox.ts` held at 80 (its dynamic-import branch needs integration-level test that's out of scope here).

## Test plan
- [x] `pnpm --filter @agentskit/tools test:coverage` — lines 90.45%, every critical file ≥ 90
- [x] `pnpm --filter @agentskit/core test:coverage` — lines 92.59%, every critical file ≥ 90
- [x] `pnpm --filter @agentskit/sandbox test:coverage` — lines 90.47%, policy.ts 100, sandbox.ts 80 (≥80)
- [x] All package tests still green

## Adversarial corpora
The adversarial corpus suites shipped in #842:

- `fetch-url`: SSRF (IMDS, RFC1918, loopback, IPv6 `::1`, GCP metadata, redirect-SSRF, maxRedirects cap, allowedHosts)
- `shell`: default-deny, every metachar family (`;` `&&` `|` `$()` backticks `>` `*`), allowlist prefix-bypass
- `filesystem`: absolute outside, deep `..` traversal, symlink escape, denySymlinks toggle
- `mcp`: requestTimeout, maxPending overflow, close()-rejects-pending, stdio maxFrameBytes overflow kills child

Phase 5 cements them as a regression-blocker via the per-file gate.

## Checklist items closed (issue #841)
- [x] Coverage report per package in CI (already present via `coverage.yml`)
- [x] Gate security-critical files at ≥90%
- [x] Adversarial corpus suites (delivered in #842; gated here)

Tracks #841.