### PR TITLE
feat(sandbox): add local-process runtimes (none/process/sandbox-exec/bwrap/docker)

### DIFF
--- a/.changeset/sandbox-local-runtimes.md
+++ b/.changeset/sandbox-local-runtimes.md
@@ -1,0 +1,12 @@
+---
+'@agentskit/sandbox': minor
+---
+
+Add local-process sandbox runtimes complementing the cloud E2B backend:
+`noneSandbox`, `processSandbox`, `sandboxExecRuntime` (macOS seatbelt),
+`bwrapRuntime` (Linux bubblewrap), `dockerRuntime`, plus `nodeSpawner`,
+`SandboxRegistry`, isolation-strictness helpers (`assertStrongIsolation`,
+`weakSandboxBanner`, `isStrongIsolation`/`isWeakIsolation`, `WeakSandboxError`),
+and the `SandboxRuntime` / `SandboxLevel` / `SandboxExecOptions` contract. Each
+runtime shells out to a host binary via the injected `Spawner` (no native deps).
+All additive; the E2B `Sandbox` surface is unchanged.

--- a/apps/docs-next/content/docs/for-agents/sandbox.mdx
+++ b/apps/docs-next/content/docs/for-agents/sandbox.mdx
@@ -20,6 +20,20 @@ npm install @agentskit/sandbox
 
 - `createMandatorySandbox({ sandbox, policy })` — enforce allow / deny / requireSandbox / validators across every tool. See [Mandatory sandbox](/docs/reference/recipes/mandatory-sandbox).
 
