### PR TITLE
feat(memory): add key-value memory store (AgentskitMemoryStore)

### DIFF
--- a/.changeset/memory-kv-store.md
+++ b/.changeset/memory-kv-store.md
@@ -1,0 +1,13 @@
+---
+'@agentskit/memory': minor
+---
+
+Add a key-value memory store (`AgentskitMemoryStore`) — generic
+`get(key)`/`set(key,value)` with TTL + max-key eviction — complementing the
+conversation `ChatMemory` model. Backends: `createInMemoryStore`,
+`createFileStore`, `createSqliteStore` (+ `tryDefaultSqliteOpener`),
+`createLocalStorageStore`, `createRedisStore` (+ `adaptIoredis`,
+`tryDefaultRedisClient`), `createVectorStore` (with `recall`), and the
+`createKvMemoryFromConfig` / `createKvMemoryFromConfigAuto` dispatch over a
+`KvMemoryConfig`. External drivers (sqlite/redis) and vector store/embedder are
+injected; all additive — the ChatMemory/VectorMemory surface is unchanged.

--- a/apps/docs-next/content/docs/for-agents/memory.mdx
+++ b/apps/docs-next/content/docs/for-agents/memory.mdx
@@ -38,6 +38,16 @@ npm install @agentskit/memory
 - `wrapVectorMemoryWithRedaction(mem, { rules, mode?, vault?, allowedRoles? })` — same for `VectorMemory.store()`. Embeddings pass through verbatim; redact the input to your embedder separately if it is a hosted provider.
 - `forgetSubject(memory, subjectId)` / `makeForgettable(memory)` — GDPR-style right-to-erasure helpers that purge all records for a subject across `ChatMemory` and `VectorMemory`.
 
