### PR TITLE
fix(memory): backend-specific driver-missing codes in createKvMemoryFromConfigAuto

### DIFF
--- a/.changeset/memory-kv-auto-codes.md
+++ b/.changeset/memory-kv-auto-codes.md
@@ -1,0 +1,7 @@
+---
+'@agentskit/memory': patch
+---
+
+`createKvMemoryFromConfigAuto` now surfaces backend-specific driver-missing codes
+(`AK_MEMORY_SQLITE_DRIVER_MISSING` / `AK_MEMORY_REDIS_DRIVER_MISSING`) instead of
+the generic `AK_MEMORY_PEER_MISSING`, matching the consuming host's error contract.

--- a/packages/memory/src/kv-store-factory.ts
+++ b/packages/memory/src/kv-store-factory.ts
@@ -114,7 +114,7 @@ export const createKvMemoryFromConfigAuto = async (config: KvMemoryConfig): Prom
     const sqlite = await tryDefaultSqliteOpener()
     if (!sqlite) {
       throw new MemoryError({
-        code: 'AK_MEMORY_PEER_MISSING',
+        code: 'AK_MEMORY_SQLITE_DRIVER_MISSING',
         message: 'createKvMemoryFromConfigAuto: sqlite backend needs `better-sqlite3` (pnpm add better-sqlite3).',
       })
     }
@@ -124,7 +124,7 @@ export const createKvMemoryFromConfigAuto = async (config: KvMemoryConfig): Prom
     const redis = await tryDefaultRedisClient(config.url)
     if (!redis) {
       throw new MemoryError({
-        code: 'AK_MEMORY_PEER_MISSING',
+        code: 'AK_MEMORY_REDIS_DRIVER_MISSING',
         message: 'createKvMemoryFromConfigAuto: redis backend needs `redis` (pnpm add redis).',
       })
     }


### PR DESCRIPTION
Surface `AK_MEMORY_SQLITE_DRIVER_MISSING` / `AK_MEMORY_REDIS_DRIVER_MISSING` (was generic `AK_MEMORY_PEER_MISSING`) so the host error contract is preserved when delegating. Patch.