+### Local-process runtimes
+
+Host-process isolation complementing the cloud E2B backend. Each implements the `SandboxRuntime` adapter (`spawn` / optional `exec`) the agent runner spawns tool subprocesses through, shelling out to a host binary via an injected `Spawner` (no native deps).
+
+- `noneSandbox` — in-process, no isolation (`spawn` rejects; for `none`-level trusted compute only).
+- `processSandbox(opts?)` — child-process with env allowlisting (`exposeAllowedEnvKeys`).
+- `sandboxExecRuntime({ policy })` — macOS seatbelt (`/usr/bin/sandbox-exec`); `renderSandboxExecProfile` emits the SBPL (default-deny + workspace-scoped writes + no outbound network).
+- `bwrapRuntime({ policy })` — Linux bubblewrap unshare-everything jail; `renderBwrapArgs`, `isBwrapSupported`, `getBwrapPath`.
+- `dockerRuntime({ policy })` — `docker run --rm` with cap-drop / no-new-privileges / read-only rootfs; `renderDockerArgs`.
+- `nodeSpawner()` — default `Spawner` over `node:child_process` (timeout + output-cap).
+- `SandboxRegistry` — maps `SandboxLevel` → runtime; `resolveOrThrow`.
+- `assertStrongIsolation` / `isStrongIsolation` / `isWeakIsolation` / `weakSandboxBanner` / `WeakSandboxError` — surface that `none`/`process` provide no OS-level fs/net isolation.
+- Contract types: `SandboxRuntime`, `SandboxLevel`, `SANDBOX_LEVELS`, `SandboxExecOptions`, `SandboxExecResult`, `Spawner`, `ChildHandle`.
+
 ## Minimal example
 
 ```ts

--- a/packages/sandbox/src/container-runtimes.ts
+++ b/packages/sandbox/src/container-runtimes.ts
@@ -1,0 +1,171 @@
+// Linux bubblewrap (`bwrap`) and Docker runtimes — kernel-namespace
+// isolation. Both shell out to the host binary via the injected `Spawner`,
+// staying free of native deps.
+
+import { existsSync } from 'node:fs'
+import { SandboxError } from '@agentskit/core'
+import { nodeSpawner } from './local-spawner'
+import type { SandboxRuntime, Spawner } from './local-sandbox-types'
+
+// --- bwrap --------------------------------------------------------------
+
+export type BwrapPolicy = {
+  readonly workspaceRoot: string
+  readonly allowNetwork?: boolean
+  readonly readOnlyPaths?: readonly string[]
+  readonly readWritePaths?: readonly string[]
+}
+
+export type BwrapRuntimeOpts = {
+  readonly policy: BwrapPolicy
+  readonly spawner?: Spawner
+  readonly bwrapPath?: string
+}
+
+const STANDARD_RO = ['/usr', '/bin', '/sbin', '/lib', '/lib64', '/etc']
+
+export const isBwrapSupported = (): boolean => process.platform === 'linux'
+
+export const getBwrapPath = (): string | null => {
+  if (!isBwrapSupported()) return null
+  const pathEnv = process.env.PATH ?? ''
+  for (const dir of pathEnv.split(':')) {
+    if (!dir) continue
+    const candidate = `${dir}/bwrap`
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+export const renderBwrapArgs = (policy: BwrapPolicy): readonly string[] => {
+  const args: string[] = []
+  for (const p of STANDARD_RO) args.push('--ro-bind-try', p, p)
+  for (const p of policy.readOnlyPaths ?? []) args.push('--ro-bind', p, p)
+  args.push('--bind', policy.workspaceRoot, policy.workspaceRoot)
+  for (const p of policy.readWritePaths ?? []) args.push('--bind', p, p)
+  args.push('--proc', '/proc')
+  args.push('--dev', '/dev')
+  args.push('--tmpfs', '/tmp')
+  args.push('--unshare-all')
+  if (policy.allowNetwork === true) args.push('--share-net')
+  args.push('--die-with-parent')
+  args.push('--new-session')
+  return args
+}
+
+export const bwrapRuntime = (opts: BwrapRuntimeOpts): SandboxRuntime => {
+  const spawnerPromise = opts.spawner ? Promise.resolve(opts.spawner) : nodeSpawner()
+  const bwrap = opts.bwrapPath ?? 'bwrap'
+  const baseArgs = renderBwrapArgs(opts.policy)
+  return {
+    level: 'process',
+    name: 'bwrap',
+    spawn: async (callOpts) => {
+      if (process.platform !== 'linux' && !opts.spawner) {
+        throw new SandboxError({
+          code: 'AK_SANDBOX_BACKEND_FAILED',
+          message: 'bwrap runtime requires linux or an injected spawner',
+        })
+      }
+      const spawner = await spawnerPromise
+      const handle = await spawner.spawn({
+        command: bwrap,
+        args: [...baseArgs, '--', callOpts.command, ...callOpts.args],
+        ...(callOpts.cwd !== undefined ? { cwd: callOpts.cwd } : {}),
+        stdio: 'pipe',
+      })
+      return { pid: handle.pid, kill: () => handle.kill() }
+    },
+  }
+}
+
+// --- docker -------------------------------------------------------------
+
+export type DockerPolicy = {
+  readonly image: string
+  readonly workspaceRoot: string
+  readonly mountTarget?: string
+  /** `--network` flag. Defaults to `none`; set to `bridge`/a named network for egress. */
+  readonly network?: string
+  readonly writableWorkspace?: boolean
+  readonly extraArgs?: readonly string[]
+  readonly user?: string
+  readonly capabilities?: readonly string[]
+}
+
+export type DockerRuntimeOpts = {
+  readonly policy: DockerPolicy
+  readonly spawner?: Spawner
+  readonly dockerPath?: string
+}
+
+const DEFAULT_MOUNT_TARGET = '/workspace'
+
+const hostUserSpec = (override: string | undefined): string | undefined => {
+  if (override !== undefined) return override
+  if (typeof process.getuid === 'function' && typeof process.getgid === 'function') {
+    return `${process.getuid()}:${process.getgid()}`
+  }
+  return undefined
+}
+
+export const renderDockerArgs = (policy: DockerPolicy): readonly string[] => {
+  const target = policy.mountTarget ?? DEFAULT_MOUNT_TARGET
+  const args: string[] = ['run', '--rm', '--init']
+  args.push('--network', policy.network ?? 'none')
+  args.push('--cap-drop', 'ALL')
+  for (const cap of policy.capabilities ?? []) args.push('--cap-add', cap)
+  args.push('--security-opt', 'no-new-privileges')
+  args.push('--read-only')
+  args.push('--tmpfs', '/tmp:rw,size=64m')
+  const user = hostUserSpec(policy.user)
+  if (user !== undefined) args.push('--user', user)
+  const mountSpec =
+    policy.writableWorkspace === true
+      ? `${policy.workspaceRoot}:${target}:rw`
+      : `${policy.workspaceRoot}:${target}:ro`
+  args.push('-v', mountSpec)
+  args.push('-w', target)
+  for (const a of policy.extraArgs ?? []) args.push(a)
+  args.push(policy.image)
+  return args
+}
+
+export const dockerRuntime = (opts: DockerRuntimeOpts): SandboxRuntime => {
+  const spawnerPromise = opts.spawner ? Promise.resolve(opts.spawner) : nodeSpawner()
+  const docker = opts.dockerPath ?? 'docker'
+  const baseArgs = renderDockerArgs(opts.policy)
+  return {
+    level: 'container',
+    name: 'docker',
+    spawn: async (callOpts) => {
+      const spawner = await spawnerPromise
+      const handle = await spawner.spawn({
+        command: docker,
+        args: [...baseArgs, callOpts.command, ...callOpts.args],
+        ...(callOpts.cwd !== undefined ? { cwd: callOpts.cwd } : {}),
+        stdio: 'pipe',
+      })
+      return { pid: handle.pid, kill: () => handle.kill() }
+    },
+    exec: async (callOpts) => {
+      const spawner = await spawnerPromise
+      const runToCompletion = spawner.exec
+      if (!runToCompletion) {
+        throw new SandboxError({
+          code: 'AK_SANDBOX_BACKEND_FAILED',
+          message: 'docker sandbox: the configured spawner does not support exec',
+          hint: 'Inject a spawner with an `exec` method, or use the default `nodeSpawner`.',
+        })
+      }
+      const execOpts: Parameters<typeof runToCompletion>[0] = {
+        command: docker,
+        args: [...baseArgs, callOpts.command, ...callOpts.args],
+      }
+      if (callOpts.cwd !== undefined) execOpts.cwd = callOpts.cwd
+      if (callOpts.timeoutMs !== undefined) execOpts.timeoutMs = callOpts.timeoutMs
+      if (callOpts.maxOutputBytes !== undefined) execOpts.maxOutputBytes = callOpts.maxOutputBytes
+      return runToCompletion(execOpts)
+    },
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -14,3 +14,53 @@ export type {
   PolicyEvent,
   MandatorySandboxWrapper,
 } from './policy'
+
+// Local-process sandbox runtimes — host-process isolation (none / process /
+// sandbox-exec / bwrap / docker) complementing the cloud E2B backend. Each
+// implements the `SandboxRuntime` adapter the agent runner spawns through.
+export { SANDBOX_LEVELS } from './local-sandbox-types'
+export type {
+  SandboxLevel,
+  SandboxRuntime,
+  SandboxExecOptions,
+  SandboxExecResult,
+  Spawner,
+  ChildHandle,
+  SpawnerExecOptions,
+  SpawnerExecResult,
+} from './local-sandbox-types'
+export { nodeSpawner } from './local-spawner'
+export {
+  noneSandbox,
+  processSandbox,
+  exposeAllowedEnvKeys,
+  sandboxExecRuntime,
+  renderSandboxExecProfile,
+} from './local-runtimes'
+export type {
+  ProcessRuntimeOptions,
+  SandboxExecPolicy,
+  SandboxExecRuntimeOpts,
+} from './local-runtimes'
+export {
+  bwrapRuntime,
+  renderBwrapArgs,
+  isBwrapSupported,
+  getBwrapPath,
+  dockerRuntime,
+  renderDockerArgs,
+} from './container-runtimes'
+export type {
+  BwrapPolicy,
+  BwrapRuntimeOpts,
+  DockerPolicy,
+  DockerRuntimeOpts,
+} from './container-runtimes'
+export {
+  SandboxRegistry,
+  isStrongIsolation,
+  isWeakIsolation,
+  assertStrongIsolation,
+  weakSandboxBanner,
+  WeakSandboxError,
+} from './local-registry'

--- a/packages/sandbox/src/local-registry.ts
+++ b/packages/sandbox/src/local-registry.ts
@@ -1,0 +1,79 @@
+// SandboxRegistry — resolves a SandboxLevel to its registered runtime.
+// Strictness helpers surface that `none`/`process` provide no OS-level
+// fs/net isolation, so callers don't silently believe `process` is sandboxed.
+
+import { SandboxError } from '@agentskit/core'
+import { noneSandbox, processSandbox } from './local-runtimes'
+import type { SandboxLevel, SandboxRuntime } from './local-sandbox-types'
+
+export class SandboxRegistry {
+  private readonly map = new Map<SandboxLevel, SandboxRuntime>()
+
+  constructor(includeBuiltins = true) {
+    if (includeBuiltins) {
+      this.register(noneSandbox)
+      this.register(processSandbox())
+    }
+  }
+
+  register(runtime: SandboxRuntime): void {
+    this.map.set(runtime.level, runtime)
+  }
+
+  has(level: SandboxLevel): boolean {
+    return this.map.has(level)
+  }
+
+  get(level: SandboxLevel): SandboxRuntime | undefined {
+    return this.map.get(level)
+  }
+
+  list(): readonly SandboxLevel[] {
+    return [...this.map.keys()]
+  }
+
+  resolveOrThrow(level: SandboxLevel): SandboxRuntime {
+    const runtime = this.map.get(level)
+    if (!runtime) {
+      throw new SandboxError({
+        code: 'AK_SANDBOX_BACKEND_FAILED',
+        message: `no sandbox runtime registered for level "${level}" (have: ${this.list().join(', ')})`,
+      })
+    }
+    return runtime
+  }
+}
+
+const STRONG_LEVELS: ReadonlySet<SandboxLevel> = new Set(['container', 'vm', 'webcontainer'])
+const WEAK_LEVELS: ReadonlySet<SandboxLevel> = new Set(['none', 'process'])
+
+export const isStrongIsolation = (level: SandboxLevel): boolean => STRONG_LEVELS.has(level)
+export const isWeakIsolation = (level: SandboxLevel): boolean => WEAK_LEVELS.has(level)
+
+export class WeakSandboxError extends Error {
+  readonly code = 'sandbox.weak_isolation'
+  readonly active: SandboxLevel
+  constructor(active: SandboxLevel) {
+    super(
+      `active sandbox level "${active}" provides no OS-level fs/net isolation; ` +
+        `expected one of: container, vm, webcontainer. Configure a stronger level ` +
+        `or pass { allowWeak: true } to opt-in explicitly.`,
+    )
+    this.active = active
+  }
+}
+
+/** Throw `WeakSandboxError` if the active level offers no OS-level isolation. */
+export const assertStrongIsolation = (
+  active: SandboxLevel,
+  opts: { readonly allowWeak?: boolean } = {},
+): void => {
+  if (opts.allowWeak === true) return
+  if (isWeakIsolation(active)) throw new WeakSandboxError(active)
+}
+
+/** Stderr-printable weak-isolation banner for runner startup. */
+export const weakSandboxBanner = (active: SandboxLevel): string =>
+  `[security] sandbox level "${active}" — no OS-level fs/net isolation. ` +
+  `child processes can read/write the filesystem and open sockets. Set ` +
+  `sandbox level to container/vm to enforce kernel-level boundaries.`

--- a/packages/sandbox/src/local-runtimes.ts
+++ b/packages/sandbox/src/local-runtimes.ts
@@ -1,0 +1,151 @@
+// In-process (`none`), child-process (`process`), and macOS `sandbox-exec`
+// runtimes. Each implements the `SandboxRuntime` adapter.
+
+import { SandboxError } from '@agentskit/core'
+import { nodeSpawner } from './local-spawner'
+import type { SandboxRuntime, Spawner } from './local-sandbox-types'
+
+// --- none ---------------------------------------------------------------
+
+export const noneSandbox: SandboxRuntime = {
+  level: 'none',
+  name: 'in-process',
+  spawn: async () => {
+    throw new SandboxError({
+      code: 'AK_SANDBOX_DENIED',
+      message:
+        'noneSandbox.spawn rejected: "none" level is for in-process compute only; use process or higher to run external commands',
+    })
+  },
+}
+
+// --- process ------------------------------------------------------------
+
+export type ProcessRuntimeOptions = {
+  readonly spawner?: Spawner
+  readonly defaultEnv?: Readonly<Record<string, string>>
+  readonly defaultCwd?: string
+}
+
+const ALLOWED_ENV_KEYS = new Set(['PATH', 'HOME', 'TZ', 'LANG', 'LC_ALL', 'NODE_ENV'])
+
+const filterEnv = (env: Readonly<Record<string, string>>): Record<string, string> => {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(env)) {
+    if (ALLOWED_ENV_KEYS.has(k) || k.startsWith('AGENTSKITOS_')) out[k] = v
+  }
+  return out
+}
+
+export const exposeAllowedEnvKeys = (): readonly string[] => [...ALLOWED_ENV_KEYS]
+
+export const processSandbox = (opts: ProcessRuntimeOptions = {}): SandboxRuntime => {
+  const spawnerPromise = opts.spawner ? Promise.resolve(opts.spawner) : nodeSpawner()
+  return {
+    level: 'process',
+    name: 'child-process',
+    spawn: async (callOpts) => {
+      const spawner = await spawnerPromise
+      const env = filterEnv(opts.defaultEnv ?? {})
+      const spawnCwd = callOpts.cwd ?? opts.defaultCwd
+      const handle = await spawner.spawn({
+        command: callOpts.command,
+        args: [...callOpts.args],
+        ...(spawnCwd !== undefined ? { cwd: spawnCwd } : {}),
+        env,
+        stdio: 'pipe',
+      })
+      return { pid: handle.pid, kill: async () => handle.kill() }
+    },
+    exec: async (callOpts) => {
+      const spawner = await spawnerPromise
+      const runToCompletion = spawner.exec
+      if (!runToCompletion) {
+        throw new SandboxError({
+          code: 'AK_SANDBOX_BACKEND_FAILED',
+          message: 'process sandbox: the configured spawner does not support exec',
+          hint: 'Inject a spawner with an `exec` method, or use the default `nodeSpawner`.',
+        })
+      }
+      const env = filterEnv(opts.defaultEnv ?? {})
+      const cwd = callOpts.cwd ?? opts.defaultCwd
+      return runToCompletion({
+        command: callOpts.command,
+        args: [...callOpts.args],
+        env,
+        ...(cwd !== undefined ? { cwd } : {}),
+        ...(callOpts.timeoutMs !== undefined ? { timeoutMs: callOpts.timeoutMs } : {}),
+        ...(callOpts.maxOutputBytes !== undefined ? { maxOutputBytes: callOpts.maxOutputBytes } : {}),
+      })
+    },
+  }
+}
+
+// --- sandbox-exec (macOS seatbelt) --------------------------------------
+
+export type SandboxExecPolicy = {
+  readonly workspaceRoot: string
+  readonly allowNetwork?: boolean
+  readonly extraReadablePaths?: readonly string[]
+}
+
+export type SandboxExecRuntimeOpts = {
+  readonly policy: SandboxExecPolicy
+  readonly spawner?: Spawner
+  readonly sandboxExecPath?: string
+}
+
+const sbplString = (raw: string): string => `"${raw.replace(/"/g, '\\"')}"`
+
+export const renderSandboxExecProfile = (policy: SandboxExecPolicy): string => {
+  const lines: string[] = [
+    '(version 1)',
+    '(deny default)',
+    '(allow process-fork)',
+    '(allow process-exec)',
+    '(allow signal (target self))',
+    '(allow file-read*)',
+    `(allow file-write* (subpath ${sbplString(policy.workspaceRoot)}))`,
+    '(allow file-write* (subpath "/private/tmp"))',
+    '(allow file-write* (subpath "/private/var/folders"))',
+    '(allow mach-lookup)',
+    '(allow ipc-posix-shm)',
+    '(allow sysctl-read)',
+  ]
+  for (const path of policy.extraReadablePaths ?? []) {
+    lines.push(`(allow file-read* (subpath ${sbplString(path)}))`)
+  }
+  if (policy.allowNetwork === true) {
+    lines.push('(allow network*)')
+  } else {
+    lines.push('(allow network-bind (local ip "*:*"))')
+    lines.push('(deny network-outbound (with no-log))')
+  }
+  return lines.join('\n')
+}
+
+export const sandboxExecRuntime = (opts: SandboxExecRuntimeOpts): SandboxRuntime => {
+  const spawnerPromise = opts.spawner ? Promise.resolve(opts.spawner) : nodeSpawner()
+  const profile = renderSandboxExecProfile(opts.policy)
+  const sandboxExec = opts.sandboxExecPath ?? '/usr/bin/sandbox-exec'
+  return {
+    level: 'process',
+    name: 'sandbox-exec',
+    spawn: async (callOpts) => {
+      if (process.platform !== 'darwin' && !opts.spawner) {
+        throw new SandboxError({
+          code: 'AK_SANDBOX_BACKEND_FAILED',
+          message: 'sandbox-exec runtime requires darwin or an injected spawner',
+        })
+      }
+      const spawner = await spawnerPromise
+      const handle = await spawner.spawn({
+        command: sandboxExec,
+        args: ['-p', profile, callOpts.command, ...callOpts.args],
+        ...(callOpts.cwd !== undefined ? { cwd: callOpts.cwd } : {}),
+        stdio: 'pipe',
+      })
+      return { pid: handle.pid, kill: () => handle.kill() }
+    },
+  }
+}