+### Key-value store (`AgentskitMemoryStore`)
+
+A generic `get(key)`/`set(key,value)` store with TTL + max-key eviction, complementing the conversation `ChatMemory` model — for agent scratchpad, pipeline state, and arbitrary JSON keyed by string.
+
+- `createInMemoryStore(config)` / `createFileStore(config)` / `createLocalStorageStore({ config, storage? })` — zero-dependency backends.
+- `createSqliteStore({ config, open })` — `open` is a better-sqlite3-style opener; `tryDefaultSqliteOpener()` lazy-imports `better-sqlite3`.
+- `createRedisStore({ config, client })` — `client` is a `RedisLike`; `adaptIoredis(io)` bridges ioredis, `tryDefaultRedisClient(url)` lazy-imports node-redis.
+- `createVectorStore({ config, vectorStore, embedder })` — exact-key `get`/`set` plus a `recall(query, k)` similarity search.
+- `createKvMemoryFromConfig({ config, sqlite?, redis?, vectorStore?, embedder? })` / `createKvMemoryFromConfigAuto(config)` — dispatch over a `KvMemoryConfig` (`in-memory`/`file`/`sqlite`/`localstorage`/`redis`/`vector`); the auto form lazy-loads optional drivers. `MEMORY_BACKEND_SUPPORT` / `isMemoryBackendSupported` / `MemoryBackendNotImplementedError` describe coverage.
+
 ## Minimal example
 
 ```ts

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -81,3 +81,41 @@ export type {
   VectorMemoryRedactionOptions,
   RedactionMode,
 } from './redaction'
+
+// Key-value memory store (AgentskitMemoryStore) — generic get(key)/set(key,value)
+// with TTL + max-key eviction, complementing the conversation ChatMemory model.
+// Backends: in-memory / file / sqlite / localstorage / redis / vector.
+export type {
+  AgentskitMemoryStore,
+  KvEntry,
+  KvMemoryConfig,
+  InMemoryKvConfig,
+  FileKvConfig,
+  SqliteKvConfig,
+  RedisKvConfig,
+  VectorKvConfig,
+  LocalStorageKvConfig,
+  RedisLike,
+  SqliteLike,
+  SqliteStmt,
+  SqliteOpener,
+  MemoryVectorStoreLike,
+  MemoryEmbedderLike,
+  LocalStorageLike,
+} from './kv-store-types'
+export { createInMemoryStore, createFileStore, createLocalStorageStore } from './kv-store-basic'
+export type { CreateLocalStorageStoreOpts } from './kv-store-basic'
+export { createSqliteStore, tryDefaultSqliteOpener } from './kv-store-sqlite'
+export type { CreateSqliteStoreOpts } from './kv-store-sqlite'
+export { createRedisStore, adaptIoredis, tryDefaultRedisClient } from './kv-store-redis'
+export type { CreateRedisStoreOpts } from './kv-store-redis'
+export { createVectorStore } from './kv-store-vector'
+export type { CreateVectorStoreOpts } from './kv-store-vector'
+export {
+  createKvMemoryFromConfig,
+  createKvMemoryFromConfigAuto,
+  MemoryBackendNotImplementedError,
+  MEMORY_BACKEND_SUPPORT,
+  isMemoryBackendSupported,
+} from './kv-store-factory'
+export type { CreateKvMemoryFromConfigOpts, MemoryBackendStatus } from './kv-store-factory'

--- a/packages/memory/src/kv-store-basic.ts
+++ b/packages/memory/src/kv-store-basic.ts
@@ -1,0 +1,148 @@
+// in-memory / file / localstorage KV backends.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import {
+  enforceMaxMessages,
+  isExpired,
+  type AgentskitMemoryStore,
+  type FileKvConfig,
+  type InMemoryKvConfig,
+  type KvEntry,
+  type LocalStorageKvConfig,
+  type LocalStorageLike,
+} from './kv-store-types'
+
+export const createInMemoryStore = (config: InMemoryKvConfig): AgentskitMemoryStore => {
+  const store = new Map<string, KvEntry>()
+  const now = () => Date.now()
+  return {
+    id: 'in-memory',
+    async get(key) {
+      const entry = store.get(key)
+      if (!entry) return undefined
+      if (isExpired(entry, config.ttlSeconds, now())) {
+        store.delete(key)
+        return undefined
+      }
+      return entry.value
+    },
+    async set(key, value) {
+      store.set(key, { value, insertedAt: now() })
+      enforceMaxMessages(store, config.maxMessages)
+    },
+  }
+}
+
+export const createFileStore = (config: FileKvConfig): AgentskitMemoryStore => {
+  const path = config.path
+  let cache: Map<string, KvEntry> | undefined
+
+  const load = async (): Promise<Map<string, KvEntry>> => {
+    if (cache) return cache
+    try {
+      const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, KvEntry>
+      cache = new Map(Object.entries(parsed))
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') cache = new Map()
+      else throw err
+    }
+    return cache
+  }
+
+  const persist = async (map: Map<string, KvEntry>): Promise<void> => {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify(Object.fromEntries(map), null, 2), { encoding: 'utf8', mode: 0o600 })
+  }
+
+  return {
+    id: `file:${path}`,
+    async get(key) {
+      const map = await load()
+      const entry = map.get(key)
+      if (!entry) return undefined
+      if (isExpired(entry, config.ttlSeconds, Date.now())) {
+        map.delete(key)
+        await persist(map)
+        return undefined
+      }
+      return entry.value
+    },
+    async set(key, value) {
+      const map = await load()
+      map.set(key, { value, insertedAt: Date.now() })
+      enforceMaxMessages(map, config.maxMessages)
+      await persist(map)
+    },
+  }
+}
+
+export interface CreateLocalStorageStoreOpts {
+  readonly config: LocalStorageKvConfig
+  readonly storage?: LocalStorageLike
+  readonly filePath?: string
+}
+
+const resolveLocalStorage = (): LocalStorageLike | undefined => {
+  const maybe = (globalThis as { localStorage?: LocalStorageLike }).localStorage
+  return maybe && typeof maybe.getItem === 'function' && typeof maybe.setItem === 'function' ? maybe : undefined
+}
+
+const defaultLocalStoragePath = (): string => `${process.cwd()}/.agentskit/memory-localstorage.json`
+
+export const createLocalStorageStore = ({
+  config,
+  storage = resolveLocalStorage(),
+  filePath = defaultLocalStoragePath(),
+}: CreateLocalStorageStoreOpts): AgentskitMemoryStore => {
+  const key = config.key
+  let cache: Map<string, KvEntry> | undefined
+
+  const mapFromJson = (raw: string | null): Map<string, KvEntry> =>
+    raw ? new Map(Object.entries(JSON.parse(raw) as Record<string, KvEntry>)) : new Map()
+
+  const loadFromFile = async (): Promise<Map<string, KvEntry>> => {
+    if (cache) return cache
+    try {
+      cache = mapFromJson(await readFile(filePath, 'utf8'))
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') cache = new Map()
+      else throw err
+    }
+    return cache
+  }
+
+  const load = async (): Promise<Map<string, KvEntry>> =>
+    storage ? mapFromJson(storage.getItem(key)) : loadFromFile()
+
+  const persist = async (map: Map<string, KvEntry>): Promise<void> => {
+    const raw = JSON.stringify(Object.fromEntries(map), null, 2)
+    if (storage) {
+      storage.setItem(key, raw)
+      return
+    }
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, raw, { encoding: 'utf8', mode: 0o600 })
+  }
+
+  return {
+    id: storage ? `localstorage:${key}` : `localstorage-file:${filePath}:${key}`,
+    async get(itemKey) {
+      const map = await load()
+      const entry = map.get(itemKey)
+      if (!entry) return undefined
+      if (isExpired(entry, config.ttlSeconds, Date.now())) {
+        map.delete(itemKey)
+        await persist(map)
+        return undefined
+      }
+      return entry.value
+    },
+    async set(itemKey, value) {
+      const map = await load()
+      map.set(itemKey, { value, insertedAt: Date.now() })
+      enforceMaxMessages(map, config.maxMessages)
+      await persist(map)
+    },
+  }
+}

--- a/packages/memory/src/kv-store-factory.ts
+++ b/packages/memory/src/kv-store-factory.ts
@@ -1,0 +1,140 @@
+// KV memory dispatch factory — maps a `KvMemoryConfig.backend` to its store.
+// Backends with external drivers (sqlite/redis) or external ports (vector) take
+// the dependency injected; `createKvMemoryFromConfigAuto` lazy-loads the optional
+// sqlite/redis drivers.
+
+import { MemoryError } from '@agentskit/core'
+import { createFileStore, createInMemoryStore, createLocalStorageStore } from './kv-store-basic'
+import { createSqliteStore, tryDefaultSqliteOpener } from './kv-store-sqlite'
+import { createRedisStore, tryDefaultRedisClient } from './kv-store-redis'
+import { createVectorStore } from './kv-store-vector'
+import type {
+  AgentskitMemoryStore,
+  KvMemoryConfig,
+  MemoryEmbedderLike,
+  MemoryVectorStoreLike,
+  RedisLike,
+  SqliteOpener,
+} from './kv-store-types'
+
+export class MemoryBackendNotImplementedError extends Error {
+  readonly code = 'MEMORY_BACKEND_NOT_IMPLEMENTED'
+  readonly backend: KvMemoryConfig['backend']
+  constructor(backend: KvMemoryConfig['backend']) {
+    super(
+      `Memory backend "${backend}" is not implemented. Supported: ` +
+        `"in-memory", "file", "sqlite", "localstorage", "redis", "vector".`,
+    )
+    this.backend = backend
+  }
+}
+
+export type MemoryBackendStatus = 'supported' | 'planned'
+
+export const MEMORY_BACKEND_SUPPORT: Readonly<Record<KvMemoryConfig['backend'], MemoryBackendStatus>> = {
+  'in-memory': 'supported',
+  file: 'supported',
+  sqlite: 'supported',
+  redis: 'supported',
+  vector: 'supported',
+  localstorage: 'supported',
+}
+
+export const isMemoryBackendSupported = (backend: KvMemoryConfig['backend']): boolean =>
+  MEMORY_BACKEND_SUPPORT[backend] === 'supported'
+
+export interface CreateKvMemoryFromConfigOpts {
+  readonly config: KvMemoryConfig
+  readonly sqlite?: SqliteOpener
+  readonly localStorageFilePath?: string
+  readonly redis?: RedisLike
+  readonly vectorStore?: MemoryVectorStoreLike
+  readonly embedder?: MemoryEmbedderLike
+}
+
+export const createKvMemoryFromConfig = ({
+  config,
+  sqlite,
+  localStorageFilePath,
+  redis,
+  vectorStore,
+  embedder,
+}: CreateKvMemoryFromConfigOpts): AgentskitMemoryStore => {
+  if (config.backend === 'in-memory') return createInMemoryStore(config)
+  if (config.backend === 'file') return createFileStore(config)
+  if (config.backend === 'localstorage') {
+    return createLocalStorageStore({
+      config,
+      ...(localStorageFilePath ? { filePath: localStorageFilePath } : {}),
+    })
+  }
+  if (config.backend === 'sqlite') {
+    if (!sqlite) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_SQLITE_OPENER_REQUIRED',
+        message:
+          'createKvMemoryFromConfig: sqlite backend requires an `open` function (better-sqlite3), ' +
+          'or call createKvMemoryFromConfigAuto which lazy-imports it.',
+      })
+    }
+    return createSqliteStore({ config, open: sqlite })
+  }
+  if (config.backend === 'redis') {
+    if (!redis) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_REDIS_CLIENT_REQUIRED',
+        message:
+          'createKvMemoryFromConfig: redis backend requires a `redis` client, ' +
+          'or call createKvMemoryFromConfigAuto which lazy-imports it.',
+      })
+    }
+    return createRedisStore({ config, client: redis })
+  }
+  if (config.backend === 'vector') {
+    if (!vectorStore) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_VECTOR_STORE_REQUIRED',
+        message: 'createKvMemoryFromConfig: vector backend requires a `vectorStore`.',
+      })
+    }
+    if (!embedder) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_VECTOR_EMBEDDER_REQUIRED',
+        message: 'createKvMemoryFromConfig: vector backend requires an `embedder`.',
+      })
+    }
+    return createVectorStore({ config, vectorStore, embedder })
+  }
+  const exhausted: never = config
+  throw new MemoryBackendNotImplementedError((exhausted as { backend: KvMemoryConfig['backend'] }).backend)
+}
+
+export const createKvMemoryFromConfigAuto = async (config: KvMemoryConfig): Promise<AgentskitMemoryStore> => {
+  if (config.backend === 'sqlite') {
+    const sqlite = await tryDefaultSqliteOpener()
+    if (!sqlite) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_PEER_MISSING',
+        message: 'createKvMemoryFromConfigAuto: sqlite backend needs `better-sqlite3` (pnpm add better-sqlite3).',
+      })
+    }
+    return createKvMemoryFromConfig({ config, sqlite })
+  }
+  if (config.backend === 'redis') {
+    const redis = await tryDefaultRedisClient(config.url)
+    if (!redis) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_PEER_MISSING',
+        message: 'createKvMemoryFromConfigAuto: redis backend needs `redis` (pnpm add redis).',
+      })
+    }
+    return createKvMemoryFromConfig({ config, redis })
+  }
+  if (config.backend === 'vector') {
+    throw new MemoryError({
+      code: 'AK_MEMORY_VECTOR_STORE_REQUIRED',
+      message: 'createKvMemoryFromConfigAuto: vector backend requires an injected vectorStore + embedder.',
+    })
+  }
+  return createKvMemoryFromConfig({ config })
+}

--- a/packages/memory/src/kv-store-redis.ts
+++ b/packages/memory/src/kv-store-redis.ts
@@ -1,0 +1,110 @@
+// redis KV backend (injected client; lazy default via node-redis).
+
+import { MemoryError } from '@agentskit/core'
+import { isExpired, type AgentskitMemoryStore, type RedisKvConfig, type RedisLike } from './kv-store-types'
+
+interface RedisEnvelope {
+  readonly value: unknown
+  readonly insertedAt: number
+}
+
+export interface CreateRedisStoreOpts {
+  readonly config: RedisKvConfig
+  readonly client: RedisLike
+}
+
+export const createRedisStore = ({ config, client }: CreateRedisStoreOpts): AgentskitMemoryStore => {
+  const prefix = config.prefix
+  const namespaced = (key: string): string => `${prefix}${key}`
+
+  const wrap = async <T>(op: string, fn: () => Promise<T>): Promise<T> => {
+    try {
+      return await fn()
+    } catch (cause) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_REDIS_CONNECTION_FAILED',
+        message: `createRedisStore.${op}: redis command failed — ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause: cause instanceof Error ? cause : undefined,
+      })
+    }
+  }
+
+  const enforce = async (): Promise<void> => {
+    if (config.maxMessages === undefined) return
+    const keys = await wrap('enforce', () => Promise.resolve(client.keys(`${prefix}*`)))
+    if (keys.length <= config.maxMessages) return
+    const envelopes: { key: string; insertedAt: number }[] = []
+    for (const fullKey of keys) {
+      const raw = await wrap('enforce', () => Promise.resolve(client.get(fullKey)))
+      if (raw === null) continue
+      envelopes.push({ key: fullKey, insertedAt: (JSON.parse(raw) as RedisEnvelope).insertedAt })
+    }
+    envelopes.sort((a, b) => a.insertedAt - b.insertedAt)
+    let excess = envelopes.length - config.maxMessages
+    for (const entry of envelopes) {
+      if (excess <= 0) break
+      await wrap('enforce', () => Promise.resolve(client.del(entry.key)))
+      excess -= 1
+    }
+  }
+
+  return {
+    id: `redis:${prefix}`,
+    async get(key) {
+      const raw = await wrap('get', () => Promise.resolve(client.get(namespaced(key))))
+      if (raw === null) return undefined
+      const envelope = JSON.parse(raw) as RedisEnvelope
+      if (isExpired({ value: envelope.value, insertedAt: envelope.insertedAt }, config.ttlSeconds, Date.now())) {
+        await wrap('get', () => Promise.resolve(client.del(namespaced(key))))
+        return undefined
+      }
+      return envelope.value
+    },
+    async set(key, value) {
+      const payload = JSON.stringify({ value, insertedAt: Date.now() } satisfies RedisEnvelope)
+      const options = config.ttlSeconds === undefined ? undefined : { EX: config.ttlSeconds }
+      await wrap('set', () => Promise.resolve(client.set(namespaced(key), payload, options)))
+      await enforce()
+    },
+  }
+}
+
+/** Bridge an `ioredis`-style client to the {@link RedisLike} options-object shape. */
+export const adaptIoredis = (io: {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, mode?: string, ttl?: number): Promise<unknown>
+  del(key: string): Promise<unknown>
+  keys(pattern: string): Promise<string[]>
+}): RedisLike => ({
+  get: (key) => io.get(key),
+  set: (key, value, options) =>
+    options?.EX === undefined ? io.set(key, value) : io.set(key, value, 'EX', options.EX),
+  del: (key) => io.del(key),
+  keys: (pattern) => io.keys(pattern),
+})
+
+/** Lazy-import `redis` (node-redis v4), connect, and return a client; `undefined` if absent. */
+export const tryDefaultRedisClient = async (url: string): Promise<RedisLike | undefined> => {
+  try {
+    const moduleId = 'redis'
+    const mod = (await import(/* @vite-ignore */ moduleId)) as unknown as {
+      readonly createClient?: (opts: { url: string }) => RedisLike & { connect(): Promise<unknown> }
+    }
+    const createClient = mod.createClient
+    if (typeof createClient !== 'function') return undefined
+    const client = createClient({ url })
+    try {
+      await client.connect()
+    } catch (cause) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_REDIS_CONNECTION_FAILED',
+        message: `tryDefaultRedisClient: redis connect() failed — ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause: cause instanceof Error ? cause : undefined,
+      })
+    }
+    return client
+  } catch (err) {
+    if (err instanceof MemoryError) throw err
+    return undefined
+  }
+}

--- a/packages/memory/src/kv-store-sqlite.ts
+++ b/packages/memory/src/kv-store-sqlite.ts
@@ -1,0 +1,81 @@
+// sqlite KV backend (injected opener; lazy default via better-sqlite3).
+
+import {
+  isExpired,
+  type AgentskitMemoryStore,
+  type SqliteKvConfig,
+  type SqliteLike,
+  type SqliteOpener,
+} from './kv-store-types'
+
+export interface CreateSqliteStoreOpts {
+  readonly config: SqliteKvConfig
+  readonly open: SqliteOpener
+}
+
+export const createSqliteStore = ({ config, open }: CreateSqliteStoreOpts): AgentskitMemoryStore => {
+  const db = open(config.path)
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS memory (
+       key TEXT PRIMARY KEY,
+       value TEXT NOT NULL,
+       inserted_at INTEGER NOT NULL
+     )`,
+  )
+
+  const getStmt = db.prepare('SELECT value, inserted_at FROM memory WHERE key = ?')
+  const setStmt = db.prepare(
+    'INSERT INTO memory(key, value, inserted_at) VALUES(?, ?, ?) ' +
+      'ON CONFLICT(key) DO UPDATE SET value=excluded.value, inserted_at=excluded.inserted_at',
+  )
+  const delStmt = db.prepare('DELETE FROM memory WHERE key = ?')
+  const oldestStmt = db.prepare('SELECT key FROM memory ORDER BY inserted_at ASC LIMIT 1')
+  const countStmt = db.prepare('SELECT COUNT(*) as n FROM memory')
+
+  const enforce = (): void => {
+    if (config.maxMessages === undefined) return
+    const countResult = countStmt.get() as { n: number } | undefined
+    let count = countResult ? countResult.n : 0
+    while (count > config.maxMessages) {
+      const oldest = oldestStmt.get() as { key: string } | undefined
+      if (!oldest) break
+      delStmt.run(oldest.key)
+      count -= 1
+    }
+  }
+
+  return {
+    id: `sqlite:${config.path}`,
+    async get(key) {
+      const row = getStmt.get(key) as { value: string; inserted_at: number } | undefined
+      if (!row) return undefined
+      if (isExpired({ value: '', insertedAt: row.inserted_at }, config.ttlSeconds, Date.now())) {
+        delStmt.run(key)
+        return undefined
+      }
+      return JSON.parse(row.value) as unknown
+    },
+    async set(key, value) {
+      setStmt.run(key, JSON.stringify(value), Date.now())
+      enforce()
+    },
+  }
+}
+
+/**
+ * Lazy-import `better-sqlite3` and return an opener, or `undefined` when the
+ * optional peer dep is absent (caller surfaces AK_MEMORY_PEER_MISSING).
+ */
+export const tryDefaultSqliteOpener = async (): Promise<SqliteOpener | undefined> => {
+  try {
+    const moduleId = 'better-sqlite3'
+    const mod = (await import(/* @vite-ignore */ moduleId)) as unknown as {
+      readonly default?: new (path: string) => SqliteLike
+    }
+    const Ctor = mod.default
+    if (typeof Ctor !== 'function') return undefined
+    return (path: string) => new Ctor(path)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/memory/src/kv-store-types.ts
+++ b/packages/memory/src/kv-store-types.ts
@@ -1,0 +1,118 @@
+// Key-value memory store (`AgentskitMemoryStore`) — a generic get(key)/set(key,value)
+// store with TTL + max-key eviction, complementing the conversation `ChatMemory`
+// abstraction. Used for agent scratchpad, pipeline state, and arbitrary JSON
+// persistence keyed by string. Backends: in-memory / file / sqlite / localstorage
+// / redis / vector.
+
+/** Minimal KV store contract. */
+export interface AgentskitMemoryStore {
+  readonly id: string | undefined
+  get(key: string): Promise<unknown>
+  set(key: string, value: unknown): Promise<void>
+}
+
+export interface KvEntry {
+  readonly value: unknown
+  readonly insertedAt: number
+}
+
+export const isExpired = (entry: KvEntry, ttlSeconds: number | undefined, now: number): boolean => {
+  if (ttlSeconds === undefined) return false
+  return now - entry.insertedAt > ttlSeconds * 1000
+}
+
+export const enforceMaxMessages = (map: Map<string, KvEntry>, maxMessages: number | undefined): void => {
+  if (maxMessages === undefined) return
+  while (map.size > maxMessages) {
+    const oldest = map.keys().next().value
+    if (oldest === undefined) break
+    map.delete(oldest)
+  }
+}
+
+// --- Config (plain interfaces; a host's Zod-validated config is structurally compatible) ---
+
+interface CommonKvConfig {
+  readonly maxMessages?: number
+  readonly ttlSeconds?: number
+}
+
+export interface InMemoryKvConfig extends CommonKvConfig {
+  readonly backend: 'in-memory'
+}
+export interface FileKvConfig extends CommonKvConfig {
+  readonly backend: 'file'
+  readonly path: string
+}
+export interface SqliteKvConfig extends CommonKvConfig {
+  readonly backend: 'sqlite'
+  readonly path: string
+}
+export interface RedisKvConfig extends CommonKvConfig {
+  readonly backend: 'redis'
+  readonly url: string
+  readonly prefix: string
+}
+export interface VectorKvConfig extends CommonKvConfig {
+  readonly backend: 'vector'
+  readonly provider: string
+  readonly collection: string
+}
+export interface LocalStorageKvConfig extends CommonKvConfig {
+  readonly backend: 'localstorage'
+  readonly key: string
+}
+
+export type KvMemoryConfig =
+  | InMemoryKvConfig
+  | FileKvConfig
+  | SqliteKvConfig
+  | RedisKvConfig
+  | VectorKvConfig
+  | LocalStorageKvConfig
+
+// --- Injected-dependency contracts (so the store stays driver-agnostic) ---
+
+export interface RedisLike {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, options?: { readonly EX?: number }): Promise<unknown>
+  del(key: string): Promise<unknown>
+  keys(pattern: string): Promise<readonly string[]>
+}
+
+export interface SqliteStmt {
+  run(...params: unknown[]): void
+  get(...params: unknown[]): unknown
+  all(...params: unknown[]): unknown[]
+}
+
+export interface SqliteLike {
+  exec(sql: string): void
+  prepare(sql: string): SqliteStmt
+}
+
+export type SqliteOpener = (path: string) => SqliteLike
+
+export interface MemoryVectorStoreLike {
+  upsert(
+    rows: readonly {
+      readonly chunkId: string
+      readonly vec: readonly number[]
+      readonly metadata: Record<string, unknown>
+    }[],
+  ): Promise<void>
+  query(
+    vec: readonly number[],
+    k: number,
+    filter?: Record<string, unknown>,
+  ): Promise<readonly { readonly chunkId: string; readonly score: number; readonly metadata: Record<string, unknown> }[]>
+}
+
+export interface MemoryEmbedderLike {
+  embed(texts: readonly string[]): Promise<number[][]>
+}
+
+export interface LocalStorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}

