### PR TITLE
fix(memory): atomic batched upsert in fileVectorMemory (vectra)

### DIFF
--- a/.changeset/fix-file-vector-atomic-upsert.md
+++ b/.changeset/fix-file-vector-atomic-upsert.md
@@ -1,0 +1,9 @@
+---
+"@agentskit/memory": patch
+---
+
+Fix flaky empty-result reads from `fileVectorMemory` (vectra backend). `upsert`
+now batches all inserts into a single atomic vectra `beginUpdate`/`endUpdate`
+block instead of writing the on-disk index once per document. The per-doc writes
+left intermediate partial index states that a subsequent `search` could read
+mid-flush on slow disks, intermittently returning zero results in CI.

--- a/packages/memory/src/file-vector.ts
+++ b/packages/memory/src/file-vector.ts
@@ -24,6 +24,9 @@ function requireVectra(): { LocalIndex: new (path: string) => VectraIndex } {
 interface VectraIndex {
   isIndexCreated(): Promise<boolean>
   createIndex(): Promise<void>
+  beginUpdate(): Promise<void>
+  endUpdate(): Promise<void>
+  cancelUpdate(): void
   insertItem(item: { vector: number[]; metadata: Record<string, unknown> }): Promise<unknown>
   queryItems(vector: number[], topK: number): Promise<Array<{ score: number; item: { metadata: Record<string, unknown> } }>>
   listItems(): Promise<Array<{ id: string; metadata: Record<string, unknown> }>>;
@@ -46,11 +49,23 @@ function createVectraStore(dirPath: string): VectorStore {
   return {
     async upsert(docs) {
       const idx = await getIndex()
-      for (const doc of docs) {
-        await idx.insertItem({
-          vector: doc.vector,
-          metadata: { _id: doc.id, ...doc.metadata },
-        })
+      // Batch all inserts into a single atomic update so the on-disk index is
+      // written once and is fully durable before any subsequent query. Calling
+      // insertItem per-doc writes the index file N times, leaving intermediate
+      // partial states a concurrent query can read mid-flush (flaky empty
+      // results on slow CI disks).
+      await idx.beginUpdate()
+      try {
+        for (const doc of docs) {
+          await idx.insertItem({
+            vector: doc.vector,
+            metadata: { _id: doc.id, ...doc.metadata },
+          })
+        }
+        await idx.endUpdate()
+      } catch (err) {
+        idx.cancelUpdate()
+        throw err
       }
     },
     async query(vector, topK) {


### PR DESCRIPTION
## Problem

CI flake in `@agentskit/memory`: `tests/file-vector.test.ts > stores and retrieves documents` intermittently fails with `expected 0 to be greater than or equal to 1` — `search()` returns zero results right after `store()`. Passes locally; only flakes on slow CI disks.

## Cause

`createVectraStore.upsert` called vectra `insertItem` once per document. Each call rewrites the on-disk index, so a multi-doc store produced N sequential index writes. A subsequent `search` could read an intermediate, partially-written index mid-flush → empty result.

## Fix

Batch all inserts into a single atomic vectra `beginUpdate()` / `endUpdate()` block (vectra's recommended bulk-insert pattern), so the index is written once and is fully durable before any query. `cancelUpdate()` on error.

Bonus: one disk write instead of N — also faster.

## Verification

- `file-vector` suite green across repeated local runs
- `pnpm --filter @agentskit/memory test:coverage` — 148 passed, coverage gate clean
- `tsc --noEmit` clean
- patch changeset included

Unrelated to the catalog work (#912) — this is a pre-existing flake surfaced by CI.