### PR TITLE
feat(observability): add replay/bisect/timeline primitives

### DIFF
--- a/.changeset/observability-replay-primitives.md
+++ b/.changeset/observability-replay-primitives.md
@@ -1,0 +1,9 @@
+---
+'@agentskit/observability': minor
+---
+
+Add replay primitives: `replayEvents` (drive sinks over historical events),
+`replayBisect` (O(log n) regression localisation over a change history), and
+`buildTimeline` / `diffState` / `positionAt` (scrubber timeline with cumulative
+cost/token/latency and per-checkpoint state diffs). All additive — no existing
+export changed.

--- a/apps/docs-next/content/docs/for-agents/observability.mdx
+++ b/apps/docs-next/content/docs/for-agents/observability.mdx
@@ -57,6 +57,14 @@ npm install @agentskit/observability
 - `createSignedAuditLog`, `createInMemoryAuditStore`. Hash-chain + HMAC. See [Audit log](/docs/reference/recipes/audit-log).
 - `appendPiiAuditEvents(log, { actor, action, hits, subjectId?, reason? })` — append one signed entry per PII redaction hit to an existing `SignedAuditLog`. `action` is `pii:redact`, `pii:reveal`, or `pii:reveal-denied`; each payload records rule id, counts, and match `offset`/`length` only (no raw spans), for tamper-evident audit evidence alongside the hash chain.
 