--- a/packages/memory/src/kv-store-vector.ts
+++ b/packages/memory/src/kv-store-vector.ts
@@ -1,0 +1,76 @@
+// vector KV backend — get/set by exact key (round-tripped through metadata),
+// plus a `recall(query, k)` similarity search.
+
+import { MemoryError } from '@agentskit/core'
+import {
+  isExpired,
+  type AgentskitMemoryStore,
+  type MemoryEmbedderLike,
+  type MemoryVectorStoreLike,
+  type VectorKvConfig,
+} from './kv-store-types'
+
+export interface CreateVectorStoreOpts {
+  readonly config: VectorKvConfig
+  readonly vectorStore: MemoryVectorStoreLike
+  readonly embedder: MemoryEmbedderLike
+}
+
+export const createVectorStore = ({
+  config,
+  vectorStore,
+  embedder,
+}: CreateVectorStoreOpts): AgentskitMemoryStore & { recall(query: string, k?: number): Promise<readonly unknown[]> } => {
+  const collection = config.collection
+
+  const embedOne = async (text: string): Promise<number[]> => {
+    const [vec] = await embedder.embed([text])
+    if (vec === undefined) {
+      throw new MemoryError({
+        code: 'AK_MEMORY_VECTOR_EMBEDDER_REQUIRED',
+        message: 'createVectorStore: embedder returned no vector for the input text.',
+      })
+    }
+    return vec
+  }
+
+  return {
+    id: `vector:${config.provider}:${collection}`,
+    async get(key) {
+      const vec = await embedOne(key)
+      const hits = await vectorStore.query(vec, 1, { __collection: collection, __key: key })
+      const hit = hits[0]
+      if (hit === undefined) return undefined
+      if (hit.metadata['__key'] !== key) return undefined
+      const insertedAt = hit.metadata['__insertedAt']
+      if (typeof insertedAt === 'number' && isExpired({ value: undefined, insertedAt }, config.ttlSeconds, Date.now())) {
+        return undefined
+      }
+      return hit.metadata['__value']
+    },
+    async set(key, value) {
+      const vec = await embedOne(key)
+      await vectorStore.upsert([
+        {
+          chunkId: `${collection}:${key}`,
+          vec,
+          metadata: { __collection: collection, __key: key, __value: value, __insertedAt: Date.now() },
+        },
+      ])
+    },
+    async recall(query, k = 5) {
+      const vec = await embedOne(query)
+      const hits = await vectorStore.query(vec, k, { __collection: collection })
+      const now = Date.now()
+      const results: unknown[] = []
+      for (const hit of hits) {
+        const insertedAt = hit.metadata['__insertedAt']
+        if (typeof insertedAt === 'number' && isExpired({ value: undefined, insertedAt }, config.ttlSeconds, now)) {
+          continue
+        }
+        results.push(hit.metadata['__value'])
+      }
+      return results
+    },
+  }
+}

