### PR TITLE
feat(cli): agentskit add <agent> — registry command

### DIFF
--- a/.changeset/cli-add-registry.md
+++ b/.changeset/cli-add-registry.md
@@ -1,0 +1,9 @@
+---
+"@agentskit/cli": minor
+---
+
+Add `agentskit add <agent>` — pull a ready-made agent from the AgentsKit registry
+(registry.agentskit.io) and copy its source into your project, shadcn-style. You
+own the copied code; no new framework dependency. Resolves from the hosted index
+first, falling back to the registry repo's raw GitHub source so it works before
+hosting is live. e.g. `npx agentskit add research`.

--- a/.changeset/cli-add-registry.md
+++ b/.changeset/cli-add-registry.md
@@ -4,6 +4,11 @@
 
 Add `agentskit add <agent>` — pull a ready-made agent from the AgentsKit registry
 (registry.agentskit.io) and copy its source into your project, shadcn-style. You
-own the copied code; no new framework dependency. Resolves from the hosted index
-first, falling back to the registry repo's raw GitHub source so it works before
-hosting is live. e.g. `npx agentskit add research`.
+own the copied code. Resolves from the hosted index first, falling back to the
+registry repo's raw GitHub source so it works before hosting is live.
+
+Supports `--run "<task>"` to execute the agent immediately after adding it (e.g.
+`npx agentskit add legal-contract-reviewer --run "review this NDA…" --provider ollama`).
+The agent runs as data (its systemPrompt), never by executing the copied code —
+no remote/local code execution. `--provider`/`--model`/`--api-key` select the
+model; tool-composing agents (research/pr-review) print a use-as-library message.

--- a/.changeset/cli-add-registry.md
+++ b/.changeset/cli-add-registry.md
@@ -2,13 +2,13 @@
 "@agentskit/cli": minor
 ---
 
-Add `agentskit add <agent>` — pull a ready-made agent from the AgentsKit registry
-(registry.agentskit.io) and copy its source into your project, shadcn-style. You
-own the copied code. Resolves from the hosted index first, falling back to the
-registry repo's raw GitHub source so it works before hosting is live.
+Registry commands for ready-made agents (registry.agentskit.io):
 
-Supports `--run "<task>"` to execute the agent immediately after adding it (e.g.
-`npx agentskit add legal-contract-reviewer --run "review this NDA…" --provider ollama`).
-The agent runs as data (its systemPrompt), never by executing the copied code —
-no remote/local code execution. `--provider`/`--model`/`--api-key` select the
-model; tool-composing agents (research/pr-review) print a use-as-library message.
+- `agentskit add <agent>` — copy an agent's source into your project (shadcn-style;
+  you own the code). Hosted index with raw-GitHub fallback. `--run "<task>"` runs it
+  immediately (as data, never executing copied code); `--provider`/`--model`/`--api-key`.
+- `agentskit diff <agent>` — show how your local copy differs from the current
+  registry source (line-level diff).
+- `agentskit update <agent>` — update your local copy to the registry source.
+
+Lets users adopt an agent, own/edit it, and still pull upstream fixes.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,40 +1,71 @@
 import type { Command } from 'commander'