+### Replay & timeline
+
+- `replayEvents(events, handlers)` — feed a historical event sequence through any number of handlers in order; generic over the event type, so it replays `AgentEvent`s, `TraceSpan`s, or a host app's own event union against live telemetry sinks.
+- `replayBisect(history, oracle, opts?)` — O(log n) regression localisation. Given a change history (oldest-first) and an async oracle that returns `'pass' | 'fail'` for a replay at a given index, it returns a `BisectVerdict` (`culprit` / `all_clean` / `all_broken` / `inconsistent`).
+- `buildTimeline(steps)` — turn recorded `ReplayStep`s into a `Timeline` of rows carrying cumulative cost / token / latency totals plus the run span.
+- `diffState(previous, next)` — structural diff between two state snapshots as `add` / `remove` / `change` entries.
+- `positionAt(steps, timeline, index)` — resolve a scrubber position to its cumulative row plus the `diffState` from the previous checkpoint (throws on an out-of-range index).
+
 ## Minimal example
 
 ```ts

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -117,3 +117,19 @@ export type {
   DevtoolsClient,
   DevtoolsEnvelope,
 } from './devtools'
+
+// Replay primitives — drive telemetry sinks against historical events,
+// bisect a change history to localise a regression, and build a scrubber
+// timeline with per-checkpoint state diffs.
+export { replayEvents } from './replay'
+export type { ReplayHandler } from './replay'
+export { replayBisect } from './replay-bisect'
+export type { BisectVerdict, ReplayOracle, BisectOpts } from './replay-bisect'
+export { buildTimeline, diffState, positionAt } from './replay-timeline'
+export type {
+  ReplayStep,
+  TimelineRow,
+  Timeline,
+  StateDiffEntry,
+  ReplayPosition,
+} from './replay-timeline'

--- a/packages/observability/src/replay-bisect.ts
+++ b/packages/observability/src/replay-bisect.ts
@@ -1,0 +1,65 @@
+// replay-bisect: find the regression-causing change.
+// Pure: caller supplies a change history (oldest-first) and an async oracle
+// that replays the run at a given change-index and returns ok/fail. The
+// bisector walks the history with O(log n) probes.
+
+export type BisectVerdict =
+  | { readonly kind: 'culprit'; readonly index: number; readonly probes: number }
+  | { readonly kind: 'all_clean'; readonly probes: number }
+  | { readonly kind: 'all_broken'; readonly probes: number }
+  | { readonly kind: 'inconsistent'; readonly probes: number; readonly detail: string }
+
+export type ReplayOracle = (changeIndex: number) => Promise<'pass' | 'fail'>
+
+export type BisectOpts = {
+  readonly maxProbes?: number
+  readonly onProbe?: (changeIndex: number, result: 'pass' | 'fail') => void
+}
+
+const DEFAULT_MAX_PROBES = 64
+
+/**
+ * Locate the earliest change that flips the run from pass to fail.
+ * Convention: index 0 is the oldest known-good change; higher indices are
+ * newer. The oracle returns 'fail' for any index ≥ the culprit and 'pass'
+ * before. Returns the first failing index, or `all_clean` / `all_broken`
+ * when no transition exists.
+ */
+export const replayBisect = async (
+  history: readonly { readonly id: string }[],
+  oracle: ReplayOracle,
+  opts: BisectOpts = {},
+): Promise<BisectVerdict> => {
+  const maxProbes = opts.maxProbes ?? DEFAULT_MAX_PROBES
+  const n = history.length
+  if (n === 0) return { kind: 'all_clean', probes: 0 }
+
+  let probes = 0
+  const probe = async (i: number): Promise<'pass' | 'fail'> => {
+    probes += 1
+    const result = await oracle(i)
+    opts.onProbe?.(i, result)
+    return result
+  }
+
+  if (probes >= maxProbes) return { kind: 'inconsistent', probes, detail: 'maxProbes=0' }
+  const head = await probe(n - 1)
+  if (head === 'pass') return { kind: 'all_clean', probes }
+
+  if (probes >= maxProbes) return { kind: 'inconsistent', probes, detail: 'reached maxProbes before tail probe' }
+  const tail = await probe(0)
+  if (tail === 'fail') return { kind: 'all_broken', probes }
+
+  let lo = 0
+  let hi = n - 1
+  while (lo + 1 < hi) {
+    if (probes >= maxProbes) {
+      return { kind: 'inconsistent', probes, detail: `maxProbes=${maxProbes} hit before convergence` }
+    }
+    const mid = Math.floor((lo + hi) / 2)
+    const result = await probe(mid)
+    if (result === 'fail') hi = mid
+    else lo = mid
+  }
+  return { kind: 'culprit', index: hi, probes }
+}

--- a/packages/observability/src/replay-timeline.ts
+++ b/packages/observability/src/replay-timeline.ts
@@ -1,0 +1,129 @@
+/**
+ * Trace replay timeline + state-diff primitives.
+ *
+ * A replay UI scrubber lets the user select any checkpoint in a run and
+ * inspect:
+ *   1. Cumulative cost / latency / token counts up to that point.
+ *   2. State delta between the previous and selected checkpoint.
+ *
+ * This module is pure — given a list of recorded steps it returns the
+ * timeline rows + per-row state diff. The UI binds the rows to scrubber
+ * positions; `replayBisect` drives re-execution from a chosen row.
+ */
+
+import { ErrorCodes, RuntimeError } from '@agentskit/core'
+
+export type ReplayStep = {
+  readonly id: string
+  readonly nodeId: string
+  readonly timestamp: number
+  readonly latencyMs: number
+  readonly tokensIn: number
+  readonly tokensOut: number
+  readonly costUsd: number
+  readonly state: Readonly<Record<string, unknown>>
+  readonly outcome: 'ok' | 'failed' | 'paused' | 'skipped'
+}
+
+export type TimelineRow = {
+  readonly index: number
+  readonly stepId: string
+  readonly nodeId: string
+  readonly timestamp: number
+  readonly cumulativeCostUsd: number
+  readonly cumulativeTokens: number
+  readonly cumulativeLatencyMs: number
+  readonly outcome: ReplayStep['outcome']
+}
+
+export type Timeline = {
+  readonly rows: readonly TimelineRow[]
+  readonly totalCostUsd: number
+  readonly totalTokens: number
+  readonly totalLatencyMs: number
+  readonly span: { readonly startedAt: number; readonly endedAt: number }
+}
+
+export const buildTimeline = (steps: readonly ReplayStep[]): Timeline => {
+  let cost = 0
+  let tokens = 0
+  let lat = 0
+  const rows: TimelineRow[] = []
+  for (let i = 0; i < steps.length; i += 1) {
+    const s = steps[i] as ReplayStep
+    cost += s.costUsd
+    tokens += s.tokensIn + s.tokensOut
+    lat += s.latencyMs
+    rows.push({
+      index: i,
+      stepId: s.id,
+      nodeId: s.nodeId,
+      timestamp: s.timestamp,
+      cumulativeCostUsd: cost,
+      cumulativeTokens: tokens,
+      cumulativeLatencyMs: lat,
+      outcome: s.outcome,
+    })
+  }
+  const startedAt = steps[0]?.timestamp ?? 0
+  const endedAt = steps[steps.length - 1]?.timestamp ?? startedAt
+  return {
+    rows,
+    totalCostUsd: cost,
+    totalTokens: tokens,
+    totalLatencyMs: lat,
+    span: { startedAt, endedAt },
+  }
+}
+
+export type StateDiffEntry =
+  | { readonly kind: 'add'; readonly key: string; readonly value: unknown }
+  | { readonly kind: 'remove'; readonly key: string; readonly previous: unknown }
+  | { readonly kind: 'change'; readonly key: string; readonly previous: unknown; readonly value: unknown }
+
+export const diffState = (
+  previous: Readonly<Record<string, unknown>>,
+  next: Readonly<Record<string, unknown>>,
+): readonly StateDiffEntry[] => {
+  const entries: StateDiffEntry[] = []
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)])
+  for (const k of keys) {
+    const a = previous[k]
+    const b = next[k]
+    const inA = k in previous
+    const inB = k in next
+    if (!inA && inB) entries.push({ kind: 'add', key: k, value: b })
+    else if (inA && !inB) entries.push({ kind: 'remove', key: k, previous: a })
+    else if (!Object.is(a, b) && JSON.stringify(a) !== JSON.stringify(b)) {
+      entries.push({ kind: 'change', key: k, previous: a, value: b })
+    }
+  }
+  return entries
+}
+
+export type ReplayPosition = {
+  readonly index: number
+  readonly cumulative: TimelineRow
+  readonly stateDiffFromPrevious: readonly StateDiffEntry[]
+}
+
+export const positionAt = (
+  steps: readonly ReplayStep[],
+  timeline: Timeline,
+  index: number,
+): ReplayPosition => {
+  if (index < 0 || index >= timeline.rows.length) {
+    throw new RuntimeError({
+      code: ErrorCodes.AK_RUNTIME_INVALID_INPUT,
+      message: `replay index ${index} out of range [0, ${timeline.rows.length})`,
+    })
+  }
+  const row = timeline.rows[index] as TimelineRow
+  const current = (steps[index] as ReplayStep).state
+  const prev = index === 0 ? {} : (steps[index - 1] as ReplayStep).state
+  return {
+    index,
+    cumulative: row,
+    stateDiffFromPrevious: diffState(prev, current),
+  }
+}

--- a/packages/observability/src/replay.ts
+++ b/packages/observability/src/replay.ts
@@ -1,0 +1,20 @@
+// Replay helper — feeds a sequence of events through any number of handlers
+// in order. Use to run live telemetry sinks against historical events loaded
+// from an audit chain or storage backend.
+//
+// Generic over the event type `E` so it works with any event stream
+// (`AgentEvent`, `TraceSpan`, or a host application's own event union) without
+// coupling the replay driver to a specific schema.
+
+export type ReplayHandler<E> = (event: E) => void | Promise<void>
+
+export const replayEvents = async <E>(
+  events: readonly E[],
+  handlers: readonly ReplayHandler<E>[],
+): Promise<void> => {
+  for (const ev of events) {
+    for (const h of handlers) {
+      await h(ev)
+    }
+  }
+}

--- a/packages/observability/tests/replay-bisect.test.ts
+++ b/packages/observability/tests/replay-bisect.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { replayBisect } from '../src/replay-bisect'
+
+describe('replayBisect', () => {
+  const history = Array.from({ length: 8 }, (_, i) => ({ id: `c${i}` }))
+
+  it('finds the earliest failing change (culprit)', async () => {
+    // culprit at index 5: pass for <5, fail for >=5
+    const verdict = await replayBisect(history, async (i) => (i >= 5 ? 'fail' : 'pass'))
+    expect(verdict).toEqual({ kind: 'culprit', index: 5, probes: expect.any(Number) })
+  })
+
+  it('reports all_clean when the newest change still passes', async () => {
+    const verdict = await replayBisect(history, async () => 'pass')
+    expect(verdict.kind).toBe('all_clean')
+  })
+
+  it('reports all_broken when the oldest change already fails', async () => {
+    const verdict = await replayBisect(history, async () => 'fail')
+    expect(verdict.kind).toBe('all_broken')
+  })
+
+  it('treats an empty history as all_clean', async () => {
+    const verdict = await replayBisect([], async () => 'fail')
+    expect(verdict).toEqual({ kind: 'all_clean', probes: 0 })
+  })
+
+  it('honours maxProbes by reporting inconsistent before convergence', async () => {
+    const verdict = await replayBisect(history, async (i) => (i >= 5 ? 'fail' : 'pass'), {
+      maxProbes: 2,
+    })
+    expect(verdict.kind).toBe('inconsistent')
+  })
+})

--- a/packages/observability/tests/replay-timeline.test.ts
+++ b/packages/observability/tests/replay-timeline.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { AgentsKitError } from '@agentskit/core'
+import { buildTimeline, diffState, positionAt, type ReplayStep } from '../src/replay-timeline'
+
+const step = (over: Partial<ReplayStep> & { id: string }): ReplayStep => ({
+  nodeId: 'n',
+  timestamp: 0,
+  latencyMs: 0,
+  tokensIn: 0,
+  tokensOut: 0,
+  costUsd: 0,
+  state: {},
+  outcome: 'ok',
+  ...over,
+})
+
+describe('buildTimeline', () => {
+  it('accumulates cost, tokens, and latency per row', () => {
+    const tl = buildTimeline([
+      step({ id: 's1', timestamp: 10, costUsd: 1, tokensIn: 2, tokensOut: 3, latencyMs: 100 }),
+      step({ id: 's2', timestamp: 20, costUsd: 2, tokensIn: 1, tokensOut: 1, latencyMs: 50 }),
+    ])
+    expect(tl.rows[1]?.cumulativeCostUsd).toBe(3)
+    expect(tl.rows[1]?.cumulativeTokens).toBe(7)
+    expect(tl.rows[1]?.cumulativeLatencyMs).toBe(150)
+    expect(tl.totalCostUsd).toBe(3)
+    expect(tl.span).toEqual({ startedAt: 10, endedAt: 20 })
+  })
+
+  it('returns a zero-span timeline for empty input', () => {
+    const tl = buildTimeline([])
+    expect(tl.rows).toEqual([])
+    expect(tl.span).toEqual({ startedAt: 0, endedAt: 0 })
+  })
+})
+
+describe('diffState', () => {
+  it('detects add / remove / change', () => {
+    expect(diffState({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual([
+      { kind: 'remove', key: 'a', previous: 1 },
+      { kind: 'change', key: 'b', previous: 2, value: 3 },
+      { kind: 'add', key: 'c', value: 4 },
+    ])
+  })
+})
+
+describe('positionAt', () => {
+  const steps = [step({ id: 's1', state: { x: 1 } }), step({ id: 's2', state: { x: 2 } })]
+  const tl = buildTimeline(steps)
+
+  it('returns the cumulative row + diff from the previous checkpoint', () => {
+    const pos = positionAt(steps, tl, 1)
+    expect(pos.cumulative.stepId).toBe('s2')
+    expect(pos.stateDiffFromPrevious).toEqual([{ kind: 'change', key: 'x', previous: 1, value: 2 }])
+  })
+
+  it('throws on an out-of-range index', () => {
+    expect(() => positionAt(steps, tl, 5)).toThrow(AgentsKitError)
+  })
+})

--- a/packages/observability/tests/replay.test.ts
+++ b/packages/observability/tests/replay.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { replayEvents } from '../src/index'
+
+describe('replayEvents', () => {
+  it('feeds each event through every handler in order', async () => {
+    const seen: string[] = []
+    await replayEvents(
+      ['a', 'b'],
+      [(e) => void seen.push(`h1:${e}`), (e) => void seen.push(`h2:${e}`)],
+    )
+    expect(seen).toEqual(['h1:a', 'h2:a', 'h1:b', 'h2:b'])
+  })
+
+  it('awaits async handlers', async () => {
+    const seen: number[] = []
+    await replayEvents(
+      [1, 2],
+      [async (e) => { await Promise.resolve(); seen.push(e) }],
+    )
+    expect(seen).toEqual([1, 2])
+  })
+})


### PR DESCRIPTION
Additive — no existing export changed. Unblocks AgentsKit-io/agentskit-os#3994 (os-observability replay/trace → upstream): host apps delegate instead of maintaining a divergent copy.

- `replayEvents(events, handlers)` — generic event-replay driver
- `replayBisect(history, oracle, opts?)` — O(log n) regression bisect → `BisectVerdict`
- `buildTimeline` / `diffState` / `positionAt` — scrubber timeline + per-checkpoint state diffs

13 new tests, 173/173 observability tests, lint clean, 13/13 lib quality gates, for-agents doc + changeset.

Validated end-to-end: agentskit-os os-observability delegates to this and passes 239/239 (local-registry proof).