--- a/packages/sandbox/src/local-sandbox-types.ts
+++ b/packages/sandbox/src/local-sandbox-types.ts
@@ -1,0 +1,84 @@
+// Local-process sandbox runtime contracts. These complement the cloud
+// (E2B) `Sandbox` backend with host-process isolation primitives — the
+// `SandboxRuntime` adapter the agent runner spawns tool subprocesses through.
+//
+// `SandboxLevel` ranks isolation strength; `SandboxRuntime` is the adapter
+// each level implements; `Spawner` abstracts `child_process` so tests inject
+// an in-memory double.
+
+export const SANDBOX_LEVELS = ['none', 'process', 'container', 'vm', 'webcontainer'] as const
+export type SandboxLevel = (typeof SANDBOX_LEVELS)[number]
+
+/** Options for {@link SandboxRuntime.exec} — a command run to completion. */
+export interface SandboxExecOptions {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly cwd?: string
+  /** Kill the process after this many ms. Undefined ⇒ no timeout. */
+  readonly timeoutMs?: number
+  /** Cap on captured stdout+stderr bytes. Undefined ⇒ runtime default. */
+  readonly maxOutputBytes?: number
+}
+
+/** Result of {@link SandboxRuntime.exec}. */
+export interface SandboxExecResult {
+  /** Process exit code; -1 when killed before exiting. */
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+  /** True when stdout or stderr was truncated at `maxOutputBytes`. */
+  readonly truncated: boolean
+  /** True when the process was killed by the `timeoutMs` deadline. */
+  readonly timedOut: boolean
+}
+
+export interface SandboxRuntime {
+  readonly level: SandboxLevel
+  readonly name: string
+  spawn(opts: { command: string; args: readonly string[]; cwd?: string }): Promise<{
+    pid: number
+    kill: () => Promise<void>
+  }>
+  /**
+   * Run a command to completion inside the sandbox. Optional: a runtime that
+   * only supports fire-and-forget `spawn` (e.g. `none`) omits it. Callers MUST
+   * check for the method's presence and degrade when it is absent.
+   */
+  exec?(opts: SandboxExecOptions): Promise<SandboxExecResult>
+}
+
+export interface ChildHandle {
+  readonly pid: number
+  kill(): Promise<void>
+}
+
+export interface SpawnerExecOptions {
+  command: string
+  args: readonly string[]
+  cwd?: string
+  env?: Readonly<Record<string, string>>
+  /** Kill the process after this many ms. Undefined ⇒ no timeout. */
+  timeoutMs?: number
+  /** Cap on captured stdout+stderr bytes. Undefined ⇒ 256 KiB. */
+  maxOutputBytes?: number
+}
+
+export interface SpawnerExecResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  truncated: boolean
+  timedOut: boolean
+}
+
+export interface Spawner {
+  spawn(opts: {
+    command: string
+    args: readonly string[]
+    cwd?: string
+    env?: Readonly<Record<string, string>>
+    stdio?: 'pipe' | 'inherit' | 'ignore'
+  }): Promise<ChildHandle>
+  /** Run a command to completion. Optional so fire-and-forget fakes satisfy `Spawner`. */
+  exec?(opts: SpawnerExecOptions): Promise<SpawnerExecResult>
+}