--- a/packages/memory/tests/kv-store-basic.test.ts
+++ b/packages/memory/tests/kv-store-basic.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { createInMemoryStore, createLocalStorageStore, type LocalStorageLike } from '../src/index'
+
+describe('createInMemoryStore', () => {
+  it('round-trips and evicts by maxMessages', async () => {
+    const s = createInMemoryStore({ backend: 'in-memory', maxMessages: 2 })
+    await s.set('a', 1)
+    await s.set('b', 2)
+    await s.set('c', 3)
+    expect(await s.get('a')).toBeUndefined()
+    expect(await s.get('c')).toBe(3)
+    expect(s.id).toBe('in-memory')
+  })
+})
+
+describe('createLocalStorageStore', () => {
+  it('persists through an injected storage', async () => {
+    const backing = new Map<string, string>()
+    const storage: LocalStorageLike = {
+      getItem: (k) => backing.get(k) ?? null,
+      setItem: (k, v) => void backing.set(k, v),
+    }
+    const s = createLocalStorageStore({ config: { backend: 'localstorage', key: 'mem' }, storage })
+    await s.set('x', { n: 1 })
+    expect(await s.get('x')).toEqual({ n: 1 })
+    expect(backing.has('mem')).toBe(true)
+  })
+})

--- a/packages/memory/tests/kv-store-factory.test.ts
+++ b/packages/memory/tests/kv-store-factory.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { AgentsKitError } from '@agentskit/core'
+import {
+  createKvMemoryFromConfig,
+  isMemoryBackendSupported,
+  MEMORY_BACKEND_SUPPORT,
+} from '../src/index'
+
+describe('createKvMemoryFromConfig', () => {
+  it('builds the in-memory backend', async () => {
+    const s = createKvMemoryFromConfig({ config: { backend: 'in-memory' } })
+    await s.set('k', 1)
+    expect(await s.get('k')).toBe(1)
+  })
+
+  it('throws when sqlite opener is missing', () => {
+    expect(() => createKvMemoryFromConfig({ config: { backend: 'sqlite', path: '/tmp/x.db' } })).toThrow(AgentsKitError)
+  })
+
+  it('throws when redis client is missing', () => {
+    expect(() =>
+      createKvMemoryFromConfig({ config: { backend: 'redis', url: 'redis://x', prefix: 'ak:' } }),
+    ).toThrow(AgentsKitError)
+  })
+
+  it('throws when vector store/embedder are missing', () => {
+    expect(() =>
+      createKvMemoryFromConfig({ config: { backend: 'vector', provider: 'pgvector', collection: 'c' } }),
+    ).toThrow(AgentsKitError)
+  })
+})
+
+describe('MEMORY_BACKEND_SUPPORT', () => {
+  it('marks all six backends supported', () => {
+    expect(Object.values(MEMORY_BACKEND_SUPPORT).every((s) => s === 'supported')).toBe(true)
+    expect(isMemoryBackendSupported('vector')).toBe(true)
+  })
+})