-import { addAgent } from '../registry'
+import { addAgent, resolveSystemPrompt } from '../registry'
+import { runAgent } from '../run'
 
 export function registerAddCommand(program: Command): void {
   program
     .command('add <agent>')
     .description(
-      'Add a ready-made agent from the AgentsKit registry (registry.agentskit.io). Copies the agent source into your project — you own the code. e.g. `agentskit add research`.',
+      'Add a ready-made agent from the AgentsKit registry (registry.agentskit.io). Copies the agent source into your project — you own the code. With --run, also executes it. e.g. `agentskit add research` or `agentskit add legal-contract-reviewer --run "review this NDA…" --provider ollama`.',
     )
     .option('--out <dir>', 'Directory to write the agent into (default: ./agents)')
     .option('-f, --force', 'Overwrite existing files')
-    .action(async (agent: string, options: { out?: string; force?: boolean }) => {
-      try {
-        const result = await addAgent(agent, { outDir: options.out, force: options.force === true })
-        process.stdout.write(`\nAdded "${result.agent.title}" → ${result.targetDir}/\n`)
-        for (const f of result.written) process.stdout.write(`  wrote  ${f}\n`)
+    .option('--run <task>', 'Run the agent on this task right after adding it')
+    .option('--provider <provider>', 'Provider for --run (openai, anthropic, gemini, ollama, demo)', 'demo')
+    .option('--model <model>', 'Model for --run')
+    .option('--api-key <key>', 'API key for --run (else read from the provider env var)')
+    .action(
+      async (
+        agent: string,
+        options: {
+          out?: string
+          force?: boolean
+          run?: string
+          provider: string
+          model?: string
+          apiKey?: string
+        },
+      ) => {
+        try {
+          const result = await addAgent(agent, { outDir: options.out, force: options.force === true })
+          process.stdout.write(`\nAdded "${result.agent.title}" → ${result.targetDir}/\n`)
+          for (const f of result.written) process.stdout.write(`  wrote  ${f}\n`)
 
-        if (result.agent.packages.length > 0) {
-          process.stdout.write(`\nInstall the packages it uses:\n`)
-          process.stdout.write(`  npm install ${result.agent.packages.join(' ')} @agentskit/adapters\n`)
+          if (result.agent.packages.length > 0) {
+            process.stdout.write(`\nInstall the packages it uses:\n`)
+            process.stdout.write(`  npm install ${result.agent.packages.join(' ')} @agentskit/adapters\n`)
+          }
+          const required = (result.agent.env ?? []).filter((e) => e.required)
+          if (required.length > 0) {
+            process.stdout.write(`\nRequired environment:\n`)
+            for (const e of required) process.stdout.write(`  ${e.name} — ${e.description}\n`)
+          }
+          const readme = result.written.find((f) => f.toLowerCase().endsWith('readme.md'))
+          process.stdout.write(readme ? `\nSee ${readme} for usage.\n` : '\n')
+
+          if (options.run) {
+            const systemPrompt = resolveSystemPrompt(result.agent)
+            if (!systemPrompt) {
+              process.stderr.write(
+                `\n--run is not supported for "${agent}" (it composes tools/keys). Use it as a library — see the README.\n`,
+              )
+              process.exit(1)
+            }
+            process.stdout.write(`\nRunning "${result.agent.title}" via ${options.provider}…\n\n`)
+            await runAgent(options.run, {
+              provider: options.provider,
+              model: options.model,
+              apiKey: options.apiKey,
+              systemPrompt,
+              maxSteps: '8',
+            })
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          process.stderr.write(`\nadd failed: ${message}\n`)
+          process.stderr.write(`(browse agents at https://registry.agentskit.io)\n`)
+          process.exit(1)
         }
-        const required = (result.agent.env ?? []).filter((e) => e.required)
-        if (required.length > 0) {
-          process.stdout.write(`\nRequired environment:\n`)
-          for (const e of required) process.stdout.write(`  ${e.name} — ${e.description}\n`)
-        }
-        const readme = result.written.find((f) => f.toLowerCase().endsWith('readme.md'))
-        process.stdout.write(
-          readme
-            ? `\nSee ${readme} for usage.\n`
-            : `\nUsage: https://registry.agentskit.io/agents/${result.agent.id}\n`,
-        )
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        process.stderr.write(`\nadd failed: ${message}\n`)
-        process.stderr.write(`(browse agents at https://registry.agentskit.io)\n`)
-        process.exit(1)
-      }
-    })
+      },
+    )
 }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,40 @@
+import type { Command } from 'commander'
+import { addAgent } from '../registry'
+
+export function registerAddCommand(program: Command): void {
+  program
+    .command('add <agent>')
+    .description(
+      'Add a ready-made agent from the AgentsKit registry (registry.agentskit.io). Copies the agent source into your project — you own the code. e.g. `agentskit add research`.',
+    )
+    .option('--out <dir>', 'Directory to write the agent into (default: ./agents)')
+    .option('-f, --force', 'Overwrite existing files')
+    .action(async (agent: string, options: { out?: string; force?: boolean }) => {
+      try {
+        const result = await addAgent(agent, { outDir: options.out, force: options.force === true })
+        process.stdout.write(`\nAdded "${result.agent.title}" → ${result.targetDir}/\n`)
+        for (const f of result.written) process.stdout.write(`  wrote  ${f}\n`)
+
+        if (result.agent.packages.length > 0) {
+          process.stdout.write(`\nInstall the packages it uses:\n`)
+          process.stdout.write(`  npm install ${result.agent.packages.join(' ')} @agentskit/adapters\n`)
+        }
+        const required = (result.agent.env ?? []).filter((e) => e.required)
+        if (required.length > 0) {
+          process.stdout.write(`\nRequired environment:\n`)
+          for (const e of required) process.stdout.write(`  ${e.name} — ${e.description}\n`)
+        }
+        const readme = result.written.find((f) => f.toLowerCase().endsWith('readme.md'))
+        process.stdout.write(
+          readme
+            ? `\nSee ${readme} for usage.\n`
+            : `\nUsage: https://registry.agentskit.io/agents/${result.agent.id}\n`,
+        )
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        process.stderr.write(`\nadd failed: ${message}\n`)
+        process.stderr.write(`(browse agents at https://registry.agentskit.io)\n`)
+        process.exit(1)
+      }
+    })
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -11,6 +11,7 @@ import { registerAiCommand } from './ai'
 import { registerFlowCommand } from './flow'
 import { registerPiiCommand } from './pii'
 import { registerRulesCommand } from './rules'
+import { registerAddCommand } from './add'
 
 export function createCli(): Command {
   const program = new Command()
@@ -30,6 +31,7 @@ export function createCli(): Command {
   registerFlowCommand(program)
   registerPiiCommand(program)
   registerRulesCommand(program)
+  registerAddCommand(program)
 
   return program
 }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -12,6 +12,7 @@ import { registerFlowCommand } from './flow'
 import { registerPiiCommand } from './pii'
 import { registerRulesCommand } from './rules'
 import { registerAddCommand } from './add'
+import { registerDiffCommand, registerUpdateCommand } from './registry-maintenance'
 
 export function createCli(): Command {
   const program = new Command()
@@ -32,6 +33,8 @@ export function createCli(): Command {
   registerPiiCommand(program)
   registerRulesCommand(program)
   registerAddCommand(program)
+  registerDiffCommand(program)
+  registerUpdateCommand(program)
 
   return program
 }

--- a/packages/cli/src/commands/registry-maintenance.ts
+++ b/packages/cli/src/commands/registry-maintenance.ts
@@ -1,0 +1,68 @@
+import type { Command } from 'commander'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { diffAgent } from '../registry'
+
+export function registerDiffCommand(program: Command): void {
+  program
+    .command('diff <agent>')
+    .description('Show how your local copy of a registry agent differs from the current registry source.')
+    .option('--out <dir>', 'Directory the agent was added into (default: ./agents)')
+    .action(async (agent: string, options: { out?: string }) => {
+      try {
+        const { targetDir, files } = await diffAgent(agent, { outDir: options.out })
+        let changed = 0
+        for (const f of files) {
+          if (f.status === 'unchanged') continue
+          changed++
+          process.stdout.write(`\n${f.status === 'missing-local' ? 'missing' : 'modified'}: ${join(targetDir, f.path)}\n`)
+          if (f.diff) {
+            for (const line of f.diff) {
+              if (line.type === ' ') continue
+              process.stdout.write(`  ${line.type} ${line.text}\n`)
+            }
+          }
+        }
+        process.stdout.write(
+          changed === 0
+            ? `\n${agent}: up to date with the registry.\n`
+            : `\n${changed} file(s) differ. Run \`agentskit update ${agent}\` to apply the registry version.\n`,
+        )
+      } catch (err) {
+        process.stderr.write(`\ndiff failed: ${err instanceof Error ? err.message : String(err)}\n`)
+        process.exit(1)
+      }
+    })
+}
+
+export function registerUpdateCommand(program: Command): void {
+  program
+    .command('update <agent>')
+    .description('Update your local copy of a registry agent to the current registry source.')
+    .option('--out <dir>', 'Directory the agent was added into (default: ./agents)')
+    .option('-f, --force', 'Apply without listing the changes first')
+    .action(async (agent: string, options: { out?: string; force?: boolean }) => {
+      try {
+        const { targetDir, files } = await diffAgent(agent, { outDir: options.out })
+        const changed = files.filter((f) => f.status !== 'unchanged')
+        if (changed.length === 0) {
+          process.stdout.write(`\n${agent}: already up to date.\n`)
+          return
+        }
+        if (!options.force) {
+          process.stdout.write(`\nWill overwrite ${changed.length} file(s) with the registry version:\n`)
+          for (const f of changed) process.stdout.write(`  ${f.path} (${f.status})\n`)
+        }
+        for (const f of changed) {
+          const dest = join(targetDir, f.path)
+          await mkdir(dirname(dest), { recursive: true })
+          await writeFile(dest, f.upstream, 'utf8')
+          process.stdout.write(`  updated ${dest}\n`)
+        }
+        process.stdout.write(`\nUpdated ${agent}. Review the changes with your VCS before committing.\n`)
+      } catch (err) {
+        process.stderr.write(`\nupdate failed: ${err instanceof Error ? err.message : String(err)}\n`)
+        process.exit(1)
+      }
+    })
+}

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -145,3 +145,85 @@ export async function addAgent(id: string, options: AddOptions = {}): Promise<Ad
   }
   return { agent, written, targetDir }
 }
+
+// ---------------------------------------------------------------------------
+// diff / update — keep a copied agent in sync with the registry (shadcn-style)
+// ---------------------------------------------------------------------------
+
+export type DiffLine = { type: ' ' | '-' | '+'; text: string }
+
+/** Minimal line-level diff (LCS) — no dependency. */
+export function lineDiff(a: string, b: string): DiffLine[] {
+  const x = a.split('\n')
+  const y = b.split('\n')
+  const m = x.length
+  const n = y.length
+  const lcs: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] = x[i] === y[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+  const out: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < m && j < n) {
+    if (x[i] === y[j]) {
+      out.push({ type: ' ', text: x[i] })
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: '-', text: x[i++] })
+    } else {
+      out.push({ type: '+', text: y[j++] })
+    }
+  }
+  while (i < m) out.push({ type: '-', text: x[i++] })
+  while (j < n) out.push({ type: '+', text: y[j++] })
+  return out
+}
+
+export interface FileDiff {
+  path: string
+  status: 'unchanged' | 'modified' | 'missing-local'
+  diff?: DiffLine[]
+  upstream: string
+}
+
+export interface DiffAgentOptions extends FetchOptions {
+  outDir?: string
+  readFileImpl?: (path: string) => Promise<string | null>
+}
+
+/** Compare a locally-copied agent against the registry's current source. */
+export async function diffAgent(id: string, options: DiffAgentOptions = {}): Promise<{
+  agent: RegistryAgent
+  targetDir: string
+  files: FileDiff[]
+}> {
+  const agent = await fetchAgent(id, options)
+  const targetDir = join(options.outDir ?? 'agents', id)
+  const readLocal =
+    options.readFileImpl ??
+    (async (p: string) => {
+      const { readFile } = await import('node:fs/promises')
+      try {
+        return await readFile(p, 'utf8')
+      } catch {
+        return null
+      }
+    })
+
+  const files: FileDiff[] = []
+  for (const f of agent.sources) {
+    const local = await readLocal(join(targetDir, f.path))
+    if (local == null) {
+      files.push({ path: f.path, status: 'missing-local', upstream: f.content })
+    } else if (local === f.content) {
+      files.push({ path: f.path, status: 'unchanged', upstream: f.content })
+    } else {
+      files.push({ path: f.path, status: 'modified', diff: lineDiff(local, f.content), upstream: f.content })
+    }
+  }
+  return { agent, targetDir, files }
+}

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -31,6 +31,14 @@ export interface RegistryAgent {
   env?: RegistryEnvVar[]
   files: string[]
   sources: RegistryFile[]
+  /** Inline skill for `--run` (data only). Null for agents that compose tools. */
+  skill?: RegistrySkill | null
+}
+
+export interface RegistrySkill {
+  name: string
+  description: string
+  systemPrompt: string
 }
 
 export interface FetchOptions {
@@ -71,6 +79,19 @@ export async function fetchAgent(id: string, options: FetchOptions = {}): Promis
     )
     return { ...meta, sources }
   }
