### PR TITLE
fix(ci): SBOM gen tolerates pnpm workspace tree (--ignore-npm-errors)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
           npx --yes @cyclonedx/cyclonedx-npm@2.0.0 \
             --output-format JSON \
             --output-file sbom.cdx.json \
-            --short-PURLs
+            --short-PURLs \
+            --ignore-npm-errors
       - name: Upload SBOM artifact
         if: steps.changesets.outputs.published == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The release `Generate SBOM (CycloneDX)` step runs `@cyclonedx/cyclonedx-npm` (an npm tool) over this **pnpm** monorepo. On publish runs, `npm ls` flags the workspace `@agentskit/*` packages as `invalid` (`ELSPROBLEMS`) → non-zero exit → the step fails *after* a successful publish (seen on release runs for #993/#995).

`--ignore-npm-errors` is cyclonedx-npm's documented flag for exactly this (npm-ls problems in workspaces); the SBOM is still generated from the resolved tree. One-line, CI-only.