### PR TITLE
feat(integrations): connect-form configFields for email + teams (#925)

### DIFF
--- a/.changeset/email-teams-config-fields.md
+++ b/.changeset/email-teams-config-fields.md
@@ -1,0 +1,10 @@
+---
+'@agentskit/integrations': minor
+---
+
+Add connect-form `configFields` to the `email` and `teams` catalog services.
+`email` exposes flat SMTP fields (host/port/user/pass/secure/from) and `teams`
+exposes a webhook URL. A host renders these as a connect form and maps the flat
+values onto each service's runtime shape — an `EmailTransport` it builds (e.g.
+via nodemailer) for `email_send`, and the nested `{ webhook: { webhookUrl } }`
+for `teams_send_webhook`. The Teams *bot* client stays adapter-injected.

--- a/packages/integrations/src/config-fields.ts
+++ b/packages/integrations/src/config-fields.ts
@@ -4,10 +4,14 @@ import type { ConfigField } from './contract'
  * Declarative connect-form fields for catalog services that authenticate with
  * structured config rather than a single API key. A host renders these as a
  * connect form; the captured values become the `config` object each action
- * reads. Adapter-injected services (email transport, Teams bot client) are not
- * here — they are wired in code, not via a form.
+ * reads. The Teams *bot* client stays adapter-injected (code, not a form); the
+ * Teams *webhook* and the email SMTP transport, however, are built by the host
+ * from these flat form fields — see the `email` / `teams` entries below.
  *
- * Field keys match the `*RuntimeConfig` shapes the service actions read.
+ * Field keys match the `*RuntimeConfig` shapes the service actions read, EXCEPT
+ * `email` and `teams`, whose flat fields the host adapter maps onto the nested
+ * runtime shape (`{ webhook: { webhookUrl } }`) / an `EmailTransport` it
+ * constructs (e.g. via nodemailer) before invoking the action.
  */
 export const CONFIG_FIELDS = {
   twilio: [
@@ -40,4 +44,25 @@ export const CONFIG_FIELDS = {
     { key: 'apiToken', label: 'REST API token', secret: true, required: false },
   ],
   pipedrive: [{ key: 'apiToken', label: 'API token', secret: true, required: true }],
+  // Flat SMTP fields; the host builds an `EmailTransport` from them (the
+  // `email_send` action reads `config.transport`, not these keys directly).
+  email: [
+    { key: 'host', label: 'SMTP host', required: true, placeholder: 'smtp.example.com' },
+    { key: 'port', label: 'SMTP port', required: true, placeholder: '587' },
+    { key: 'user', label: 'Username', required: true },
+    { key: 'pass', label: 'Password', secret: true, required: true },
+    { key: 'secure', label: 'Use TLS (true/false)', required: false, placeholder: 'false' },
+    { key: 'from', label: 'Default from address', required: false, placeholder: 'bot@example.com' },
+  ],
+  // Flat webhook URL; the host nests it as `{ webhook: { webhookUrl } }` (the
+  // shape `teams_send_webhook` reads from `config.webhook`).
+  teams: [
+    {
+      key: 'webhookUrl',
+      label: 'Incoming webhook URL',
+      secret: true,
+      required: true,
+      placeholder: 'https://outlook.office.com/webhook/…',
+    },
+  ],
 } as const satisfies Record<string, ConfigField[]>

--- a/packages/integrations/src/services/email/index.ts
+++ b/packages/integrations/src/services/email/index.ts
@@ -1,4 +1,5 @@
 import { defineIntegration } from '../../contract'
+import { CONFIG_FIELDS } from '../../config-fields'
 import { registerIntegration } from '../../registry'
 import { emailActions } from './actions'
 
@@ -8,6 +9,9 @@ export const emailIntegration = defineIntegration({
   categories: ['comms'],
   // Driver-injected (SMTP transport / IMAP client) via ctx.config; no base URL.
   auth: { kind: 'none' },
+  // Flat SMTP fields; the host builds an `EmailTransport` (e.g. via nodemailer)
+  // from them and injects it as `config.transport` for `email_send`.
+  configFields: CONFIG_FIELDS.email,
   actions: emailActions,
   capabilities: { send: 'email_send', notify: 'email_send' },
 })

--- a/packages/integrations/src/services/teams/index.ts
+++ b/packages/integrations/src/services/teams/index.ts
@@ -1,4 +1,5 @@
 import { defineIntegration } from '../../contract'
+import { CONFIG_FIELDS } from '../../config-fields'
 import { registerIntegration } from '../../registry'
 import { teamsActions } from './actions'
 
@@ -7,6 +8,8 @@ export const teamsIntegration = defineIntegration({
   displayName: 'Microsoft Teams',
   categories: ['comms'],
   auth: { kind: 'none' },
+  // Flat `webhookUrl`; the host nests it as `{ webhook: { webhookUrl } }`.
+  configFields: CONFIG_FIELDS.teams,
   actions: teamsActions,
   capabilities: { send: 'teams_send_webhook', notify: 'teams_send_webhook' },
 })

--- a/packages/integrations/tests/config-fields.test.ts
+++ b/packages/integrations/tests/config-fields.test.ts
@@ -30,9 +30,17 @@ describe('CONFIG_FIELDS', () => {
     const withFields = listIntegrations().filter((i) => i.configFields)
     // every declared connector is wired
     expect(withFields.length).toBe(Object.keys(CONFIG_FIELDS).length)
-    // adapter-injected services are intentionally excluded
-    expect(getIntegration('email')!.configFields).toBeUndefined()
-    expect(getIntegration('teams')!.configFields).toBeUndefined()
+    // email + teams expose flat fields the host maps onto their runtime shape
+    // (SMTP transport / nested webhook) — see CONFIG_FIELDS doc comment.
+    expect(getIntegration('email')!.configFields?.map((f) => f.key)).toEqual([
+      'host',
+      'port',
+      'user',
+      'pass',
+      'secure',
+      'from',
+    ])
+    expect(getIntegration('teams')!.configFields?.map((f) => f.key)).toEqual(['webhookUrl'])
     // api-key + oauth connectors don't use configFields
     expect(getIntegration('firecrawl')!.configFields).toBeUndefined()
     expect(getIntegration('gmail')!.configFields).toBeUndefined()


### PR DESCRIPTION
## What
Add `configFields` to the `email` and `teams` catalog services so a host can render a connect form for them.

- **email**: flat SMTP fields (host/port/user/pass/secure/from). The host builds an `EmailTransport` (e.g. via nodemailer) from these and injects it as `config.transport` for `email_send`.
- **teams**: a webhook URL. The host nests it as `{ webhook: { webhookUrl } }` for `teams_send_webhook`. The Teams *bot* client stays adapter-injected.

## Test
- `config-fields.test.ts` updated: email/teams now assert their field keys (was: asserted undefined). 112 tests pass.
- Changeset: `@agentskit/integrations` minor (0.3.0 → 0.4.0).

Unblocks the AKOS-side adapter that builds the SMTP transport + nests the webhook in `buildCatalogTools`.