--- a/packages/memory/tests/kv-store-redis.test.ts
+++ b/packages/memory/tests/kv-store-redis.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { adaptIoredis, createRedisStore, type RedisLike } from '../src/index'
+
+const fakeRedis = (): RedisLike => {
+  const m = new Map<string, string>()
+  return {
+    get: async (k) => m.get(k) ?? null,
+    set: async (k, v) => void m.set(k, v),
+    del: async (k) => void m.delete(k),
+    keys: async (pattern) => {
+      const prefix = pattern.replace(/\*$/, '')
+      return [...m.keys()].filter((k) => k.startsWith(prefix))
+    },
+  }
+}
+
+describe('createRedisStore', () => {
+  it('namespaces keys by prefix and round-trips', async () => {
+    const client = fakeRedis()
+    const s = createRedisStore({ config: { backend: 'redis', url: 'redis://x', prefix: 'ak:' }, client })
+    await s.set('greeting', 'hi')
+    expect(await s.get('greeting')).toBe('hi')
+    expect(await client.keys('ak:*')).toEqual(['ak:greeting'])
+  })
+
+  it('evicts oldest beyond maxMessages', async () => {
+    const s = createRedisStore({
+      config: { backend: 'redis', url: 'redis://x', prefix: 'ak:', maxMessages: 1 },
+      client: fakeRedis(),
+    })
+    await s.set('a', 1)
+    await s.set('b', 2)
+    expect(await s.get('a')).toBeUndefined()
+    expect(await s.get('b')).toBe(2)
+  })
+})
+
+describe('adaptIoredis', () => {
+  it('bridges the positional EX form', async () => {
+    const calls: unknown[][] = []
+    const io = {
+      get: async () => null,
+      set: async (...args: unknown[]) => void calls.push(args),
+      del: async () => {},
+      keys: async () => [],
+    }
+    const r = adaptIoredis(io)
+    await r.set('k', 'v', { EX: 30 })
+    expect(calls[0]).toEqual(['k', 'v', 'EX', 30])
+  })
+})

