### PR TITLE
fix(mcp): add CHANGELOG.md seed so the release action can publish

### DIFF
--- a/.changeset/mcp-changelog-seed.md
+++ b/.changeset/mcp-changelog-seed.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the `@agentskit/mcp` package CHANGELOG.md seed so the changesets release action can generate GitHub releases (the repo uses `changelog: false`, so `changeset version` doesn't create one for a brand-new package). Mirrors every other package; unblocks the release/publish that was failing with ENOENT on `packages/mcp/CHANGELOG.md`.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
The Release workflow fails on every push to main with `ENOENT: packages/mcp/CHANGELOG.md` — the new `@agentskit/mcp` package has no CHANGELOG, and the repo uses `changelog: false` so `changeset version` doesn't create one. Same fix already applied to other packages (#931). Unblocks publishing the new `@agentskit/integrations` (webhook triggers #943 + oauth specs #944).