+}
+
+/**
+ * Resolve an agent's runnable systemPrompt — from the hosted `skill` field, or
+ * by extracting the inline skill from the fetched `agent.ts` source (raw-GitHub
+ * fallback). Returns null for tool-composing agents (no inline prompt).
+ */
+export function resolveSystemPrompt(agent: RegistryAgent): string | null {
+  if (agent.skill?.systemPrompt) return agent.skill.systemPrompt
+  const src = agent.sources.find((f) => f.path === 'agent.ts')?.content
+  if (!src) return null
+  const m = src.match(/systemPrompt:\s*`((?:\\.|[^`\\])*)`/)
+  return m ? m[1].replace(/\\`/g, '`').replace(/\\\$\{/g, '${') : null
 }
 
 export interface AddOptions extends FetchOptions {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,126 @@
+/**
+ * AgentsKit Registry client — fetches ready-made agents from the registry and
+ * copies their source into the user's project (shadcn-style; the user owns the
+ * code). Sources, in order:
+ *   1. Hosted index   — https://registry.agentskit.io/r/<id>.json (meta + inlined sources)
+ *   2. Raw GitHub      — the registry repo's registry/<id>/ files (works before hosting is live)
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+const HOSTED_BASE = 'https://registry.agentskit.io/r'
+const RAW_BASE = 'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main'
+
+export interface RegistryEnvVar {
+  name: string
+  description: string
+  required?: boolean
+}
+
+export interface RegistryFile {
+  path: string
+  content: string
+}
+
+export interface RegistryAgent {
+  id: string
+  title: string
+  description: string
+  category: string
+  packages: string[]
+  env?: RegistryEnvVar[]
+  files: string[]
+  sources: RegistryFile[]
+}
+
+export interface FetchOptions {
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch
+}
+
+async function getJson(url: string, fetchImpl: typeof fetch): Promise<unknown> {
+  const res = await fetchImpl(url)
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+async function getText(url: string, fetchImpl: typeof fetch): Promise<string> {
+  const res = await fetchImpl(url)
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.text()
+}
+
+/** Fetch an agent descriptor with inlined file sources, hosted first then raw GitHub. */
+export async function fetchAgent(id: string, options: FetchOptions = {}): Promise<RegistryAgent> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch
+  try {
+    const hosted = (await getJson(`${HOSTED_BASE}/${id}.json`, fetchImpl)) as RegistryAgent
+    if (hosted?.sources?.length) return hosted
+    throw new Error('hosted entry missing sources')
+  } catch {
+    // Fallback: read the repo source directly (no hosting required).
+    const meta = (await getJson(`${RAW_BASE}/registry/${id}/meta.json`, fetchImpl)) as Omit<
+      RegistryAgent,
+      'sources'
+    >
+    const sources = await Promise.all(
+      meta.files.map(async (rel) => ({
+        path: rel,
+        content: await getText(`${RAW_BASE}/registry/${id}/${rel}`, fetchImpl),
+      })),
+    )
+    return { ...meta, sources }
+  }
+}
+
+export interface AddOptions extends FetchOptions {
+  /** Directory to write the agent into. Default `./agents`. */
+  outDir?: string
+  /** Overwrite existing files. Default false. */
+  force?: boolean
+  /** Injectable writer (tests). */
+  writeFileImpl?: (path: string, content: string) => Promise<void>
+  /** Injectable existence check (tests). */
+  existsImpl?: (path: string) => Promise<boolean>
+}
+
+export interface AddResult {
+  agent: RegistryAgent
+  written: string[]
+  targetDir: string
+}
+
+async function defaultExists(path: string): Promise<boolean> {
+  const { access } = await import('node:fs/promises')
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Fetch an agent and write its source files into the project. */
+export async function addAgent(id: string, options: AddOptions = {}): Promise<AddResult> {
+  const agent = await fetchAgent(id, options)
+  const baseDir = options.outDir ?? 'agents'
+  const targetDir = join(baseDir, id)
+  const exists = options.existsImpl ?? defaultExists
+  const write =
+    options.writeFileImpl ??
+    (async (path: string, content: string) => {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, content, 'utf8')
+    })
+
+  const written: string[] = []
+  for (const file of agent.sources) {
+    const dest = join(targetDir, file.path)
+    if (!options.force && (await exists(dest))) {
+      throw new Error(`${dest} already exists (re-run with --force to overwrite)`)
+    }
+    await write(dest, file.content)
+    written.push(dest)
+  }
+  return { agent, written, targetDir }
+}

