### PR TITLE
fix(security): CodeQL URL substring in mcp test

### DIFF
--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -98,7 +98,8 @@ describe('fetchAgentSkill', () => {
   it('returns null for a tool-composing agent (skill: null) with no inline prompt', async () => {
     const { fetchAgentSkill } = await import('../src/registry-fetch')
     const fetchImpl = (async (url: string) => {
-      if (url.includes('registry.agentskit.io')) return new Response(JSON.stringify({ skill: null }), { status: 200 })
+      if (new URL(url).hostname === 'registry.agentskit.io')
+        return new Response(JSON.stringify({ skill: null }), { status: 200 })
       if (url.endsWith('meta.json')) return new Response(JSON.stringify({ description: 'd' }), { status: 200 })
       return new Response('import { researcher } from "@agentskit/skills"', { status: 200 })
     }) as unknown as typeof fetch


### PR DESCRIPTION
Resolves the new CodeQL High alert (incomplete URL substring sanitization) in `packages/mcp/tests/server.test.ts`: the fetch mock used `url.includes('registry.agentskit.io')` (matches host anywhere). Now `new URL(url).hostname === 'registry.agentskit.io'`. Test-only mock; logic unchanged. Swept src + tests — this was the only remaining occurrence (cli test already uses hostname). Verified: mcp build + tests pass.