--- a/packages/memory/tests/kv-store-sqlite.test.ts
+++ b/packages/memory/tests/kv-store-sqlite.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createSqliteStore, type SqliteLike, type SqliteStmt } from '../src/index'
+
+// Minimal in-memory fake of the better-sqlite3 surface the store uses.
+const fakeSqlite = (): SqliteLike => {
+  const rows = new Map<string, { value: string; inserted_at: number }>()
+  const stmt = (sql: string): SqliteStmt => ({
+    run: (...p: unknown[]) => {
+      if (sql.startsWith('INSERT')) rows.set(p[0] as string, { value: p[1] as string, inserted_at: p[2] as number })
+      else if (sql.startsWith('DELETE')) rows.delete(p[0] as string)
+    },
+    get: (...p: unknown[]) => {
+      if (sql.startsWith('SELECT value')) return rows.get(p[0] as string)
+      if (sql.startsWith('SELECT COUNT')) return { n: rows.size }
+      if (sql.startsWith('SELECT key')) {
+        const first = [...rows.entries()].sort((a, b) => a[1].inserted_at - b[1].inserted_at)[0]
+        return first ? { key: first[0] } : undefined
+      }
+      return undefined
+    },
+    all: () => [],
+  })
+  return { exec: () => {}, prepare: stmt }
+}
+
+describe('createSqliteStore', () => {
+  it('round-trips JSON values', async () => {
+    const s = createSqliteStore({ config: { backend: 'sqlite', path: ':memory:' }, open: fakeSqlite })
+    await s.set('k', { hi: true })
+    expect(await s.get('k')).toEqual({ hi: true })
+    expect(await s.get('missing')).toBeUndefined()
+  })
+
+  it('evicts oldest beyond maxMessages', async () => {
+    const s = createSqliteStore({ config: { backend: 'sqlite', path: ':memory:', maxMessages: 1 }, open: fakeSqlite })
+    await s.set('a', 1)
+    await s.set('b', 2)
+    expect(await s.get('a')).toBeUndefined()
+    expect(await s.get('b')).toBe(2)
+  })
+})

