### PR TITLE
feat(docs): redesign home — ecosystem diagram, install tabs, demo carousel

### DIFF
--- a/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
+++ b/apps/docs-next/app/(home)/_components/hero-demo/hero-demo.tsx
@@ -43,11 +43,22 @@ export function HeroDemo() {
   const [sceneIdx, setSceneIdx] = useState(0)
   const [frame, setFrame] = useState<Frame>(EMPTY)
   const [reducedMotion, setReducedMotion] = useState(false)
+  const railRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const m = window.matchMedia('(prefers-reduced-motion: reduce)')
     setReducedMotion(m.matches)
   }, [])
+
+  // pin the active scene chip to the start of the single-line carousel so the
+  // current demo always leads, clearly highlighted
+  useEffect(() => {
+    const rail = railRef.current
+    const el = rail?.children[sceneIdx] as HTMLElement | undefined
+    if (!rail || !el) return
+    const delta = el.getBoundingClientRect().left - rail.getBoundingClientRect().left
+    rail.scrollTo({ left: rail.scrollLeft + delta - 8, behavior: 'smooth' })
+  }, [sceneIdx])
 
   useEffect(() => {
     let cancelled = false
@@ -279,14 +290,27 @@ export function HeroDemo() {
         </div>
       </div>
 
-      <div className="flex items-center justify-center border-t border-ak-border bg-ak-surface px-4 py-2.5">
-        <div className="flex flex-wrap justify-center gap-1.5">
+      <div className="flex items-center gap-1 border-t border-ak-border bg-ak-surface px-2 py-2">
+        <button
+          type="button"
+          aria-label="Previous demo"
+          onClick={() => selectScene((sceneIdx - 1 + SCENES.length) % SCENES.length)}
+          className="shrink-0 rounded-md p-1 text-ak-graphite transition hover:bg-ak-midnight hover:text-ak-foam"
+        >
+          <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+        <div
+          ref={railRef}
+          className="flex flex-1 gap-1.5 overflow-x-auto [mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
           {SCENES.map((s, i) => (
             <button
               key={s.id}
               type="button"
               onClick={() => selectScene(i)}
-              className={`rounded-full px-2.5 py-1 font-mono text-[11px] transition ${
+              className={`shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 font-mono text-[11px] transition ${
                 i === sceneIdx
                   ? 'bg-ak-blue/20 text-ak-blue'
                   : 'text-ak-graphite hover:text-ak-foam'
@@ -301,6 +325,16 @@ export function HeroDemo() {
             </button>
           ))}
         </div>
+        <button
+          type="button"
+          aria-label="Next demo"
+          onClick={() => selectScene((sceneIdx + 1) % SCENES.length)}
+          className="shrink-0 rounded-md p-1 text-ak-graphite transition hover:bg-ak-midnight hover:text-ak-foam"
+        >
+          <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
       </div>
     </div>
   )

--- a/apps/docs-next/app/(home)/_components/install-command.tsx
+++ b/apps/docs-next/app/(home)/_components/install-command.tsx
@@ -2,55 +2,71 @@
 
 import { useState } from 'react'
 
-const SCAFFOLD = 'npx @agentskit/cli init'
-const ADD = 'npm install @agentskit/core @agentskit/adapters'
-const RUN_AGENT = 'npx @agentskit/cli add research --run'
-
-const SUBTEXT = {
-  scaffold: 'Scaffold a chat, terminal, or runtime starter — zero-config demo provider, hot-reload included.',
-  add: 'The 5 KB substrate. Works in browser, Node, Deno, Bun — anywhere JS runs.',
-  run: 'Copy a ready-made agent from the registry and run it on any provider.',
-}
+const STEPS: { label: string; command: string; subtext: string; recommended?: boolean }[] = [
+  {
+    label: 'Start fresh',
+    command: 'npx @agentskit/cli init',
+    recommended: true,
+    subtext: 'Scaffold a chat, terminal, or runtime starter — zero-config demo provider, hot-reload included.',
+  },
+  {
+    label: 'Add to a project',
+    command: 'npm install @agentskit/core @agentskit/adapters',
+    subtext: 'The 5 KB substrate. Works in browser, Node, Deno, Bun — anywhere JS runs.',
+  },
+  {
+    label: 'Run a built agent',
+    command: 'npx @agentskit/cli add research --run',
+    subtext: 'Copy a ready-made agent from the registry and run it on any provider.',
+  },
+] as const
 
 export function InstallCommand({ withSubtext = false }: { withSubtext?: boolean }) {
+  const [active, setActive] = useState(0)
+  const step = STEPS[active]
+
   return (
-    <div className="flex w-full min-w-0 flex-col gap-2.5">
-      <Card
-        step={1}
-        label="Start fresh"
-        command={SCAFFOLD}
-        subtext={withSubtext ? SUBTEXT.scaffold : undefined}
-        primary
-      />
-      <Card
-        step={2}
-        label="Add to a project"
-        command={ADD}
-        subtext={withSubtext ? SUBTEXT.add : undefined}
-      />
-      <Card
-        step={3}
-        label="Run a built agent"
-        command={RUN_AGENT}
-        subtext={withSubtext ? SUBTEXT.run : undefined}
-      />
+    <div className="w-full min-w-0">
+      <div
+        role="tablist"
+        aria-label="Install options"
+        className="flex flex-wrap items-center gap-1 rounded-lg bg-ak-surface/40 p-1"
+      >
+        {STEPS.map((s, i) => (
+          <button
+            key={s.label}
+            type="button"
+            role="tab"
+            aria-selected={i === active}
+            onClick={() => setActive(i)}
+            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-mono text-[11px] uppercase tracking-wide transition sm:text-xs ${
+              i === active
+                ? 'bg-ak-surface text-ak-foam'
+                : 'text-ak-graphite hover:text-ak-foam'
+            }`}
+          >
+            {s.label}
+            {s.recommended && (
+              <span
+                className="h-1.5 w-1.5 rounded-full bg-ak-green"
+                title="Recommended"
+                aria-label="recommended"
+              />
+            )}
+          </button>
+        ))}
+      </div>
+
+      <CommandLine command={step.command} />
+
+      {withSubtext && (
+        <p className="mt-2 text-xs leading-snug text-ak-graphite">{step.subtext}</p>
+      )}
     </div>
   )
 }
 
-function Card({
-  step,
-  label,
-  command,
-  subtext,
-  primary = false,
-}: {
-  step: number
-  label: string
-  command: string
-  subtext?: string
-  primary?: boolean
-}) {
+function CommandLine({ command }: { command: string }) {
   const [copied, setCopied] = useState(false)
   const copy = () => {
     navigator.clipboard?.writeText(command)
@@ -59,48 +75,22 @@ function Card({
   }
 
   return (
-    <div
-      className={`flex w-full min-w-0 flex-col gap-2 rounded-md border p-3 text-left transition ${
-        primary
-          ? 'border-ak-blue/40 bg-ak-surface'
-          : 'border-ak-border bg-ak-surface/60'
-      }`}
+    <button
+      type="button"
+      onClick={copy}
+      className="group mt-2 flex w-full min-w-0 items-center gap-2 rounded-md bg-ak-surface/50 px-2.5 py-2.5 text-left font-mono text-[11px] text-ak-foam transition hover:bg-ak-surface sm:gap-3 sm:px-3 sm:text-[13px] md:text-sm"
     >
-      <div className="flex items-center justify-between gap-2">
-        <span className="flex items-center gap-2">
-          <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-ak-border font-mono text-[10px] text-ak-graphite">
-            {step}
-          </span>
-          <span className="font-mono text-xs uppercase tracking-wider text-ak-graphite">
-            {label}
-          </span>
-        </span>
-        {primary && (
-          <span className="rounded-full border border-ak-blue/40 px-2 py-0.5 font-mono text-[10px] text-ak-blue">
-            recommended
-          </span>
-        )}
-      </div>
-      <button
-        type="button"
-        onClick={copy}
-        className="group flex w-full min-w-0 items-center gap-2 rounded-md border border-ak-border bg-ak-midnight px-2.5 py-2 text-left font-mono text-[11px] text-ak-foam transition hover:border-ak-blue sm:gap-3 sm:px-3 sm:text-[13px] md:text-sm"
+      <span className="shrink-0 text-ak-green">$</span>
+      <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {command}
+      </span>
+      <span
+        className={`shrink-0 rounded px-2 py-0.5 text-[11px] transition sm:text-xs ${
+          copied ? 'text-ak-green' : 'text-ak-graphite group-hover:text-ak-foam'
+        }`}
       >
-        <span className="shrink-0 text-ak-green">$</span>
-        <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {command}
-        </span>
-        <span
-          className={`shrink-0 rounded border border-ak-border px-2 py-0.5 text-[11px] transition sm:text-xs ${
-            copied ? 'border-ak-green text-ak-green' : 'text-ak-graphite'
-          }`}
-        >
-          {copied ? '✓ copied' : 'copy'}
-        </span>
-      </button>
-      {subtext ? (
-        <p className="text-xs leading-snug text-ak-graphite">{subtext}</p>
-      ) : null}
-    </div>
+        {copied ? '✓ copied' : 'copy'}
+      </span>
+    </button>
   )
 }

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -3,13 +3,13 @@ import { InstallCommand } from './_components/install-command'
 import { HeroDemo } from './_components/hero-demo/hero-demo'
 import { AnimatedLogo } from '@/components/brand/animated-logo'
 import { JsonLd } from '@/components/seo/json-ld'
-import { FadeIn, Stagger, StaggerItem } from '@/components/motion/fade-in'
+import { FadeIn } from '@/components/motion/fade-in'
 import {
   CliSection,
   ComposeSection,
-  IntegrationsSection,
-  LlmsSection,
+  WorksWithSection,
 } from '@/components/home/showcases'
+import { Icon } from '@/components/home/icons'
 import { counts, approx } from '@/lib/ecosystem-stats'
 
 export const metadata = {
@@ -83,12 +83,10 @@ export default function HomePage() {
     <main className="flex w-full max-w-full flex-1 flex-col overflow-x-clip">
       <JsonLd data={JSON_LD} />
       <Hero />
-      <IntegrationsSection />
-      <LlmsSection />
+      <WorksWithSection />
       <CliSection />
       <ComposeSection />
       <EcosystemStats />
-      <ProofSection />
       <FinalCta />
       <SiteFooter />
     </main>
@@ -97,7 +95,7 @@ export default function HomePage() {
 
 function Hero() {
   return (
-    <section className="relative overflow-hidden border-b border-ak-border bg-ak-midnight px-4 pt-14 pb-16 sm:px-6 sm:pt-20 sm:pb-24 md:pt-28 md:pb-32">
+    <section className="relative overflow-hidden bg-ak-midnight px-4 pt-14 pb-16 sm:px-6 sm:pt-20 sm:pb-24 md:pt-28 md:pb-32">
       <div className="mx-auto grid max-w-6xl gap-8 sm:gap-10 md:gap-12 lg:grid-cols-[1.1fr_1fr] lg:items-end">
         <div className="min-w-0">
           <div className="mb-5 flex items-center gap-3 sm:mb-6">
@@ -107,16 +105,9 @@ function Hero() {
             </span>
           </div>
 
-          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-ak-border bg-ak-surface px-3 py-1 font-mono text-[11px] text-ak-graphite sm:mb-5 sm:text-xs">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-ak-green" />
-            core v1.0 · {counts.packages} packages · MIT
-          </div>
-
           <FadeIn>
             <h1 className="mb-5 max-w-2xl text-[2rem] font-bold leading-[1.08] tracking-tight text-ak-foam sm:mb-6 sm:text-4xl md:text-5xl lg:text-6xl">
-              <span className="bg-gradient-to-r from-ak-foam via-ak-blue to-ak-foam bg-clip-text text-transparent">
-                Ship AI agents in JavaScript.
-              </span>
+              Ship AI agents in JavaScript.
               <span className="block text-ak-graphite">
                 Without gluing 8 libraries together.
               </span>
@@ -125,16 +116,18 @@ function Hero() {
 
           <FadeIn delay={0.1}>
           <p className="mb-7 max-w-xl text-base leading-relaxed text-ak-graphite sm:mb-8 sm:text-lg">
-            AgentsKit gives you chat UI, runtime, tools, memory, RAG, and
-            production guardrails in one ecosystem. Swap{' '}
+            Chat UI, runtime, tools, memory, and RAG in one ecosystem. Swap{' '}
             <span className="text-ak-foam">OpenAI for Claude</span>, React for
-            terminal, in-memory for vector DB. Start small, grow into the
-            full stack, and keep your code intact.
+            terminal, in-memory for vector DB — without a rewrite.
           </p>
           </FadeIn>
 
           <FadeIn delay={0.2}>
             <InstallCommand />
+          </FadeIn>
+
+          <FadeIn delay={0.3}>
+            <HeroFrameworks />
           </FadeIn>
         </div>
 
@@ -156,9 +149,9 @@ function Hero() {
             </Link>
             <Link
               href="/docs/reference/examples"
-              className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-4 py-2.5 text-sm font-medium text-ak-foam transition hover:border-ak-blue sm:px-5"
+              className="inline-flex items-center gap-2 px-2 py-2.5 text-sm font-medium text-ak-graphite transition hover:text-ak-foam sm:px-3"
             >
-              See live examples
+              See live examples →
             </Link>
           </div>
         </div>
@@ -167,49 +160,149 @@ function Hero() {
   )
 }
 
-function EcosystemStats() {
-  const stats = [
-    { value: String(counts.packages), label: 'packages', href: '/docs/reference/packages' },
-    { value: String(counts.frameworkBindings), label: 'framework bindings', href: '/docs/ui' },
-    { value: approx(counts.catalogProviders), label: 'LLM providers', href: '/docs/data/providers' },
-    { value: `${counts.integrations}+`, label: 'tool integrations', href: '/docs/agents/tools/integrations' },
-    { value: `${counts.recipes}+`, label: 'recipes', href: '/docs/reference/recipes' },
-    { value: String(counts.skills), label: 'ready-made skills', href: '/docs/agents/skills/personas' },
-    { value: `${counts.memoryBackends}+`, label: 'memory backends', href: '/docs/data/memory' },
-    { value: '< 10 KB', label: 'zero-dep core', href: '/docs/reference/packages/core' },
-  ]
+// color override forces a visible fill for brands whose Simple Icons default is
+// near-black (invisible on the dark hero) — e.g. Angular (#0F0F11).
+const FRAMEWORKS: { slug: string; label: string; color?: string }[] = [
+  { slug: 'react', label: 'React' },
+  { slug: 'vuedotjs', label: 'Vue' },
+  { slug: 'svelte', label: 'Svelte' },
+  { slug: 'solid', label: 'Solid' },
+  { slug: 'angular', label: 'Angular', color: 'dd0031' },
+  { slug: 'nodedotjs', label: 'Node' },
+  { slug: 'deno', label: 'Deno', color: 'ffffff' },
+  { slug: 'bun', label: 'Bun', color: 'fbf0df' },
+]
+
+/** Quiet static proof that the UI layer spans every framework. No animation. */
+function HeroFrameworks() {
   return (
-    <section className="border-b border-ak-border bg-ak-midnight px-4 py-14 sm:px-6 sm:py-20">
+    <div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-ak-graphite/60">
+        Works with
+      </span>
+      {FRAMEWORKS.map((f) => (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          key={f.label}
+          src={`https://cdn.simpleicons.org/${f.slug}${f.color ? `/${f.color}` : ''}`}
+          alt={f.label}
+          title={f.label}
+          width={22}
+          height={22}
+          loading="lazy"
+          className="h-[22px] w-[22px]"
+        />
+      ))}
+    </div>
+  )
+}
+
+const LAYERS = [
+  { name: 'Adapters', icon: 'adapters', href: '/docs/data/providers', meta: `${counts.nativeAdapters} adapters · ${approx(counts.catalogProviders)} providers` },
+  { name: 'UI', icon: 'ui', href: '/docs/ui', meta: `${counts.frameworkBindings} frameworks` },
+  { name: 'Runtime', icon: 'runtime', href: '/docs/reference/packages/runtime', meta: 'ReAct · planning · multi-agent' },
+  { name: 'Tools', icon: 'tools', href: '/docs/agents/tools/integrations', meta: `${counts.integrations}+ integrations` },
+  { name: 'Skills', icon: 'skills', href: '/docs/agents/skills/personas', meta: `${counts.skills} ready-made` },
+  { name: 'Memory', icon: 'memory', href: '/docs/data/memory', meta: `${counts.memoryBackends}+ backends` },
+  { name: 'RAG', icon: 'rag', href: '/docs/reference/packages/rag', meta: 'chunk · embed · retrieve' },
+  { name: 'Observability', icon: 'observability', href: '/docs/reference/packages/observability', meta: 'traces · LangSmith · OTel' },
+] as const
+
+// Percent-coordinate arcs (viewBox 0 0 100 100, preserveAspectRatio none → maps
+// 1:1 onto the diagram box). One dest per layer row; rows are evenly stacked so
+// each center sits at (i + 0.5) / 8 of the height. Source = core's right edge.
+const ARC_DESTS = [6.25, 18.75, 31.25, 43.75, 56.25, 68.75, 81.25, 93.75]
+const arcPath = (y: number) => `M 21 50 C 42 50, 42 ${y}, 63 ${y}`
+
+function EcosystemStats() {
+  return (
+    <section className="bg-ak-midnight px-4 py-14 sm:px-6 sm:py-20">
       <div className="mx-auto max-w-6xl">
-        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-green sm:mb-4 sm:text-xs">
+        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-graphite/60 sm:mb-4 sm:text-xs">
           The ecosystem
         </p>
-        <h2 className="mb-8 max-w-3xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-10 sm:text-3xl md:text-4xl">
-          Everything you need. Nothing you don&apos;t.
+        <h2 className="mb-3 max-w-3xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:text-3xl md:text-4xl">
+          One core. Everything else plugs in.
         </h2>
-        <Stagger className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4" stagger={0.05}>
-          {stats.map((s) => (
-            <StaggerItem key={s.label}>
-            <Link
-              href={s.href}
-              className="group block rounded-xl border border-ak-border bg-ak-surface p-5 transition hover:-translate-y-0.5 hover:border-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)]"
-            >
-              <div className="mb-1 font-mono text-2xl font-bold text-ak-foam transition group-hover:text-ak-blue sm:text-3xl">
-                {s.value}
-              </div>
-              <div className="font-mono text-[11px] uppercase tracking-wide text-ak-graphite sm:text-xs">
-                {s.label}
-              </div>
-            </Link>
-            </StaggerItem>
-          ))}
-        </Stagger>
-        <p className="mt-6 text-sm text-ak-graphite">
-          Every number above is a click-through. Install what you need; the core stays under 10 KB gzipped.
+        <p className="mb-10 max-w-2xl text-sm text-ak-graphite sm:mb-12 sm:text-base">
+          Six contracts on one tiny core. Every layer is optional and swappable —
+          click any to dive in.
         </p>
 
-        <div className="mt-12 border-t border-ak-border pt-10">
-          <p className="mb-6 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-blue sm:text-xs">
+        <div className="relative mt-10">
+          {/* animated convergence arcs (md+), AKOS-style flowing packets */}
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="pointer-events-none absolute inset-0 hidden h-full w-full md:block"
+          >
+            {ARC_DESTS.map((y, i) => (
+              <g key={y}>
+                {/* static line */}
+                <path
+                  d={arcPath(y)}
+                  pathLength={100}
+                  fill="none"
+                  stroke="var(--ak-accent)"
+                  strokeWidth={1}
+                  strokeOpacity={0.22}
+                  vectorEffect="non-scaling-stroke"
+                />
+                {/* traveling dot */}
+                <path
+                  d={arcPath(y)}
+                  pathLength={100}
+                  fill="none"
+                  stroke="var(--ak-accent)"
+                  strokeWidth={2.5}
+                  strokeLinecap="round"
+                  vectorEffect="non-scaling-stroke"
+                  className="ak-flow-out"
+                  style={{ animationDelay: `${-Math.floor(i / 2)}s` }}
+                />
+              </g>
+            ))}
+          </svg>
+
+          <div className="relative grid gap-8 md:grid-cols-[minmax(0,15rem)_1fr] md:items-stretch md:gap-10">
+            <div className="self-center rounded-2xl bg-ak-surface/60 p-6">
+              <div className="font-mono text-sm text-ak-graphite">@agentskit/core</div>
+              <div className="mt-2 font-mono text-4xl font-bold text-ak-foam">&lt; 10 KB</div>
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.15em] text-ak-graphite/70">
+                zero dependencies
+              </div>
+              <p className="mt-4 text-sm leading-relaxed text-ak-graphite">
+                Types, events, and six contracts. Every package plugs into this — swap
+                any layer without touching the rest.
+              </p>
+            </div>
+
+            <ul className="flex flex-col justify-between md:ml-auto md:w-[440px]">
+              {LAYERS.map((l) => (
+                <li key={l.name}>
+                  <Link
+                    href={l.href}
+                    className="group flex items-center gap-2.5 rounded-xl px-3 py-2 transition hover:bg-ak-surface/50"
+                  >
+                    <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-ak-surface text-ak-blue transition group-hover:bg-ak-blue group-hover:text-ak-midnight">
+                      <Icon name={l.icon} className="h-[18px] w-[18px]" />
+                    </span>
+                    <span className="font-mono text-sm font-medium text-ak-foam transition group-hover:text-ak-blue">
+                      {l.name}
+                    </span>
+                    <span className="ml-auto text-right font-mono text-[11px] text-ak-graphite sm:text-xs">
+                      {l.meta}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-16">
+          <p className="mb-6 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-graphite/60 sm:text-xs">
             Beyond the libraries
           </p>
           <div className="grid gap-4 sm:gap-5 md:grid-cols-3">
@@ -219,17 +312,24 @@ function EcosystemStats() {
                 href={p.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex flex-col rounded-xl border border-ak-border bg-ak-surface p-6 transition hover:-translate-y-0.5 hover:border-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)]"
+                className="group relative flex flex-col overflow-hidden rounded-2xl bg-ak-surface/50 p-6 transition hover:bg-ak-surface"
               >
-                <div className="mb-2 flex items-center justify-between gap-3">
-                  <span className="font-mono text-base font-bold text-ak-foam transition group-hover:text-ak-blue">
-                    {p.name}
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-ak-blue/0 blur-2xl transition group-hover:bg-ak-blue/10"
+                />
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <span className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-ak-blue/10 text-ak-blue transition group-hover:bg-ak-blue group-hover:text-ak-midnight">
+                    <Icon name={p.icon} className="h-5 w-5" />
                   </span>
-                  <span className="font-mono text-sm text-ak-graphite transition group-hover:text-ak-blue">
+                  <span className="font-mono text-sm text-ak-graphite transition group-hover:translate-x-0.5 group-hover:text-ak-blue">
                     ↗
                   </span>
                 </div>
-                <span className="mb-2 font-mono text-[11px] uppercase tracking-wide text-ak-green">
+                <span className="font-mono text-base font-bold text-ak-foam transition group-hover:text-ak-blue">
+                  {p.name}
+                </span>
+                <span className="mb-2 mt-1 font-mono text-[11px] uppercase tracking-wide text-ak-graphite/60">
                   {p.tag}
                 </span>
                 <p className="text-sm leading-relaxed text-ak-graphite">{p.desc}</p>
@@ -245,107 +345,40 @@ function EcosystemStats() {
 const ECOSYSTEM_PROPERTIES = [
   {
     name: 'Registry',
+    icon: 'registry',
     href: 'https://registry.agentskit.io',
     tag: 'Ready-made agents',
     desc: 'Copy production-ready agents into your project — research, PR review, support, and more. You own the source, zero lock-in.',
   },
   {
     name: 'Playbook',
+    icon: 'playbook',
     href: 'https://playbook.agentskit.io',
     tag: 'Best practices',
     desc: 'The engineering standards for building agents that ship — runtime validation, quality gates, security, and evals.',
   },
   {
     name: 'AKOS',
+    icon: 'akos',
     href: 'https://akos.agentskit.io',
     tag: 'Production OS',
     desc: 'The operating system for agents at scale — orchestration, egress control, and RBAC for running agents in production.',
   },
 ] as const
 
-function ProofSection() {
-  const starters = [
-    {
-      title: 'Scaffold a starter',
-      href: '/docs/production/cli/init',
-      desc: 'Use `agentskit init` to spin up a React chat, Ink terminal app, runtime worker, or multi-agent starter.',
-      cta: 'See starters',
-    },
-    {
-      title: 'Browse live examples',
-      href: '/docs/reference/examples',
-      desc: 'Open interactive demos for support bots, code assistants, RAG chat, runtime agents, and multi-agent planning.',
-      cta: 'Open examples',
-    },
-    {
-      title: 'Copy runnable recipes',
-      href: '/docs/reference/recipes',
-      desc: 'Jump straight into end-to-end snippets for integrations, replay, security, evals, and retrieval pipelines.',
-      cta: 'Open recipes',
-    },
-  ] as const
-
-  return (
-    <section className="border-b border-ak-border bg-ak-midnight px-4 py-16 sm:px-6 sm:py-20 md:py-24">
-      <div className="mx-auto max-w-6xl">
-        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.2em] text-ak-green sm:mb-4 sm:text-xs">
-          Proof, not promises
-        </p>
-        <h2 className="mb-4 max-w-3xl text-[1.75rem] font-bold leading-[1.15] text-ak-foam sm:mb-5 sm:text-3xl md:text-4xl lg:text-5xl">
-          Start from a template, a demo, or a runnable recipe.
-        </h2>
-        <p className="mb-8 max-w-2xl text-base text-ak-graphite sm:mb-12 sm:text-lg">
-          Scaffold a project, inspect a live demo, or copy a recipe and run it
-          locally. Pick the angle you trust.
-        </p>
-        <div className="grid gap-4 sm:gap-5 lg:grid-cols-3">
-          {starters.map((item) => (
-            <Link
-              key={item.title}
-              href={item.href}
-              className="group flex flex-col rounded-xl border border-ak-border bg-ak-surface p-6 transition hover:-translate-y-0.5 hover:border-ak-blue hover:shadow-[0_0_0_1px_var(--ak-blue)]"
-            >
-              <h3 className="mb-3 text-xl font-semibold text-ak-foam transition group-hover:text-ak-blue">
-                {item.title}
-              </h3>
-              <p className="mb-5 flex-1 text-sm leading-relaxed text-ak-graphite">
-                {item.desc}
-              </p>
-              <span className="font-mono text-sm text-ak-blue">
-                {item.cta} →
-              </span>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
 function FinalCta() {
   return (
-    <section className="relative overflow-hidden border-b border-ak-border bg-ak-midnight px-4 py-24 sm:px-6 sm:py-28 md:py-32">
-      {/* glow */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 mx-auto h-px max-w-4xl bg-gradient-to-r from-transparent via-ak-blue to-transparent opacity-60"
-      />
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute left-1/2 top-0 -z-0 h-[420px] w-[820px] max-w-none -translate-x-1/2 rounded-full bg-ak-blue/10 blur-[120px]"
-      />
+    <section className="relative overflow-hidden bg-ak-midnight px-4 py-24 sm:px-6 sm:py-28 md:py-32">
       <div className="relative mx-auto max-w-3xl text-center">
         <div className="mb-6 flex justify-center">
           <AnimatedLogo variant="hero" size={60} loop />
         </div>
-        <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-ak-border bg-ak-surface px-3 py-1 font-mono text-[11px] text-ak-graphite sm:text-xs">
+        <div className="mb-5 inline-flex items-center gap-2 font-mono text-[11px] text-ak-graphite/70 sm:text-xs">
           <span className="inline-block h-1.5 w-1.5 rounded-full bg-ak-green" />
           {counts.packages} packages · {approx(counts.catalogProviders)} providers · MIT
         </div>
-        <h2 className="mb-5 text-[2.25rem] font-bold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
-          <span className="bg-gradient-to-r from-ak-foam via-ak-blue to-ak-foam bg-clip-text text-transparent">
-            Build the agent.
-          </span>
+        <h2 className="mb-5 text-[2.25rem] font-bold leading-[1.05] tracking-tight text-ak-foam sm:text-5xl md:text-6xl lg:text-7xl">
+          Build the agent.
           <span className="block text-ak-graphite">Skip the plumbing.</span>
         </h2>
         <p className="mx-auto mb-9 max-w-xl text-base text-ak-graphite sm:mb-10 sm:text-lg">
@@ -360,7 +393,7 @@ function FinalCta() {
         <div className="flex flex-wrap justify-center gap-2.5 sm:gap-3">
           <Link
             href="/docs/get-started/getting-started/build-your-first-agent"
-            className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-6 py-3 text-sm font-semibold text-ak-midnight shadow-[0_0_0_1px_var(--ak-blue),0_8px_30px_-12px_var(--ak-blue)] transition hover:bg-white sm:px-7"
+            className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-6 py-3 text-sm font-semibold text-ak-midnight transition hover:bg-white sm:px-7"
           >
             Build your first agent →
           </Link>
@@ -368,7 +401,7 @@ function FinalCta() {
             href={GITHUB}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-md border border-ak-border bg-ak-surface px-6 py-3 text-sm font-medium text-ak-foam transition hover:border-ak-blue sm:px-7"
+            className="inline-flex items-center gap-2 px-4 py-3 text-sm font-medium text-ak-graphite transition hover:text-ak-foam sm:px-5"
           >
             Star on GitHub
           </a>
@@ -442,7 +475,7 @@ function SiteFooter() {
                 href={GITHUB}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-md border border-ak-border bg-ak-surface px-3 py-1.5 font-mono text-xs text-ak-graphite transition hover:border-ak-blue hover:text-ak-foam"
+                className="rounded-md bg-ak-surface/60 px-3 py-1.5 font-mono text-xs text-ak-graphite transition hover:text-ak-foam"
               >
                 GitHub
               </a>
@@ -450,7 +483,7 @@ function SiteFooter() {
                 href="https://www.npmjs.com/org/agentskit"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-md border border-ak-border bg-ak-surface px-3 py-1.5 font-mono text-xs text-ak-graphite transition hover:border-ak-blue hover:text-ak-foam"
+                className="rounded-md bg-ak-surface/60 px-3 py-1.5 font-mono text-xs text-ak-graphite transition hover:text-ak-foam"
               >
                 npm
               </a>

--- a/apps/docs-next/app/global.css
+++ b/apps/docs-next/app/global.css
@@ -213,3 +213,26 @@ button[data-theme-toggle] > svg {
   --color-fd-accent-foreground: #E6EDF3;
   --color-fd-ring: #58A6FF;
 }
+
+/* Animated convergence arcs for the ecosystem diagram — a short dash ("packet")
+   travels along each bezier from the core out to a layer. Mirrors the AKOS
+   homepage flow. Decorative; frozen for reduced-motion. */
+/* paths carry pathLength="100". The dash pattern is 4× the path length, so one
+   "packet" rides the static line and is on-path only the first 1/4 of the cycle
+   — staggered into 4 pairs, that means ~2 dots travelling at any moment. */
+.ak-flow-out {
+  stroke-dasharray: 1.5 398.5;
+  animation: ak-flow-out 4s linear infinite;
+}
+
+@keyframes ak-flow-out {
+  to {
+    stroke-dashoffset: -400;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ak-flow-out {
+    animation: none;
+  }
+}

--- a/apps/docs-next/components/home/cli-showcase.tsx
+++ b/apps/docs-next/components/home/cli-showcase.tsx
@@ -102,8 +102,8 @@ export function CliShowcase() {
         </span>
       </div>
 
-      {/* Terminal body */}
-      <div className="space-y-1.5 px-4 py-4 leading-relaxed">
+      {/* Terminal body — fixed height so progressive lines don't grow the box */}
+      <div className="min-h-[15rem] space-y-1.5 px-4 py-4 leading-relaxed">
         <p className="break-words text-ak-foam">
           <span>{displayCommand}</span>
           {!commandComplete && <Cursor />}

--- a/apps/docs-next/components/home/icons.tsx
+++ b/apps/docs-next/components/home/icons.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Minimal inline stroke icons (Lucide path data, MIT). Inlined instead of
+ * pulling in lucide-react so the docs app keeps its dependency surface small.
+ */
+const PATHS: Record<string, ReactNode> = {
+  adapters: (
+    <>
+      <path d="M12 22v-5" />
+      <path d="M9 8V2" />
+      <path d="M15 8V2" />
+      <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
+    </>
+  ),
+  ui: (
+    <>
+      <rect width="7" height="7" x="3" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="14" rx="1" />
+      <rect width="7" height="7" x="3" y="14" rx="1" />
+    </>
+  ),
+  runtime: (
+    <>
+      <rect width="16" height="16" x="4" y="4" rx="2" />
+      <rect width="6" height="6" x="9" y="9" rx="1" />
+      <path d="M15 2v2M15 20v2M2 15h2M2 9h2M20 15h2M20 9h2M9 2v2M9 20v2" />
+    </>
+  ),
+  tools: (
+    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+  ),
+  skills: (
+    <>
+      <path d="M9.94 15.5A2 2 0 0 0 8.5 14.06l-6.14-1.58a.5.5 0 0 1 0-.96L8.5 9.94A2 2 0 0 0 9.94 8.5l1.58-6.14a.5.5 0 0 1 .96 0L14.06 8.5A2 2 0 0 0 15.5 9.94l6.14 1.58a.5.5 0 0 1 0 .96L15.5 14.06a2 2 0 0 0-1.44 1.44l-1.58 6.14a.5.5 0 0 1-.96 0z" />
+      <path d="M20 3v4M22 5h-4M4 17v2M5 18H3" />
+    </>
+  ),
+  memory: (
+    <>
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M3 5v14a9 3 0 0 0 18 0V5" />
+      <path d="M3 12a9 3 0 0 0 18 0" />
+    </>
+  ),
+  rag: (
+    <>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </>
+  ),
+  observability: (
+    <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" />
+  ),
+  registry: (
+    <>
+      <path d="m7.5 4.27 9 5.15" />
+      <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+      <path d="m3.3 7 8.7 5 8.7-5" />
+      <path d="M12 22V12" />
+    </>
+  ),
+  playbook: (
+    <path d="M12 7v14M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+  ),
+  akos: (
+    <>
+      <rect width="20" height="8" x="2" y="2" rx="2" />
+      <rect width="20" height="8" x="2" y="14" rx="2" />
+      <path d="M6 6h.01M6 18h.01" />
+    </>
+  ),
+}
+
+export function Icon({ name, className }: { name: string; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {PATHS[name]}
+    </svg>
+  )
+}

--- a/apps/docs-next/components/home/logo-marquee.tsx
+++ b/apps/docs-next/components/home/logo-marquee.tsx
@@ -14,27 +14,26 @@ function Logo({ item }: { item: MarqueeItem }) {
   const slug = brandSlug(item.id)
   const monogram = item.label.replace(/[^a-zA-Z0-9]/g, '').charAt(0).toUpperCase() || '•'
   return (
-    <span className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-ak-border bg-ak-surface/40 px-3 py-2">
-      {!failed ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={`https://cdn.simpleicons.org/${slug}/a9a9b3`}
-          alt=""
-          width={16}
-          height={16}
-          loading="lazy"
-          onError={() => setFailed(true)}
-          className="h-4 w-4"
-        />
-      ) : (
-        <span
-          aria-hidden="true"
-          className="inline-flex h-4 w-4 items-center justify-center rounded-[3px] border border-ak-border bg-ak-midnight font-mono text-[9px] font-bold text-ak-graphite"
-        >
-          {monogram}
-        </span>
-      )}
-      <span className="font-mono text-xs text-ak-graphite">{item.label}</span>
+    <span className="inline-flex shrink-0 items-center gap-2.5 pr-3">
+      <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-ak-foam/90">
+        {!failed ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={`https://cdn.simpleicons.org/${slug}`}
+            alt=""
+            width={20}
+            height={20}
+            loading="lazy"
+            onError={() => setFailed(true)}
+            className="h-5 w-5"
+          />
+        ) : (
+          <span aria-hidden="true" className="font-mono text-xs font-bold text-ak-midnight">
+            {monogram}
+          </span>
+        )}
+      </span>
+      <span className="font-mono text-sm text-ak-graphite">{item.label}</span>
     </span>
   )
 }

--- a/apps/docs-next/components/home/showcases.tsx
+++ b/apps/docs-next/components/home/showcases.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { counts, lists } from '@/lib/ecosystem-stats'
+import { brandSlug } from '@/lib/brand-slugs'
 import { CliShowcase } from './cli-showcase'
 import { ComposeShowcase } from './compose-showcase'
 import { LogoMarquee, type MarqueeItem } from './logo-marquee'
@@ -34,11 +35,11 @@ function Section({
 }) {
   return (
     <section
-      className={`border-b border-ak-border px-4 py-16 sm:px-6 sm:py-20 ${alt ? 'bg-ak-surface/40' : 'bg-ak-midnight'}`}
+      className={`px-4 py-16 sm:px-6 sm:py-20 ${alt ? 'bg-ak-surface/40' : 'bg-ak-midnight'}`}
     >
       <div className="mx-auto grid max-w-6xl items-center gap-8 md:gap-12 lg:grid-cols-2">
         <div className="min-w-0">
-          <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">{eyebrow}</div>
+          <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite/60">{eyebrow}</div>
           <h2 className="mt-2 text-[1.6rem] font-bold leading-tight tracking-tight text-ak-foam sm:text-3xl md:text-4xl">
             {title}
           </h2>
@@ -51,51 +52,60 @@ function Section({
   )
 }
 
-/**
- * Full-bleed marquee band — heading centered above, the logo rows span the
- * whole viewport width so there is room to read every chip as it scrolls.
- */
-function MarqueeBand({
-  eyebrow,
-  title,
-  blurb,
-  cta,
-  items,
-  alt,
-}: {
-  eyebrow: string
-  title: string
-  blurb: string
-  cta: Cta
-  items: MarqueeItem[]
-  alt?: boolean
-}) {
-  const half = Math.ceil(items.length / 2)
-  return (
-    <section
-      className={`overflow-hidden border-b border-ak-border py-16 sm:py-20 ${alt ? 'bg-ak-surface/40' : 'bg-ak-midnight'}`}
-    >
-      <div className="mx-auto mb-10 flex max-w-3xl flex-col items-center px-4 text-center sm:px-6">
-        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">{eyebrow}</div>
-        <h2 className="mt-2 text-[1.6rem] font-bold leading-tight tracking-tight text-ak-foam sm:text-3xl md:text-4xl">
-          {title}
-        </h2>
-        <p className="mx-auto mt-3 max-w-xl text-ak-graphite">{blurb}</p>
-        <CtaLink cta={cta} />
-      </div>
-      <div className="flex flex-col gap-3">
-        <LogoMarquee items={items.slice(0, half)} duration={50} />
-        <LogoMarquee items={items.slice(half)} duration={58} reverse />
-      </div>
-    </section>
-  )
-}
-
 function pretty(id: string): string {
   return id.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
-function toItems(ids: string[]): MarqueeItem[] {
-  return ids.map((id) => ({ id, label: pretty(id) }))
+
+/**
+ * Simple Icons slugs verified (curl, 2026-06) to resolve to a real logo on the
+ * CDN. The marquee shows logos only (no text), so an id without a live logo
+ * would render broken — we filter to this set and dedupe by slug. Brands whose
+ * logos Simple Icons dropped for trademark reasons (Slack, OpenAI, Twilio,
+ * Salesforce, AWS, Azure…) are intentionally absent; the full catalog lives
+ * behind the "All N …" links. Re-run scripts/check-brand-logos if logos break.
+ */
+const VERIFIED_SLUGS = new Set<string>([
+  // integrations
+  'github', 'notion', 'stripe', 'linear', 'jira', 'discord', 'gmail',
+  'googlecalendar', 'googledrive', 'dropbox', 'box', 'figma', 'airtable',
+  'asana', 'hubspot', 'intercom', 'sentry', 'shopify', 'telegram', 'whatsapp',
+  'mailchimp', 'caldotcom', 'confluence', 'pagerduty', 'elevenlabs',
+  'googlemaps', 'bigcommerce', 'calendly',
+  // providers
+  'anthropic', 'google', 'googlegemini', 'mistralai', 'deepseek', 'huggingface',
+  'perplexity', 'vercel', 'openrouter', 'x', 'googlecloud', 'alibabacloud',
+  'cloudflare', 'ollama', 'replicate',
+])
+
+/** Proper display names where title-casing the id reads wrong. */
+const LABEL_OVERRIDES: Record<string, string> = {
+  github: 'GitHub',
+  hubspot: 'HubSpot',
+  pagerduty: 'PagerDuty',
+  whatsapp: 'WhatsApp',
+  elevenlabs: 'ElevenLabs',
+  bigcommerce: 'BigCommerce',
+  'cal-com': 'Cal.com',
+  maps: 'Google Maps',
+  deepseek: 'DeepSeek',
+  huggingface: 'Hugging Face',
+  openrouter: 'OpenRouter',
+  xai: 'xAI',
+  'google-vertex': 'Vertex AI',
+  'cloudflare-ai-gateway': 'Cloudflare',
+}
+
+/** Items with a live logo, one per slug (drops 404s and slug collisions). */
+function logoItems(ids: string[]): MarqueeItem[] {
+  const seen = new Set<string>()
+  const out: MarqueeItem[] = []
+  for (const id of ids) {
+    const slug = brandSlug(id)
+    if (!VERIFIED_SLUGS.has(slug) || seen.has(slug)) continue
+    seen.add(slug)
+    out.push({ id, label: LABEL_OVERRIDES[id] ?? pretty(id) })
+  }
+  return out
 }
 
 export function CliSection() {
@@ -125,27 +135,35 @@ export function ComposeSection() {
   )
 }
 
-export function IntegrationsSection() {
+/**
+ * One band for the whole catalog — integrations on the top row, model
+ * providers on the bottom. Replaces the two back-to-back marquees so the page
+ * shows scale once, with breathing room.
+ */
+export function WorksWithSection() {
   return (
-    <MarqueeBand
-      eyebrow="Integrations"
-      title={`${counts.integrations} built-in integrations.`}
-      blurb="Slack, Notion, Stripe, GitHub, Linear, Jira, and dozens more — one contract, ready to call."
-      cta={{ href: '/docs/agents/tools/integrations', text: `All ${counts.integrations} integrations & how to use` }}
-      items={toItems(lists.integrations)}
-    />
-  )
-}
-
-export function LlmsSection() {
-  return (
-    <MarqueeBand
-      eyebrow="Models"
-      title={`${counts.catalogProviders} providers, ${counts.catalogModels.toLocaleString()} models.`}
-      blurb="OpenAI, Anthropic, Google, Mistral, Groq, and the long tail — one adapter contract, fed by the models.dev catalog."
-      cta={{ href: '/docs/data/providers', text: `All ${counts.catalogProviders} providers & how to use` }}
-      items={toItems(lists.providers.slice(0, 64))}
-      alt
-    />
+    <section className="overflow-hidden bg-ak-midnight py-16 sm:py-20">
+      <div className="mx-auto mb-10 flex max-w-3xl flex-col items-center px-4 text-center sm:px-6">
+        <div className="font-mono text-xs uppercase tracking-[0.2em] text-ak-graphite/60">
+          Works with everything
+        </div>
+        <h2 className="mt-2 text-[1.6rem] font-bold leading-tight tracking-tight text-ak-foam sm:text-3xl md:text-4xl">
+          One contract. Every tool, every model.
+        </h2>
+        <p className="mx-auto mt-3 max-w-xl text-ak-graphite">
+          {counts.integrations}+ built-in integrations and {Math.floor(counts.catalogProviders / 100) * 100}+ providers
+          ({Math.floor(counts.catalogModels / 1000)}k+ models) behind a single contract — Slack,
+          Notion, Stripe, OpenAI, Anthropic, and the long tail.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-x-6">
+          <CtaLink cta={{ href: '/docs/agents/tools/integrations', text: `All ${counts.integrations} integrations` }} />
+          <CtaLink cta={{ href: '/docs/data/providers', text: `All ${counts.catalogProviders} providers` }} />
+        </div>
+      </div>
+      <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 sm:px-6">
+        <LogoMarquee items={logoItems(lists.integrations)} duration={50} />
+        <LogoMarquee items={logoItems(lists.providers)} duration={58} reverse />
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## What

Redesign of the docs home (`apps/docs-next/app/(home)`) toward a cleaner, more "sellable" dev-tool landing, iterated against references like flueframework.com and akos.agentskit.io.

### Hero
- Drop the version badge; tighten subhead to two lines.
- New **"Works with"** framework row — React, Vue, Svelte, Solid, Angular, Node, Deno, Bun (colored via Simple Icons CDN, with overrides for dark-brand logos).

### Install
- Steps become **tabs** (Start fresh / Add to a project / Run a built agent), one command at a time with copy. Recommended marked with a dot.

### Hero demo
- Scene selector is now a **single-line carousel** with prev/next arrows; active demo stays highlighted and pinned to the start.
- Terminal has a **fixed height** so progressive lines don't grow the box.

### "Works with everything" band
- Merged the two back-to-back marquees (integrations + models) into **one band**.
- Logos filtered to a **curl-verified Simple Icons allowlist** and **deduped by slug** — no broken or duplicate logos. Colored logos on light tiles with labels.

### Ecosystem diagram
- Replaced the flat 8-stat strip with a **core → layers architecture diagram** + **AKOS-style animated flow dots** (one packet per arc, ~2 travelling at a time). Iconed nodes; list aligned to the AKOS card's right edge.
- Fancier **"Beyond the libraries"** cards with icons.

### Housekeeping
- De-border pass (whitespace / subtle-bg separation instead of lines).
- **No new dependency** — inline icon set instead of `lucide-react`; flow keyframes added to `global.css`.

## Test plan
- `pnpm --filter @agentskit/docs-next exec tsc --noEmit` — clean.
- Verified locally (dev server + Playwright screenshots) across hero, marquee, diagram, tabs, carousel.
- Diagram + arcs are `md+` only; reduced-motion freezes the flow dots.

## Notes
- The "Ask the docs" chat is unrelated to this PR; a follow-up plan covers making it a full RAG + eval reference implementation.