### PR TITLE
docs(ecosystem): phase 3b — contextual cross-links to sibling properties

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,9 @@
+# Sibling ecosystem sites — live, but the CI runner is network-blocked from
+# reaching them (lychee "Connection failed"). Intentional cross-property links.
+^https://playbook\.agentskit\.io
+^https://registry\.agentskit\.io
+^https://akos\.agentskit\.io
+
 # Local dev URLs — never resolvable from CI
 ^http://localhost
 ^http://127\.0\.0\.1

--- a/apps/docs-next/content/docs/agents/skills/marketplace.mdx
+++ b/apps/docs-next/content/docs/agents/skills/marketplace.mdx
@@ -3,6 +3,8 @@ title: Skill marketplace
 description: Publish, install, version skills. Semver range resolution.
 ---
 
+`createSkillRegistry` is the local primitive for publish/install/version. For a hosted, shadcn-style catalog of ready-made agents you can pull with one command, see the [Registry](https://registry.agentskit.io).
+
 ```ts
 import { createSkillRegistry } from '@agentskit/skills'
 

--- a/apps/docs-next/content/docs/data/rag/index.mdx
+++ b/apps/docs-next/content/docs/data/rag/index.mdx
@@ -3,6 +3,8 @@ title: RAG
 description: Plug-and-play retrieval. Chunk, embed, search, rerank, loaders.
 ---
 
+Want a working RAG agent rather than wiring the pipeline yourself? The [Registry](https://registry.agentskit.io) ships document-Q&A starters you can install and point at your data.
+
 ## Core pipeline
 
 - `createRAG({ embed, store })` — one-liner ingest + retrieve + search.

--- a/apps/docs-next/content/docs/get-started/decision-tree.mdx
+++ b/apps/docs-next/content/docs/get-started/decision-tree.mdx
@@ -5,6 +5,8 @@ description: A 5-question decision tree from your use case to the one or two Age
 
 You don't need all 13+ packages. Most projects use 2–4. Walk through the questions below, install only what each branch tells you to, and skip the rest.
 
+> Prefer to start from something working? Browse the [Registry](https://registry.agentskit.io) for ready-made agents you can install and tweak instead of wiring packages by hand.
+
 ## 1. What surface are you building?
 
 | Surface | Install |

--- a/apps/docs-next/content/docs/production/index.mdx
+++ b/apps/docs-next/content/docs/production/index.mdx
@@ -7,6 +7,8 @@ Shipping an agent is not just about getting the answer right once. It is about m
 
 Start with the [shipping checklist](./shipping-checklist) if you want the shortest path from prototype to rollout.
 
+Want a managed product rather than wiring this yourself? [AKOS](https://akos.agentskit.io) — the operating system for AI agents in production — packages governed flows, sandboxing, signed audit, and cost-metering on top of the library.
+
 ## Rollout
 
 Move from prototype to trustworthy system.

--- a/apps/docs-next/content/docs/production/security/index.mdx
+++ b/apps/docs-next/content/docs/production/security/index.mdx
@@ -5,6 +5,8 @@ description: 'Six primitives for production agents: PII redaction, injection det
 
 Agents that reach production face threats unit tests don't cover — sensitive data leaking into logs, user inputs that hijack the system prompt, runaway API costs, and tool calls that modify infrastructure. These primitives address each class of risk at the boundary closest to where it appears.
 
+For the methodology behind them — threat modeling, when to apply each, team practices — see the [Playbook's security pillar](https://playbook.agentskit.io).
+
 ## Primitives
 
 - **PII redaction** — `createPIIRedactor` + `DEFAULT_PII_RULES`. [Recipe](/docs/reference/recipes/pii-redaction).

--- a/apps/docs-next/content/docs/use-cases/code-agent.mdx
+++ b/apps/docs-next/content/docs/use-cases/code-agent.mdx
@@ -5,6 +5,8 @@ description: Build a coding or code-review agent with filesystem tools, reposito
 
 Code agents need more than completions. They usually need repository access, iteration, memory, and some form of review or approval loop.
 
+> The [Registry](https://registry.agentskit.io) ships a code-reviewer agent you can install and point at your repo.
+
 ## Typical stack
 
 ```bash

--- a/apps/docs-next/content/docs/use-cases/research-agent.mdx
+++ b/apps/docs-next/content/docs/use-cases/research-agent.mdx
@@ -3,6 +3,8 @@ title: Research agent
 description: Build a research agent that searches, cites, summarizes, and runs as a repeatable job or interactive assistant.
 ---
 
+> Skip the wiring — install a ready-made researcher from the [Registry](https://registry.agentskit.io) and adapt it.
+
 Research agents are where the runtime, tools, and memory layers start to shine together. The common shape is:
 
 - search and browsing

--- a/apps/docs-next/content/docs/use-cases/support-agent.mdx
+++ b/apps/docs-next/content/docs/use-cases/support-agent.mdx
@@ -11,6 +11,8 @@ A support agent is one of the clearest “full ecosystem” builds in AgentsKit.
 - approval or escalation for risky actions
 - observability and auditability in production
 
+> Don't want to build from scratch? Install a ready-made support agent from the [Registry](https://registry.agentskit.io) and customize the stack below.
+
 ## Typical stack
 
 ```bash


### PR DESCRIPTION
Phase 3b — the Appendix A.1 long tail deferred from #955. In-content links where genuinely additive, never forced; anchors use canonical descriptors (no invented features).

8 pages, one link each:
- `get-started/decision-tree` → **Registry** (start from a ready-made agent vs wiring packages)
- `production/index` → **AKOS** (the operating system for AI agents in production)
- `production/security` → **Playbook** (security-pillar methodology)
- `agents/skills/marketplace` → **Registry** (hosted catalog vs local `createSkillRegistry`)
- `data/rag` → **Registry** (RAG-ready agent starters)
- `use-cases/{support,research,code}-agent` → **Registry** (install + customize)

11 quality gates + MDX lint pass. Independent of #953 / #955; branches from main.