--- a/packages/memory/tests/kv-store-types.test.ts
+++ b/packages/memory/tests/kv-store-types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { enforceMaxMessages, isExpired, type KvEntry } from '../src/kv-store-types'
+
+describe('isExpired', () => {
+  it('is false when no ttl', () => {
+    expect(isExpired({ value: 1, insertedAt: 0 }, undefined, 10_000)).toBe(false)
+  })
+  it('is true past ttl', () => {
+    expect(isExpired({ value: 1, insertedAt: 0 }, 5, 6_000)).toBe(true)
+    expect(isExpired({ value: 1, insertedAt: 0 }, 5, 4_000)).toBe(false)
+  })
+})
+
+describe('enforceMaxMessages', () => {
+  it('evicts oldest (insertion order) beyond the cap', () => {
+    const m = new Map<string, KvEntry>([
+      ['a', { value: 1, insertedAt: 1 }],
+      ['b', { value: 2, insertedAt: 2 }],
+      ['c', { value: 3, insertedAt: 3 }],
+    ])
+    enforceMaxMessages(m, 2)
+    expect([...m.keys()]).toEqual(['b', 'c'])
+  })
+  it('no-op without a cap', () => {
+    const m = new Map<string, KvEntry>([['a', { value: 1, insertedAt: 1 }]])
+    enforceMaxMessages(m, undefined)
+    expect(m.size).toBe(1)
+  })
+})