--- a/packages/cli/tests/commands-registry.test.ts
+++ b/packages/cli/tests/commands-registry.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Command } from 'commander'
+import { registerAddCommand } from '../src/commands/add'
+import { registerDiffCommand, registerUpdateCommand } from '../src/commands/registry-maintenance'
+
+const AGENT = {
+  id: 'x',
+  title: 'X',
+  description: 'an agent',
+  category: 'support',
+  packages: ['@agentskit/core', '@agentskit/runtime'],
+  env: [{ name: 'OPENAI_API_KEY', description: 'key', required: true }],
+  files: ['agent.ts'],
+  skill: { name: 'x', description: 'an agent', systemPrompt: 'You are X.' },
+  sources: [{ path: 'agent.ts', content: 'export const x = 1\n' }],
+}
+
+let origFetch: typeof globalThis.fetch
+let out = ''
+let origOut: typeof process.stdout.write
+let origErr: typeof process.stderr.write
+let origExit: typeof process.exit
+
+beforeEach(() => {
+  origFetch = globalThis.fetch
+  globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(AGENT), { status: 200 })) as never
+  out = ''
+  origOut = process.stdout.write
+  origErr = process.stderr.write
+  origExit = process.exit
+  process.stdout.write = ((s: string) => ((out += s), true)) as never
+  process.stderr.write = ((s: string) => ((out += s), true)) as never
+  process.exit = (() => undefined) as never
+})
+afterEach(() => {
+  globalThis.fetch = origFetch
+  process.stdout.write = origOut
+  process.stderr.write = origErr
+  process.exit = origExit
+})
+
+function cli(): Command {
+  const p = new Command()
+  p.exitOverride()
+  registerAddCommand(p)
+  registerDiffCommand(p)
+  registerUpdateCommand(p)
+  return p
+}
+
+describe('registry commands', () => {
+  it('add writes the agent and prints packages + required env', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'x', '--out', dir])
+    expect(out).toContain('Added')
+    expect(out).toContain('@agentskit/runtime')
+    expect(out).toContain('OPENAI_API_KEY')
+  })
+
+  it('add --run executes the agent via the demo provider', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'x', '--out', dir, '--run', 'do it', '--provider', 'demo'])
+    expect(out).toContain('Running')
+    expect(out.toLowerCase()).toContain('demo')
+  })
+
+  it('diff reports up to date right after add', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'x', '--out', dir])
+    out = ''
+    await cli().parseAsync(['node', 'cli', 'diff', 'x', '--out', dir])
+    expect(out).toContain('up to date')
+  })
+
+  it('update reports already up to date when unchanged', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'x', '--out', dir])
+    out = ''
+    await cli().parseAsync(['node', 'cli', 'update', 'x', '--out', dir])
+    expect(out).toContain('up to date')
+  })
+})

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { addAgent, fetchAgent } from '../src/registry'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+function textResponse(body: string): Response {
+  return new Response(body, { status: 200 })
+}
+function notFound(): Response {
+  return new Response('not found', { status: 404 })
+}
+
+const META = {
+  id: 'research',
+  title: 'Research Agent',
+  description: 'd',
+  category: 'research',
+  packages: ['@agentskit/runtime'],
+  env: [{ name: 'OPENAI_API_KEY', description: 'k', required: false }],
+  files: ['agent.ts'],
+}
+
+describe('fetchAgent', () => {
+  it('uses the hosted index when it has inlined sources', async () => {
+    const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'export const x = 1' }] }
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toContain('registry.agentskit.io/r/research.json')
+      return jsonResponse(hosted)
+    }) as unknown as typeof fetch
+    const agent = await fetchAgent('research', { fetchImpl })
+    expect(agent.sources[0].content).toBe('export const x = 1')
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to raw GitHub when hosted is unavailable', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('registry.agentskit.io')) return notFound()
+      if (url.endsWith('/meta.json')) return jsonResponse(META)
+      if (url.endsWith('/agent.ts')) return textResponse('export const y = 2')
+      return notFound()
+    }) as unknown as typeof fetch
+    const agent = await fetchAgent('research', { fetchImpl })
+    expect(agent.sources).toEqual([{ path: 'agent.ts', content: 'export const y = 2' }])
+  })
+})
+
+describe('addAgent', () => {
+  it('writes fetched sources and reports packages/env', async () => {
+    const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'CODE' }] }
+    const fetchImpl = vi.fn(async () => jsonResponse(hosted)) as unknown as typeof fetch
+    const writes: Record<string, string> = {}
+    const result = await addAgent('research', {
+      fetchImpl,
+      existsImpl: async () => false,
+      writeFileImpl: async (p, c) => {
+        writes[p] = c
+      },
+    })
+    expect(result.targetDir).toBe('agents/research')
+    expect(writes['agents/research/agent.ts']).toBe('CODE')
+    expect(result.agent.packages).toContain('@agentskit/runtime')
+  })
+
+  it('refuses to overwrite without force', async () => {
+    const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'CODE' }] }
+    const fetchImpl = vi.fn(async () => jsonResponse(hosted)) as unknown as typeof fetch
+    await expect(
+      addAgent('research', { fetchImpl, existsImpl: async () => true, writeFileImpl: async () => {} }),
+    ).rejects.toThrow(/already exists/)
+  })
+
+  it('overwrites with force', async () => {
+    const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'CODE' }] }
+    const fetchImpl = vi.fn(async () => jsonResponse(hosted)) as unknown as typeof fetch
+    const writes: string[] = []
+    await addAgent('research', {
+      force: true,
+      fetchImpl,
+      existsImpl: async () => true,
+      writeFileImpl: async (p) => {
+        writes.push(p)
+      },
+    })
+    expect(writes).toEqual(['agents/research/agent.ts'])
+  })
+})

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { addAgent, fetchAgent } from '../src/registry'
+import { addAgent, fetchAgent, resolveSystemPrompt } from '../src/registry'
+import type { RegistryAgent } from '../src/registry'
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
@@ -42,6 +43,34 @@ describe('fetchAgent', () => {
     }) as unknown as typeof fetch
     const agent = await fetchAgent('research', { fetchImpl })
     expect(agent.sources).toEqual([{ path: 'agent.ts', content: 'export const y = 2' }])
