### PR TITLE
fix(release): ignore private example apps in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,6 +16,12 @@
     "@agentskit/example-flow",
     "@agentskit/example-edge",
     "@agentskit/example-webllm",
-    "@agentskit/example-embedded"
+    "@agentskit/example-embedded",
+    "@agentskit/example-discord-bot",
+    "@agentskit/example-slack-bot",
+    "@agentskit/example-teams-bot",
+    "@agentskit/example-dspy",
+    "@agentskit/landing",
+    "@agentskit/visual-react"
   ]
 }


### PR DESCRIPTION
## Problem

The changesets release action failed on `pnpm changeset version`:

```
Error: ENOENT: no such file or directory, open '.../apps/example-discord-bot/CHANGELOG.md'
```

## Cause

`@agentskit/adapters` was bumped (PR #912). Changesets bumps internal *dependents* too. The newer **private** example apps — `example-discord-bot`, `example-slack-bot`, `example-teams-bot`, `example-dspy`, `landing`, `visual-react` — depend on adapters but were never added to the changeset `ignore` list. They have no `CHANGELOG.md` and are never published, so `changeset version` crashed trying to write one.

## Fix

Add those 6 private apps to `.changeset/config.json` `ignore`, alongside the example apps already there. All are `private: true`.

## Verification

Ran `pnpm changeset version` locally with the fix applied against all pending changesets — completes cleanly, **no ENOENT** (mutations reverted, not committed).