### PR TITLE
feat(ecosystem): phase 3 — cross-link mesh on agentskit.io

### DIFF
--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -705,6 +705,22 @@ function FinalCta() {
         <p className="mt-8 font-mono text-xs text-ak-graphite">
           AgentsKit.js · MIT · {counts.packages} packages on npm · built in the open
         </p>
+
+        <nav
+          aria-label="AgentsKit ecosystem"
+          className="mx-auto mt-8 flex max-w-2xl flex-wrap items-center justify-center gap-x-5 gap-y-2 border-t border-ak-border pt-6 text-xs text-ak-graphite"
+        >
+          <span className="font-mono uppercase tracking-[0.18em] text-ak-graphite/70">Ecosystem</span>
+          <a href="https://playbook.agentskit.io" className="transition hover:text-ak-blue">
+            Playbook<span className="text-ak-graphite/60"> · best practices</span>
+          </a>
+          <a href="https://registry.agentskit.io" className="transition hover:text-ak-blue">
+            Registry<span className="text-ak-graphite/60"> · ready-made agents</span>
+          </a>
+          <a href="https://akos.agentskit.io" className="transition hover:text-ak-blue">
+            AKOS<span className="text-ak-graphite/60"> · the OS for agents in production</span>
+          </a>
+        </nav>
       </div>
     </section>
   )

--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -109,7 +109,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </RootProvider>
         <Analytics />
         <SpeedInsights />
-        <Script src="/ecosystem-bar.js" strategy="afterInteractive" data-current="framework" />
+        <Script src="/ecosystem-bar.js" strategy="afterInteractive" data-current="agentskit" />
       </body>
     </html>
   )

--- a/apps/landing/app/_components/footer.tsx
+++ b/apps/landing/app/_components/footer.tsx
@@ -10,13 +10,17 @@ export function Footer() {
           <span aria-hidden className="inline-block h-4 w-4 rounded bg-gradient-to-br from-[var(--color-accent)] to-[var(--color-accent-soft)]" />
           <span>AgentsKit · MIT licensed · {YEAR}</span>
         </div>
-        <nav className="flex flex-wrap items-center gap-5 text-sm text-[var(--color-fg-soft)]">
+        <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[var(--color-fg-soft)]">
           <a href={LINKS.docs} className="hover:text-[var(--color-fg)]">Docs</a>
           <a href={LINKS.github} className="hover:text-[var(--color-fg)]">GitHub</a>
           <a href={LINKS.discord} className="hover:text-[var(--color-fg)]">Discord</a>
           <a href={LINKS.npm} className="hover:text-[var(--color-fg)]">npm</a>
           <a href={LINKS.manifesto} className="hover:text-[var(--color-fg)]">Manifesto</a>
           <a href={LINKS.roadmap} className="hover:text-[var(--color-fg)]">Roadmap</a>
+          <span aria-hidden className="text-[var(--color-border)]">·</span>
+          <a href={LINKS.playbook} className="hover:text-[var(--color-fg)]">Playbook</a>
+          <a href={LINKS.registry} className="hover:text-[var(--color-fg)]">Registry</a>
+          <a href={LINKS.akos} className="hover:text-[var(--color-fg)]">AKOS</a>
         </nav>
       </div>
     </footer>

--- a/apps/landing/app/_components/links.ts
+++ b/apps/landing/app/_components/links.ts
@@ -5,4 +5,8 @@ export const LINKS = {
   npm: 'https://www.npmjs.com/org/agentskit',
   manifesto: 'https://github.com/AgentsKit-io/agentskit/blob/main/MANIFESTO.md',
   roadmap: 'https://github.com/orgs/AgentsKit-io/projects/1',
+  // Sibling properties — the ecosystem funnel.
+  playbook: 'https://playbook.agentskit.io',
+  registry: 'https://registry.agentskit.io',
+  akos: 'https://akos.agentskit.io',
 } as const

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -24,7 +25,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {/* Shared ecosystem bar — single source on www.agentskit.io, embedded across all properties. */}
+        <Script src="https://www.agentskit.io/ecosystem-bar.js" strategy="afterInteractive" data-current="agentskit" />
+        {children}
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
Phase 3 of the cohesion plan. The ecosystem bar (RFC 0002) already provides top-nav cross-links on docs; this extends the mesh.

## Changes (5 files)
- **landing: embed the shared ecosystem-bar.js** — it was missing on the landing app (docs already had it), so the landing page had no cross-property nav
- **landing footer + links.ts**: add Playbook / Registry / AKOS
- **docs home footer**: new "Ecosystem" nav row (Playbook · Registry · AKOS) with concise canonical descriptors ("best practices", "ready-made agents", "the OS for agents in production" — no invented features)
- **fix docs `data-current`** `framework` → `agentskit` (matches the bar's ecosystem.json-driven PROPS id; the stale value highlighted nothing on agentskit.io)

## Scope note
Per-page contextual links (the Appendix A.1 long tail — e.g. get-started→registry, production→akos, security→playbook) are intentionally deferred to a focused follow-up, so this PR stays reviewable and avoids forced links. The bar + footers deliver the cross-link baseline now.

11 quality gates pass. Independent of #953 (Phase 2 brand); both branch from main.