--- a/packages/sandbox/src/local-spawner.ts
+++ b/packages/sandbox/src/local-spawner.ts
@@ -1,0 +1,88 @@
+// Default `Spawner` over node:child_process. Lazy-imports child_process so
+// the module stays importable in non-node environments.
+
+import { SandboxError } from '@agentskit/core'
+import type { Spawner, SpawnerExecResult } from './local-sandbox-types'
+
+/** Default cap on captured stdout+stderr (256 KiB). */
+const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024
+
+export const nodeSpawner = async (): Promise<Spawner> => {
+  const { spawn } = await import('node:child_process')
+  return {
+    spawn: async (opts) => {
+      const spawnArgs: import('node:child_process').SpawnOptions = { stdio: opts.stdio ?? 'pipe' }
+      if (opts.cwd !== undefined) spawnArgs.cwd = opts.cwd
+      if (opts.env !== undefined) spawnArgs.env = opts.env
+      const child = spawn(opts.command, [...opts.args], spawnArgs)
+      const pid = child.pid
+      if (typeof pid !== 'number') {
+        child.kill()
+        throw new SandboxError({
+          code: 'AK_SANDBOX_BACKEND_FAILED',
+          message: `failed to spawn child process: ${opts.command}`,
+          hint: 'Check that the command exists on PATH, the working directory is valid, and the sandbox has permission to execute it.',
+          cause: { command: opts.command, cwd: opts.cwd },
+        })
+      }
+      return {
+        pid,
+        kill: async () => {
+          if (!child.killed) child.kill()
+        },
+      }
+    },
+    exec: (opts) =>
+      new Promise<SpawnerExecResult>((resolve, reject) => {
+        const maxBytes = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
+        const execArgs: import('node:child_process').SpawnOptionsWithoutStdio = { stdio: 'pipe' }
+        if (opts.cwd !== undefined) execArgs.cwd = opts.cwd
+        if (opts.env !== undefined) execArgs.env = opts.env
+        const child = spawn(opts.command, [...opts.args], execArgs)
+        let stdout = ''
+        let stderr = ''
+        let truncated = false
+        let timedOut = false
+        const append = (cur: string, chunk: Buffer): string => {
+          if (cur.length >= maxBytes) {
+            truncated = true
+            return cur
+          }
+          const next = cur + chunk.toString('utf-8')
+          if (next.length > maxBytes) {
+            truncated = true
+            return next.slice(0, maxBytes)
+          }
+          return next
+        }
+        child.stdout?.on('data', (c: Buffer) => {
+          stdout = append(stdout, c)
+        })
+        child.stderr?.on('data', (c: Buffer) => {
+          stderr = append(stderr, c)
+        })
+        const timer =
+          opts.timeoutMs !== undefined
+            ? setTimeout(() => {
+                timedOut = true
+                child.kill('SIGKILL')
+              }, opts.timeoutMs)
+            : undefined
+        child.on('error', () => {
+          if (timer) clearTimeout(timer)
+          reject(
+            new SandboxError({
+              code: 'AK_SANDBOX_BACKEND_FAILED',
+              message: `failed to exec child process: ${opts.command}`,
+              hint: 'Check that the command exists on PATH and is executable.',
+              cause: { command: opts.command, cwd: opts.cwd },
+            }),
+          )
+        })
+        child.on('close', (code) => {
+          if (timer) clearTimeout(timer)
+          resolve({ exitCode: code ?? -1, stdout, stderr, truncated, timedOut })
+        })
+      }),
+  }
+}

