### PR TITLE
feat(mcp): @agentskit/mcp — expose AgentsKit tools as an MCP server

### DIFF
--- a/.changeset/agentskit-mcp.md
+++ b/.changeset/agentskit-mcp.md
@@ -1,0 +1,8 @@
+---
+"@agentskit/mcp": minor
+---
+
+New package `@agentskit/mcp` — expose AgentsKit tools as an MCP server over stdio,
+so any MCP host (Claude Desktop, Cursor, Windsurf) can call them. `npx @agentskit/mcp
+--tools fetch,search`, or `createAgentsKitMcpServer({ tools })` programmatically. A
+thin bridge over `@agentskit/tools/mcp` — no new protocol logic.

--- a/apps/docs-next/content/docs/for-agents/mcp.mdx
+++ b/apps/docs-next/content/docs/for-agents/mcp.mdx
@@ -1,0 +1,47 @@
+---
+title: '@agentskit/mcp — for agents'
+description: Expose AgentsKit tools as an MCP server over stdio for Claude Desktop, Cursor, Windsurf.
+---
+
+## Purpose
+
+Serve AgentsKit tools to any MCP host. A thin bridge over `@agentskit/tools/mcp`
+(`createMcpServer` + `createStdioTransport`).
+
+## Install
+
+```bash
+npm install @agentskit/mcp
+```
+
+## Primary exports
+
+- `createAgentsKitMcpServer({ tools, serverInfo?, onEvent?, transport? })` —
+  expose `ToolDefinition[]` as an MCP server. Defaults to stdio over the current
+  process; pass `transport` to override (tests / custom hosts).
+- `processStdio()` — adapt the Node process into the `StdioLikeProcess` the
+  transport expects (server receives on stdin, sends on stdout).
+
+## Bin
+
+`agentskit-mcp` — `npx @agentskit/mcp --tools fetch,search`. Flags: `--tools`,
+`--fs-root`, `--sqlite`, `--allow-shell`. stdout is the JSON-RPC channel; logs go to stderr.
+
+## Minimal example
+
+```ts
+import { createAgentsKitMcpServer } from '@agentskit/mcp'
+import { fetchUrl } from '@agentskit/tools'
+
+createAgentsKitMcpServer({ tools: [fetchUrl()] })
+```
+
+## Related packages
+
+- [@agentskit/tools](/docs/for-agents/tools) — the tools you expose + the MCP primitives.
+- [@agentskit/core](/docs/for-agents/core) — the `ToolDefinition` contract.
+
+## Source
+
+- npm: https://www.npmjs.com/package/@agentskit/mcp
+- repo: https://github.com/AgentsKit-io/agentskit/tree/main/packages/mcp

