### PR TITLE
feat(integrations): @agentskit/integrations catalog foundation (P1)

### DIFF
--- a/.changeset/integrations-foundation.md
+++ b/.changeset/integrations-foundation.md
@@ -1,0 +1,15 @@
+---
+'@agentskit/integrations': minor
+---
+
+New package `@agentskit/integrations` — the foundation for a unified, single-descriptor service-integration catalog (RFC: integrations split/unification).
+
+Ships the contract and registry only; the catalog is populated in later phases.
+
+- **`Integration` descriptor** — one definition per service (`auth`, `actions[]`, `triggers[]`, `capabilities`) that every consumer layer (agent tools, connector senders, inbound triggers, OAuth specs, marketplace listings) projects from, eliminating the per-service duplication that exists today across `@agentskit/tools` and the OS.
+- **`defineIntegration` / `defineAction` / `defineTrigger`** authoring helpers; actions use canonical JSON Schema and receive an auth-bound `IntegrationHttp` client so they never touch raw credentials.
+- **Registry** — `createRegistry`, plus the default catalog accessors `registerIntegration` / `getIntegration` / `listIntegrations` / `integrationsByCategory`.
+- **`@agentskit/integrations/testing`** — pure contract validators (`validateIntegration`, `assertValidIntegration`) to gate every service descriptor in CI.
+- **`pnpm gen:integration <name>`** scaffolds a new service from `services/_template`.
+
+Dependency-light (only `@agentskit/core`; `fetch` + `node:crypto` at runtime). No existing package changes — purely additive.

--- a/apps/docs-next/content/docs/for-agents/integrations.mdx
+++ b/apps/docs-next/content/docs/for-agents/integrations.mdx
@@ -1,0 +1,72 @@
+---
+title: '@agentskit/integrations — for agents'
+description: Unified single-descriptor service-integration catalog projected into tools, connectors, triggers, and OAuth.
+---
+
+## Install
+
+```bash
+npm install @agentskit/integrations
+```
+
+## What it is
+
+One descriptor per service (`Integration`) that every consumer layer projects from —
+agent tools, connector senders, inbound triggers, OAuth specs, marketplace listings.
+Eliminates the per-service duplication that otherwise spreads across `@agentskit/tools`
+and host runtimes. Dependency-light: only `@agentskit/core`, with `fetch` + `node:crypto`
+at runtime. The catalog of concrete services is populated in later phases; this entry
+ships the contract + registry.
+
+## Primary exports (main entry)
+
+- `defineIntegration` — author an `Integration` descriptor (`auth`, `actions`, `triggers`, `capabilities`).
+- `defineAction` — define one action; receives an auth-bound `IntegrationHttp` client, uses canonical JSON Schema.
+- `defineTrigger` — define one inbound trigger (`verify` signature + `normalize` to a uniform event).
+- `httpJson` — shared HTTP helper (query/body/timeout, non-2xx → typed error).
+- `bindHttp` — bind options into a reusable `IntegrationHttp` client.
+- `createRegistry` — build an isolated catalog instance.
+- `registerIntegration` — register a descriptor into the default catalog.
+- `getIntegration` — look up a descriptor by service slug.
+- `listIntegrations` — list all registered descriptors.
+- `integrationsByCategory` — filter the default catalog by category.
+
+## Subpath exports
+
+| Subpath | Contents |
+|---|---|
+| `@agentskit/integrations/testing` | Pure contract validators: `validateIntegration`, `validateAction`, `validateTrigger`, `assertValidIntegration`. Gate every service descriptor in CI. |
+
+## Minimal example
+
+```ts
+import { defineIntegration, defineAction } from '@agentskit/integrations'
+
+const ping = defineAction({
+  name: 'demo_ping',
+  description: 'Echo a message.',
+  schema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+  sideEffect: 'read',
+  execute: (args, http) => http({ method: 'POST', path: '/ping', body: { message: args.message } }),
+})
+
+export const demo = defineIntegration({
+  name: 'demo',
+  displayName: 'Demo',
+  categories: ['example'],
+  http: { baseUrl: 'https://api.example.com' },
+  auth: { kind: 'apiKey', header: 'authorization', prefix: 'Bearer ' },
+  actions: [ping],
+  capabilities: {},
+})
+```
+
+## Scaffolding
+
+```bash
+pnpm gen:integration <name>   # copies services/_template → services/<name>
+```
+
+## Related
+
+- [Tools](/docs/for-agents/tools) — `@agentskit/tools` (legacy integration home; being unified here).

--- a/apps/docs-next/content/docs/for-agents/meta.json
+++ b/apps/docs-next/content/docs/for-agents/meta.json
@@ -15,6 +15,7 @@
     "react-native",
     "angular",
     "tools",
+    "integrations",
     "memory",
     "rag",
     "skills",

