### PR TITLE
fix(registry-app): sidebar + richer agent pages

### DIFF
--- a/apps/registry/app/agents/[id]/page.tsx
+++ b/apps/registry/app/agents/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getAgent, getRegistryIndex } from '@/lib/registry'
+import { factoryName, getAgent, getRegistryIndex } from '@/lib/registry'
 
 export const revalidate = 3600
 export const dynamicParams = true
@@ -17,12 +17,26 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   return { title: agent.title, description: agent.description }
 }
 
+function H2({ children }: { children: React.ReactNode }) {
+  return <h2 className="mt-8 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">{children}</h2>
+}
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg border border-ak-border bg-ak-surface/40 p-4 text-sm text-ak-foam">
+      <code>{children}</code>
+    </pre>
+  )
+}
+
 export default async function AgentPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const agent = await getAgent(id)
   if (!agent) notFound()
 
+  const fn = `create${factoryName(agent.id)}Agent`
+  const dir = `./agents/${agent.id}`
   const required = (agent.env ?? []).filter((e) => e.required)
+  const agentSrc = agent.sources?.find((s) => s.path === 'agent.ts')?.content
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-12">
@@ -36,12 +50,57 @@ export default async function AgentPage({ params }: { params: Promise<{ id: stri
         <p className="mt-2 text-ak-graphite">{agent.description}</p>
       </div>
 
-      <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Add it</h2>
-      <div className="rounded-lg border border-ak-border bg-ak-surface/40 px-4 py-3 font-mono text-sm text-ak-foam">
-        npx agentskit add {agent.id}
+      <div className="rounded-xl border border-ak-border bg-ak-surface/30 p-4 text-sm text-ak-graphite">
+        Copy the source into your project, then run it. Pass optional config to wire tools, RAG, MCP, memory,
+        permissions, and orchestration — all overridable. Full guides:{' '}
+        <Link href="/docs/using" className="text-ak-blue hover:underline">
+          Using
+        </Link>{' '}
+        ·{' '}
+        <Link href="/docs/authoring" className="text-ak-blue hover:underline">
+          Create your own
+        </Link>
+        .
       </div>
 
-      <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Packages</h2>
+      <H2>Add it</H2>
+      <Code>{`npx agentskit add ${agent.id}`}</Code>
+
+      <H2>Use it</H2>
+      <Code>{`import { openai } from '@agentskit/adapters'
+import { ${fn} } from '${dir}/agent'
+
+const agent = ${fn}({
+  adapter: openai({ apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o' }),
+})
+const { content } = await agent.run('…')`}</Code>
+      <p className="text-sm text-ak-graphite">
+        Or in one command: <code className="text-ak-foam">npx agentskit add {agent.id} --run &quot;…&quot; --provider ollama</code>.
+        Provider/model can also come from a <code className="text-ak-foam">.agentskit.config.json</code> file.
+      </p>
+
+      <H2>Add tools, RAG, MCP, memory, permissions</H2>
+      <Code>{`import { webSearch } from '@agentskit/tools'
+import { createMcpClient, toolsFromMcpClient } from '@agentskit/tools/mcp'
+
+const agent = ${fn}({
+  adapter,
+  tools: [webSearch(), ...(await toolsFromMcpClient(await createMcpClient(/* … */)))], // tools + MCP
+  retriever: rag.retrieve,             // RAG grounding
+  memory,                              // conversation context
+  onConfirm: (call) => approve(call),  // per-tool permission (HITL / RBAC)
+  observers: [tracer],                 // tracing / audit
+})`}</Code>
+      <p className="text-sm text-ak-graphite">
+        For orchestration, agents expose <code className="text-ak-foam">.asHandle()</code> for{' '}
+        <code className="text-ak-foam">supervisor</code> / <code className="text-ak-foam">swarm</code>. See{' '}
+        <Link href="/docs/using" className="text-ak-blue hover:underline">
+          Using
+        </Link>
+        .
+      </p>
+
+      <H2>Packages</H2>
       <div className="flex flex-wrap gap-2">
         {agent.packages.map((p) => (
           <span key={p} className="rounded-full border border-ak-border px-3 py-1 font-mono text-xs text-ak-graphite">
@@ -52,7 +111,7 @@ export default async function AgentPage({ params }: { params: Promise<{ id: stri
 
       {required.length > 0 && (
         <>
-          <h2 className="mt-6 mb-2 font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">Required env</h2>
+          <H2>Required env</H2>
           <ul className="space-y-1 text-sm text-ak-graphite">
             {required.map((e) => (
               <li key={e.name}>
@@ -63,15 +122,11 @@ export default async function AgentPage({ params }: { params: Promise<{ id: stri
         </>
       )}
 
-      {agent.skill?.systemPrompt && (
-        <details className="mt-6">
-          <summary className="cursor-pointer font-mono text-xs uppercase tracking-[0.18em] text-ak-graphite">
-            System prompt
-          </summary>
-          <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded-lg border border-ak-border bg-ak-surface/40 p-4 text-sm text-ak-graphite">
-            {agent.skill.systemPrompt}
-          </pre>
-        </details>
+      {agentSrc && (
+        <>
+          <H2>agent.ts — the factory</H2>
+          <Code>{agentSrc}</Code>
+        </>
       )}
 
       <p className="mt-8 text-sm text-ak-graphite">
@@ -82,11 +137,7 @@ export default async function AgentPage({ params }: { params: Promise<{ id: stri
           href={`https://github.com/AgentsKit-io/agentskit-registry/tree/main/registry/${agent.id}`}
         >
           view source
-        </a>{' '}
-        ·{' '}
-        <Link href="/docs/authoring" className="text-ak-blue hover:underline">
-          create your own
-        </Link>
+        </a>
       </p>
     </main>
   )

--- a/apps/registry/app/global.css
+++ b/apps/registry/app/global.css
@@ -223,3 +223,16 @@ button[data-theme-toggle] > svg {
   --color-fd-accent-foreground: #E6EDF3;
   --color-fd-ring: #58A6FF;
 }
+
+/* Registry app tweaks */
+:root {
+  /* Narrower docs sidebar (closer to the search box width). */
+  --fd-sidebar-width: 16rem;
+}
+/* Code blocks wrap instead of scrolling horizontally — the agent factory stays fully visible. */
+.prose pre,
+pre.shiki,
+figure[data-rehype-pretty-code-figure] pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/apps/registry/app/layout.config.tsx
+++ b/apps/registry/app/layout.config.tsx
@@ -9,9 +9,7 @@ export const baseOptions: BaseLayoutProps = {
   },
   links: [
     { text: 'Agents', url: '/', active: 'none' },
-    { text: 'Using', url: '/docs/using' },
-    { text: 'Create an agent', url: '/docs/authoring' },
-    { text: 'Contributing', url: '/docs/contributing' },
+    { text: 'Docs', url: '/docs', active: 'nested-url' },
     { text: 'Framework', url: 'https://www.agentskit.io', external: true },
   ],
   githubUrl: 'https://github.com/AgentsKit-io/agentskit-registry',

--- a/apps/registry/lib/registry.ts
+++ b/apps/registry/lib/registry.ts
@@ -27,6 +27,12 @@ export interface RegistryEnvVar {
 export interface RegistryAgentDetail extends RegistryAgentSummary {
   env?: RegistryEnvVar[]
   skill?: { name: string; description: string; systemPrompt: string } | null
+  sources?: { path: string; content: string }[]
+}
+
+/** PascalCase factory name for an agent id, e.g. "legal-contract-reviewer" -> "LegalContractReviewer". */
+export function factoryName(id: string): string {
+  return id.replace(/(^|-)([a-z])/g, (_m, _s, c: string) => c.toUpperCase())
 }
 
 export async function getRegistryIndex(): Promise<RegistryAgentSummary[]> {


### PR DESCRIPTION
- Sidebar: dedup nav (Agents/Docs/Framework) + narrower width; code blocks wrap (no horizontal scroll) so the agent factory is fully visible.
- Per-agent page: overview + links, correct factory name in 'Use it', a 'Add tools/RAG/MCP/memory/permissions' section, config-file note, and the full agent.ts source. No AKOS deploy CTA.
tsc clean, build 45 pages.