--- a/packages/sandbox/tests/container-runtimes.test.ts
+++ b/packages/sandbox/tests/container-runtimes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { renderBwrapArgs, renderDockerArgs } from '../src/index'
+
+describe('renderBwrapArgs', () => {
+  it('unshares everything and binds the workspace', () => {
+    const args = renderBwrapArgs({ workspaceRoot: '/ws' })
+    expect(args).toContain('--unshare-all')
+    expect(args).toContain('--die-with-parent')
+    const i = args.indexOf('--bind')
+    expect([args[i + 1], args[i + 2]]).toEqual(['/ws', '/ws'])
+    expect(args).not.toContain('--share-net')
+  })
+
+  it('shares net only when allowed', () => {
+    expect(renderBwrapArgs({ workspaceRoot: '/ws', allowNetwork: true })).toContain('--share-net')
+  })
+})
+
+describe('renderDockerArgs', () => {
+  it('drops caps, disables network, mounts workspace read-only by default', () => {
+    const args = renderDockerArgs({ image: 'node:20', workspaceRoot: '/ws' })
+    expect(args.slice(0, 3)).toEqual(['run', '--rm', '--init'])
+    expect(args).toContain('--cap-drop')
+    expect(args).toContain('ALL')
+    const n = args.indexOf('--network')
+    expect(args[n + 1]).toBe('none')
+    expect(args).toContain('/ws:/workspace:ro')
+    expect(args[args.length - 1]).toBe('node:20')
+  })
+
+  it('mounts read-write and sets a named network when configured', () => {
+    const args = renderDockerArgs({
+      image: 'node:20',
+      workspaceRoot: '/ws',
+      writableWorkspace: true,
+      network: 'egress-net',
+    })
+    expect(args).toContain('/ws:/workspace:rw')
+    const n = args.indexOf('--network')
+    expect(args[n + 1]).toBe('egress-net')
+  })
+})