--- a/docs/studies/integrations-refactor-plan.md
+++ b/docs/studies/integrations-refactor-plan.md
@@ -1,0 +1,340 @@
+# Entrega 2 — Plano completo de refatoração (lib + agentskit-os)
+
+> Status: APROVADO (arquitetura §3 de `integrations-unification.md`). Data: 2026-06-09.
+> Decisões travadas: descritor único + projeções finas · apagar duplicatas `os-runtime/tools/*` ·
+> schema JSON Schema + `ZodLike` · boundary open-core confirmado · MCP split em fase própria.
+> Execução **faseada, não-breaking, gates sempre verdes**. Sem big-bang.
+
+Convenção: `[lib]` = repo `EmersonBraun/lib` · `[os]` = `AgentsKit-io/agentskit-os`.
+`+`=criar `~`=editar `-`=deletar. Changeset semver por pacote em cada PR.
+
+---
+
+## 0. Visão das fases e ordem de PR
+
+| PR | Fase | Repo | Entrega | Quebra? |
+|---|---|---|---|---|
+| P1 | Fundação | lib | `@agentskit/integrations` (contrato+http+registry+gen+CI) | não (pacote novo) |
+| P2 | Mover 40 | lib | 40 → `services/*` + re-export deprecado em `tools` | não (alias) |
+| P3 | Projeção lib | lib | `toToolDefinitions` + runtime/cli consomem catálogo | não |
+| P4 | Binding OS | os | `@agentskit/os-integrations` (adapters de projeção) | não (pacote novo) |
+| P5 | Parar duplicação | os | `os-runtime-agentskit` consome catálogo, **deleta `tools/*`** | interno (paridade testada) |
+| P6 | Connectors | os | `os-connectors` projeta `actions[sendCapability]` | não |
+| P7 | Triggers | os | `os-triggers` projeta `verify/normalize` + canoniza Slack | corrige bug |
+| P8 | OAuth | os | `os-oauth` lê `auth(oauth2)` do catálogo | não |
+| P9 | Notifications | os | `os-notifications` projeta `capabilities.notify` | não |
+| P10 | Marketplace | os | `toListing` gera listings do catálogo | aditivo |
+| P11 | Ondas catálogo | lib | +30 serviços (Ondas 1→3) | aditivo |
+| P12 | MCP | lib | `@agentskit/mcp` split + catálogo via MCP | major tools |
+
+Regra de verde: cada PR passa `pnpm check:all` (lib) / `pnpm check:rfc-0007`+build+test (os)
+isoladamente. OS só consome versão **publicada** do catálogo (não workspace cross-repo).
+
+---
+
+## 1. P1 — Fundação `@agentskit/integrations` [lib]
+
+**Objetivo:** pacote novo, vazio de serviços, com contrato congelável. Nada quebra (ninguém usa ainda).
+
+Arquivos:
+```
++ packages/integrations/package.json          # name @agentskit/integrations; dep: @agentskit/core; tsup dual CJS/ESM
++ packages/integrations/tsup.config.ts         # entries: index + services/* + auth + mcp (subpaths)
++ packages/integrations/src/contract.ts        # Integration, IntegrationAction, IntegrationTrigger, AuthSpec, NormalizedEvent, WebhookInput, VerifyResult
++ packages/integrations/src/http.ts            # MOVER de tools/src/integrations/http.ts (httpJson, HttpToolOptions)
++ packages/integrations/src/registry.ts        # createRegistry(), listIntegrations(), getIntegration(name)
++ packages/integrations/src/index.ts           # re-export contract + registry + http
++ packages/integrations/src/services/_template/ # gabarito: index.ts, actions.ts, triggers.ts, auth.ts, README
++ packages/integrations/src/zod-bridge.ts      # re-export ZodLike de tools/src/zod.ts (ou mover p/ core; ver nota)
+~ pnpm-workspace.yaml                           # (já cobre packages/*) — confirmar
+~ turbo.json                                    # pipeline herdada
+```
+
+Contrato (`contract.ts`) = §3.1 do doc de unificação. Pontos finos:
+- `IntegrationAction.execute(args, http)` recebe `http` (cliente `httpJson` já com auth aplicada
+  pela camada de `auth`) → action não conhece token, só chama endpoints. Absorve quirks (Slack
+  `ok:false`, Stripe form-encoded) dentro do `execute`.
+- `schema: JSONSchema7` (canônico). `IntegrationAction.sideEffect` p/ o gate de autonomia do OS.
+- `sendCapability?: string` (id da SendCapability do connector, ex `'chat.postMessage'`).
+
+Tooling à prova de futuro:
+```
++ scripts/gen-integration.ts                   # `pnpm gen:integration <name>` copia _template + registra
++ packages/integrations/src/testing/contract-test.ts  # harness: valida schema de cada action + golden webhook por trigger
+~ package.json (root)                           # script "gen:integration", "check:integrations-contract"
++ .changeset/integrations-foundation.md         # minor: new package
+```
+Freeze: adicionar `check:rfc-integrations` (espelha `check:rfc-0007`) sobre a superfície pública de
+`contract.ts` + `registry.ts`. `pnpm api:update` após mudança intencional.
+
+**Nota Zod bridge:** `ZodLike` vive em `tools/src/zod.ts`. Opção limpa: **mover `ZodLike`/`defineZodTool`
+para `@agentskit/core`** (é contrato puro, zero-dep — respeita `[[feedback_zero-dep-core]]`) e
+re-exportar de tools (deprecado) + usar em integrations. Decidir em P1; barato.
+
+Gate: `pnpm --filter @agentskit/integrations build test` verde. Resto do monorepo intocado.
+
+---
+
+## 2. P2 — Mover as 40 + alias deprecado [lib]
+
+**Objetivo:** catálogo real, sem quebrar quem importa `@agentskit/tools/integrations/*`.
+
+Por serviço (×40), exemplo `slack`:
+```
++ packages/integrations/src/services/slack/actions.ts   # recorte de tools/src/integrations/slack.ts (defineTool → IntegrationAction)
++ packages/integrations/src/services/slack/auth.ts      # AuthSpec { kind:'apiKey'|'oauth2' }
++ packages/integrations/src/services/slack/triggers.ts  # se houver (stripe-webhook, postgres-cdc)
++ packages/integrations/src/services/slack/index.ts     # define Integration{...}; registra no registry
+```
+- `http.ts` já movido em P1; ajustar imports das 40.
+- `stripe-webhook.ts`/`postgres-cdc.ts` → viram `triggers` reais (deixam de ser "tool de verify"):
+  `verify`+`normalize`. Primeira materialização do conceito de trigger.
+
+Compat em tools (não quebra consumidores):
+```
+~ packages/tools/src/integrations/slack.ts     # vira shim: re-export from '@agentskit/integrations/services/slack' + @deprecated JSDoc
+~ packages/tools/src/integrations/index.ts      # re-exports apontam p/ shims
+~ packages/tools/package.json                   # + dep @agentskit/integrations (workspace:*)
+- packages/tools/src/integrations/http.ts        # movido; deixar shim re-export
++ .changeset/integrations-move-40.md             # integrations: minor (catálogo) ; tools: MAJOR (origem mudou, embora alias preserve runtime)
+```
+`discovery.ts` **não muda** (nunca tocou integrations).
+
+Verificação:
+```
++ packages/tools/tests/integration-alias.test.ts # garante shims re-exportam mesma fn (identidade)
+```
+Gate: `pnpm --filter @agentskit/tools test`, `--filter @agentskit/integrations test` verdes.
+Migração doc: `docs/migration/tools-integrations-to-integrations.md` (mapa import antigo→novo).
+
+---
+
+## 3. P3 — Projeção lib + consumo runtime/cli [lib]
+
+**Objetivo:** agente da lib usa catálogo direto. `actions` já são `ToolDefinition`-compatíveis.
+
+```
++ packages/integrations/src/project/to-tool-definitions.ts  # Integration → ToolDefinition[] (mapeia execute(args,http)→execute(args,ctx) injetando http c/ auth)
+~ packages/integrations/src/index.ts                         # export toToolDefinitions
+```
+Consumo (exemplos, opcional — runtime já aceita `ToolDefinition[]`):
+```
+~ packages/runtime/README / examples                         # mostrar `tools: toToolDefinitions(github({token}))`
+~ packages/cli/src/run.ts                                     # resolveTools aceita nome de integração do catálogo (getIntegration)
++ .changeset/integrations-projection-lib.md                  # minor
+```
+Sem mudança no `buildToolMap`/`RuntimeConfig` (já é `ToolDefinition[]`). Zero breaking.
+Gate: `pnpm check:all` (lib).
+
+**→ Marco: lib unificada. Publicar `@agentskit/integrations` no npm** (P1–P3) p/ o OS consumir versão real.
+
+---
+
+## 4. P4 — Binding package no OS [os]
+
+**Objetivo:** uma única aresta de dependência OS→catálogo. Pacote fino que projeta o descritor nos
+contratos do OS. Mantém os seams (egress/vault/audit) fora.
+
+```
++ packages/os-integrations/package.json    # name @agentskit/os-integrations; deps: @agentskit/integrations (npm), @agentskit/os-core (workspace)
++ packages/os-integrations/src/to-agentskit-tools.ts   # Integration → AgentskitTool[] (schema→parameters, retorno→AgentskitToolReturn, getToken lazy, sideEffect, e2e short-circuit)
++ packages/os-integrations/src/to-connection-senders.ts # Integration → ConnectionSender[] (actions[sendCapability]; usa resolveSecret + egress-fetch injetados)
++ packages/os-integrations/src/to-webhook-providers.ts  # Integration → WebhookProvider[] (verify/parse a partir de triggers)
++ packages/os-integrations/src/to-incoming-adapters.ts  # triggers.normalize → buildIncoming(IncomingEvent)
++ packages/os-integrations/src/to-oauth-provider-specs.ts # auth(oauth2) → OAuthProviderSpec
++ packages/os-integrations/src/to-listings.ts           # Integration → MarketplaceListing (category:'connector')
++ packages/os-integrations/src/index.ts
++ packages/os-integrations/tests/parity/*.test.ts       # paridade: projeção vs implementação OS atual (golden)
++ .changeset/os-integrations-binding.md                 # minor: new package
+```
+**Crítico (paridade):** antes de qualquer deleção no OS, os testes de paridade comparam o output das
+projeções com as implementações atuais (mesmos args → mesmo request HTTP / mesmo IncomingEvent).
+Trava regressão.
+
+Gate: `pnpm --filter @agentskit/os-integrations build test` + `check:rfc-0007` (não toca superfície
+contratual ainda).
+
+---
+
+## 5. P5 — Parar duplicação: `os-runtime-agentskit` consome catálogo [os]
+
+**Objetivo:** deletar os 11 tools duplicados; agente do OS usa o catálogo via binding.
+
+```
+~ packages/os-runtime-agentskit/package.json   # @agentskit/tools/@agentskit/integrations de optional→peer dep efetiva; + @agentskit/os-integrations
+~ packages/os-runtime-agentskit/src/<wiring>   # onde hoje monta os tools: trocar createXTools locais por toAgentskitTools(getIntegration(name), {getToken,...})
+- packages/os-runtime-agentskit/src/tools/slack.ts
+- packages/os-runtime-agentskit/src/tools/github.ts
+- packages/os-runtime-agentskit/src/tools/linear.ts
+- packages/os-runtime-agentskit/src/tools/notion.ts
+- packages/os-runtime-agentskit/src/tools/stripe.ts
+- packages/os-runtime-agentskit/src/tools/twilio.ts
+- packages/os-runtime-agentskit/src/tools/discord.ts
+- packages/os-runtime-agentskit/src/tools/sentry.ts
+- packages/os-runtime-agentskit/src/tools/pagerduty.ts
+- packages/os-runtime-agentskit/src/tools/http.ts          # se equivalente no catálogo
+  (manter locais SEM equivalente: fs, shell, git-diff, llm, memory, rag-search, pdf-generator, sql, file-reader, web-search, read-helpers)
+~ packages/os-runtime-agentskit/src/tools/index.ts          # remover exports deletados; manter os locais
++ .changeset/os-runtime-consume-catalog.md                  # minor (interno; sem mudança de contrato público)
+```
+`createAgentskitToolExecutor` aceita `AgentskitTool[]` de qualquer origem → assinatura intocada.
+Preservar deltas OS no adapter `to-agentskit-tools`: `sideEffect` (gate autonomia), `getToken` lazy,
+`isE2eTestMode` short-circuit, retry/timeout via `os-core/http` (passar como `http` runner).
+
+Verificação: testes de paridade P4 + e2e existentes (`conn-ext-integrations.spec.ts`).
+Gate: build+test os; `check:rfc-0007` verde (sem mudança de superfície).
+
+---
+
+## 6. P6 — Connectors projetam o catálogo [os]
+
+```
+~ packages/os-connectors/src/slack-sender.ts   # createSlackConnectionSender passa a derivar endpoint/payload de getIntegration('slack').actions[sendCapability]; mantém send()+resolveSecret+egress
+~ ... github/discord/email/linear/webhook senders idem
+~ packages/os-connectors/src/connector-senders.ts # createConnectorSenders pode gerar via toConnectionSenders(catalog) — OU manter lista explícita chamando adapters
+~ packages/os-connectors/package.json           # + @agentskit/os-integrations
++ .changeset/os-connectors-project-catalog.md    # patch/minor (interno)
+```
+SendCapability constants (`SLACK_POST_MESSAGE`) migram p/ `action.sendCapability` no catálogo;
+connector lê de lá (remove a 2ª cópia de HTTP). Egress/idempotência/audit ficam no
+`connection-send-seam` (intocado).
+Gate: `appendAuditLedgerEntry`/egress tests verdes; paridade de request.
+
+---
+
+## 7. P7 — Triggers projetam + canonização Slack [os]
+
+```
+~ packages/os-triggers/src/webhooks/webhook-slack.ts   # verify/parse derivam de getIntegration('slack').triggers (single source)
+~ packages/os-triggers/src/kinds/slack.ts               # ELIMINAR 2º NormalizedSlackEvent — usar o canônico do catálogo (inclui threadTs)
+~ packages/os-triggers/src/adapters/slack-incoming.ts   # normalize via catálogo → buildIncoming
+~ ... github/linear/discord/twilio/sentry/pagerduty/stripe/s3 idem
+~ packages/os-triggers/src/webhooks/webhook-provider-registry.ts # registrar via toWebhookProviders(catalog)
+~ packages/os-triggers/src/registry/contracts.ts        # triggerContractFor: gerar variantes do catálogo (reduz o switch)
+~ packages/os-triggers/package.json                      # + @agentskit/os-integrations
++ .changeset/os-triggers-project-catalog.md              # patch/minor; FIX divergência NormalizedSlackEvent
+```
+**Corrige o bug** das 2 shapes. `IncomingEvent`/`buildIncoming` (os-core) intocados — catálogo
+satisfaz o contrato, não substitui.
+Gate: golden webhook tests; `check:rfc-0007`.
+
+---
+
+## 8. P8 — OAuth lê o catálogo [os]
+
+```
+~ packages/os-oauth/src/oauth-hub.ts   # OAUTH_PROVIDERS = catalog.filter(auth.kind==='oauth2').map(toOAuthProviderSpec)  (ou merge: catálogo + extras OS-only)
+~ packages/os-oauth/package.json        # + @agentskit/os-integrations
++ .changeset/os-oauth-from-catalog.md   # patch
+```
+Flow `startOAuthFlow`/`completeOAuthFlow`, connection store, token-persist/vault: **intocados**
+(genéricos). App client id/secret continuam via env `AKOS_OAUTH_*` (OS-side, nunca no catálogo).
+Gate: oauth flow tests verdes.
+
+---
+
+## 9. P9 — Notifications projetam [os]
+
+```
+~ packages/os-notifications/src/channels/slack-channel.ts # dispatchSlackMessage usa action do catálogo (capabilities.notify) — elimina 3ª cópia HTTP Slack
+~ ... discord-channel/email-channel idem
+~ packages/os-notifications/package.json                   # + @agentskit/os-integrations
++ .changeset/os-notifications-project-catalog.md           # patch
+```
+Router/severity/dedup (`router-adapter`, os-observability): intocados.
+Gate: notifications tests.
+
+---
+
+## 10. P10 — Marketplace gera listings do catálogo [os]
+
+```
++ packages/os-marketplace/src/catalog-listings.ts   # toListing(integration) → MarketplaceListing{category:'connector', id=name, integrityHash, compat}
+~ packages/os-marketplace/src/<seed/registry>        # seed inicial a partir do catálogo
++ .changeset/os-marketplace-catalog-listings.md      # minor (aditivo)
+```
+**ConnectionKind enum (RFC-frozen):** se algum serviço novo do catálogo não estiver no enum →
+PR de extensão do enum em `os-contracts` (única mudança frozen, aditiva) + `pnpm api:update`.
+Listing/install/billing/signing/SBOM: intocados.
+Gate: `check:rfc-0007` (enum diff intencional aprovado), marketplace tests.
+
+---
+
+## 11. P11 — Ondas de catálogo (+30) [lib]
+
+Cada serviço = 1 PR (ou agrupado por onda), `pnpm gen:integration <name>`, contract test obrigatório.
+Mapa do Activepieces (auth+actions+triggers) — **código próprio via `httpJson`, nunca copiar**.
+
+- Onda 1 (ausências alto uso): gmail, google-calendar, jira, hubspot, airtable, shopify
+- Onda 2 (pedidos): telegram, whatsapp, sendgrid, mailchimp, intercom, salesforce, pipedrive,
+  google-drive, dropbox, cal-com
+- Onda 3 (CRM/automação/AI/cloud): attio, apollo, asana, calendly, acuity, box, amazon-s3/ses/sns/sqs,
+  amazon-bedrock, azure-openai, assemblyai, webhook+schedule genéricos
+
+Cada serviço novo no catálogo → aparece no OS via P4–P10 automaticamente (tool, sender se
+`sendCapability`, trigger se `triggers`, oauth se `auth.oauth2`, listing). `+ .changeset` por serviço.
+Gate: `check:integrations-contract` + build/test.
+
+---
+
+## 12. P12 — MCP split + catálogo via MCP [lib] (opcional, paralelo)
+
+```
++ packages/mcp/* (de packages/tools/src/mcp + mcp-devtools)   # @agentskit/mcp (client/server/devtools)
+~ packages/tools/src/mcp/*                                      # shim deprecado → @agentskit/mcp
++ packages/integrations/src/mcp/server.ts                      # expõe catálogo como MCP tools (qualquer agente MCP usa)
++ .changeset/mcp-split.md                                      # tools: MAJOR ; mcp: minor
+```
+Gate: `pnpm check:all`.
+
+---
+
+## 13. Changesets & versionamento (resumo)
+
+| Pacote | Bump | Quando |
+|---|---|---|
+| `@agentskit/integrations` (novo) | 0.x minor a cada fase | P1,P2,P3,P11,P12 |
+| `@agentskit/tools` | **major** (origem moveu; alias preserva runtime) | P2; major2 em P12 (mcp) |
+| `@agentskit/core` | minor (se mover ZodLike) | P1 |
+| `@agentskit/os-integrations` (novo) | minor | P4 |
+| `os-runtime-agentskit` | minor (interno) | P5 |
+| `os-connectors`/`os-triggers`/`os-oauth`/`os-notifications` | patch/minor | P6–P9 |
+| `os-marketplace` | minor (aditivo) | P10 |
+| `os-contracts` | minor (enum extension, se preciso) | P10 |
+
+---
+
+## 14. Contract tests & gates (rede de segurança)
+
+1. **Alias identity** (P2): shims de tools re-exportam a mesma função.
+2. **Paridade** (P4, pré-deleção): projeção OS == implementação atual (request HTTP / IncomingEvent
+   idênticos) por serviço. **Bloqueia P5–P9.**
+3. **Action schema** (P11): JSON Schema de cada action válido + exemplo executa (mock fetch).
+4. **Golden webhook** (P7): payloads reais → `verify`+`normalize` estáveis.
+5. **Freeze**: `check:rfc-integrations` (lib) + `check:rfc-0007` (os) por PR.
+6. **Boundary lint**: `@agentskit/integrations` não importa `agentskit-os` (regra dep-cruzada).
+7. **Verde isolado**: cada PR passa `check:all`/`check:rfc-0007`+build+test sozinho.
+
+---
+
+## 15. Rollback & ordem segura
+
+- P1–P3 (lib) e P4 (os) são **puramente aditivos** → rollback = remover pacote/PR.
+- P5–P9 deletam/editam OS: cada um atrás de **testes de paridade** (P4). Rollback = reverter o PR;
+  shims/implementações antigas só somem quando paridade verde por ≥1 release.
+- Publicar `@agentskit/integrations` no npm **antes** de P4 (OS consome versão fixa, não workspace).
+- Nunca deletar `os-runtime/tools/*` (P5) antes da paridade + e2e verdes.
+- `ConnectionKind` enum: só estende em P10/P11 quando serviço real precisa, com `api:update`.
+
+---
+
+## 16. Resumo executável (caminho crítico)
+
+```
+P1 → P2 → P3 → [publicar @agentskit/integrations npm] → P4 → P5 (deletar duplicatas)
+   → P6 → P7 (fix Slack) → P8 → P9 → P10 → P11 (ondas) ; P12 (mcp) em paralelo a partir de P3
+```
+Resultado: 1 descritor por serviço, 4 HTTP→1, 0 duplicação OS↔lib, adicionar=1 pasta, agentes
+consomem direto (lib `ToolDefinition` / OS `AgentskitTool` / MCP), infra OS (egress/vault/audit/
+marketplace) intacta e proprietária.
+```

--- a/docs/studies/integrations-split-study.md
+++ b/docs/studies/integrations-split-study.md
@@ -1,0 +1,298 @@
+# Estudo: integrações para o AgentsKit-OS (AKOS) — catálogo único, simples, à prova de futuro
+
+> Status: DRAFT para decisão. Autor: sessão Claude + EmersonBraun. Data: 2026-06-09.
+> **Foco: AKOS.** O AKOS precisa de largura de integrações, reusando o que já existe,
+> de forma **simples de adicionar, manter e evoluir**. Este estudo (1) diagnostica que a
+> camada de integração do AKOS está **espalhada e duplicada**, (2) propõe um **catálogo
+> único** (`@agentskit/integrations`, OSS livre) que o AKOS consome via adapters finos, e
+> (3) entrega plano de migração + catálogo priorizado (~30, mapeado do Activepieces).
+
+---
+
+## 0. TL;DR
+
+- **As 40 integrações da lib NÃO estão no AKOS.** ~21 ausentes; ~19 presentes só como
+  trigger/sender/storage com cobertura de action menor. AKOS **não tem catálogo de actions**.
+- **Pior: o AKOS DUPLICA.** `os-runtime-agentskit/src/tools/` reimplementa slack/github/
+  linear/notion/stripe/twilio/etc — sem depender de `@agentskit/tools`. Mesma integração
+  reescrita 2×.
+- **A camada está ESPALHADA.** Uma integração (ex: slack) vive em **5 pacotes / ~8 arquivos**
+  sem fonte única. Adicionar uma nova = tocar 5 lugares. **Não é à prova de futuro.**
+- **Activepieces vale — como mapa, não código.** É exatamente a largura de catálogo que falta.
+- **Solução:** `Integration` canônico único no pacote livre; cada camada do AKOS (runtime-tool,
+  connector, trigger, notification, oauth) vira **adapter fino** que lê dessa definição única.
+  Adicionar integração passa de "tocar 5 pacotes" para "1 arquivo + registrar".
+
+---
+
+## 1. Diagnóstico: a integração no AKOS está espalhada (evidência)
+
+### 1.1 Onde uma integração vive HOJE no AKOS — exemplo `slack`
+
+| # | Arquivo | Pacote | Papel |
+|---|---|---|---|
+| 1 | `src/tools/slack.ts` | `os-runtime-agentskit` | action de agente (**duplica a lib**) |
+| 2 | `src/slack-sender.ts` | `os-connectors` | sender outbound (`ConnectionSender`) |
+| 3 | `src/adapters/slack-incoming.ts` | `os-triggers` | normaliza evento inbound |
+| 4 | `src/kinds/slack.ts` | `os-triggers` | config Zod do trigger |
+| 5 | `src/webhooks/webhook-slack.ts` | `os-triggers` | handler webhook |
+| 6 | `src/webhooks/webhook-slack-autoregister.ts` | `os-triggers` | auto-registro webhook |
+| 7 | `src/channels/slack-channel.ts` | `os-notifications` | canal de notificação |
+| 8 | (oauth provider config) | `os-oauth` | flow auth |
+
+→ **5 pacotes, ~8 arquivos, zero fonte única.** github = padrão igual (sender + tool +
+trigger adapter/kind/webhook). Não há registry central que cruze connector+trigger+tool+oauth
+por serviço — `os-triggers/registry` cobre **só triggers**.
+
+### 1.2 Duplicação confirmada: `os-runtime-agentskit/src/tools/`
+
+Reimplementa, **sem depender de `@agentskit/tools`** (deps reais: `node-sql-parser`, `pdfkit`):
+```
+discord, github, http, linear, notion, pagerduty, sentry, slack, sql, stripe, twilio
+```
+São os mesmos serviços que a lib já tem em `@agentskit/tools/integrations`. **Trabalho feito 2×,**
+divergem com o tempo, bug corrigido num lado não no outro. Débito clássico.
+
+### 1.3 Veredito de arquitetura
+
+| Critério | Estado atual | Nota |
+|---|---|---|
+| Fonte única por integração | ❌ espalhado em 5 pacotes | ruim |
+| Reuso da lib | ❌ reimplementa | ruim |
+| Fácil adicionar | ❌ tocar 5 lugares, sem template | ruim |
+| Manutenção | ❌ correção em N lugares | ruim |
+| À prova de futuro | ⚠️ infra boa (triggers/oauth/egress), mas sem coesão de catálogo | médio |
+
+A **infra** do AKOS é forte (triggers, oauth, webhooks, egress, vault, marketplace). O que
+falta é **coesão**: um lugar canônico onde "uma integração" é descrita inteira, e adapters
+finos que projetam essa descrição em cada camada.
+
+---
+
+## 2. As 40 da lib × AKOS (overlap)
+
+| Status no AKOS | Serviços |
+|---|---|
+| **Ausente total** (21) | github-actions, gmail, teams (MS Teams), hubspot, shopify, jira, airtable, figma, google-calendar, cloudflare-r2, openai-images, elevenlabs, deepgram, whisper, firecrawl, browser-agent, reader, maps, weather, coingecko, document-parsers |
+| **Parcial — só trigger/sender/tool** (9) | github, slack, discord, linear, email, twilio, stripe, sentry, pagerduty |
+| **Parcial — só storage/rag** (8) | postgres, s3, sqlite, notion, confluence (+ rag: drive/dropbox/gcs/onedrive) |
+| genérico (2) | http, sqlite-query |
+
+Mesmo os "parciais" cobrem **menos actions** que a lib (ex: AKOS github = comment+push trigger;
+lib github = search/create/comment). **A largura de action da lib é, na prática, ausente no AKOS.**
+
+---
+
+## 3. Activepieces — vale adicionar ao AKOS?
+
+**Sim. É precisamente o gap.** AKOS tem a infra difícil; falta **largura de catálogo**
+(400 serviços × actions + auth shapes + triggers). Activepieces resolve isso — **como mapa**:
+
+- ✅ Usar como referência: quais serviços, qual auth, quais actions/triggers principais.
+- ❌ **Não copiar código** — pieces têm licenças/deps variadas (core MIT, mas peças não
+  garantidas). Reimplementar limpo via `httpJson`. Sem atribuição herdada, sem risco copyleft.
+
+---
+
+## 4. Arquitetura alvo: catálogo único → adapters finos no AKOS
+
+### 4.1 Princípio
+
+**Uma integração = uma definição.** Vive em `@agentskit/integrations` (livre). Cada camada do
+AKOS lê dessa definição em vez de reimplementar.
+
+```
+@agentskit/integrations (OSS livre)
+  services/slack/
+    index.ts     →  Integration { auth, actions[], triggers[] }
+    actions.ts   →  postMessage, search, ... (defineTool / httpJson)
+    triggers.ts  →  normalize + verify (webhook signature)
+    auth.ts      →  AuthSpec (oauth2 scopes | apiKey)
+        ↓ consumido por adapters FINOS no AKOS
+agentskit-os
+  os-runtime-agentskit  → tool adapter: integration.actions → agent tools   (deixa de reimplementar)
+  os-connectors         → sender adapter: integration.actions[send] + egress/audit/vault
+  os-triggers           → trigger adapter: integration.triggers + webhook infra/auto-registro
+  os-notifications      → channel adapter: integration.actions[notify]
+  os-oauth              → consome integration.auth (scopes/urls) no flow
+  os-marketplace        → lista integrations como pieces instaláveis
+```
+
+### 4.2 Contrato (`@agentskit/integrations`)
+
+```ts
+interface Integration {
+  name: string                 // 'slack'
+  displayName: string
+  categories: string[]         // ['comms']
+  auth: AuthSpec
+  actions: ToolDefinition[]    // reusa defineTool — vira agent-tool no AKOS sem reescrita
+  triggers?: TriggerSpec[]     // normalize + verify — alimenta os-triggers
+  capabilities?: {             // hints pros adapters do AKOS projetarem a definição
+    notify?: string            // qual action é canal de notificação
+    send?: string              // qual action é o sender canônico
+  }
+}
+```
+Princípios:
+- **actions = `Tool`** → `os-runtime-agentskit` para de reimplementar; só mapeia.
+- **triggers** carregam `normalize`/`verify` → `os-triggers` injeta egress/audit/auto-registro.
+- **auth declarativo** → `os-oauth` lê scopes/urls; o flow seguro/vault fica no AKOS.
+- **`capabilities`** = ponteiros pra notification/sender saberem qual action usar — sem
+  duplicar lógica.
+
+### 4.3 "Adicionar 1 integração": antes × depois
+
+| | Hoje (AKOS) | Alvo |
+|---|---|---|
+| Arquivos a tocar | ~8, em 5 pacotes | **1 pasta** `services/X/` no pacote livre |
+| Action de agente | reescrever em `os-runtime/tools` | grátis (adapter lê `actions`) |
+| Trigger | adapter+kind+webhook+autoregister | `triggers.ts` (normalize/verify); infra é genérica |
+| Notificação | `os-notifications/channels/X` | grátis se `capabilities.notify` setado |
+| Auth | config espalhada | `auth.ts` declarativo |
+| Manutenção de bug | corrigir em N lugares | 1 lugar |
+
+→ Adicionar serviço = **escrever uma pasta + registrar**. À prova de futuro.
+
+### 4.4 Schema: Zod vs JSON Schema
+- lib/core: JSON Schema canônico, dep-free (`feedback_json-schema-canonical`). AKOS: Zod.
+- `@agentskit/integrations` não é core → pode ter dep, mas recomendo **JSON Schema nas actions**
+  (reusa as 40 sem reescrita, consistente) + **`ZodLike` estrutural** (já existe `tools/src/zod.ts`)
+  pra aceitar Zod do usuário sem dep dura. Triggers do AKOS (hoje Zod) são **traduzidos uma vez**
+  na migração para o evento canônico do pacote.
+
+---
+
+## 5. Catálogo priorizado para o AKOS (~30, mapeado do Activepieces)
+
+Auth: `key`=API key/token · `oauth2`=OAuth2 · `webhook`=assinatura. Actions/triggers = principais.
+
+### Onda 1 — preencher ausências de alto uso (6)
+| Serviço | Auth | Actions principais | Triggers |
+|---|---|---|---|
+| gmail | oauth2 | send, list, get, modifyLabels, draft | new-email |
+| google-calendar | oauth2 | listEvents, createEvent, updateEvent, freeBusy | event-start |
+| jira | oauth2/key | createIssue, updateIssue, search(JQL), comment, transition | issue-created/updated |
+| hubspot | oauth2 | upsertContact, createDeal, search, addNote | contact/deal-changed |
+| airtable | key | listRecords, createRecord, updateRecord, deleteRecord | record-created |
+| shopify | key | listOrders, createProduct, updateInventory, getCustomer | order-created |
+
+### Onda 2 — novos pedidos de alto valor (10)
+| Serviço | Auth | Actions principais | Triggers |
+|---|---|---|---|
+| telegram | key | sendMessage, sendPhoto, editMessage, answerCallback | new-message (webhook) |
+| whatsapp (cloud API) | key | sendMessage, sendTemplate, markRead | inbound-message |
+| sendgrid | key | sendEmail, addContact, sendTemplate | (delivery webhook) |
+| mailchimp | oauth2/key | addMember, updateMember, sendCampaign, tagMember | subscribe/unsubscribe |
+| intercom | oauth2 | createContact, sendMessage, tagUser, createTicket | conversation-created |
+| salesforce | oauth2 | createRecord, updateRecord, SOQL query, upsert | record-changed (CDC) |
+| pipedrive | oauth2/key | createDeal, updatePerson, search, addActivity | deal-updated |
+| google-drive | oauth2 | upload, download, list, createFolder, share | file-added |
+| dropbox | oauth2 | upload, download, list, share, move | file-added |
+| cal-com | key | listBookings, createBooking, cancel, availability | booking-created |
+
+### Onda 3 — CRM/automação/AI/cloud (14)
+| Serviço | Auth | Actions principais | Triggers |
+|---|---|---|---|
+| attio | key | createRecord, updateRecord, query, addNote | record-changed |
+| apollo | key | searchPeople, enrichContact, createContact | — |
+| asana | oauth2/key | createTask, updateTask, addComment, listProjects | task-changed |
+| calendly | oauth2 | listEvents, getInvitee, cancel | invitee-created |
+| acuity | key | listAppointments, scheduleAppointment, cancel | appointment-scheduled |
+| box | oauth2 | upload, download, list, share | file-uploaded |
+| amazon-s3 | key/IAM | putObject, getObject, list, presign | (s3-event via triggers) |
+| amazon-ses | key/IAM | sendEmail, sendTemplated | (bounce/complaint webhook) |
+| amazon-sns | key/IAM | publish, subscribe | (topic notification) |
+| amazon-sqs | key/IAM | sendMessage, receiveMessage, deleteMessage | queue-message |
+| amazon-bedrock | key/IAM | invokeModel, converse, embed | — |
+| azure-openai | key | chat, embed, completions | — |
+| assemblyai | key | transcribe, getTranscript, lemur | transcript-ready |
+| webhook + schedule (genéricos) | webhook/none | postWebhook, cron emit | inbound-webhook / cron |
+
+**Completar os parciais** (sem novo serviço): adicionar à lib/pacote as actions que faltam em
+github (search/issues), slack (richer), linear, notion, stripe (refund/customer), antes de
+re-projetar no AKOS.
+
+---
+
+## 6. Plano de migração (AKOS-first, não-breaking)
+
+**Fase 0 — Catálogo único.** Criar `@agentskit/integrations`: contrato §4.2, `http.ts`,
+`registry.ts`. RFC + `check:rfc-*` pra congelar o contrato público.
+
+**Fase 1 — Mover as 40 da lib** → `services/*`. Re-export deprecado em `@agentskit/tools`
+(não quebra; changeset major tools / minor integrations).
+
+**Fase 2 — AKOS para de duplicar (maior ganho).** `os-runtime-agentskit` passa a **depender de
+`@agentskit/integrations`** e mapear `integration.actions → agent tools`. **Apagar**
+`os-runtime-agentskit/src/tools/{slack,github,linear,notion,stripe,twilio,discord,sentry,pagerduty,http,sql}`.
+Bug fixes passam a ter 1 fonte.
+
+**Fase 3 — Adapters finos.** `os-connectors`/`os-triggers`/`os-notifications`/`os-oauth` leem da
+definição única (injetam egress/audit/vault/auto-registro). Remover catálogo espelhado.
+
+**Fase 4 — Largura (Ondas 1→3).** Cada serviço novo: uma pasta no pacote → aparece no AKOS via
+adapters + vira listing no marketplace. Priorizar por valor.
+
+---
+
+## 7. Manutenção e à prova de futuro (garantias)
+
+1. **Fonte única + adapters finos** — bug/melhoria em 1 lugar; camadas projetam, não reimplementam.
+2. **Template de serviço** — `services/_template/` + gerador `pnpm gen:integration <name>` →
+   estrutura idêntica sempre. Adicionar = preencher, não descobrir 5 lugares.
+3. **Contract tests por serviço** — golden payloads de webhook + schema de action validados em CI.
+   APIs externas quebram; teste de contrato pega cedo.
+4. **Contract freeze** — `check:rfc-*` no contrato `Integration` (padrão `os` RFC-0007). Mudança
+   de superfície = intencional + `api:update`.
+5. **Boundary lint** — `@agentskit/integrations` **nunca** importa `agentskit-os` (proibir ciclo).
+6. **Versão independente futura** — se catálogo crescer, versionar por serviço (à la Activepieces).
+7. **Zero-dep por serviço** — manter padrão `httpJson`/`node:crypto`; SDKs externos só como
+   `optionalDependencies` quando inevitável (tree-shaking + `sideEffects:false`).
+
+---
+
+## 8. Tradeoffs e riscos
+
+**Ganhos:** fim da duplicação AKOS↔lib; adicionar integração de 5 pacotes → 1 pasta; AKOS ganha
+largura barato; comunidade mantém conectores (passivo sai do AKOS); 1 contrato em vez de 4 shapes.
+
+**Custos / riscos:**
+| Risco | Sev | Mitigação |
+|---|---|---|
+| Reconciliar 4 shapes (lib JSON Schema, AKOS runtime-tool, connector, trigger Zod) | Alta | tradução one-time; JSON Schema + ZodLike; contract tests |
+| Inversão de dep: AKOS (privado) → pacote público | Média | direção saudável; lint proíbe ciclo reverso |
+| Apagar `os-runtime/tools` quebra fluxos atuais | Média | mapear 1:1 antes de apagar; testes de paridade |
+| Passivo de manutenção ~30+ APIs | Média | Ondas, qualidade>cobertura (`feedback_foundation_over_speed`), contract tests |
+| Cópia acidental Activepieces | Média | política "mapa não código", review de PR |
+| Boundary free/pago mal traçado | Média | catálogo+auth+trigger livres; vault/egress/audit/marketplace fechados (open-core) |
+
+---
+
+## 9. Boundary free vs proprietário (open-core)
+
+| Componente | Recomendação | Razão |
+|---|---|---|
+| Catálogo de actions (httpJson) | **FREE** | commodity, adoção |
+| Trigger normalize/verify | **FREE** | gancho de adoção; sem isso agente externo é cego |
+| OAuth2 runner + token-store *interface* | **FREE** | padrão |
+| Connection store multi-tenant + vault/sealer | **AKOS** | enterprise |
+| Egress guard, audit assinado, idempotência distribuída | **AKOS** | diferencial |
+| Marketplace (listing, billing, publish, payouts) | **AKOS** | monetização |
+
+Dá de graça o que cansa manter (catálogo); cobra pela orquestração/segurança/marketplace.
+
+---
+
+## 10. Dúvidas abertas (preciso de você)
+
+1. **Apagar `os-runtime-agentskit/src/tools/*` duplicados** e depender de `@agentskit/integrations`?
+   (recomendo sim — é o maior ganho)
+2. **Boundary free/pago (§9)** — confirma a linha? Triggers/oauth ficam livres?
+3. **Schema (§4.4)** — JSON Schema + ZodLike (recomendado) ou Zod 1:1 com o AKOS?
+4. **Escopo de lançamento** — Fase 0–2 (parar duplicação + mover 40) primeiro, Ondas depois?
+   (recomendo)
+5. **RAG connectors** (`os-rag-adapters`: drive/dropbox/gcs/notion/onedrive) — ficam no rag ou
+   entram no catálogo como categoria "knowledge sources"?
+6. **MCP split** (`@agentskit/mcp`) — junto neste RFC ou separado?
+```

--- a/docs/studies/integrations-unification.md
+++ b/docs/studies/integrations-unification.md
@@ -1,0 +1,253 @@
+# Unificação de integrações — análise profunda + arquitetura alvo
+
+> Status: DRAFT para decisão. Data: 2026-06-09. Companheiro de `integrations-split-study.md`.
+> Entrega 1 de 2: **análise profunda + plano de unificação** (o "como deve ser"). A Entrega 2
+> (plano completo de refatoração nos dois repos) vem após alinhamento desta.
+> Base: leitura de conteúdo real de `lib` (local) e `AgentsKit-io/agentskit-os` (privado).
+
+---
+
+## 0. TL;DR
+
+Hoje **uma integração (ex: slack) vive em 6+ lugares com 3–4 implementações HTTP separadas**,
+contratos diferentes e shapes divergentes. Não há descritor único de serviço.
+
+**Alvo:** **um descritor canônico por serviço** em `@agentskit/integrations` (OSS livre). Cada
+camada (agent-tool, connector outbound, trigger inbound, oauth, notification, marketplace) vira
+**projeção fina** desse descritor. Adicionar integração: de "tocar 6 pacotes" → "1 pasta +
+registrar". Manutenção: de "corrigir em N" → "1 fonte". Agente: "import + usar".
+
+Viável **sem big-bang**: peer dep já existe, oauth já é declarativo, dispatch opera em runtime,
+só 1 superfície frozen (`ConnectionKind` enum) muda — e de forma aditiva.
+
+---
+
+## 1. Análise profunda — superfícies reais hoje
+
+### 1.1 Quatro contratos de "ação" para o MESMO serviço
+
+| Camada | Repo/pacote | Contrato | Schema | Auth | HTTP |
+|---|---|---|---|---|---|
+| Agent tool (lib) | `tools/integrations/slack.ts` | `defineTool` → `ToolDefinition` | JSON Schema | `config.token` | `httpJson` |
+| Agent tool (OS) | `os-runtime-agentskit/tools/slack.ts` | **`AgentskitTool` (local)** | JSON Schema (`parameters`) | `getBotToken: () => string` (lazy) | `os-core/http` (`fetchWithTimeout`,`retryWithBackoff`) |
+| Connector outbound | `os-connectors/slack-sender.ts` | `ConnectionSender` | Zod (`target`/`payload`) | `resolveSecret(ref)` (vault) | egress-fetch injetado |
+| Notification | `os-notifications/slack-channel.ts` | ad-hoc `dispatchSlackMessage` | — | env/override | fetch próprio (10s) |
+
+→ **4 implementações HTTP do `chat.postMessage`.** Divergem em silêncio.
+
+Detalhes que importam pra unificar:
+- `ToolDefinition` (core): `{ name, description?, schema?: JSONSchema7, execute(args,ctx)=>unknown|AsyncIterable, init?, dispose?, tags?, category?, requiresConfirmation? }`. **Sem conceito de trigger** — `stripe-webhook` é modelado como tool comum de "verify".
+- `AgentskitTool` (OS): `{ name, description?, parameters?: JSONSchema, sideEffect?: 'none'|'read'|'write'|'destructive'|'external', execute(args,ctx)=>AgentskitToolReturn }`. **Diferenças vs core:** (1) `parameters` vs `schema` (mesmo JSON Schema, nome diferente), (2) retorno `AgentskitToolReturn` discriminado (`{kind:'ok'|'error'}`) vs `unknown`, (3) `sideEffect` alimenta o gate de autonomia, (4) credencial **lazy** `() => string`, (5) `isE2eTestMode` short-circuit.
+- **`@agentskit/tools` JÁ é optional peer dep** do `os-runtime-agentskit` (deps diretas: só `node-sql-parser`, `pdfkit`). O binding foi antecipado; só não consome o catálogo.
+
+### 1.2 Trigger inbound — bom design, 1 ponto de co-edição
+
+- `WebhookProvider<TCtx,TEvent> = { kind, verify(input)=>Result<TCtx>, parse(input,ctx)=>TEvent }`,
+  registrado via `registerWebhookProvider(provider)` (open/close — **sem switch**).
+- Adapter `raw → IncomingEvent` via `buildIncoming(common, source, payload, raw, opts)`.
+- `IncomingEvent` = envelope CloudEvents (Zod), `data` discriminado por `source`
+  (slack/github/.../s3/mcp), `ExternalThreadRef` p/ session stitch.
+- **1 ponto de co-edição restante:** `triggerContractFor(kind)` switch em `os-triggers/registry/contracts.ts` + o union Zod de 15 kinds.
+- **Bug latente:** 2 `NormalizedSlackEvent` divergentes (`kinds/slack.ts` tem `threadTs`, `webhooks/webhook-slack.ts` não).
+
+### 1.3 Auth — já declarativo (mover é trivial)
+
+`os-oauth/oauth-hub.ts`: `OAUTH_PROVIDERS: OAuthProviderSpec[]` (14 providers):
+```ts
+type OAuthProviderSpec = {
+  providerId; displayName; authorizationUrl; tokenUrl;
+  defaultScopes: string[]; usePkce: boolean; extraAuthParams?: Record<string,string>
+}
+```
+**Zero código por-provider.** Flow `startOAuthFlow`/`completeOAuthFlow` é genérico. Connection
+store guarda só metadata (state/scopes); **tokens ficam no vault** (`os-storage`). Credenciais
+de app via env `AKOS_OAUTH_<PROVIDER>_CLIENT_ID/SECRET`.
+
+### 1.4 Canônico + frozen + dispatch (o que NÃO pode mover)
+
+- `os-core/integrations` (Zod): `IncomingEvent`, `OutgoingMessage` (`correlationId` obrigatório,
+  `idempotencyKey`), `ConnectionSender`, `SessionRegistry`. **Contratos canônicos — o pacote livre
+  deve satisfazê-los, não substituí-los.**
+- `os-contracts`: `ConnectionKind = z.enum([slack,github,linear,discord,email,cron,file,webhook,
+  cdc,twilio,sentry,pagerduty,stripe,s3,mcp,llm])` — **única superfície RFC-frozen (`check:rfc-0007`)
+  que nomeia kinds em compile-time.** Tudo mais opera em `connection.kind` (string) em runtime.
+- Dispatch (`connection-send-seam.ts`): `parse → store.get(connectionId) → capability check →
+  EGRESS GATE → IDEMPOTENCY RING → SIGNED AUDIT → registry.get(kind).send({...,resolveSecret})`.
+  **Egress/idempotência/audit/vault disparam ANTES do sender** — ficam no OS, sempre.
+- Marketplace: listing `category:'connector'` + `PluginManifest`; **aditivo**, sem FK de integração.
+- Ponto de injeção de senders: `createIntegrationConnectionsHandlers(opts.senders)` no boot.
+
+---
+
+## 2. Diagnóstico (resposta direta: espalhado ou no lugar certo?)
+
+**Espalhado.** A *infra* (dispatch, egress, vault, audit, oauth flow, trigger registry) está
+**bem desenhada e no lugar certo** — seams limpos, RFC-governados. O que está **errado** é a
+**ausência de um descritor de serviço único**: cada serviço é redescrito em 4–6 lugares, com 3–4
+HTTP clients, 2 shapes divergentes. Resultado: adicionar/manter exige tocar muitos pontos, e as
+cópias derivam.
+
+| Critério | Infra (seams) | Catálogo (por-serviço) |
+|---|---|---|
+| Desenho | ✅ limpo, RFC-frozen | ❌ espalhado, duplicado |
+| Fácil adicionar | n/a | ❌ 6 lugares |
+| Manutenção | ✅ | ❌ N cópias |
+| À prova de futuro | ✅ | ❌ deriva |
+
+**Tese de unificação: manter a infra, extrair o catálogo para um descritor único.**
+
+---
+
+## 3. Arquitetura alvo — descritor único + projeções finas
+
+### 3.1 O descritor canônico (`@agentskit/integrations`)
+
+```ts
+// Núcleo do pacote livre. Uma definição por serviço.
+interface Integration {
+  name: ConnectionKindSlug          // 'slack' — casa com ConnectionKind do OS
+  displayName: string
+  categories: string[]              // ['comms']
+  http?: { baseUrl: string }        // fatos de transporte compartilhados
+
+  auth: AuthSpec                    // unifica OAUTH_PROVIDERS + apiKey + webhookSecret
+  actions: IntegrationAction[]      // 1 fonte p/ agent-tool + connector + notification
+  triggers?: IntegrationTrigger[]   // 1 fonte p/ webhook verify/parse + IncomingEvent
+  capabilities?: { send?: string; notify?: string }  // ponteiros p/ projeções
+}
+
+interface IntegrationAction {
+  name: string                      // 'slack_post_message'
+  description: string
+  schema: JSONSchema7               // canônico (reusa defineTool)
+  sideEffect?: 'none'|'read'|'write'|'destructive'|'external'  // p/ gate de autonomia do OS
+  sendCapability?: string           // 'chat.postMessage' — id da SendCapability do connector
+  execute(args, http): MaybePromise<unknown>   // transporte ÚNICO (httpJson)
+}
+
+interface IntegrationTrigger {
+  name: string                      // 'slack.message'
+  source: IncomingSource            // 'slack' (casa com IncomingEventData)
+  verify(input: WebhookInput): VerifyResult        // assinatura
+  normalize(raw, ctx): NormalizedEvent             // → payload de IncomingEvent
+  externalThreadRef?(raw): ExternalThreadRef       // session stitch
+}
+
+type AuthSpec =
+  | { kind:'oauth2'; authorizationUrl; tokenUrl; defaultScopes:string[]; usePkce:boolean; extraAuthParams?:Record<string,string> }  // = OAuthProviderSpec
+  | { kind:'apiKey'; header:string; envHint?:string }
+  | { kind:'webhookSecret'; scheme:'hmac-sha256'|... }
+  | { kind:'none' }
+```
+
+Princípios:
+- **`execute` é o único HTTP.** As 4 cópias colapsam numa. `httpJson` vira base do pacote.
+- **`schema` em JSON Schema** (reusa as 40 sem reescrita; consistente com core/`feedback_json-schema-canonical`). Aceita Zod do usuário via `ZodLike` (já existe `tools/src/zod.ts`).
+- **`auth` oauth2 = `OAuthProviderSpec` verbatim** → move sem fricção.
+- **`triggers` carregam `verify`+`normalize`** → alimentam `WebhookProvider` + `buildIncoming` do OS.
+- **`name` = `ConnectionKind` slug** → casa com o enum frozen e o dispatch.
+
+### 3.2 Projeções finas (adapters por camada)
+
+Cada camada deixa de reimplementar e passa a **projetar** o descritor:
+
+| Camada (consumidor) | Adapter (novo, fino) | Lê do descritor | Mantém local |
+|---|---|---|---|
+| Agent tool lib (`runtime`/`cli`) | `toToolDefinitions(integration)` | `actions` | — (já é `ToolDefinition`) |
+| Agent tool OS (`os-runtime-agentskit`) | `toAgentskitTools(integration, {getToken})` | `actions` | `sideEffect` gate, lazy cred, e2e short-circuit |
+| Connector outbound (`os-connectors`) | `toConnectionSenders(integration)` | `actions[sendCapability]` | egress-fetch, `resolveSecret`, idempotência, audit |
+| Trigger inbound (`os-triggers`) | `toWebhookProvider(integration)` + `toIncomingAdapter` | `triggers` | auto-registro, dispatch, registry |
+| Auth (`os-oauth`) | `toOAuthProviderSpec(integration)` | `auth(oauth2)` | flow, vault, connection store |
+| Notification (`os-notifications`) | `toNotifChannel(integration)` | `actions[capabilities.notify]` | router/severity |
+| Marketplace (`os-marketplace`) | `toListing(integration)` | metadata | listing/install/billing |
+
+**Resultado por serviço:** 1 descritor (pasta `services/slack/`) → 7 projeções automáticas.
+Egress/vault/audit/idempotência/billing **permanecem no OS** (disparam antes/around das projeções).
+
+### 3.3 Fluxo "adicionar Slack" — antes × depois
+
+```
+ANTES:  tools/integrations/slack.ts (lib)
+      + os-runtime-agentskit/tools/slack.ts
+      + os-connectors/slack-sender.ts
+      + os-triggers/{adapters,kinds,webhooks×2}/slack
+      + os-notifications/channels/slack-channel.ts
+      + os-oauth/oauth-hub.ts (entry)
+      + os-contracts ConnectionKind (já tem)
+   = 6 pacotes, ~9 arquivos, 4 HTTP clients
+
+DEPOIS: @agentskit/integrations/services/slack/{index,actions,triggers,auth}.ts
+      + registrar no catálogo
+   = 1 pasta. Projeções geram o resto.
+```
+
+### 3.4 Por que isso é "fácil pro agente"
+
+- lib: `integration.actions` já são `ToolDefinition[]` → `runtime({ tools })` consome direto
+  (mecanismo `buildToolMap` atual, sem mudança).
+- OS: `toAgentskitTools` devolve `AgentskitTool[]` → `createAgentskitToolExecutor` aceita igual.
+- Um `registry.list()` no pacote dá descoberta (`listIntegrations()`, `getIntegration('slack')`).
+- MCP: catálogo pode ser exposto via `@agentskit/mcp` server → qualquer agente MCP usa.
+
+---
+
+## 4. Garantias de "à prova de futuro"
+
+1. **Descritor único + projeções** — bug/feature em 1 lugar; camadas projetam.
+2. **Template + gerador** — `services/_template/` + `pnpm gen:integration <name>`; estrutura
+   idêntica sempre.
+3. **Contract tests por serviço** — golden payloads de webhook + validação de schema de action em
+   CI. Pega quebra de API externa cedo.
+4. **Contract freeze** — `Integration` sob `check:rfc-*` (padrão `[[project_agentskit_os_contract_freeze]]`).
+5. **Boundary lint** — `@agentskit/integrations` **nunca** importa `agentskit-os` (proíbe ciclo).
+   OS importa o pacote, não o contrário.
+6. **Canonicalização única** — resolver os 2 `NormalizedSlackEvent` num só shape no descritor
+   (elimina a divergência atual).
+7. **Schema canônico** — JSON Schema + `ZodLike`; sem dep dura de Zod no pacote base.
+8. **Zero-dep por serviço** — padrão `httpJson`/`node:crypto`; SDK externo só `optionalDependencies`
+   + `sideEffects:false` p/ tree-shaking.
+
+---
+
+## 5. Pontos de risco da unificação (a tratar na Entrega 2)
+
+| Risco | Detalhe | Mitigação |
+|---|---|---|
+| 4 contratos divergentes | core `ToolDefinition` vs OS `AgentskitTool` (`schema`/`parameters`, retorno, `sideEffect`) | adapter de projeção mapeia campos; testes de paridade antes de apagar |
+| 3–4 HTTP clients | comportamentos sutis (Slack `ok:false`, Stripe form-encoded+idempotency, retry/timeout) | descritor `execute` absorve quirks; golden tests por action |
+| Shapes divergentes | 2 `NormalizedSlackEvent` | canonicalizar no descritor (single source) |
+| `ConnectionKind` frozen | adicionar kind = mudar enum RFC-frozen | enum extension PR (única mudança frozen), aditiva; `api:update` |
+| Inversão de dep | OS (privado) passa a depender de pacote público | direção saudável; boundary lint proíbe ciclo |
+| Apagar `os-runtime/tools` | quebra fluxos atuais | mapear 1:1 + testes paridade antes de deletar |
+| Auth: app creds | OAuth client id/secret via env OS-side | descritor traz só spec público (urls/scopes); secret fica no OS/vault |
+
+---
+
+## 6. Boundary free vs OS (open-core) — recap
+
+| Componente | Onde | Razão |
+|---|---|---|
+| Descritor `Integration` (actions+triggers+auth spec) + `execute` HTTP | **FREE** `@agentskit/integrations` | catálogo = commodity/adoção |
+| `verify`/`normalize` de webhook | **FREE** | gancho de adoção |
+| OAuth2 spec (urls/scopes) + flow genérico + token-store *interface* | **FREE** | padrão |
+| Egress gate, signed audit, idempotency ring | **OS** | dispara around das projeções; diferencial |
+| Vault/sealer (resolveSecret, AES-256-GCM, keychain) | **OS** | secret material |
+| Multi-tenant connection store, app client secrets | **OS** | enterprise |
+| Marketplace (listing/install/billing/signing/SBOM) | **OS** | monetização |
+
+---
+
+## 7. Decisões pendentes (destravam a Entrega 2)
+
+1. **Aprovar a arquitetura §3** (descritor único + projeções finas)?
+2. **Apagar `os-runtime-agentskit/src/tools/*` duplicados** e consumir o pacote? (recomendo sim)
+3. **Schema:** JSON Schema + `ZodLike` (recomendado) ou Zod 1:1 com OS?
+4. **Boundary §6** confirmado?
+5. **Escopo da Entrega 2:** faseado não-breaking (mover 40 → parar duplicação OS → projeções →
+   ondas de catálogo)? Ou priorizar largura primeiro?
+6. **`@agentskit/mcp` split + expor catálogo via MCP** entra no mesmo RFC?
+
+> Após aprovação desta entrega, escrevo a **Entrega 2: plano completo de refatoração** — passo a
+> passo, arquivo a arquivo, changesets, ordem de PRs nos dois repos, contract tests, e a sequência
+> que mantém tudo verde (gates) sem big-bang.
+```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e:ui": "playwright test --ui",
     "lint": "turbo run lint",
     "sync:models": "node scripts/sync-models-dev.mjs",
+    "gen:integration": "node scripts/gen-integration.mjs",
     "check:quality-gates": "node scripts/check-quality-gates.mjs",
     "check:all": "pnpm check:quality-gates && pnpm lint && pnpm build && pnpm test",
     "prepare": "husky",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@agentskit/integrations",
+  "version": "0.0.0",
+  "description": "Unified, plug-and-play service integrations for AgentsKit agents — one descriptor per service projected into tools, connectors, triggers, and auth.",
+  "keywords": [
+    "agentskit",
+    "ai",
+    "agents",
+    "llm",
+    "integrations",
+    "connectors",
+    "tools",
+    "webhooks",
+    "oauth",
+    "typescript",
+    "openai",
+    "anthropic",
+    "claude",
+    "gemini",
+    "function-calling",
+    "tool-use"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js",
+      "require": "./dist/testing.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/json-schema": "^7.0.15",
+    "@types/node": "^25.9.1",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "agentskit": {
+    "stability": "experimental",
+    "stabilityNote": "Integration contract v1 — descriptor + registry. Catalog populated in later phases."
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/integrations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/integrations"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
+}

--- a/packages/integrations/src/contract.ts
+++ b/packages/integrations/src/contract.ts
@@ -1,0 +1,161 @@
+import type { JSONSchema7 } from 'json-schema'
+import type { MaybePromise } from '@agentskit/core'
+import type { IntegrationHttp } from './http'
+
+// ---------------------------------------------------------------------------
+// Side effects — drives the OS autonomy gate when projected into AgentskitTool.
+// ---------------------------------------------------------------------------
+
+export type SideEffect = 'none' | 'read' | 'write' | 'destructive' | 'external'
+
+// ---------------------------------------------------------------------------
+// Auth — one declarative spec per service. `oauth2` mirrors the OS
+// OAuthProviderSpec verbatim so it projects with zero translation.
+// ---------------------------------------------------------------------------
+
+export interface OAuth2AuthSpec {
+  kind: 'oauth2'
+  authorizationUrl: string
+  tokenUrl: string
+  defaultScopes: string[]
+  usePkce: boolean
+  /** Non-standard authorize params (e.g. Dropbox `token_access_type=offline`). */
+  extraAuthParams?: Record<string, string>
+}
+
+export interface ApiKeyAuthSpec {
+  kind: 'apiKey'
+  /** Header the credential is sent in (e.g. `authorization`). */
+  header: string
+  /** Optional prefix, e.g. `Bearer ` or `token `. */
+  prefix?: string
+  /** Hint for where the key is conventionally read from (docs/UX only). */
+  envHint?: string
+}
+
+export interface WebhookSecretAuthSpec {
+  kind: 'webhookSecret'
+  /** Signature scheme used to verify inbound webhooks. */
+  scheme: 'hmac-sha256' | 'ed25519' | 'custom'
+}
+
+export interface NoAuthSpec {
+  kind: 'none'
+}
+
+export type AuthSpec =
+  | OAuth2AuthSpec
+  | ApiKeyAuthSpec
+  | WebhookSecretAuthSpec
+  | NoAuthSpec
+
+// ---------------------------------------------------------------------------
+// Actions — the single source for agent tools, connector senders, and
+// notification channels. `execute` receives an auth-bound HTTP client and
+// never sees the raw credential.
+// ---------------------------------------------------------------------------
+
+export interface IntegrationAction {
+  /** Stable, namespaced id, e.g. `slack_post_message`. */
+  name: string
+  description: string
+  /** JSON Schema (canonical) for the action arguments. */
+  schema: JSONSchema7
+  sideEffect?: SideEffect
+  /**
+   * SendCapability id this action fulfils when projected as an outbound
+   * connector sender (e.g. `chat.postMessage`). Absent = not a sender.
+   */
+  sendCapability?: string
+  execute: (args: Record<string, unknown>, http: IntegrationHttp) => MaybePromise<unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Triggers — the single source for inbound webhook verification + the
+// canonical normalized event (projected into the OS IncomingEvent).
+// ---------------------------------------------------------------------------
+
+export interface WebhookInput {
+  /** Verification secret (signing secret / shared token). */
+  secret: string
+  /** Raw, unparsed request body — required for signature verification. */
+  rawBody: string
+  headers: Record<string, string>
+  /** Override for replay-window checks; defaults to now. */
+  nowSeconds?: number
+  requestUrl?: string
+}
+
+export type VerifyResult = { ok: true } | { ok: false; reason: string }
+
+/** External thread reference — basis for session stitching across turns. */
+export interface ExternalThreadRef {
+  kind: string
+  id: string
+  parentId?: string
+}
+
+/** Provider payload normalized to a uniform shape before canonicalization. */
+export interface NormalizedEvent {
+  /** Provider event type, e.g. `message`, `issues.opened`. */
+  kind: string
+  payload: unknown
+  /** Untouched provider envelope, kept for replay/debug. */
+  raw?: unknown
+}
+
+export interface IntegrationTrigger {
+  /** Stable id, e.g. `slack.message`. */
+  name: string
+  /** Canonical source slug — matches the OS IncomingEvent `source`. */
+  source: string
+  /** Verify inbound signature. Omit only for unauthenticated sources. */
+  verify?: (input: WebhookInput) => VerifyResult
+  /** Normalize a raw provider payload into a uniform event. */
+  normalize: (raw: unknown) => NormalizedEvent
+  /** Extract a thread reference for session stitching, when available. */
+  externalThreadRef?: (raw: unknown) => ExternalThreadRef | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Integration — one descriptor per service. Every consumer layer projects
+// from this single definition.
+// ---------------------------------------------------------------------------
+
+export interface Integration {
+  /** Service slug — matches the OS ConnectionKind, e.g. `slack`. */
+  name: string
+  displayName: string
+  categories: string[]
+  /** Shared transport facts (base URL) applied to every action. */
+  http?: { baseUrl: string }
+  auth: AuthSpec
+  actions: IntegrationAction[]
+  triggers?: IntegrationTrigger[]
+  /** Pointers letting projections pick the canonical send/notify action. */
+  capabilities?: {
+    /** Action name used as the canonical outbound sender. */
+    send?: string
+    /** Action name used as the canonical notification channel. */
+    notify?: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Authoring helpers — identity casts that anchor types at definition sites.
+// ---------------------------------------------------------------------------
+
+/** Define an integration descriptor (identity; anchors the type). */
+export function defineIntegration(integration: Integration): Integration {
+  return integration
+}
+
+/** Define a single action (identity; anchors the type). */
+export function defineAction(action: IntegrationAction): IntegrationAction {
+  return action
+}
+
+/** Define a single trigger (identity; anchors the type). */
+export function defineTrigger(trigger: IntegrationTrigger): IntegrationTrigger {
+  return trigger
+}

--- a/packages/integrations/src/http.ts
+++ b/packages/integrations/src/http.ts
@@ -1,0 +1,110 @@
+import { ErrorCodes, ToolError } from '@agentskit/core'
+
+export interface HttpToolOptions {
+  baseUrl?: string
+  /** Header bag merged into every request (auth, user-agent, etc.). */
+  headers?: Record<string, string>
+  /** Per-request timeout in ms. Default 20_000. */
+  timeoutMs?: number
+  /** Swap in a fake for tests. */
+  fetch?: typeof globalThis.fetch
+}
+
+export interface HttpJsonRequest {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  path: string
+  query?: Record<string, string | number | undefined>
+  body?: unknown
+  headers?: Record<string, string>
+}
+
+/**
+ * Shared HTTP helper used by the service integrations. Handles query string
+ * encoding, JSON body + response parsing, timeouts, and turns non-2xx into
+ * throwable errors with the server payload attached.
+ *
+ * Auth lives entirely in `options.headers` — an action never sees the raw
+ * credential; the auth layer binds it before the action runs.
+ */
+export async function httpJson<TResult = unknown>(
+  options: HttpToolOptions,
+  request: HttpJsonRequest,
+): Promise<TResult> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  if (!fetchImpl) {
+    throw new ToolError({
+      code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+      message: 'no fetch available',
+      hint: 'Run on Node ≥ 18 (or pass options.fetch explicitly).',
+    })
+  }
+
+  const url = new URL(
+    request.path,
+    options.baseUrl ? new URL(options.baseUrl).toString() : 'http://invalid/',
+  )
+  if (!options.baseUrl) {
+    url.href = request.path
+  }
+  for (const [key, value] of Object.entries(request.query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, String(value))
+  }
+
+  const timeoutMs = options.timeoutMs ?? 20_000
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(url.toString(), {
+      method: request.method ?? 'GET',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        ...options.headers,
+        ...request.headers,
+      },
+      body: request.body === undefined ? undefined : JSON.stringify(request.body),
+      signal: controller.signal,
+    })
+    const text = await response.text()
+    const contentType = response.headers.get('content-type') ?? ''
+    const parsed = text.length > 0 ? safeParse(text, contentType, url.toString()) : undefined
+    if (!response.ok) {
+      throw new ToolError({
+        code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+        message: `HTTP ${response.status} ${response.statusText}: ${text.slice(0, 500)}`,
+        hint: `URL ${url.toString()}.`,
+      })
+    }
+    return parsed as TResult
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function safeParse(text: string, contentType: string, url: string): unknown {
+  try {
+    return JSON.parse(text) as unknown
+  } catch (err) {
+    if (/\bjson\b/i.test(contentType)) {
+      throw new ToolError({
+        code: ErrorCodes.AK_TOOL_EXEC_FAILED,
+        message: `Invalid JSON from ${url} (content-type: ${contentType})`,
+        hint: `Body preview: ${text.slice(0, 200)}`,
+        cause: err,
+      })
+    }
+    return text
+  }
+}
+
+/**
+ * An auth-bound HTTP client handed to every `IntegrationAction.execute`. The
+ * `baseUrl`, auth headers, and timeout are already applied — the action only
+ * supplies the per-request path/method/body.
+ */
+export type IntegrationHttp = <TResult = unknown>(request: HttpJsonRequest) => Promise<TResult>
+
+/** Bind `httpJson` to a fixed set of options, producing an `IntegrationHttp`. */
+export function bindHttp(options: HttpToolOptions): IntegrationHttp {
+  return <TResult = unknown>(request: HttpJsonRequest) => httpJson<TResult>(options, request)
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,0 +1,38 @@
+// @agentskit/integrations — unified service-integration catalog.
+//
+// One descriptor per service (Integration), projected by each consumer layer
+// into agent tools, connector senders, inbound triggers, and OAuth specs.
+// The catalog itself is dependency-light (fetch + node:crypto only).
+
+export type {
+  Integration,
+  IntegrationAction,
+  IntegrationTrigger,
+  AuthSpec,
+  OAuth2AuthSpec,
+  ApiKeyAuthSpec,
+  WebhookSecretAuthSpec,
+  NoAuthSpec,
+  SideEffect,
+  WebhookInput,
+  VerifyResult,
+  NormalizedEvent,
+  ExternalThreadRef,
+} from './contract'
+export { defineIntegration, defineAction, defineTrigger } from './contract'
+
+export type { HttpToolOptions, HttpJsonRequest, IntegrationHttp } from './http'
+export { httpJson, bindHttp } from './http'
+
+export type { IntegrationRegistry } from './registry'
+export {
+  createRegistry,
+  registerIntegration,
+  getIntegration,
+  listIntegrations,
+  integrationsByCategory,
+} from './registry'
+
+// Side-effect import: registers every catalog service into the default
+// registry. Empty until services land in the move/add phases.
+import './services'

--- a/packages/integrations/src/registry.ts
+++ b/packages/integrations/src/registry.ts
@@ -1,0 +1,65 @@
+import { ConfigError, ErrorCodes } from '@agentskit/core'
+import type { Integration } from './contract'
+
+/**
+ * In-memory catalog of integration descriptors. A service registers once at
+ * module load; every consumer layer (agent tools, connectors, triggers, auth,
+ * marketplace) reads from the same registry.
+ */
+export interface IntegrationRegistry {
+  /** Register a descriptor. Throws on duplicate `name`. */
+  register(integration: Integration): void
+  get(name: string): Integration | undefined
+  has(name: string): boolean
+  list(): Integration[]
+  /** Descriptors in a given category, e.g. `comms`. */
+  byCategory(category: string): Integration[]
+}
+
+export function createRegistry(initial: Integration[] = []): IntegrationRegistry {
+  const map = new Map<string, Integration>()
+
+  const register = (integration: Integration): void => {
+    if (map.has(integration.name)) {
+      throw new ConfigError({
+        code: ErrorCodes.AK_CONFIG_INVALID,
+        message: `integration "${integration.name}" is already registered`,
+        hint: 'Each integration name must be unique in a registry.',
+      })
+    }
+    map.set(integration.name, integration)
+  }
+
+  for (const integration of initial) register(integration)
+
+  return {
+    register,
+    get: (name) => map.get(name),
+    has: (name) => map.has(name),
+    list: () => [...map.values()],
+    byCategory: (category) =>
+      [...map.values()].filter((i) => i.categories.includes(category)),
+  }
+}
+
+/**
+ * Default catalog. Service modules call `registerIntegration(...)` at load;
+ * consumers call `listIntegrations()` / `getIntegration(name)`.
+ */
+const defaultRegistry = createRegistry()
+
+export function registerIntegration(integration: Integration): void {
+  defaultRegistry.register(integration)
+}
+
+export function getIntegration(name: string): Integration | undefined {
+  return defaultRegistry.get(name)
+}
+
+export function listIntegrations(): Integration[] {
+  return defaultRegistry.list()
+}
+
+export function integrationsByCategory(category: string): Integration[] {
+  return defaultRegistry.byCategory(category)
+}

--- a/packages/integrations/src/services/_template/actions.ts
+++ b/packages/integrations/src/services/_template/actions.ts
@@ -1,0 +1,22 @@
+import { defineAction } from '../../contract'
+
+// One factory per API call. `http` is already auth-bound — never read the
+// credential here. Absorb provider quirks (form bodies, `ok:false`, etc.)
+// inside execute so every consumer layer inherits the fix.
+export const templatePing = defineAction({
+  name: 'template_ping',
+  description: 'Example action — replace with a real API call.',
+  schema: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'Text to echo.' },
+    },
+    required: ['message'],
+  },
+  sideEffect: 'read',
+  async execute(args, http) {
+    return http({ method: 'POST', path: '/ping', body: { message: args.message } })
+  },
+})
+
+export const templateActions = [templatePing]

--- a/packages/integrations/src/services/_template/auth.ts
+++ b/packages/integrations/src/services/_template/auth.ts
@@ -1,0 +1,11 @@
+import type { AuthSpec } from '../../contract'
+
+// Replace with the real auth shape. Common options:
+//   { kind: 'apiKey', header: 'authorization', prefix: 'Bearer ', envHint: 'TEMPLATE_API_KEY' }
+//   { kind: 'oauth2', authorizationUrl, tokenUrl, defaultScopes, usePkce }
+export const templateAuth: AuthSpec = {
+  kind: 'apiKey',
+  header: 'authorization',
+  prefix: 'Bearer ',
+  envHint: 'TEMPLATE_API_KEY',
+}

--- a/packages/integrations/src/services/_template/index.ts
+++ b/packages/integrations/src/services/_template/index.ts
@@ -1,0 +1,26 @@
+import { defineIntegration } from '../../contract'
+import { registerIntegration } from '../../registry'
+import { templateAuth } from './auth'
+import { templateActions } from './actions'
+import { templateTriggers } from './triggers'
+
+/**
+ * Service descriptor scaffold. Copy this directory to `services/<name>` (or run
+ * `pnpm gen:integration <name>`), then replace every `template` token.
+ *
+ * `name` MUST match the service slug used as the OS ConnectionKind.
+ */
+export const template = defineIntegration({
+  name: 'template',
+  displayName: 'Template',
+  categories: ['example'],
+  http: { baseUrl: 'https://api.example.com' },
+  auth: templateAuth,
+  actions: templateActions,
+  triggers: templateTriggers,
+  capabilities: {},
+})
+
+// Real services register on load so the catalog picks them up. The scaffold is
+// never imported by the catalog index, so this line does not run.
+registerIntegration(template)

--- a/packages/integrations/src/services/_template/triggers.ts
+++ b/packages/integrations/src/services/_template/triggers.ts
@@ -1,0 +1,12 @@
+import { defineTrigger } from '../../contract'
+
+// One trigger per inbound event source. `verify` checks the webhook signature;
+// `normalize` maps the raw provider payload to a uniform event. Delete this
+// file (and the `triggers` field) for services with no inbound events.
+export const templateEvent = defineTrigger({
+  name: 'template.event',
+  source: 'template',
+  normalize: (raw) => ({ kind: 'event', payload: raw, raw }),
+})
+
+export const templateTriggers = [templateEvent]

--- a/packages/integrations/src/services/index.ts
+++ b/packages/integrations/src/services/index.ts
@@ -1,0 +1,4 @@
+// Service barrel — side-effect imports that register each descriptor into the
+// default catalog. `pnpm gen:integration <name>` appends a line here.
+// (Empty until the first service lands in the move/add phases.)
+export {}

--- a/packages/integrations/src/testing/index.ts
+++ b/packages/integrations/src/testing/index.ts
@@ -1,0 +1,8 @@
+// @agentskit/integrations/testing — contract validators for service descriptors.
+export type { ValidationProblem } from './validate'
+export {
+  validateIntegration,
+  validateAction,
+  validateTrigger,
+  assertValidIntegration,
+} from './validate'

--- a/packages/integrations/src/testing/validate.ts
+++ b/packages/integrations/src/testing/validate.ts
@@ -1,0 +1,108 @@
+import { ConfigError, ErrorCodes } from '@agentskit/core'
+import type { JSONSchema7 } from 'json-schema'
+import type { Integration, IntegrationAction, IntegrationTrigger } from '../contract'
+
+/**
+ * Pure contract validators — no test-runner dependency. Wire these into a
+ * vitest (or any) suite per service. They enforce the shape rules every
+ * descriptor must satisfy before it can be projected by a consumer layer.
+ */
+
+export interface ValidationProblem {
+  /** Dotted path to the offending field, e.g. `actions[0].schema`. */
+  path: string
+  message: string
+}
+
+const SLUG_RE = /^[a-z][a-z0-9-]*$/
+const ACTION_NAME_RE = /^[a-z][a-z0-9_]*$/
+
+function isObjectSchema(schema: JSONSchema7 | undefined): boolean {
+  return !!schema && schema.type === 'object'
+}
+
+export function validateAction(action: IntegrationAction, path: string): ValidationProblem[] {
+  const problems: ValidationProblem[] = []
+  if (!ACTION_NAME_RE.test(action.name)) {
+    problems.push({ path: `${path}.name`, message: `invalid action name "${action.name}" (expected snake_case)` })
+  }
+  if (!action.description?.trim()) {
+    problems.push({ path: `${path}.description`, message: 'description is required' })
+  }
+  if (!isObjectSchema(action.schema)) {
+    problems.push({ path: `${path}.schema`, message: 'schema must be a JSON Schema object (type: "object")' })
+  }
+  if (typeof action.execute !== 'function') {
+    problems.push({ path: `${path}.execute`, message: 'execute must be a function' })
+  }
+  return problems
+}
+
+export function validateTrigger(trigger: IntegrationTrigger, path: string): ValidationProblem[] {
+  const problems: ValidationProblem[] = []
+  if (!trigger.name?.trim()) {
+    problems.push({ path: `${path}.name`, message: 'name is required' })
+  }
+  if (!SLUG_RE.test(trigger.source)) {
+    problems.push({ path: `${path}.source`, message: `invalid source slug "${trigger.source}"` })
+  }
+  if (typeof trigger.normalize !== 'function') {
+    problems.push({ path: `${path}.normalize`, message: 'normalize must be a function' })
+  }
+  return problems
+}
+
+/** Validate a full descriptor. Returns an empty array when the shape is sound. */
+export function validateIntegration(integration: Integration): ValidationProblem[] {
+  const problems: ValidationProblem[] = []
+
+  if (!SLUG_RE.test(integration.name)) {
+    problems.push({ path: 'name', message: `invalid integration slug "${integration.name}" (expected kebab-case)` })
+  }
+  if (!integration.displayName?.trim()) {
+    problems.push({ path: 'displayName', message: 'displayName is required' })
+  }
+  if (!integration.categories?.length) {
+    problems.push({ path: 'categories', message: 'at least one category is required' })
+  }
+  if (!integration.actions?.length && !integration.triggers?.length) {
+    problems.push({ path: 'actions', message: 'an integration must declare at least one action or trigger' })
+  }
+
+  const actionNames = new Set<string>()
+  integration.actions?.forEach((action, i) => {
+    problems.push(...validateAction(action, `actions[${i}]`))
+    if (actionNames.has(action.name)) {
+      problems.push({ path: `actions[${i}].name`, message: `duplicate action name "${action.name}"` })
+    }
+    actionNames.add(action.name)
+  })
+
+  integration.triggers?.forEach((trigger, i) => {
+    problems.push(...validateTrigger(trigger, `triggers[${i}]`))
+  })
+
+  // capabilities pointers must reference declared actions
+  const { send, notify } = integration.capabilities ?? {}
+  if (send && !actionNames.has(send)) {
+    problems.push({ path: 'capabilities.send', message: `points to unknown action "${send}"` })
+  }
+  if (notify && !actionNames.has(notify)) {
+    problems.push({ path: 'capabilities.notify', message: `points to unknown action "${notify}"` })
+  }
+
+  return problems
+}
+
+/** Throw if the descriptor is invalid — convenient inside a single `it(...)`. */
+export function assertValidIntegration(integration: Integration): void {
+  const problems = validateIntegration(integration)
+  if (problems.length > 0) {
+    const lines = problems.map((p) => `  - ${p.path}: ${p.message}`).join('\n')
+    throw new ConfigError({
+      code: ErrorCodes.AK_CONFIG_INVALID,
+      message: `integration "${integration.name}" failed contract validation:\n${lines}`,
+      hint: 'Fix the listed fields in the integration descriptor.',
+    })
+  }
+}

--- a/packages/integrations/tests/default-registry.test.ts
+++ b/packages/integrations/tests/default-registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import {
+  registerIntegration,
+  getIntegration,
+  listIntegrations,
+  integrationsByCategory,
+} from '../src/registry'
+import { defineIntegration, defineAction } from '../src/contract'
+
+const fixture = defineIntegration({
+  name: 'fixture-svc',
+  displayName: 'Fixture',
+  categories: ['example'],
+  auth: { kind: 'none' },
+  actions: [
+    defineAction({
+      name: 'fixture_noop',
+      description: 'noop',
+      schema: { type: 'object', properties: {}, required: [] },
+      async execute() {
+        return null
+      },
+    }),
+  ],
+})
+
+describe('default registry', () => {
+  it('registers into and reads from the shared catalog', () => {
+    registerIntegration(fixture)
+    expect(getIntegration('fixture-svc')?.displayName).toBe('Fixture')
+    expect(listIntegrations().some((i) => i.name === 'fixture-svc')).toBe(true)
+    expect(integrationsByCategory('example').some((i) => i.name === 'fixture-svc')).toBe(true)
+  })
+})

--- a/packages/integrations/tests/http.test.ts
+++ b/packages/integrations/tests/http.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { httpJson, bindHttp } from '../src/http'
+
+function fakeFetch(handler: (url: string, init: RequestInit) => Response): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) =>
+    handler(String(input), init ?? {})) as typeof globalThis.fetch
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('httpJson', () => {
+  it('GETs against baseUrl and parses JSON', async () => {
+    let seenUrl = ''
+    let seenMethod = ''
+    const fetch = fakeFetch((url, init) => {
+      seenUrl = url
+      seenMethod = String(init.method)
+      return jsonResponse({ ok: true, value: 42 })
+    })
+    const result = await httpJson<{ value: number }>(
+      { baseUrl: 'https://api.example.com', headers: { authorization: 'Bearer x' }, fetch },
+      { path: '/things', query: { limit: 10, skip: undefined } },
+    )
+    expect(result.value).toBe(42)
+    expect(seenUrl).toBe('https://api.example.com/things?limit=10')
+    expect(seenMethod).toBe('GET')
+  })
+
+  it('serializes a JSON body on POST', async () => {
+    let seenBody = ''
+    const fetch = fakeFetch((_url, init) => {
+      seenBody = String(init.body)
+      return jsonResponse({ created: true })
+    })
+    await httpJson({ baseUrl: 'https://api.example.com', fetch }, {
+      method: 'POST',
+      path: '/things',
+      body: { name: 'x' },
+    })
+    expect(JSON.parse(seenBody)).toEqual({ name: 'x' })
+  })
+
+  it('uses an absolute path when no baseUrl is set', async () => {
+    let seenUrl = ''
+    const fetch = fakeFetch((url) => {
+      seenUrl = url
+      return jsonResponse({ ok: true })
+    })
+    await httpJson({ fetch }, { path: 'https://other.example.com/x' })
+    expect(seenUrl).toBe('https://other.example.com/x')
+  })
+
+  it('returns raw text for non-JSON content-type', async () => {
+    const fetch = fakeFetch(() => new Response('plain', { status: 200, headers: { 'content-type': 'text/plain' } }))
+    const result = await httpJson({ baseUrl: 'https://api.example.com', fetch }, { path: '/x' })
+    expect(result).toBe('plain')
+  })
+
+  it('throws on non-2xx with the server body attached', async () => {
+    const fetch = fakeFetch(() => new Response('nope', { status: 404, statusText: 'Not Found' }))
+    await expect(
+      httpJson({ baseUrl: 'https://api.example.com', fetch }, { path: '/missing' }),
+    ).rejects.toThrow(/HTTP 404/)
+  })
+
+  it('throws when a JSON content-type body is unparseable', async () => {
+    const fetch = fakeFetch(() => new Response('{bad', { status: 200, headers: { 'content-type': 'application/json' } }))
+    await expect(
+      httpJson({ baseUrl: 'https://api.example.com', fetch }, { path: '/x' }),
+    ).rejects.toThrow(/Invalid JSON/)
+  })
+
+})
+
+describe('bindHttp', () => {
+  it('binds options into a reusable client', async () => {
+    const fetch = fakeFetch(() => jsonResponse({ pong: true }))
+    const http = bindHttp({ baseUrl: 'https://api.example.com', fetch })
+    const result = await http<{ pong: boolean }>({ path: '/ping' })
+    expect(result.pong).toBe(true)
+  })
+})

