### PR TITLE
feat(docs): unified registry gallery at /agents

### DIFF
--- a/.changeset/cli-cdn-index.md
+++ b/.changeset/cli-cdn-index.md
@@ -1,0 +1,8 @@
+---
+"@agentskit/cli": patch
+---
+
+`agentskit add` now fetches the prebuilt registry index from the committed
+`public/r` in the registry repo (served via raw GitHub / CDN) instead of a
+separate `registry.agentskit.io` host — no separate deploy required. Falls back
+to walking the agent source as before.

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -583,6 +583,10 @@ function ProviderStrip() {
           <Link href="/docs/reference/packages/adapters#catalog" className="underline decoration-dotted underline-offset-2 hover:text-ak-blue">
             models.dev catalog →
           </Link>
+          <span className="mx-2">·</span>
+          <Link href="/agents" className="underline decoration-dotted underline-offset-2 hover:text-ak-blue">
+            ready-to-use agents →
+          </Link>
         </p>
       </div>
     </section>

--- a/apps/docs-next/app/agents/[id]/page.tsx
+++ b/apps/docs-next/app/agents/[id]/page.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getAgent, getRegistryIndex } from '@/lib/registry'
+
+export const revalidate = 3600
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+  const agents = await getRegistryIndex()
+  return agents.map((a) => ({ id: a.id }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const agent = await getAgent(id)
+  if (!agent) return { title: 'Agent not found' }
+  return {
+    title: `${agent.title} — AgentsKit agent`,
+    description: agent.description,
+  }
+}
+
+export default async function AgentPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const agent = await getAgent(id)
+  if (!agent) notFound()
+
+  const required = (agent.env ?? []).filter((e) => e.required)
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-12">
+      <Link href="/agents" className="font-mono text-xs text-ak-graphite hover:text-ak-blue">
+        ← all agents
+      </Link>
+
+      <div className="mt-4 mb-6">
+        <div className="font-mono text-xs uppercase tracking-[0.18em] text-ak-blue">{agent.category}</div>
+        <h1 className="mt-1 text-3xl font-semibold tracking-tight text-ak-foam">{agent.title}</h1>
+        <p className="mt-2 text-ak-graphite">{agent.description}</p>
+      </div>
+
+      <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Add it</h2>
+      <div className="rounded-lg border border-ak-border bg-ak-surface/40 px-4 py-3 font-mono text-sm text-ak-foam">
+        npx agentskit add {agent.id}
+      </div>
+
+      <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Packages</h2>
+      <div className="flex flex-wrap gap-2">
+        {agent.packages.map((p) => (
+          <span key={p} className="rounded-full border border-ak-border px-3 py-1 font-mono text-xs text-ak-graphite">
+            {p}
+          </span>
+        ))}
+      </div>
+
+      {required.length > 0 && (
+        <>
+          <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Required env</h2>
+          <ul className="space-y-1 text-sm text-ak-graphite">
+            {required.map((e) => (
+              <li key={e.name}>
+                <span className="font-mono text-ak-foam">{e.name}</span> — {e.description}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {agent.skill?.systemPrompt && (
+        <details className="mt-6">
+          <summary className="cursor-pointer font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">
+            System prompt
+          </summary>
+          <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded-lg border border-ak-border bg-ak-surface/40 p-4 text-sm text-ak-graphite">
+            {agent.skill.systemPrompt}
+          </pre>
+        </details>
+      )}
+
+      <p className="mt-8 text-sm text-ak-graphite">
+        {agent.source ? `Adapted from ${agent.source} · ` : ''}
+        {agent.license ?? 'MIT'} ·{' '}
+        <a
+          className="underline decoration-dotted underline-offset-2 hover:text-ak-blue"
+          href={`https://github.com/AgentsKit-io/agentskit-registry/tree/main/registry/${agent.id}`}
+        >
+          view source
+        </a>{' '}
+        · Run managed on{' '}
+        <a className="underline decoration-dotted underline-offset-2 hover:text-ak-blue" href="https://akos.agentskit.io">
+          AKOS (soon)
+        </a>
+      </p>
+    </main>
+  )
+}

--- a/apps/docs-next/app/agents/page.tsx
+++ b/apps/docs-next/app/agents/page.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link'
+import { getRegistryIndex, groupByCategory } from '@/lib/registry'
+
+export const metadata = {
+  title: 'Agents — ready-to-use AI agents for AgentsKit',
+  description:
+    'Browse ready-to-use AI agents. Copy the source into your project with `npx agentskit add <agent>` — you own the code. No lock-in.',
+}
+
+export const revalidate = 3600
+
+export default async function AgentsPage() {
+  const agents = await getRegistryIndex()
+  const byCategory = groupByCategory(agents)
+  const categories = Object.keys(byCategory).sort()
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-12">
+      <div className="mb-8">
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-foam">Registry</div>
+        <h1 className="mt-2 text-4xl font-semibold tracking-tight text-ak-foam">Ready-to-use agents</h1>
+        <p className="mt-3 max-w-2xl text-ak-graphite">
+          Copy an agent&apos;s source into your project — you own the code, no new framework dependency.
+        </p>
+        <div className="mt-4 rounded-lg border border-ak-border bg-ak-surface/40 px-4 py-3 font-mono text-sm text-ak-foam">
+          npx agentskit add &lt;agent&gt;
+        </div>
+      </div>
+
+      {agents.length === 0 ? (
+        <p className="text-ak-graphite">Could not load the registry. Try again shortly.</p>
+      ) : (
+        categories.map((cat) => (
+          <section key={cat} className="mb-10">
+            <h2 className="mb-3 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">{cat}</h2>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {byCategory[cat].map((a) => (
+                <Link
+                  key={a.id}
+                  href={`/agents/${a.id}`}
+                  className="flex flex-col gap-2 rounded-xl border border-ak-border bg-ak-surface/40 p-4 transition hover:border-ak-foam/40"
+                >
+                  <span className="font-medium text-ak-foam">{a.title}</span>
+                  <span className="line-clamp-3 text-sm text-ak-graphite">{a.description}</span>
+                  <span className="mt-auto font-mono text-[11px] text-ak-blue">npx agentskit add {a.id}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+
+      <p className="mt-8 text-sm text-ak-graphite">
+        {agents.length} agents ·{' '}
+        <a
+          className="underline decoration-dotted underline-offset-2 hover:text-ak-blue"
+          href="https://github.com/AgentsKit-io/agentskit-registry"
+        >
+          source on GitHub
+        </a>{' '}
+        ·{' '}
+        <a
+          className="underline decoration-dotted underline-offset-2 hover:text-ak-blue"
+          href="https://github.com/AgentsKit-io/agentskit-registry/blob/main/CONTRIBUTING.md"
+        >
+          contribute an agent
+        </a>
+      </p>
+    </main>
+  )
+}

--- a/apps/docs-next/lib/registry.ts
+++ b/apps/docs-next/lib/registry.ts
@@ -1,0 +1,58 @@
+/**
+ * AgentsKit Registry data — fetched from the committed index in the
+ * `agentskit-registry` repo (raw GitHub, server-side, revalidated). Keeps the
+ * agent source decoupled (RFC 0002) while the gallery lives in the docs site.
+ */
+const BASE = 'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main/public/r'
+const REVALIDATE = 3600 // 1h — new agents appear without a docs rebuild
+
+export interface RegistryAgentSummary {
+  id: string
+  title: string
+  description: string
+  category: string
+  version?: string
+  source?: string
+  license?: string
+  tags?: string[]
+  packages: string[]
+  runnable?: boolean
+}
+
+export interface RegistryEnvVar {
+  name: string
+  description: string
+  required?: boolean
+}
+
+export interface RegistryAgentDetail extends RegistryAgentSummary {
+  env?: RegistryEnvVar[]
+  skill?: { name: string; description: string; systemPrompt: string } | null
+}
+
+export async function getRegistryIndex(): Promise<RegistryAgentSummary[]> {
+  try {
+    const res = await fetch(`${BASE}/index.json`, { next: { revalidate: REVALIDATE } })
+    if (!res.ok) return []
+    const data = (await res.json()) as { agents?: RegistryAgentSummary[] }
+    return data.agents ?? []
+  } catch {
+    return []
+  }
+}
+
+export async function getAgent(id: string): Promise<RegistryAgentDetail | null> {
+  try {
+    const res = await fetch(`${BASE}/${encodeURIComponent(id)}.json`, { next: { revalidate: REVALIDATE } })
+    if (!res.ok) return null
+    return (await res.json()) as RegistryAgentDetail
+  } catch {
+    return null
+  }
+}
+
+export function groupByCategory(agents: RegistryAgentSummary[]): Record<string, RegistryAgentSummary[]> {
+  const out: Record<string, RegistryAgentSummary[]> = {}
+  for (const a of agents) (out[a.category] ??= []).push(a)
+  return out
+}

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -8,8 +8,10 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-const HOSTED_BASE = 'https://registry.agentskit.io/r'
 const RAW_BASE = 'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main'
+// The committed, prebuilt index (fast path) — served straight from the repo, no
+// separate deploy. Falls back to walking the agent source below.
+const HOSTED_BASE = `${RAW_BASE}/public/r`
 
 export interface RegistryEnvVar {
   name: string

--- a/packages/cli/tests/commands-registry.test.ts
+++ b/packages/cli/tests/commands-registry.test.ts
@@ -82,4 +82,23 @@ describe('registry commands', () => {
     await cli().parseAsync(['node', 'cli', 'update', 'x', '--out', dir])
     expect(out).toContain('up to date')
   })
+
+  it('add --run on a tool-composing agent prints "not supported"', async () => {
+    const toolAgent = {
+      ...AGENT,
+      skill: null,
+      sources: [{ path: 'agent.ts', content: 'import { researcher } from "@agentskit/skills"' }],
+    }
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(toolAgent), { status: 200 })) as never
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'x', '--out', dir, '--run', 'do it', '--provider', 'demo'])
+    expect(out).toContain('not supported')
+  })
+
+  it('add reports failure when the agent cannot be fetched', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 404 })) as never
+    const dir = mkdtempSync(join(tmpdir(), 'ak-cmd-'))
+    await cli().parseAsync(['node', 'cli', 'add', 'missing', '--out', dir])
+    expect(out).toContain('add failed')
+  })
 })

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -26,7 +26,7 @@ describe('fetchAgent', () => {
   it('uses the hosted index when it has inlined sources', async () => {
     const hosted = { ...META, sources: [{ path: 'agent.ts', content: 'export const x = 1' }] }
     const fetchImpl = vi.fn(async (url: string) => {
-      expect(url).toContain('registry.agentskit.io/r/research.json')
+      expect(url).toContain('/public/r/research.json')
       return jsonResponse(hosted)
     }) as unknown as typeof fetch
     const agent = await fetchAgent('research', { fetchImpl })

--- a/rfcs/0002-agent-registry-and-ecosystem-cohesion.md
+++ b/rfcs/0002-agent-registry-and-ecosystem-cohesion.md
@@ -243,3 +243,17 @@ with the current property highlighted. Consistent footer listing all four.
   is curation + tests, not the full monorepo gate suite.
 - `@agentskit/agents` (option A) is explicitly deferred; it may still be earned
   later if a real second consumer needs the agents as an importable package.
+
+## Addendum (2026-06-10) — gallery hosting
+
+The gallery was originally specced as its own static site on `registry.agentskit.io`.
+It now lives **inside the docs site** (fumadocs/Next) at `agentskit.io/agents`
+(list) and `/agents/[id]` (per-agent pages). The agent **source** stays in the
+decoupled `agentskit-registry` repo; only the gallery UI unifies — one site, one
+deploy, better SEO, free per-agent pages.
+
+Data is served from the registry repo's **committed** built index (`public/r`,
+via raw GitHub / jsDelivr) and fetched server-side with `revalidate`, so new
+agents appear without a docs rebuild. The CLI reads the same committed index.
+`registry.agentskit.io` becomes a redirect to `/agents` (or is dropped). No
+separate Vercel project for the registry is required.


### PR DESCRIPTION
Unifies the registry gallery into the docs site (fumadocs/Next) — **one site, one Vercel project, no separate `registry.agentskit.io` deploy.**

## What
- `/agents` — gallery list, grouped by category (server component, SSG + ISR).
- `/agents/[id]` — per-agent page: add command, packages, required env, system prompt, source link, AKOS CTA. `generateStaticParams` from the index + `dynamicParams` for new ones → SEO + on-demand.
- Data server-fetched from the **committed index** (`public/r`) in the registry repo via raw GitHub, `revalidate: 3600` → new agents appear without a docs rebuild.
- Home page links to `/agents`.
- **CLI** now reads the same committed index (`public/r`) — drops the need for a separate registry host.

## Why this keeps RFC 0002
The agent **source** stays in the decoupled `agentskit-registry` repo (cadence/community). Only the **gallery UI** moves into the docs. Addendum to RFC 0002 follows.

## Depends on
Registry PR #7 (commits `public/r` so it's CDN/raw-servable). Until merged, the gallery renders empty gracefully (fetch returns []).

## Verification
- docs-next tsc clean · cli 402 tests · 9/9 gates · changeset (cli patch)