### PR TITLE
feat(integrations): add webhook triggers (verify + normalize) for 7 providers (#943)

### DIFF
--- a/.changeset/integrations-webhook-triggers.md
+++ b/.changeset/integrations-webhook-triggers.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/integrations': minor
+---
+
+Add inbound webhook **triggers** (signature `verify` + payload `normalize`) to the catalog for slack, github, linear, sentry, pagerduty, twilio, and discord — the open, dependency-light counterpart to the actions already in the catalog. Covers every signature scheme in the wild: HMAC-SHA256 over the raw body (github `sha256=`, linear/sentry bare hex), Slack's `v0:ts:body` with a 300s replay window, PagerDuty's multi-`v1=` list, Twilio's HMAC-SHA1 over URL+sorted-params, and Discord's Ed25519. Pure `node:crypto`, no extra deps. This lets any agent (not just the OS) authenticate inbound provider webhooks.

--- a/packages/integrations/src/services/discord/index.ts
+++ b/packages/integrations/src/services/discord/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { discordActions } from './actions'
+import { discordTriggers } from './triggers'
 
 export const discordIntegration = defineIntegration({
   name: 'discord',
@@ -9,6 +10,7 @@ export const discordIntegration = defineIntegration({
   http: { baseUrl: 'https://discord.com/api/v10' },
   auth: { kind: 'apiKey', header: 'authorization', prefix: 'Bot ', envHint: 'DISCORD_BOT_TOKEN' },
   actions: discordActions,
+  triggers: discordTriggers,
   capabilities: { send: 'discord_post_message', notify: 'discord_post_message' },
 })
 

--- a/packages/integrations/src/services/discord/triggers.ts
+++ b/packages/integrations/src/services/discord/triggers.ts
@@ -1,0 +1,15 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyDiscord } from '../../webhook-verify'
+
+export const discordInteraction = defineTrigger({
+  name: 'discord.interaction',
+  source: 'discord',
+  verify: verifyDiscord,
+  normalize: (raw): NormalizedEvent => {
+    const json = (typeof raw === 'string' ? JSON.parse(raw) : raw) as { type?: number }
+    const kind = json.type === 1 ? 'ping' : typeof json.type === 'number' ? 'interaction' : 'unknown'
+    return { kind, payload: json, raw }
+  },
+})
+
+export const discordTriggers = [discordInteraction]

--- a/packages/integrations/src/services/github/index.ts
+++ b/packages/integrations/src/services/github/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { githubActionsList } from './actions'
+import { githubTriggers } from './triggers'
 
 export const githubIntegration = defineIntegration({
   name: 'github',
@@ -12,6 +13,7 @@ export const githubIntegration = defineIntegration({
   },
   auth: { kind: 'apiKey', header: 'authorization', prefix: 'Bearer ', envHint: 'GITHUB_TOKEN' },
   actions: githubActionsList,
+  triggers: githubTriggers,
   capabilities: { send: 'github_comment_issue' },
 })
 

--- a/packages/integrations/src/services/github/triggers.ts
+++ b/packages/integrations/src/services/github/triggers.ts
@@ -1,0 +1,17 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyHmacSha256Body } from '../../webhook-verify'
+
+export const githubEvent = defineTrigger({
+  name: 'github.event',
+  source: 'github',
+  verify: (input) => verifyHmacSha256Body(input, 'x-hub-signature-256', 'sha256='),
+  normalize: (raw): NormalizedEvent => {
+    const json = (typeof raw === 'string' ? JSON.parse(raw) : raw) as Record<string, unknown>
+    const action = typeof json.action === 'string' ? json.action : undefined
+    const kind = json.pull_request ? 'pull_request' : json.issue ? 'issues' : json.release ? 'release' : json.ref ? 'push' : 'unknown'
+    const repo = (json.repository as { full_name?: string } | undefined)?.full_name
+    return { kind, payload: { action, repo, body: json }, raw }
+  },
+})
+
+export const githubTriggers = [githubEvent]

--- a/packages/integrations/src/services/linear/index.ts
+++ b/packages/integrations/src/services/linear/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { linearActions } from './actions'
+import { linearTriggers } from './triggers'
 
 export const linearIntegration = defineIntegration({
   name: 'linear',
@@ -10,6 +11,7 @@ export const linearIntegration = defineIntegration({
   // Linear personal API keys go in the Authorization header verbatim (no Bearer).
   auth: { kind: 'apiKey', header: 'authorization', prefix: '', envHint: 'LINEAR_API_KEY' },
   actions: linearActions,
+  triggers: linearTriggers,
   capabilities: { send: 'linear_create_issue' },
 })
 

--- a/packages/integrations/src/services/linear/triggers.ts
+++ b/packages/integrations/src/services/linear/triggers.ts
@@ -1,0 +1,20 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyHmacSha256Bare } from '../../webhook-verify'
+
+interface LinearEnvelope {
+  action?: 'create' | 'update' | 'remove'
+  type?: string
+  data?: { identifier?: string; title?: string; state?: { name?: string } }
+}
+
+export const linearEvent = defineTrigger({
+  name: 'linear.event',
+  source: 'linear',
+  verify: (input) => verifyHmacSha256Bare(input, 'linear-signature'),
+  normalize: (raw): NormalizedEvent => {
+    const json = (typeof raw === 'string' ? JSON.parse(raw) : raw) as LinearEnvelope
+    return { kind: `${json.type ?? 'unknown'}.${json.action ?? 'unknown'}`, payload: { action: json.action, resourceType: json.type, identifier: json.data?.identifier, title: json.data?.title, state: json.data?.state?.name }, raw }
+  },
+})
+
+export const linearTriggers = [linearEvent]

--- a/packages/integrations/src/services/pagerduty/index.ts
+++ b/packages/integrations/src/services/pagerduty/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { pagerdutyActions } from './actions'
+import { pagerdutyTriggers } from './triggers'
 
 export const pagerdutyIntegration = defineIntegration({
   name: 'pagerduty',
@@ -10,6 +11,7 @@ export const pagerdutyIntegration = defineIntegration({
   // built per-call from ctx.config; no single auth/base URL.
   auth: { kind: 'none' },
   actions: pagerdutyActions,
+  triggers: pagerdutyTriggers,
   capabilities: { send: 'pagerduty_trigger' },
 })
 

--- a/packages/integrations/src/services/pagerduty/triggers.ts
+++ b/packages/integrations/src/services/pagerduty/triggers.ts
@@ -1,0 +1,14 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyPagerDuty } from '../../webhook-verify'
+
+export const pagerdutyEvent = defineTrigger({
+  name: 'pagerduty.event',
+  source: 'pagerduty',
+  verify: verifyPagerDuty,
+  normalize: (raw): NormalizedEvent => {
+    const json = (typeof raw === 'string' ? JSON.parse(raw) : raw) as { event?: { event_type?: string; data?: unknown } }
+    return { kind: json.event?.event_type ?? 'unknown', payload: json.event?.data ?? json, raw }
+  },
+})
+
+export const pagerdutyTriggers = [pagerdutyEvent]

--- a/packages/integrations/src/services/sentry/index.ts
+++ b/packages/integrations/src/services/sentry/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { sentryActions } from './actions'
+import { sentryTriggers } from './triggers'
 
 export const sentryIntegration = defineIntegration({
   name: 'sentry',
@@ -9,6 +10,7 @@ export const sentryIntegration = defineIntegration({
   http: { baseUrl: 'https://sentry.io/api/0' },
   auth: { kind: 'apiKey', header: 'authorization', prefix: 'Bearer ', envHint: 'SENTRY_AUTH_TOKEN' },
   actions: sentryActions,
+  triggers: sentryTriggers,
 })
 
 registerIntegration(sentryIntegration)

--- a/packages/integrations/src/services/sentry/triggers.ts
+++ b/packages/integrations/src/services/sentry/triggers.ts
@@ -1,0 +1,18 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyHmacSha256Bare, headerValue } from '../../webhook-verify'
+
+export const sentryEvent = defineTrigger({
+  name: 'sentry.event',
+  source: 'sentry',
+  verify: (input) => {
+    const resource = headerValue(input.headers, 'sentry-hook-resource')
+    if (resource === undefined) return { ok: false, reason: 'missing sentry-hook-resource' }
+    return verifyHmacSha256Bare(input, 'sentry-hook-signature')
+  },
+  normalize: (raw): NormalizedEvent => {
+    const json = (typeof raw === 'string' ? JSON.parse(raw) : raw) as { action?: string; data?: unknown }
+    return { kind: json.action ?? 'unknown', payload: json.data ?? json, raw }
+  },
+})
+
+export const sentryTriggers = [sentryEvent]

--- a/packages/integrations/src/services/slack/index.ts
+++ b/packages/integrations/src/services/slack/index.ts
@@ -2,6 +2,7 @@ import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { slackAuth } from './auth'
 import { slackActions } from './actions'
+import { slackTriggers } from './triggers'
 
 export const slackIntegration = defineIntegration({
   name: 'slack',
@@ -10,6 +11,7 @@ export const slackIntegration = defineIntegration({
   http: { baseUrl: 'https://slack.com/api' },
   auth: slackAuth,
   actions: slackActions,
+  triggers: slackTriggers,
   capabilities: { send: 'slack_post_message', notify: 'slack_post_message' },
 })
 

--- a/packages/integrations/src/services/slack/triggers.ts
+++ b/packages/integrations/src/services/slack/triggers.ts
@@ -1,0 +1,28 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifySlack } from '../../webhook-verify'
+
+interface SlackEnvelope {
+  type?: string
+  team_id?: string
+  event?: { type?: string; channel?: string; user?: string; text?: string; thread_ts?: string }
+}
+
+export const slackEvent = defineTrigger({
+  name: 'slack.event',
+  source: 'slack',
+  verify: verifySlack,
+  normalize: (raw): NormalizedEvent => {
+    const env = (typeof raw === 'string' ? JSON.parse(raw) : raw) as SlackEnvelope
+    const kind = env.event?.type ?? env.type ?? 'unknown'
+    return { kind, payload: { teamId: env.team_id, channel: env.event?.channel, user: env.event?.user, text: env.event?.text, threadTs: env.event?.thread_ts }, raw }
+  },
+  externalThreadRef: (raw) => {
+    const env = (typeof raw === 'string' ? JSON.parse(raw) : raw) as SlackEnvelope
+    const ts = env.event?.thread_ts
+    const channel = env.event?.channel
+    if (!ts || !channel) return undefined
+    return { kind: 'slack.thread', id: `${channel}:${ts}`, parentId: channel }
+  },
+})
+
+export const slackTriggers = [slackEvent]

--- a/packages/integrations/src/services/twilio/index.ts
+++ b/packages/integrations/src/services/twilio/index.ts
@@ -1,6 +1,7 @@
 import { defineIntegration } from '../../contract'
 import { registerIntegration } from '../../registry'
 import { twilioActions } from './actions'
+import { twilioTriggers } from './triggers'
 
 export const twilioIntegration = defineIntegration({
   name: 'twilio',
@@ -10,6 +11,7 @@ export const twilioIntegration = defineIntegration({
   // Basic auth (accountSid:authToken) is built per-call from ctx.config.
   auth: { kind: 'none' },
   actions: twilioActions,
+  triggers: twilioTriggers,
   capabilities: { send: 'twilio_send_sms', notify: 'twilio_send_sms' },
 })
 

--- a/packages/integrations/src/services/twilio/triggers.ts
+++ b/packages/integrations/src/services/twilio/triggers.ts
@@ -1,0 +1,21 @@
+import { defineTrigger, type NormalizedEvent } from '../../contract'
+import { verifyTwilio } from '../../webhook-verify'
+
+export const twilioEvent = defineTrigger({
+  name: 'twilio.event',
+  source: 'twilio',
+  verify: verifyTwilio,
+  normalize: (raw): NormalizedEvent => {
+    // Twilio inbound bodies are application/x-www-form-urlencoded.
+    const form: Record<string, string> = {}
+    if (typeof raw === 'string') {
+      for (const [k, v] of new URLSearchParams(raw)) form[k] = v
+    } else if (raw && typeof raw === 'object') {
+      Object.assign(form, raw as Record<string, string>)
+    }
+    const kind = form.MessageSid ? 'message' : form.CallSid ? 'call' : 'unknown'
+    return { kind, payload: form, raw }
+  },
+})
+
+export const twilioTriggers = [twilioEvent]

--- a/packages/integrations/src/webhook-verify.ts
+++ b/packages/integrations/src/webhook-verify.ts
@@ -1,0 +1,118 @@
+import { createHmac, timingSafeEqual, verify as nodeEd25519Verify } from 'node:crypto'
+import type { WebhookInput, VerifyResult } from './contract'
+
+/** Case-insensitive header lookup. */
+export function headerValue(headers: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) return headers[key]
+  }
+  return undefined
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ba.length === bb.length && timingSafeEqual(ba, bb)
+}
+
+export function hmacSha256Hex(secret: string, payload: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex')
+}
+
+export function hmacSha1Base64(secret: string, payload: string): string {
+  return createHmac('sha1', secret).update(payload).digest('base64')
+}
+
+/** Generic HMAC-SHA256-over-raw-body verifier: signature header equals
+ *  `${prefix}${hmacSha256Hex(secret, rawBody)}` (e.g. github `sha256=`). */
+export function verifyHmacSha256Body(
+  input: WebhookInput,
+  headerName: string,
+  prefix = '',
+): VerifyResult {
+  const sig = headerValue(input.headers, headerName)
+  if (sig === undefined) return { ok: false, reason: `missing ${headerName}` }
+  return safeEqual(sig, `${prefix}${hmacSha256Hex(input.secret, input.rawBody)}`)
+    ? { ok: true }
+    : { ok: false, reason: 'signature mismatch' }
+}
+
+const SLACK_REPLAY_WINDOW_SECONDS = 300
+
+/** Slack: `x-slack-signature: v0=<hex>` over `v0:${ts}:${body}`, 300s replay. */
+export function verifySlack(input: WebhookInput): VerifyResult {
+  const ts = headerValue(input.headers, 'x-slack-request-timestamp')
+  const sig = headerValue(input.headers, 'x-slack-signature')
+  if (ts === undefined || sig === undefined) return { ok: false, reason: 'missing slack headers' }
+  const tsInt = Number(ts)
+  if (!Number.isFinite(tsInt)) return { ok: false, reason: 'invalid timestamp' }
+  const now = input.nowSeconds ?? Math.floor(Date.now() / 1000)
+  if (Math.abs(now - tsInt) > SLACK_REPLAY_WINDOW_SECONDS) {
+    return { ok: false, reason: 'timestamp outside replay window' }
+  }
+  return safeEqual(sig, `v0=${hmacSha256Hex(input.secret, `v0:${ts}:${input.rawBody}`)}`)
+    ? { ok: true }
+    : { ok: false, reason: 'signature mismatch' }
+}
+
+/** PagerDuty v3: `x-pagerduty-signature: v1=<hex>,v1=<hex>`; any match passes. */
+export function verifyPagerDuty(input: WebhookInput): VerifyResult {
+  const header = headerValue(input.headers, 'x-pagerduty-signature')
+  if (header === undefined) return { ok: false, reason: 'missing x-pagerduty-signature' }
+  const candidates = header.split(',').map((s) => s.trim()).filter((s) => s.startsWith('v1=')).map((s) => s.slice(3))
+  if (candidates.length === 0) return { ok: false, reason: 'no v1 signature in header' }
+  const expected = hmacSha256Hex(input.secret, input.rawBody)
+  return candidates.some((c) => safeEqual(c, expected))
+    ? { ok: true }
+    : { ok: false, reason: 'signature mismatch' }
+}
+
+/** Twilio: `x-twilio-signature` = base64(HMAC-SHA1(authToken, url + sorted form k+v)). */
+export function verifyTwilio(input: WebhookInput): VerifyResult {
+  const sig = headerValue(input.headers, 'x-twilio-signature')
+  if (sig === undefined || sig.length === 0) return { ok: false, reason: 'missing x-twilio-signature' }
+  if (input.requestUrl === undefined || input.requestUrl.length === 0) {
+    return { ok: false, reason: 'missing request url for twilio verification' }
+  }
+  const form: Record<string, string> = {}
+  for (const [k, v] of new URLSearchParams(input.rawBody)) form[k] = v
+  let canonical = input.requestUrl
+  for (const key of Object.keys(form).sort()) canonical += key + form[key]
+  return safeEqual(sig, hmacSha1Base64(input.secret, canonical))
+    ? { ok: true }
+    : { ok: false, reason: 'signature mismatch' }
+}
+
+/** DER SubjectPublicKeyInfo prefix for a raw 32-byte Ed25519 key (RFC 8410). */
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+
+function hexToBuffer(value: string): Buffer | undefined {
+  if (value.length === 0 || value.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(value)) return undefined
+  return Buffer.from(value, 'hex')
+}
+
+/** Discord: Ed25519 over `timestamp + body`; `secret` = app public key (hex). */
+export function verifyDiscord(input: WebhookInput): VerifyResult {
+  const signature = headerValue(input.headers, 'x-signature-ed25519')
+  const timestamp = headerValue(input.headers, 'x-signature-timestamp')
+  if (signature === undefined || timestamp === undefined) return { ok: false, reason: 'missing discord signature headers' }
+  const sigBytes = hexToBuffer(signature)
+  const keyBytes = hexToBuffer(input.secret)
+  if (!sigBytes || sigBytes.length !== 64) return { ok: false, reason: 'malformed ed25519 signature' }
+  if (!keyBytes || keyBytes.length !== 32) return { ok: false, reason: 'malformed ed25519 public key' }
+  const spki = Buffer.concat([ED25519_SPKI_PREFIX, keyBytes])
+  const message = Buffer.from(timestamp + input.rawBody, 'utf8')
+  try {
+    const valid = nodeEd25519Verify(null, message, { key: spki, format: 'der', type: 'spki' }, sigBytes)
+    return valid ? { ok: true } : { ok: false, reason: 'ed25519 signature mismatch' }
+  } catch {
+    return { ok: false, reason: 'ed25519 verification error' }
+  }
+}
+
+/** Generic HMAC-SHA256 verifier where the header carries the bare hex digest
+ *  of the raw body (Linear `linear-signature`, Sentry `sentry-hook-signature`). */
+export function verifyHmacSha256Bare(input: WebhookInput, headerName: string): VerifyResult {
+  return verifyHmacSha256Body(input, headerName, '')
+}

--- a/packages/integrations/tests/webhook-triggers.test.ts
+++ b/packages/integrations/tests/webhook-triggers.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { createHmac, generateKeyPairSync, sign as edSign } from 'node:crypto'
+import { slackEvent } from '../src/services/slack/triggers'
+import { githubEvent } from '../src/services/github/triggers'
+import { linearEvent } from '../src/services/linear/triggers'
+import { sentryEvent } from '../src/services/sentry/triggers'
+import { pagerdutyEvent } from '../src/services/pagerduty/triggers'
+import { twilioEvent } from '../src/services/twilio/triggers'
+import { discordInteraction } from '../src/services/discord/triggers'
+import { slackIntegration } from '../src/services/slack/index'
+import { githubIntegration } from '../src/services/github/index'
+import { assertValidIntegration } from '../src/testing/validate'
+import type { WebhookInput } from '../src/contract'
+import { hmacSha256Hex, hmacSha1Base64, headerValue } from '../src/webhook-verify'
+
+const hmac256 = (s: string, p: string) => createHmac('sha256', s).update(p).digest('hex')
+const inp = (over: Partial<WebhookInput>): WebhookInput => ({ secret: 'sk', rawBody: '{}', headers: {}, ...over })
+
+describe('webhook triggers — descriptors valid', () => {
+  it('slack + github descriptors with triggers validate', () => {
+    expect(() => assertValidIntegration(slackIntegration)).not.toThrow()
+    expect(() => assertValidIntegration(githubIntegration)).not.toThrow()
+    expect(slackIntegration.triggers?.[0]?.source).toBe('slack')
+  })
+})
+
+describe('slack', () => {
+  const secret = 'slacksecret'; const ts = '1700000000'
+  const body = JSON.stringify({ type: 'event_callback', team_id: 'T1', event: { type: 'app_mention', channel: 'C1', user: 'U1', text: 'hi', thread_ts: '1.2' } })
+  const sig = `v0=${hmac256(secret, `v0:${ts}:${body}`)}`
+  it('verifies a valid signature within the replay window', () => {
+    expect(slackEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-slack-signature': sig, 'x-slack-request-timestamp': ts }, nowSeconds: Number(ts) }))).toEqual({ ok: true })
+  })
+  it('rejects a stale timestamp and a bad signature', () => {
+    expect(slackEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-slack-signature': sig, 'x-slack-request-timestamp': ts }, nowSeconds: Number(ts) + 1000 })).ok).toBe(false)
+    expect(slackEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-slack-signature': 'v0=bad', 'x-slack-request-timestamp': ts }, nowSeconds: Number(ts) })).ok).toBe(false)
+  })
+  it('normalizes + extracts thread ref', () => {
+    expect(slackEvent.normalize(body).kind).toBe('app_mention')
+    expect(slackEvent.externalThreadRef!(body)).toEqual({ kind: 'slack.thread', id: 'C1:1.2', parentId: 'C1' })
+  })
+})
+
+describe('github', () => {
+  const secret = 'ghsecret'; const body = JSON.stringify({ action: 'opened', pull_request: { number: 1 }, repository: { full_name: 'o/r' } })
+  it('verifies sha256= signature + normalizes', () => {
+    expect(githubEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-hub-signature-256': `sha256=${hmac256(secret, body)}` } }))).toEqual({ ok: true })
+    expect(githubEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-hub-signature-256': 'sha256=bad' } })).ok).toBe(false)
+    const n = githubEvent.normalize(body)
+    expect(n.kind).toBe('pull_request')
+    expect((n.payload as { repo: string }).repo).toBe('o/r')
+  })
+})
+
+describe('linear', () => {
+  const secret = 'lnsecret'; const body = JSON.stringify({ action: 'create', type: 'Issue', data: { identifier: 'ENG-1', title: 't', state: { name: 'Todo' } } })
+  it('verifies bare hex signature + normalizes', () => {
+    expect(linearEvent.verify!(inp({ secret, rawBody: body, headers: { 'linear-signature': hmac256(secret, body) } }))).toEqual({ ok: true })
+    expect(linearEvent.normalize(body).kind).toBe('Issue.create')
+  })
+})
+
+describe('sentry', () => {
+  const secret = 'sesecret'; const body = JSON.stringify({ action: 'created', data: { issue: { id: '1' } } })
+  it('requires the resource header + verifies', () => {
+    expect(sentryEvent.verify!(inp({ secret, rawBody: body, headers: { 'sentry-hook-signature': hmac256(secret, body), 'sentry-hook-resource': 'issue' } }))).toEqual({ ok: true })
+    expect(sentryEvent.verify!(inp({ secret, rawBody: body, headers: { 'sentry-hook-signature': hmac256(secret, body) } })).ok).toBe(false)
+    expect(sentryEvent.normalize(body).kind).toBe('created')
+  })
+})
+
+describe('pagerduty', () => {
+  const secret = 'pdsecret'; const body = JSON.stringify({ event: { event_type: 'incident.triggered', data: { id: 'P1' } } })
+  it('matches any v1 signature in the list', () => {
+    const good = hmac256(secret, body)
+    expect(pagerdutyEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-pagerduty-signature': `v1=deadbeef,v1=${good}` } }))).toEqual({ ok: true })
+    expect(pagerdutyEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-pagerduty-signature': 'v1=deadbeef' } })).ok).toBe(false)
+    expect(pagerdutyEvent.normalize(body).kind).toBe('incident.triggered')
+  })
+})
+
+describe('twilio', () => {
+  const secret = 'twtoken'; const url = 'https://hook.example/twilio'
+  const body = 'MessageSid=SM1&From=%2B15551234&Body=hi'
+  it('verifies HMAC-SHA1 over url + sorted params', () => {
+    const form: Record<string, string> = {}
+    for (const [k, v] of new URLSearchParams(body)) form[k] = v
+    let canonical = url
+    for (const k of Object.keys(form).sort()) canonical += k + form[k]
+    const sig = createHmac('sha1', secret).update(canonical).digest('base64')
+    expect(twilioEvent.verify!(inp({ secret, rawBody: body, requestUrl: url, headers: { 'x-twilio-signature': sig } }))).toEqual({ ok: true })
+    expect(twilioEvent.verify!(inp({ secret, rawBody: body, headers: { 'x-twilio-signature': sig } })).ok).toBe(false) // no url
+    expect(twilioEvent.normalize(body).kind).toBe('message')
+  })
+})
+
+describe('discord', () => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const pubHex = publicKey.export({ format: 'der', type: 'spki' }).subarray(-32).toString('hex')
+  const ts = '1700000000'; const body = JSON.stringify({ type: 2 })
+  it('verifies a valid Ed25519 signature', () => {
+    const sig = edSign(null, Buffer.from(ts + body, 'utf8'), privateKey).toString('hex')
+    expect(discordInteraction.verify!(inp({ secret: pubHex, rawBody: body, headers: { 'x-signature-ed25519': sig, 'x-signature-timestamp': ts } }))).toEqual({ ok: true })
+    expect(discordInteraction.verify!(inp({ secret: pubHex, rawBody: body, headers: { 'x-signature-ed25519': 'aa'.repeat(64), 'x-signature-timestamp': ts } })).ok).toBe(false)
+    expect(discordInteraction.normalize(body).kind).toBe('interaction')
+    expect(discordInteraction.normalize(JSON.stringify({ type: 1 })).kind).toBe('ping')
+  })
+})
+
+describe('webhook-verify helpers', () => {
+  it('hmacSha256Hex / hmacSha1Base64 are deterministic', () => {
+    expect(hmacSha256Hex('k', 'm')).toBe(createHmac('sha256', 'k').update('m').digest('hex'))
+    expect(hmacSha1Base64('k', 'm')).toBe(createHmac('sha1', 'k').update('m').digest('base64'))
+  })
+  it('headerValue is case-insensitive', () => {
+    expect(headerValue({ 'X-Foo': 'bar' }, 'x-foo')).toBe('bar')
+    expect(headerValue({}, 'x-foo')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #943. Ports the pure inbound webhook logic for **slack, github, linear, sentry, pagerduty, twilio, discord** into the catalog as `IntegrationTrigger`s — the open, dependency-light counterpart to the actions.

Signature schemes (all `node:crypto`, no extra deps):
- HMAC-SHA256 over raw body — github (`sha256=`), linear / sentry (bare hex)
- Slack — `v0:ts:body` + 300s replay window
- PagerDuty — multi `v1=` list (any match)
- Twilio — HMAC-SHA1 over URL + sorted form params
- Discord — Ed25519 (app public key)

Each trigger `verify()`s a golden signed payload, rejects bad/stale signatures, and `normalize()`s the event. 106 tests, 95.96% coverage, 9 quality gates green.

Boundary kept: only the portable verify/normalize cores come up — the OS keeps canonical IncomingEvent, correlation/SessionRegistry, webhook auto-registration, egress/audit. Step 1 of the 'move up' plan; unblocks agentskit-os#3920.