--- a/packages/integrations/tests/registry.test.ts
+++ b/packages/integrations/tests/registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { createRegistry } from '../src/registry'
+import { defineIntegration, defineAction } from '../src/contract'
+
+const ping = defineAction({
+  name: 'demo_ping',
+  description: 'ping',
+  schema: { type: 'object', properties: {}, required: [] },
+  async execute() {
+    return 'pong'
+  },
+})
+
+function demo(name: string, categories = ['example']) {
+  return defineIntegration({
+    name,
+    displayName: name,
+    categories,
+    auth: { kind: 'none' },
+    actions: [ping],
+  })
+}
+
+describe('createRegistry', () => {
+  it('registers, gets, and lists descriptors', () => {
+    const reg = createRegistry([demo('slack', ['comms'])])
+    reg.register(demo('github', ['dev']))
+    expect(reg.has('slack')).toBe(true)
+    expect(reg.get('github')?.displayName).toBe('github')
+    expect(reg.list().map((i) => i.name).sort()).toEqual(['github', 'slack'])
+  })
+
+  it('throws on duplicate registration', () => {
+    const reg = createRegistry([demo('slack')])
+    expect(() => reg.register(demo('slack'))).toThrow(/already registered/)
+  })
+
+  it('filters by category', () => {
+    const reg = createRegistry([demo('slack', ['comms']), demo('github', ['dev'])])
+    expect(reg.byCategory('comms').map((i) => i.name)).toEqual(['slack'])
+  })
+
+  it('returns undefined for unknown names', () => {
+    const reg = createRegistry()
+    expect(reg.get('nope')).toBeUndefined()
+    expect(reg.has('nope')).toBe(false)
+  })
+})