--- a/packages/memory/tests/kv-store-vector.test.ts
+++ b/packages/memory/tests/kv-store-vector.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { createVectorStore, type MemoryEmbedderLike, type MemoryVectorStoreLike } from '../src/index'
+
+// Fake vector store: exact-key lookup via the __key metadata filter.
+const fakeVector = (): MemoryVectorStoreLike => {
+  const rows: { chunkId: string; metadata: Record<string, unknown> }[] = []
+  return {
+    upsert: async (input) => {
+      for (const r of input) {
+        const i = rows.findIndex((x) => x.chunkId === r.chunkId)
+        const row = { chunkId: r.chunkId, metadata: r.metadata }
+        if (i >= 0) rows[i] = row
+        else rows.push(row)
+      }
+    },
+    query: async (_vec, k, filter) => {
+      const matches = rows.filter((r) =>
+        Object.entries(filter ?? {}).every(([key, val]) => r.metadata[key] === val),
+      )
+      return matches.slice(0, k).map((r) => ({ chunkId: r.chunkId, score: 1, metadata: r.metadata }))
+    },
+  }
+}
+
+const embedder: MemoryEmbedderLike = { embed: async (texts) => texts.map(() => [0.1, 0.2, 0.3]) }
+
+describe('createVectorStore', () => {
+  const config = { backend: 'vector' as const, provider: 'pgvector', collection: 'c' }
+
+  it('round-trips by exact key', async () => {
+    const s = createVectorStore({ config, vectorStore: fakeVector(), embedder })
+    await s.set('topic', { summary: 'x' })
+    expect(await s.get('topic')).toEqual({ summary: 'x' })
+    expect(await s.get('absent')).toBeUndefined()
+  })
+
+  it('recall returns stored values for the collection', async () => {
+    const s = createVectorStore({ config, vectorStore: fakeVector(), embedder })
+    await s.set('a', 1)
+    await s.set('b', 2)
+    const out = await s.recall('anything', 5)
+    expect(out).toEqual(expect.arrayContaining([1, 2]))
+  })
+})


### PR DESCRIPTION
Additive — complements the conversation `ChatMemory`/`VectorMemory` model with a generic key-value store (`get(key)`/`set(key,value)`, TTL + max-key eviction). Unblocks AgentsKit-io/agentskit-os#3996 (os-runtime memory backends → upstream).

- `AgentskitMemoryStore` + `KvMemoryConfig` (in-memory/file/sqlite/localstorage/redis/vector)
- `createInMemoryStore`/`createFileStore`/`createLocalStorageStore` (zero-dep)
- `createSqliteStore` + `tryDefaultSqliteOpener`; `createRedisStore` + `adaptIoredis` + `tryDefaultRedisClient`; `createVectorStore` (+ `recall`) — external drivers/ports injected
- `createKvMemoryFromConfig` / `createKvMemoryFromConfigAuto` dispatch + `MEMORY_BACKEND_SUPPORT`

166 tests, lint clean, 13/13 lib quality gates. The ChatMemory/VectorMemory surface is unchanged.