--- a/packages/sandbox/tests/local-registry.test.ts
+++ b/packages/sandbox/tests/local-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SandboxRegistry,
+  WeakSandboxError,
+  assertStrongIsolation,
+  isStrongIsolation,
+  isWeakIsolation,
+  weakSandboxBanner,
+} from '../src/index'
+
+describe('SandboxRegistry', () => {
+  it('ships none + process builtins', () => {
+    const reg = new SandboxRegistry()
+    expect(reg.has('none')).toBe(true)
+    expect(reg.has('process')).toBe(true)
+    expect(reg.list()).toEqual(expect.arrayContaining(['none', 'process']))
+  })
+
+  it('throws for an unregistered level', () => {
+    const reg = new SandboxRegistry(false)
+    expect(() => reg.resolveOrThrow('container')).toThrow(/no sandbox runtime registered/)
+  })
+})
+
+describe('strictness', () => {
+  it('classifies isolation strength', () => {
+    expect(isStrongIsolation('container')).toBe(true)
+    expect(isWeakIsolation('process')).toBe(true)
+    expect(isStrongIsolation('process')).toBe(false)
+  })
+
+  it('throws WeakSandboxError for weak levels unless opted in', () => {
+    expect(() => assertStrongIsolation('process')).toThrow(WeakSandboxError)
+    expect(() => assertStrongIsolation('process', { allowWeak: true })).not.toThrow()
+    expect(() => assertStrongIsolation('container')).not.toThrow()
+  })
+
+  it('renders a stderr banner', () => {
+    expect(weakSandboxBanner('process')).toContain('no OS-level fs/net isolation')
+  })
+})