--- a/packages/integrations/tests/validate.test.ts
+++ b/packages/integrations/tests/validate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateIntegration,
+  assertValidIntegration,
+} from '../src/testing/validate'
+import { defineIntegration, defineAction, defineTrigger } from '../src/contract'
+
+const goodAction = defineAction({
+  name: 'svc_do',
+  description: 'do a thing',
+  schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+  sideEffect: 'write',
+  async execute() {
+    return 'ok'
+  },
+})
+
+const goodTrigger = defineTrigger({
+  name: 'svc.event',
+  source: 'svc',
+  verify: () => ({ ok: true }),
+  normalize: (raw) => ({ kind: 'event', payload: raw, raw }),
+  externalThreadRef: () => ({ kind: 'svc.thread', id: '1' }),
+})
+
+const good = defineIntegration({
+  name: 'svc',
+  displayName: 'Service',
+  categories: ['example'],
+  auth: { kind: 'apiKey', header: 'authorization' },
+  actions: [goodAction],
+  triggers: [goodTrigger],
+  capabilities: { send: 'svc_do' },
+})
+
+describe('validateIntegration', () => {
+  it('passes a well-formed descriptor', () => {
+    expect(validateIntegration(good)).toEqual([])
+    expect(() => assertValidIntegration(good)).not.toThrow()
+  })
+
+  it('flags an invalid slug, missing displayName, and empty categories', () => {
+    const bad = { ...good, name: 'Bad Name', displayName: '', categories: [] }
+    const paths = validateIntegration(bad).map((p) => p.path)
+    expect(paths).toContain('name')
+    expect(paths).toContain('displayName')
+    expect(paths).toContain('categories')
+  })
+
+  it('flags a descriptor with no actions and no triggers', () => {
+    const bad = defineIntegration({
+      name: 'empty',
+      displayName: 'Empty',
+      categories: ['example'],
+      auth: { kind: 'none' },
+      actions: [],
+    })
+    expect(validateIntegration(bad).some((p) => p.path === 'actions')).toBe(true)
+  })
+
+  it('flags bad action shape and duplicate action names', () => {
+    const dup = defineAction({
+      name: 'svc_do',
+      description: '',
+      schema: { type: 'array' } as never,
+      execute: undefined as never,
+    })
+    const bad = { ...good, actions: [goodAction, dup] }
+    const paths = validateIntegration(bad).map((p) => p.path)
+    expect(paths).toContain('actions[1].description')
+    expect(paths).toContain('actions[1].schema')
+    expect(paths).toContain('actions[1].execute')
+    expect(paths).toContain('actions[1].name')
+  })
+
+  it('flags a bad trigger and dangling capability pointers', () => {
+    const badTrigger = defineTrigger({
+      name: '',
+      source: 'Bad Source',
+      normalize: undefined as never,
+    })
+    const bad = { ...good, triggers: [badTrigger], capabilities: { send: 'nope', notify: 'nope2' } }
+    const paths = validateIntegration(bad).map((p) => p.path)
+    expect(paths).toContain('triggers[0].name')
+    expect(paths).toContain('triggers[0].source')
+    expect(paths).toContain('triggers[0].normalize')
+    expect(paths).toContain('capabilities.send')
+    expect(paths).toContain('capabilities.notify')
+  })
+
+  it('assertValidIntegration throws with a readable summary', () => {
+    const bad = { ...good, name: 'Nope' }
+    expect(() => assertValidIntegration(bad)).toThrow(/failed contract validation/)
+  })
+})

