### PR TITLE
fix(integrations): add CHANGELOG.md seed so the release action can publish

### DIFF
--- a/.changeset/integrations-changelog-seed.md
+++ b/.changeset/integrations-changelog-seed.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/integrations': patch
+---
+
+Add the package CHANGELOG.md seed so the changesets release action can generate GitHub releases for the package's first publish.

--- a/packages/integrations/CHANGELOG.md
+++ b/packages/integrations/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
The Release workflow (changesets/action with `createGithubReleases: true`) has been failing on every push to main: it reads each versioned package's `CHANGELOG.md`, but `@agentskit/integrations` had none (the repo uses `changelog: false`, so `changeset version` doesn't create one for a brand-new package). Every other package ships a committed `# Changelog` seed; this adds the missing one so the release/publish can proceed.

Unblocks the first npm publish of `@agentskit/integrations` (the 50-service catalog).