### PR TITLE
fix(ci): skip husky pre-push in CI so the release bot can publish

### DIFF
--- a/.changeset/fix-pre-push-ci-guard.md
+++ b/.changeset/fix-pre-push-ci-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: skip the husky pre-push hook in CI so the changesets release bot can push the version-packages branch without re-running (and failing) the local dev gate suite.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,8 @@
 # Structural gates + typecheck + build before pushing.
+# Skipped in CI: automation (e.g. the changesets release bot) pushes here, and
+# CI already runs the full suite via dedicated workflows. Running the dev hook
+# during a CI push double-runs heavy checks and breaks on app-only/generated
+# state (e.g. docs-next's generated ask-context). HUSKY=0 also bypasses locally.
+[ -n "$CI" ] && exit 0
 # Fast, build-light checks first; full test suite runs in CI.
-# To bypass in an emergency, use `git push --no-verify` (discouraged).
 pnpm check:quality-gates && pnpm lint && pnpm build


### PR DESCRIPTION
The Release workflow (changesets/action) was failing to create the version-packages PR: when the bot runs `git push` for the `changeset-release/main` branch, the local `.husky/pre-push` hook fires and runs `check:quality-gates && lint && build`, which fails in CI on docs-next's generated `ask-context` (`Cannot find module '@/lib/ask-context'`).

Hooks meant for local dev pushes shouldn't run on CI automation pushes — CI runs the full suite via dedicated workflows. This adds the standard `[ -n "$CI" ] && exit 0` guard (HUSKY=0 still bypasses locally). Unblocks the first npm publish of `@agentskit/integrations`.