--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}

--- a/packages/integrations/tsup.config.ts
+++ b/packages/integrations/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    testing: 'src/testing/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/integrations/vitest.config.ts
+++ b/packages/integrations/vitest.config.ts
@@ -1,0 +1,15 @@
+import { createTestConfig } from '../../vitest.shared'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+// @agentskit/integrations — lines threshold: 80.
+// The scaffold under services/_template is excluded: it is a generator source,
+// never imported by the catalog, and gains real coverage once instantiated.
+export default defineConfig(
+  mergeConfig(createTestConfig({ linesThreshold: 80 }), {
+    test: {
+      coverage: {
+        exclude: ['src/services/_template/**'],
+      },
+    },
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,28 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/integrations:
+    dependencies:
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/memory:
     dependencies:
       '@agentskit/core':

--- a/scripts/gen-integration.mjs
+++ b/scripts/gen-integration.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Scaffold a new service integration from the _template directory.
+//   pnpm gen:integration <name>
+// <name> must be a kebab-case slug matching the OS ConnectionKind, e.g. `cal-com`.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PKG = path.resolve(__dirname, '../packages/integrations')
+const TEMPLATE = path.join(PKG, 'src/services/_template')
+const SERVICES = path.join(PKG, 'src/services')
+
+function toCamel(slug) {
+  return slug.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase())
+}
+function toPascal(slug) {
+  const camel = toCamel(slug)
+  return camel.charAt(0).toUpperCase() + camel.slice(1)
+}
+
+async function main() {
+  const name = process.argv[2]
+  if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
+    console.error('usage: pnpm gen:integration <kebab-case-name>')
+    process.exit(1)
+  }
+
+  const dest = path.join(SERVICES, name)
+  if (await fs.stat(dest).then(() => true).catch(() => false)) {
+    console.error(`service "${name}" already exists at ${dest}`)
+    process.exit(1)
+  }
+
+  const camel = toCamel(name) // value tokens: templateAuth -> <camel>Auth
+  const pascal = toPascal(name) // displayName
+  const replace = (s) =>
+    s
+      .replaceAll('template', camel)
+      .replaceAll('Template', pascal)
+      .replaceAll('TEMPLATE', name.toUpperCase().replaceAll('-', '_'))
+
+  await fs.mkdir(dest, { recursive: true })
+  for (const file of await fs.readdir(TEMPLATE)) {
+    const body = await fs.readFile(path.join(TEMPLATE, file), 'utf8')
+    await fs.writeFile(path.join(dest, file), replace(body))
+  }
+
+  // Set the descriptor `name` to the real slug (replace defaults to camelCase).
+  const indexPath = path.join(dest, 'index.ts')
+  let index = await fs.readFile(indexPath, 'utf8')
+  index = index.replace(/name: '[^']*',/, `name: '${name}',`)
+  await fs.writeFile(indexPath, index)
+
+  // Append the side-effect import to the service barrel.
+  const barrelPath = path.join(SERVICES, 'index.ts')
+  const barrel = await fs.readFile(barrelPath, 'utf8')
+  const importLine = `import './${name}'\n`
+  if (!barrel.includes(importLine)) {
+    await fs.writeFile(barrelPath, barrel.replace(/export \{\}\n?/, '') + importLine)
+  }
+
+  console.log(`✓ created packages/integrations/src/services/${name}`)
+  console.log('  next: fill in actions.ts / triggers.ts / auth.ts, then add a contract test.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## What

P1 of the integrations unification effort: a new **`@agentskit/integrations`** package — the foundation for a unified, single-descriptor service-integration catalog. Purely additive; no existing package behavior changes.

Today a single service (e.g. Slack) is redefined in 4–6 places with 3–4 separate HTTP clients across `@agentskit/tools` and the OS runtime. This package introduces **one descriptor per service** that every consumer layer (agent tools, connector senders, inbound triggers, OAuth specs, marketplace listings) will *project* from — eliminating the duplication.

This PR ships the **contract + registry only**. The concrete catalog (moving the 40 existing integrations, adding ~30 more) lands in later phases.

## Contents

- **contract** — `Integration` descriptor (`auth`, `actions[]`, `triggers[]`, `capabilities`) + `defineIntegration` / `defineAction` / `defineTrigger`. Actions use canonical JSON Schema and receive an auth-bound `IntegrationHttp` client (never see raw credentials).
- **http** — shared `httpJson` / `bindHttp` (zero deps beyond core; `fetch` + `node:crypto`).
- **registry** — `createRegistry` + default-catalog accessors (`registerIntegration` / `getIntegration` / `listIntegrations` / `integrationsByCategory`).
- **`/testing`** — pure contract validators (`validateIntegration`, `assertValidIntegration`) to gate every descriptor in CI.
- **`pnpm gen:integration <name>`** — scaffolds a service from `services/_template`.
- **for-agents** reference page + changeset.

## Design docs

Under `docs/studies/`: split rationale (AKOS-first), deep unification analysis (real-code read of both repos), and the full file-by-file refactor plan (P1–P12) across `lib` + `agentskit-os`.

## Verification

- ✅ lint (tsc) clean
- ✅ build ESM/CJS/DTS
- ✅ coverage **97.84% lines** (gate: 80%), 18 tests
- ✅ all 9 quality gates pass

## Next

**P2** — move the 40 existing `@agentskit/tools` integrations into `services/*` with deprecated re-export shims (tools = major, integrations = minor).