### PR TITLE
feat(registry-app): per-agent canonical + OG/social previews

### DIFF
--- a/apps/registry/app/agents/[id]/opengraph-image.tsx
+++ b/apps/registry/app/agents/[id]/opengraph-image.tsx
@@ -1,0 +1,43 @@
+import { ImageResponse } from 'next/og'
+import { getAgent } from '@/lib/registry'
+
+// Per-agent social/link preview card. Shared to X/Slack/LinkedIn when an
+// individual agent is linked. Registry accent = blue.
+export const alt = 'AgentsKit Registry agent'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OG({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const agent = await getAgent(id)
+  const title = agent?.title ?? 'AgentsKit Registry'
+  const description = agent?.description ?? 'Ready-to-use AI agents for AgentsKit.'
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+          background:
+            'radial-gradient(ellipse at top left, rgba(88,166,255,0.22), transparent 55%), #0d1117',
+          color: '#e6edf3',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        <div style={{ fontSize: '22px', color: '#58a6ff', marginBottom: '20px', letterSpacing: '0.12em' }}>
+          AGENTSKIT REGISTRY
+        </div>
+        <div style={{ fontSize: '60px', fontWeight: 700, lineHeight: 1.05, maxWidth: '960px' }}>{title}</div>
+        <div style={{ fontSize: '28px', color: '#8b949e', marginTop: '20px', maxWidth: '960px' }}>
+          {description.length > 140 ? description.slice(0, 137) + '…' : description}
+        </div>
+        <div style={{ fontSize: '22px', color: '#58a6ff', marginTop: '40px' }}>npx agentskit add {id}</div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/apps/registry/app/agents/[id]/page.tsx
+++ b/apps/registry/app/agents/[id]/page.tsx
@@ -14,7 +14,14 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const { id } = await params
   const agent = await getAgent(id)
   if (!agent) return { title: 'Agent not found' }
-  return { title: agent.title, description: agent.description }
+  const url = `https://registry.agentskit.io/agents/${id}`
+  return {
+    title: agent.title,
+    description: agent.description,
+    alternates: { canonical: url },
+    openGraph: { title: agent.title, description: agent.description, url, type: 'article' },
+    twitter: { card: 'summary_large_image', title: agent.title, description: agent.description },
+  }
 }
 
 function H2({ children }: { children: React.ReactNode }) {

--- a/apps/registry/app/opengraph-image.tsx
+++ b/apps/registry/app/opengraph-image.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from 'next/og'
+
+// Default social/link preview for the registry gallery. Registry accent = blue.
+export const alt = 'AgentsKit Registry — ready-to-use AI agents'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function OG() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+          background:
+            'radial-gradient(ellipse at top left, rgba(88,166,255,0.22), transparent 55%), #0d1117',
+          color: '#e6edf3',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        <div style={{ fontSize: '64px', fontWeight: 700, lineHeight: 1.05 }}>AgentsKit Registry</div>
+        <div style={{ fontSize: '30px', color: '#8b949e', marginTop: '20px', maxWidth: '900px' }}>
+          Ready-to-use AI agents. Copy the source into your project — you own the code.
+        </div>
+        <div style={{ fontSize: '22px', color: '#58a6ff', marginTop: '40px' }}>npx agentskit add &lt;agent&gt;</div>
+      </div>
+    ),
+    size,
+  )
+}


### PR DESCRIPTION
Gap-completion Phase A/B for the /agents gallery (registry.agentskit.io, apps/registry). Per-agent pages had no canonical/OG and there was no OG image anywhere — individual agents unfurled with no preview card.

- per-agent generateMetadata: `alternates.canonical` + `openGraph` + twitter summary_large_image
- per-agent **dynamic OG image** (agent title + description + `npx agentskit add <id>`)
- root OG image for the gallery (registry blue accent)

Bar already embedded (data-current=registry). Closes the registry side of social-preview + per-page SEO gaps.