--- a/packages/mcp/CONVENTIONS.md
+++ b/packages/mcp/CONVENTIONS.md
@@ -1,0 +1,8 @@
+# @agentskit/mcp conventions
+
+- Composition package: depends on `@agentskit/core` and `@agentskit/tools` only.
+- Bridges, never reimplements: wraps `createMcpServer` / `createStdioTransport`
+  from `@agentskit/tools/mcp`. New MCP protocol logic belongs in `tools`, not here.
+- `stdout` is reserved for the MCP JSON-RPC channel. Never write logs/diagnostics
+  to stdout — use `stderr`.
+- Named exports only. No bare throws — surface errors via `onEvent` / process exit.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,40 @@
+# @agentskit/mcp
+
+Expose AgentsKit tools as an [MCP](https://modelcontextprotocol.io) server — use
+them from Claude Desktop, Cursor, Windsurf, or any MCP host.
+
+```bash
+npx @agentskit/mcp --tools fetch,search
+```
+
+Then point your MCP host at the command. Example (Claude Desktop config):
+
+```json
+{
+  "mcpServers": {
+    "agentskit": { "command": "npx", "args": ["@agentskit/mcp", "--tools", "fetch,search"] }
+  }
+}
+```
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--tools <a,b>` | which tools to expose (default `fetch,search`). Available: `fetch`, `search`, `filesystem`, `shell`, `sqlite` |
+| `--fs-root <dir>` | enable the filesystem tool, rooted at `<dir>` |
+| `--sqlite <file>` | enable the sqlite query tool against `<file>` |
+| `--allow-shell` | enable the shell tool (off by default — it runs commands) |
+
+`stdout` is the MCP JSON-RPC channel; human output goes to `stderr`.
+
+## Programmatic
+
+```ts
+import { createAgentsKitMcpServer } from '@agentskit/mcp'
+import { fetchUrl } from '@agentskit/tools'
+
+createAgentsKitMcpServer({ tools: [fetchUrl()] }) // stdio by default
+```
+
+Pass `transport` to use a custom MCP transport (e.g. in-memory for tests).

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@agentskit/mcp",
+  "version": "0.1.0",
+  "description": "Expose AgentsKit tools as an MCP server — use them from Claude Desktop, Cursor, Windsurf, or any MCP host.",
+  "keywords": ["agentskit", "mcp", "model-context-protocol", "tools", "ai", "agents", "claude", "cursor"],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "agentskit-mcp": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@agentskit/core": "workspace:*",
+    "@agentskit/tools": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "publishConfig": { "access": "public" },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/mcp",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/mcp"
+  },
+  "author": "AgentsKit Contributors"
+}

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import type { ToolDefinition } from '@agentskit/core'
+import { fetchUrl, webSearch, filesystem, shell, sqliteQueryTool } from '@agentskit/tools'
+import { createAgentsKitMcpServer } from './index'
+
+/**
+ * `agentskit-mcp` — start an MCP server exposing AgentsKit tools over stdio.
+ *
+ * Flags:
+ *   --tools <a,b,...>   which tools to expose (default: fetch,search)
+ *                       available: fetch, search, filesystem, shell, sqlite
+ *   --fs-root <dir>     root for the filesystem tool (required to enable it)
+ *   --sqlite <file>     database file for the sqlite tool (required to enable it)
+ *   --allow-shell       enable the shell tool (off by default — it runs commands)
+ *
+ * stdout is the MCP JSON-RPC channel; all human output goes to stderr.
+ */
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(name)
+  return i >= 0 ? process.argv[i + 1] : undefined
+}
+function has(name: string): boolean {
+  return process.argv.includes(name)
+}
+
+function buildTools(): ToolDefinition[] {
+  const requested = (flag('--tools') ?? 'fetch,search').split(',').map((s) => s.trim())
+  const tools: ToolDefinition[] = []
+  const warn = (msg: string) => process.stderr.write(`agentskit-mcp: ${msg}\n`)
+
+  if (requested.includes('fetch')) tools.push(fetchUrl())
+  if (requested.includes('search')) tools.push(webSearch())
+  if (requested.includes('filesystem')) {
+    const root = flag('--fs-root')
+    if (root) tools.push(...filesystem({ basePath: root }))
+    else warn('skipping "filesystem": pass --fs-root <dir> to enable it')
+  }
+  if (requested.includes('sqlite')) {
+    const file = flag('--sqlite')
+    if (file) tools.push(sqliteQueryTool({ path: file }))
+    else warn('skipping "sqlite": pass --sqlite <file> to enable it')
+  }
+  if (requested.includes('shell')) {
+    if (has('--allow-shell')) tools.push(shell())
+    else warn('skipping "shell": pass --allow-shell to enable it (runs commands)')
+  }
+  return tools
+}
+
+const tools = buildTools()
+if (tools.length === 0) {
+  process.stderr.write('agentskit-mcp: no tools enabled — nothing to serve. See --tools.\n')
+  process.exit(1)
+}
+
+createAgentsKitMcpServer({
+  tools,
+  onEvent: (e) => {
+    if (e.type === 'error') process.stderr.write(`agentskit-mcp: tool error (${e.tool}): ${e.error}\n`)
+  },
+})
+process.stderr.write(`agentskit-mcp: serving ${tools.length} tool(s) over stdio (${tools.map((t) => t.name).join(', ')})\n`)

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,53 @@
+import type { ToolDefinition } from '@agentskit/core'
+import {
+  createMcpServer,
+  createStdioTransport,
+  type McpServer,
+  type McpTransport,
+  type StdioLikeProcess,
+} from '@agentskit/tools/mcp'
+
+export interface AgentsKitMcpServerOptions {
+  /** AgentsKit tools to expose to the MCP host. */
+  tools: ToolDefinition[]
+  serverInfo?: { name: string; version: string }
+  /** Observability hook (call / error / list). Logs must NOT go to stdout — it is the MCP channel. */
+  onEvent?: (event: { type: 'call' | 'error' | 'list'; tool?: string; error?: string }) => void
+  /**
+   * Transport override. Defaults to stdio over the current process (the form
+   * Claude Desktop / Cursor / Windsurf launch). Inject a custom transport for tests.
+   */
+  transport?: McpTransport
+}
+
+/**
+ * Adapt the current Node process to the `StdioLikeProcess` the transport expects:
+ * the server RECEIVES JSON-RPC on stdin and SENDS on stdout.
+ */
+export function processStdio(): StdioLikeProcess {
+  return {
+    stdin: { write: (chunk: string) => void process.stdout.write(chunk) },
+    stdout: {
+      on: (_event: 'data', cb: (chunk: Buffer | string) => void) => void process.stdin.on('data', cb),
+      off: (_event: 'data', cb: (chunk: Buffer | string) => void) => void process.stdin.off('data', cb),
+    },
+    on: (event: 'exit' | 'close', cb: () => void) =>
+      void process.on(event === 'close' ? 'beforeExit' : 'exit', cb),
+  }
+}
+
+/**
+ * Expose a set of AgentsKit tools as an MCP server (over stdio by default), so
+ * any MCP host — Claude Desktop, Cursor, Windsurf — can call them.
+ */
+export function createAgentsKitMcpServer(options: AgentsKitMcpServerOptions): McpServer {
+  const transport = options.transport ?? createStdioTransport(processStdio())
+  return createMcpServer({
+    transport,
+    tools: options.tools,
+    serverInfo: options.serverInfo ?? { name: 'agentskit-mcp', version: '0.1.0' },
+    onEvent: options.onEvent,
+  })
+}
+
+export type { McpServer, McpTransport } from '@agentskit/tools/mcp'

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import type { ToolDefinition } from '@agentskit/core'
+import { createInMemoryTransportPair, type JsonRpcMessage } from '@agentskit/tools/mcp'
+import { createAgentsKitMcpServer } from '../src/index'
+
+const echo: ToolDefinition = {
+  name: 'echo',
+  description: 'Echo the input text.',
+  schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+  execute: (args: Record<string, unknown>) => ({ echoed: args.text }),
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('createAgentsKitMcpServer', () => {
+  it('lists and calls exposed tools over an MCP transport', async () => {
+    const [client, server] = createInMemoryTransportPair()
+    const srv = createAgentsKitMcpServer({ tools: [echo], transport: server })
+
+    const got: JsonRpcMessage[] = []
+    client.onMessage((m) => got.push(m))
+
+    await client.send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    await client.send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+    await client.send({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { text: 'hi' } },
+    })
+    await flush()
+
+    const serialized = JSON.stringify(got)
+    expect(serialized).toContain('echo')
+    expect(serialized).toContain('hi')
+
+    const listResponse = got.find((m) => 'id' in m && m.id === 2)
+    expect(listResponse).toBeDefined()
+
+    await srv.close()
+  })
+
+  it('reports tool errors via onEvent without crashing', async () => {
+    const boom: ToolDefinition = {
+      name: 'boom',
+      description: 'always throws',
+      schema: { type: 'object' },
+      execute: () => {
+        throw new Error('kaboom')
+      },
+    }
+    const [client, server] = createInMemoryTransportPair()
+    const events: string[] = []
+    const srv = createAgentsKitMcpServer({
+      tools: [boom],
+      transport: server,
+      onEvent: (e) => events.push(e.type),
+    })
+    client.onMessage(() => {})
+    await client.send({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'boom', arguments: {} } })
+    await flush()
+    expect(events).toContain('error')
+    await srv.close()
+  })
+})

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "types": ["node"] },
+  "include": ["src"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts', bin: 'src/bin.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ['@agentskit/core', '@agentskit/tools'],
+})

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,4 @@
+import { createTestConfig } from '../../vitest.shared'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(createTestConfig({ linesThreshold: 80 }))

--- a/scripts/check-src-test-parity.mjs
+++ b/scripts/check-src-test-parity.mjs
@@ -38,6 +38,8 @@ const ALLOW_FILES = new Set([
   'packages/cli/src/bin.ts',
   'packages/cli/src/index.ts',
   'packages/cli/src/commands.ts',
+  // CLI entry: process.argv parsing + stdio server bootstrap (logic lives in index.ts, tested).
+  'packages/mcp/src/bin.ts',
   // Aggregate-tested. Listed individually so the gate fails when the
   // referencing test file goes away.
   // - chat.service.ts → tests/service.test.ts (covers AgentskitChat).


### PR DESCRIPTION
New package **`@agentskit/mcp`** — serve AgentsKit tools to any MCP host (Claude Desktop, Cursor, Windsurf).

```bash
npx @agentskit/mcp --tools fetch,search
```
```json
{ "mcpServers": { "agentskit": { "command": "npx", "args": ["@agentskit/mcp", "--tools", "fetch,search"] } } }
```

## What
- `createAgentsKitMcpServer({ tools, serverInfo?, onEvent?, transport? })` — expose `ToolDefinition[]` as an MCP server, stdio by default (`transport` override for tests/custom hosts).
- `processStdio()` — adapts the Node process (server receives on stdin, sends on stdout).
- Bin `agentskit-mcp`: `--tools fetch,search` default; `filesystem`/`sqlite`/`shell` behind explicit flags (`--fs-root`, `--sqlite`, `--allow-shell`). **stdout reserved for JSON-RPC; logs → stderr.**

## Design
Thin **bridge** over `@agentskit/tools/mcp` (`createMcpServer` + `createStdioTransport`) — no new protocol logic (manifesto: prefer the standard). Composition package depending on `core` + `tools`, same tier as `cli` (per ADR-0009).

This is the manifesto-blessed MCP play (RFC 0002 / 0003): the OSS tools (and, next, agents/integrations) become callable from every MCP client — a huge install surface.

## Verification
- 9/9 quality gates (added `for-agents/mcp.mdx`; `bin.ts` in parity allowlist like `cli/src/bin.ts`)
- 2/2 tests (in-memory MCP transport: tools/list + tools/call + error-via-onEvent)
- tsc clean · build ok · changeset (minor)

## Follow-up
Expose registry **agents** as MCP tools (needs a model adapter in the server) — separate PR.