### PR TITLE
chore(deps): pin marked<16 & commander<15 (incompatible majors)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,12 @@ updates:
     directory: "/packages/ink"
     schedule:
       interval: "weekly"
+    ignore:
+      # marked >=16 drops compatibility with marked-terminal@7
+      # (peerDependencies: "marked": ">=1 <16"), and no marked-terminal
+      # release supports marked 16+. Pinned to 15.x until it does.
+      - dependency-name: "marked"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/packages/adapters"
@@ -46,6 +52,11 @@ updates:
     directory: "/packages/cli"
     schedule:
       interval: "weekly"
+    ignore:
+      # commander 15 requires node >=22.12.0; the CLI stays installable on
+      # node 20 LTS. Revisit when the project raises its node floor.
+      - dependency-name: "commander"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/packages/runtime"


### PR DESCRIPTION
## Why

Three dependabot major bumps are not mergeable — closing them and adding ignore rules so they stop reopening.

| PR | Bump | Blocker |
|----|------|---------|
| #910, #884 | marked 15 → 18 | `marked-terminal@7.3.0` peer is `marked >=1 <16`; **no marked-terminal release supports marked 16+**. `packages/ink` needs it for terminal rendering. |
| #906 | commander 14 → 15 | commander 15 `engines.node >=22.12.0`; CLI stays installable on **node 20 LTS**. |

No security advisories on any of the three (audit clean). marked already at latest 15.x.

## Change
Adds `ignore` (semver-major) for `marked` under `/packages/ink` and `commander` under `/packages/cli`. Minor/patch still flow. Revisit when marked-terminal ships marked-16 support / when the project raises its node floor.