--- a/packages/sandbox/tests/local-runtimes.test.ts
+++ b/packages/sandbox/tests/local-runtimes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentsKitError } from '@agentskit/core'
+import {
+  noneSandbox,
+  processSandbox,
+  renderSandboxExecProfile,
+  type Spawner,
+} from '../src/index'
+
+const fakeSpawner = (): Spawner => ({
+  spawn: vi.fn(async (opts) => ({ pid: 4242, kill: async () => {}, _opts: opts }) as never),
+  exec: vi.fn(async () => ({ exitCode: 0, stdout: 'ok', stderr: '', truncated: false, timedOut: false })),
+})
+
+describe('noneSandbox', () => {
+  it('rejects spawn (in-process only)', async () => {
+    await expect(noneSandbox.spawn({ command: 'ls', args: [] })).rejects.toBeInstanceOf(AgentsKitError)
+  })
+})
+
+describe('processSandbox', () => {
+  it('spawns through the injected spawner', async () => {
+    const spawner = fakeSpawner()
+    const rt = processSandbox({ spawner })
+    const handle = await rt.spawn({ command: 'echo', args: ['hi'] })
+    expect(handle.pid).toBe(4242)
+    expect(spawner.spawn).toHaveBeenCalledOnce()
+  })
+
+  it('filters env to the allowlist', async () => {
+    const spawner = fakeSpawner()
+    const rt = processSandbox({ spawner, defaultEnv: { PATH: '/usr/bin', SECRET: 'nope' } })
+    await rt.spawn({ command: 'echo', args: [] })
+    const passedEnv = (spawner.spawn as ReturnType<typeof vi.fn>).mock.calls[0][0].env
+    expect(passedEnv).toEqual({ PATH: '/usr/bin' })
+  })
+
+  it('execs through the injected spawner', async () => {
+    const rt = processSandbox({ spawner: fakeSpawner() })
+    const res = await rt.exec!({ command: 'echo', args: ['hi'] })
+    expect(res.exitCode).toBe(0)
+  })
+})
+
+describe('renderSandboxExecProfile', () => {
+  it('denies network by default and scopes writes to the workspace', () => {
+    const profile = renderSandboxExecProfile({ workspaceRoot: '/ws' })
+    expect(profile).toContain('(deny default)')
+    expect(profile).toContain('(allow file-write* (subpath "/ws"))')
+    expect(profile).toContain('(deny network-outbound (with no-log))')
+  })
+
+  it('allows network when requested', () => {
+    expect(renderSandboxExecProfile({ workspaceRoot: '/ws', allowNetwork: true })).toContain('(allow network*)')
+  })
+})