+  })
+})
+
+describe('resolveSystemPrompt', () => {
+  const base: RegistryAgent = {
+    id: 'x', title: 'X', description: 'd', category: 'support', packages: [], files: ['agent.ts'], sources: [],
+  }
+
+  it('prefers the hosted skill field', () => {
+    const agent = { ...base, skill: { name: 'x', description: 'd', systemPrompt: 'You are X.' } }
+    expect(resolveSystemPrompt(agent)).toBe('You are X.')
+  })
+
+  it('falls back to extracting the inline skill from agent.ts source', () => {
+    const src = 'const skill = {\n  systemPrompt: `You are Y.\nLine two.`,\n}'
+    const agent = { ...base, sources: [{ path: 'agent.ts', content: src }] }
+    expect(resolveSystemPrompt(agent)).toBe('You are Y.\nLine two.')
+  })
+
+  it('unescapes backticks and ${ in the extracted prompt', () => {
+    const src = 'const skill = { systemPrompt: `Use \\`code\\` and \\${vars}.` }'
+    const agent = { ...base, sources: [{ path: 'agent.ts', content: src }] }
+    expect(resolveSystemPrompt(agent)).toBe('Use `code` and ${vars}.')
+  })
+
+  it('returns null for a tool-composing agent (no inline prompt)', () => {
+    const agent = { ...base, skill: null, sources: [{ path: 'agent.ts', content: 'import { researcher } from "@agentskit/skills"' }] }
+    expect(resolveSystemPrompt(agent)).toBeNull()
   })
 })
 

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -36,7 +36,11 @@ describe('fetchAgent', () => {
 
   it('falls back to raw GitHub when hosted is unavailable', async () => {
     const fetchImpl = vi.fn(async (url: string) => {
-      if (url.includes('registry.agentskit.io')) return notFound()
+      try {
+        if (new URL(url).hostname === 'registry.agentskit.io') return notFound()
+      } catch {
+        // Ignore malformed/non-absolute URLs in test mocks and continue with path checks.
+      }
       if (url.endsWith('/meta.json')) return jsonResponse(META)
       if (url.endsWith('/agent.ts')) return textResponse('export const y = 2')
       return notFound()

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -114,3 +114,42 @@ describe('addAgent', () => {
     expect(writes).toEqual(['agents/research/agent.ts'])
   })
 })
+
+describe('lineDiff', () => {
+  it('marks added, removed, and unchanged lines', async () => {
+    const { lineDiff } = await import('../src/registry')
+    const d = lineDiff('a\nb\nc', 'a\nx\nc')
+    expect(d.filter((l) => l.type === '-').map((l) => l.text)).toEqual(['b'])
+    expect(d.filter((l) => l.type === '+').map((l) => l.text)).toEqual(['x'])
+    expect(d.filter((l) => l.type === ' ').map((l) => l.text)).toEqual(['a', 'c'])
+  })
+})
+
+describe('diffAgent', () => {
+  const hosted = {
+    id: 'x', title: 'X', description: 'd', category: 'support', packages: [], files: ['agent.ts'],
+    sources: [{ path: 'agent.ts', content: 'line1\nline2\n' }],
+  }
+  function fetchHosted() {
+    return vi.fn(async () => new Response(JSON.stringify(hosted), { status: 200 })) as unknown as typeof fetch
+  }
+
+  it('reports unchanged when local matches upstream', async () => {
+    const { diffAgent } = await import('../src/registry')
+    const out = await diffAgent('x', { fetchImpl: fetchHosted(), readFileImpl: async () => 'line1\nline2\n' })
+    expect(out.files[0].status).toBe('unchanged')
+  })
+
+  it('reports modified with a diff', async () => {
+    const { diffAgent } = await import('../src/registry')
+    const out = await diffAgent('x', { fetchImpl: fetchHosted(), readFileImpl: async () => 'line1\nCHANGED\n' })
+    expect(out.files[0].status).toBe('modified')
+    expect(out.files[0].diff?.some((l) => l.type === '+' && l.text === 'line2')).toBe(true)
+  })
+
+  it('reports missing-local when the file is absent', async () => {
+    const { diffAgent } = await import('../src/registry')
+    const out = await diffAgent('x', { fetchImpl: fetchHosted(), readFileImpl: async () => null })
+    expect(out.files[0].status).toBe('missing-local')
+  })
+})


### PR DESCRIPTION
Implements RFC 0002 step 1 — the CLI side of the agent registry.

## What
`agentskit add <agent>` pulls a ready-made agent from the [AgentsKit registry](https://github.com/AgentsKit-io/agentskit-registry) and copies its source into the project (shadcn-style — the user owns the code, no new framework dependency).

```bash
npx agentskit add research
npx agentskit add pr-review --out ./src/agents --force
```

## Resolution order
1. Hosted index — `https://registry.agentskit.io/r/<id>.json` (meta + inlined sources)
2. **Fallback** — the registry repo's raw GitHub source (`registry/<id>/`), so it works **today**, before Vercel/DNS is set up.

Prints the `@agentskit/*` packages to install and any required env vars.

## Structure
- `src/registry.ts` — fetch + write logic, fully injectable (`fetchImpl`, `writeFileImpl`, `existsImpl`) for tests.
- `src/commands/add.ts` — thin command wiring.

## Verification
- tsc clean · cli suite 388 passed (incl. new `registry.test.ts`: hosted path, raw-GitHub fallback, write, force/no-force)
- **E2E**: ran `agentskit add research` against the live registry repo — fetched and wrote `agent.ts` + `README.md` correctly.
- 9/9 quality gates · changeset (minor)

## Companion
Registry repo (already live): https://github.com/AgentsKit-io/agentskit-registry — seed agents `research` + `pr-review`, verified against published packages.

Part of RFC 0002 (#925). Vercel hosting of `registry.agentskit.io` is a follow-up (owner); the raw-GitHub fallback makes this usable now.