### PR TITLE
feat(core,ink): agent progress events + headless progress renderer (RFC 0005)

### DIFF
--- a/.changeset/agent-progress-events.md
+++ b/.changeset/agent-progress-events.md
@@ -1,0 +1,9 @@
+---
+"@agentskit/core": minor
+"@agentskit/ink": minor
+---
+
+Add agent progress events + a headless progress renderer (RFC 0005).
+
+- `@agentskit/core`: new additive `AgentEvent` variant `{ type: 'progress'; label; status: 'start' | 'ok' | 'skip' | 'error'; detail?; durationMs? }`, so multi-stage agents can emit their own domain stages through the standard `observers` channel.
+- `@agentskit/ink`: `createProgressObserver()` — a headless ANSI spinner renderer for standalone (non-chat) agent runs, plus the shared `SPINNER_FRAMES` export.

--- a/apps/docs-next/content/docs/for-agents/ink.mdx
+++ b/apps/docs-next/content/docs/for-agents/ink.mdx
@@ -65,6 +65,21 @@ function Chat() {
 render(<Chat />)
 ```
 
+## Headless progress renderer (standalone agents)
+
+For non-chat agents (cron jobs, CI pipelines, registry agents), `createProgressObserver()` returns an `Observer` that renders `{ type: 'progress' }` `AgentEvent`s as an animated spinner line per stage — pure ANSI, no Ink/React render tree, so it also works in piped CI output.
+
+```ts
+import { createProgressObserver } from '@agentskit/ink'
+
+const agent = createMyAgent({ adapter, observers: [createProgressObserver()] })
+// the agent emits { type: 'progress', label, status, detail?, durationMs? } and
+// this renders: ⠹ classify → ✓ classify  ui-ux · enrich  (0.6s)
+```
+
+- `createProgressObserver(options?)` — `options.write` overrides the output sink (default `process.stdout`); `options.plain` disables the spinner/colors (auto-on for non-TTY). The interval is `unref`'d, so it never keeps the process alive.
+- `SPINNER_FRAMES` — the shared braille frames (also used by `ThinkingIndicator`), exported for custom renderers.
+
 ## Common patterns
 
 - **Node only / TTY required**: `@agentskit/ink` uses Ink which writes directly to `process.stdout`. It does not run in the browser or in non-TTY environments (e.g. piped CI output). Use `@agentskit/react` for browser targets.

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -9,6 +9,13 @@ export type AgentEvent =
   | { type: 'agent:step'; step: number; action: string }
   | { type: 'agent:delegate:start'; name: string; task: string; depth: number }
   | { type: 'agent:delegate:end'; name: string; result: string; durationMs: number; depth: number }
+  /**
+   * A domain-level progress step the agent (not the runtime) defines — e.g. a
+   * multi-stage pipeline reporting "classify", "sanitize", "publish". Lets agents
+   * emit their own stages through the SAME observer channel as runtime events, so
+   * one Observer renders both. The runtime never emits this; agents do.
+   */
+  | { type: 'progress'; label: string; status: 'start' | 'ok' | 'skip' | 'error'; detail?: string; durationMs?: number }
   | { type: 'error'; error: Error }
 
 export interface Observer {

--- a/packages/ink/src/index.ts
+++ b/packages/ink/src/index.ts
@@ -38,6 +38,9 @@ export type {
 
 export { useChat } from './useChat'
 
+export { createProgressObserver, SPINNER_FRAMES } from './progress-observer'
+export type { ProgressObserverOptions } from './progress-observer'
+
 export {
   ChatContainer,
   Message,

--- a/packages/ink/src/progress-observer.test.ts
+++ b/packages/ink/src/progress-observer.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { createProgressObserver } from './progress-observer'
+
+describe('createProgressObserver', () => {
+  it('renders progress AgentEvents and ignores non-progress events', () => {
+    const out: string[] = []
+    const obs = createProgressObserver({ write: (s) => out.push(s), plain: true })
+
+    obs.on({ type: 'progress', label: 'classify', status: 'start' })
+    obs.on({ type: 'progress', label: 'classify', status: 'ok', detail: 'ui-ux · enrich', durationMs: 600 })
+    obs.on({ type: 'progress', label: 'leak-gate', status: 'error', detail: 'blocked: ACME-42' })
+    obs.on({ type: 'llm:start', model: 'x', messageCount: 1 }) // not a progress event → ignored
+
+    const text = out.join('')
+    expect(text).toContain('classify')
+    expect(text).toContain('✓')
+    expect(text).toContain('ui-ux · enrich')
+    expect(text).toContain('(0.6s)')
+    expect(text).toContain('⛔')
+    expect(text).not.toContain('llm:start')
+  })
+})

--- a/packages/ink/src/progress-observer.ts
+++ b/packages/ink/src/progress-observer.ts
@@ -1,0 +1,75 @@
+import type { AgentEvent, Observer } from '@agentskit/core'
+
+/**
+ * Headless progress renderer for standalone (non-chat) agent runs. Returns an
+ * Observer you pass in `observers: [...]`; it renders `{ type: 'progress' }`
+ * AgentEvents as an animated spinner line per stage — no Ink/React render tree,
+ * just ANSI, so it works in any terminal or CI log. Same braille frames as the
+ * chat-UI ThinkingIndicator.
+ *
+ * ```ts
+ * import { createProgressObserver } from '@agentskit/ink'
+ * const agent = createMyAgent({ adapter, observers: [createProgressObserver()] })
+ * ```
+ */
+export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const
+
+const C = {
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  reset: '\x1b[0m',
+}
+
+export interface ProgressObserverOptions {
+  /** Where to write. Default: process.stdout. */
+  write?: (chunk: string) => void
+  /** Disable ANSI colors/animation (e.g. non-TTY CI). Default: !process.stdout.isTTY. */
+  plain?: boolean
+}
+
+export function createProgressObserver(options: ProgressObserverOptions = {}): Observer {
+  const write = options.write ?? ((s: string) => process.stdout.write(s))
+  const plain = options.plain ?? !process.stdout?.isTTY
+  let timer: ReturnType<typeof setInterval> | null = null
+  let frame = 0
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  return {
+    name: 'progress-renderer',
+    on(event: AgentEvent) {
+      if (event.type !== 'progress') return
+      const label = event.label.padEnd(12)
+
+      if (event.status === 'start') {
+        if (plain) {
+          write(`  … ${event.label}\n`)
+          return
+        }
+        stop()
+        timer = setInterval(() => {
+          frame = (frame + 1) % SPINNER_FRAMES.length
+          write(`\r  ${C.cyan}${SPINNER_FRAMES[frame]}${C.reset} ${label}`)
+        }, 80)
+        return
+      }
+
+      stop()
+      const sym = event.status === 'ok' ? '✓' : event.status === 'error' ? '⛔' : '–'
+      const color = event.status === 'ok' ? C.green : event.status === 'error' ? C.red : C.yellow
+      const time = event.durationMs ? ` ${C.dim}(${(event.durationMs / 1000).toFixed(1)}s)${C.reset}` : ''
+      const cr = plain ? '' : '\r'
+      const c = plain ? '' : color
+      const r = plain ? '' : C.reset
+      const d = plain ? '' : C.dim
+      write(`${cr}  ${c}${sym}${r} ${label} ${d}${event.detail ?? ''}${r}${time}\n`)
+    },
+  }
+}

--- a/packages/ink/src/progress-observer.ts
+++ b/packages/ink/src/progress-observer.ts
@@ -56,8 +56,11 @@ export function createProgressObserver(options: ProgressObserverOptions = {}): O
         stop()
         timer = setInterval(() => {
           frame = (frame + 1) % SPINNER_FRAMES.length
-          write(`\r  ${C.cyan}${SPINNER_FRAMES[frame]}${C.reset} ${label}`)
+          write(`\r  ${C.cyan}${SPINNER_FRAMES[frame]}${C.reset} ${label}\x1b[K`)
         }, 80)
+        // Don't let the spinner keep the event loop alive if the run throws
+        // before the resolving event fires.
+        timer.unref?.()
         return
       }
 
@@ -66,10 +69,11 @@ export function createProgressObserver(options: ProgressObserverOptions = {}): O
       const color = event.status === 'ok' ? C.green : event.status === 'error' ? C.red : C.yellow
       const time = event.durationMs ? ` ${C.dim}(${(event.durationMs / 1000).toFixed(1)}s)${C.reset}` : ''
       const cr = plain ? '' : '\r'
+      const clr = plain ? '' : '\x1b[K' // clear to EOL so a long spinner line leaves no leftover chars
       const c = plain ? '' : color
       const r = plain ? '' : C.reset
       const d = plain ? '' : C.dim
-      write(`${cr}  ${c}${sym}${r} ${label} ${d}${event.detail ?? ''}${r}${time}\n`)
+      write(`${cr}  ${c}${sym}${r} ${label} ${d}${event.detail ?? ''}${r}${time}${clr}\n`)
     },
   }
 }

--- a/packages/ink/tests/progress-observer.test.ts
+++ b/packages/ink/tests/progress-observer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createProgressObserver } from './progress-observer'
+import { createProgressObserver } from '../src/progress-observer'
 
 describe('createProgressObserver', () => {
   it('renders progress AgentEvents and ignores non-progress events', () => {

--- a/rfcs/0005-agent-progress-events.md
+++ b/rfcs/0005-agent-progress-events.md
@@ -1,0 +1,104 @@
+# RFC 0005 — Agent progress events + a headless progress renderer
+
+- **Status**: Proposed
+- **Date**: 2026-06-17
+- **Author**: @EmersonBraun
+- **Related packages**: `@agentskit/core`, `@agentskit/ink`, `@agentskit/runtime`
+- **Prototype**: branch `feat/agent-progress-events` (this branch)
+
+## Summary
+
+Two small, additive changes so **standalone (non-chat) agents** can report and render multi-stage progress without each one hand-rolling ANSI:
+
+1. **`@agentskit/core`** — add one variant to `AgentEvent`:
+   `{ type: 'progress'; label: string; status: 'start' | 'ok' | 'skip' | 'error'; detail?: string; durationMs? }`.
+   Agents emit their own domain stages (e.g. `classify`, `sanitize`, `publish`) through the **same `observers` channel** as runtime events.
+2. **`@agentskit/ink`** — add a headless `createProgressObserver()` that returns an `Observer` rendering those events as an animated spinner line (ANSI, no React render tree), reusing the chat UI's braille `SPINNER_FRAMES`.
+
+No new callback, no new contract surface. One channel (`observers`) for runtime + domain events; one renderer any standalone agent can drop in.
+
+## Motivation
+
+The runtime already has a progress channel: `observers: Observer[]` receiving `AgentEvent`s (`llm:start`, `tool:start/end`, `agent:step`, `agent:delegate:*`, `error`). That covers **runtime-level** progress.
+
+But a multi-stage agent's progress is **domain-level** — "classify → sanitize → leak-gate → publish" — which the runtime can't know. Today there is no place for it:
+
+- `AgentEvent` is a **closed union** with no generic/custom variant.
+- `agent:step` (`{ step, action }`) is too thin: no `status` (start vs ok vs skip vs error), no `durationMs`, no human label/detail.
+
+So agent authors hand-roll a bespoke `onProgress` callback **and** a bespoke ANSI renderer. Real example — the registry's `knowledge-promoter` agent ships exactly that today:
+
+```ts
+// agent config — a one-off callback the framework knows nothing about
+onProgress?: (e: { stage; status; detail?; durationMs? }) => void
+// …and ~40 lines of ANSI spinner in the consumer (src/reporter.ts)
+```
+
+Every standalone/registry agent re-invents both. That is the gap.
+
+## Proposal
+
+### 1. `AgentEvent` gains a `progress` variant (additive, non-breaking)
+
+```ts
+export type AgentEvent =
+  | …existing variants…
+  | { type: 'progress'; label: string; status: 'start' | 'ok' | 'skip' | 'error'; detail?: string; durationMs?: number }
+  | { type: 'error'; error: Error }
+```
+
+Additive: existing observers already switch on `event.type` and ignore unknown variants. The **runtime never emits this** — only agents do, via the observers they were given:
+
+```ts
+const emit = (label, status, detail?, durationMs?) => {
+  for (const o of config.observers ?? []) void o.on({ type: 'progress', label, status, detail, durationMs })
+}
+```
+
+### 2. `@agentskit/ink` gains `createProgressObserver()`
+
+A headless renderer (no Ink/React tree — pure ANSI, works in CI logs too):
+
+```ts
+import { createProgressObserver } from '@agentskit/ink'
+
+const agent = createKnowledgePromoterAgent({
+  adapter,
+  observers: [createProgressObserver()], // ← fancy run, zero hand-rolled ANSI
+})
+```
+
+It renders each `progress` event as an animated spinner line that resolves to `✓ / – / ⛔` with timing. Reuses `SPINNER_FRAMES` from `ThinkingIndicator`. `{ plain }` falls back to plain lines on non-TTY.
+
+### Before / after for an agent author
+
+```ts
+// before: bespoke callback + bespoke renderer per agent
+createAgent({ adapter, onProgress: makeMyAnsiReporter() })
+
+// after: standard channel + standard renderer
+createAgent({ adapter, observers: [createProgressObserver()] })
+```
+
+The agent emits `progress` through `observers`; the renderer is shared. Logging, tracing, and a TUI all consume the same stream.
+
+## Alternatives considered
+
+- **Keep the per-agent `onProgress` callback.** Works, but every agent re-invents the callback shape and the renderer; nothing composes (a logger and a TUI can't share one channel). Rejected — it's the status quo this RFC removes.
+- **Overload `agent:step`.** Too thin (no status/duration/label); changing its shape is breaking. Rejected.
+- **A full Ink `<AgentRun>` React component.** Useful later, but standalone agents (cron, CI, registry one-liners) have no render tree — the headless ANSI observer fits them. The React component can layer on top of the same event later.
+
+## Prototype & validation
+
+On this branch:
+- `packages/core/src/types/agent.ts` — the `progress` variant.
+- `packages/ink/src/progress-observer.ts` — `createProgressObserver()` + `SPINNER_FRAMES`.
+- `packages/ink/src/progress-observer.test.ts` — renders progress events, ignores non-progress, formats timing/symbols. **Passes.**
+
+The registry `knowledge-promoter` agent stays on its local `onProgress` until core ships this (CONTRIBUTING: published packages only); the one-line migration above lands when it does.
+
+## Rollout
+
+1. Merge the `progress` variant to `@agentskit/core` (patch, additive).
+2. Ship `createProgressObserver()` in `@agentskit/ink`.
+3. Registry agents migrate `onProgress` → `observers: [createProgressObserver()]` and emit `progress` events. Update the registry agent template + CONTRIBUTING to recommend the pattern.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -26,3 +26,4 @@ An RFC may grow into an ADR once the decision is committed and implemented.
 | [0002](./0002-agent-registry-and-ecosystem-cohesion.md) | Agent Registry & ecosystem cohesion | Accepted |
 | [0003](./0003-oss-akos-boundary.md) | OSS / AKOS product boundary | Accepted |
 | [0004](./0004-framework-binding-stability.md) | Framework binding stability (beta → stable) | Proposed |
+| [0005](./0005-agent-progress-events.md) | Agent progress events + headless progress renderer | Proposed |


### PR DESCRIPTION
Implements **RFC 0002** (`rfcs/0002-agent-progress-events.md`). Two small, additive changes so standalone (non-chat) agents can report + render multi-stage progress without each hand-rolling ANSI.

## Changes
- **`@agentskit/core`** — add one `AgentEvent` variant: `{ type: 'progress'; label: string; status: 'start'|'ok'|'skip'|'error'; detail?: string; durationMs?: number }`. Additive (existing observers ignore unknown variants). The **runtime never emits it — agents do**, through the `observers` they're given. Closes the gap: `AgentEvent` was a closed union and `agent:step` is too thin (no status/duration/label).
- **`@agentskit/ink`** — `createProgressObserver()`: a **headless** renderer (Observer, pure ANSI, no React tree → works in CI logs) that draws each `progress` event as an animated spinner line resolving to `✓ / – / ⛔` with timing. Reuses the chat UI's `SPINNER_FRAMES`.
- **RFC 0002** + index.

## Why
The runtime's `observers`/`AgentEvent` already carry runtime progress (`llm:*`, `tool:*`). But a multi-stage agent's **domain** progress (classify → sanitize → publish) has nowhere to go, so every standalone/registry agent re-invents a bespoke `onProgress` callback **and** an ANSI renderer. This gives them one shared channel + one shared renderer:

```ts
// before: bespoke callback + ~40 lines of ANSI per agent
createAgent({ adapter, onProgress: makeMyAnsiReporter() })
// after:
createAgent({ adapter, observers: [createProgressObserver()] })
```

## Validation
- `packages/ink/src/progress-observer.test.ts` — renders progress events, ignores non-progress, formats timing/symbols. **Passes** (`vitest run packages/ink/src/progress-observer.test.ts`).

## Rollout
Merge core (patch, additive) → ship ink → registry agents migrate `onProgress` → `observers: [createProgressObserver()]`. The `knowledge-promoter` registry agent stays on its local `onProgress` until this publishes (registry depends on published packages only).