--- a/packages/sandbox/tests/local-sandbox-types.test.ts
+++ b/packages/sandbox/tests/local-sandbox-types.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { SANDBOX_LEVELS } from '../src/index'
+
+describe('SANDBOX_LEVELS', () => {
+  it('ranks isolation strength from none upward', () => {
+    expect(SANDBOX_LEVELS).toEqual(['none', 'process', 'container', 'vm', 'webcontainer'])
+  })
+})

--- a/packages/sandbox/tests/local-spawner.test.ts
+++ b/packages/sandbox/tests/local-spawner.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { nodeSpawner } from '../src/index'
+
+describe('nodeSpawner', () => {
+  it('execs a command to completion capturing stdout + exit code', async () => {
+    const spawner = await nodeSpawner()
+    const res = await spawner.exec!({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write("hi")'],
+    })
+    expect(res.exitCode).toBe(0)
+    expect(res.stdout).toBe('hi')
+    expect(res.timedOut).toBe(false)
+  })
+
+  it('reports a non-zero exit code', async () => {
+    const spawner = await nodeSpawner()
+    const res = await spawner.exec!({
+      command: process.execPath,
+      args: ['-e', 'process.exit(3)'],
+    })
+    expect(res.exitCode).toBe(3)
+  })
+
+  it('truncates output past maxOutputBytes', async () => {
+    const spawner = await nodeSpawner()
+    const res = await spawner.exec!({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write("x".repeat(1000))'],
+      maxOutputBytes: 100,
+    })
+    expect(res.truncated).toBe(true)
+    expect(res.stdout.length).toBeLessThanOrEqual(100)
+  })
+})


### PR DESCRIPTION
Additive — the E2B cloud `Sandbox` surface is unchanged. Unblocks AgentsKit-io/agentskit-os#3995 (the os-sandbox egress-enforcer + kernel-egress stay in os; only runtimes upstream, per ADR-0143).

- `SandboxRuntime` / `SandboxLevel` / `SandboxExecOptions` contract
- `noneSandbox`, `processSandbox` (env-allowlist), `sandboxExecRuntime` (macOS SBPL), `bwrapRuntime` (Linux), `dockerRuntime` (cap-drop/read-only/no-net default)
- `nodeSpawner` (timeout + output cap), `SandboxRegistry`, isolation-strictness helpers

All shell out via an injected `Spawner` — no native deps. 51 tests, lint clean, 13/13 lib gates, for-agents doc + changeset.

Validated end-to-end: agentskit-os os-sandbox delegates to this and passes 118/118 (local-registry proof; the e2e run caught + fixed an env-prefix bug).