### PR TITLE
fix(adapters): fallback cascades past leading provider error chunks

### DIFF
--- a/.changeset/fallback-error-chunk.md
+++ b/.changeset/fallback-error-chunk.md
@@ -1,0 +1,10 @@
+---
+"@agentskit/adapters": patch
+---
+
+createFallbackAdapter now advances to the next candidate when one surfaces a
+leading `error` chunk (e.g. a 404 stale-model or 429 rate-limit that the
+provider adapter emits as a chunk instead of throwing), not just on thrown
+errors. This makes multi-model fallback chains (e.g. several free models)
+actually cascade past rate-limited/unavailable models. Errors that occur after a
+candidate has committed a real content chunk still propagate without retrying.

--- a/packages/adapters/src/fallback.ts
+++ b/packages/adapters/src/fallback.ts
@@ -65,12 +65,36 @@ export function createFallbackAdapter(
             }
             active = source
 
+            // Pull until the first *committing* chunk. A throw, zero chunks, or
+            // a leading `error` chunk (e.g. a 404 stale-model / 429 rate-limit
+            // that the provider adapter surfaces as a chunk instead of throwing)
+            // marks this candidate failed → advance to the next. Once a real
+            // content chunk commits, mid-stream errors propagate (no retry).
             const iter = source.stream()[Symbol.asyncIterator]()
-            let first: IteratorResult<StreamChunk>
+            let firstReal: StreamChunk | undefined
+            let branchError: Error | undefined
             try {
-              first = await iter.next()
+              while (true) {
+                const r = await iter.next()
+                if (r.done) {
+                  branchError = new Error(`candidate ${candidate.id} emitted no chunks`)
+                  break
+                }
+                if (r.value.type === 'error') {
+                  branchError = new Error(
+                    `candidate ${candidate.id}: ${r.value.content ?? 'stream error'}`,
+                  )
+                  break
+                }
+                firstReal = r.value
+                break
+              }
             } catch (err) {
-              const error = err instanceof Error ? err : new Error(String(err))
+              branchError = err instanceof Error ? err : new Error(String(err))
+            }
+
+            if (branchError || !firstReal) {
+              const error = branchError ?? new Error(`candidate ${candidate.id} emitted no chunks`)
               errors.push({ id: candidate.id, error })
               options.onFallback?.({ id: candidate.id, index: i, error })
               if (options.shouldRetry && !options.shouldRetry(error, i)) throw error
@@ -78,17 +102,7 @@ export function createFallbackAdapter(
               continue
             }
 
-            if (first.done) {
-              // Candidate produced zero chunks — treat as a failed branch.
-              const error = new Error(`candidate ${candidate.id} emitted no chunks`)
-              errors.push({ id: candidate.id, error })
-              options.onFallback?.({ id: candidate.id, index: i, error })
-              if (options.shouldRetry && !options.shouldRetry(error, i)) throw error
-              active = undefined
-              continue
-            }
-
-            yield first.value
+            yield firstReal
             while (true) {
               const next = await iter.next()
               if (next.done) return

--- a/packages/adapters/tests/fallback.test.ts
+++ b/packages/adapters/tests/fallback.test.ts
@@ -48,6 +48,18 @@ function emitsNone(): AdapterFactory {
   }
 }
 
+/** Surfaces a provider failure (e.g. 404/429) as a leading `error` chunk. */
+function errorsOnFirst(msg: string): AdapterFactory {
+  return {
+    createSource: () => ({
+      abort: () => {},
+      stream: async function* () {
+        yield { type: 'error', content: msg } as StreamChunk
+      },
+    }),
+  }
+}
+
 async function collect(factory: AdapterFactory): Promise<StreamChunk[]> {
   const out: StreamChunk[] = []
   for await (const c of factory.createSource(req()).stream()) out.push(c)
@@ -93,6 +105,45 @@ describe('createFallbackAdapter', () => {
     ])
     const chunks = await collect(f)
     expect(chunks[0]!.content).toBe('B')
+  })
+
+  it('falls through when a candidate emits a leading error chunk', async () => {
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: errorsOnFirst('OpenAI API error: 404') },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('B')
+  })
+
+  it('cascades across several failing free models to the first healthy one', async () => {
+    const f = createFallbackAdapter([
+      { id: 'm1', adapter: errorsOnFirst('429 rate-limited') },
+      { id: 'm2', adapter: errorsOnFirst('404 stale model') },
+      { id: 'm3', adapter: throwsOnOpen() },
+      { id: 'm4', adapter: ok('M4') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('M4')
+  })
+
+  it('an error chunk *after* a candidate commits is propagated, not retried', async () => {
+    const lateError: AdapterFactory = {
+      createSource: () => ({
+        abort: () => {},
+        stream: async function* () {
+          yield { type: 'text', content: 'hi' } as StreamChunk
+          yield { type: 'error', content: 'boom' } as StreamChunk
+        },
+      }),
+    }
+    const f = createFallbackAdapter([
+      { id: 'a', adapter: lateError },
+      { id: 'b', adapter: ok('B') },
+    ])
+    const chunks = await collect(f)
+    expect(chunks[0]!.content).toBe('hi')
+    expect(chunks.some((c) => c.type === 'error')).toBe(true)
   })
 
   it('aggregates errors when every candidate fails', async () => {


### PR DESCRIPTION
## Problem

`createFallbackAdapter` committed to the first candidate as soon as it emitted **any** chunk — including an `error` chunk. Providers like OpenRouter surface a **404 (stale model)** or **429 (rate-limit)** as a leading `error` chunk rather than throwing, so multi-model fallback chains never advanced past the first failing model. The chain looked like fallback but, in practice, stopped at the first model that rate-limited.

## Fix

A leading `error` chunk (before any `text`/`tool_call` commits) is now treated as a failed branch → advance to the next candidate. Errors that occur **after** a candidate has committed a real content chunk still propagate without retrying (no duplicate tool calls / cross-candidate retries).

## Why it matters

Makes several-model fallback chains (e.g. a pool of free models) actually cascade past rate-limited/unavailable models — which is exactly what's needed for resilient $0 / free-tier setups.

## Tests

Adds cases for: leading-error fallthrough, multi-model cascade to the first healthy candidate, and post-commit error propagation. `13/13` fallback tests pass; package typecheck + build clean.

Found while building a RAG docs-chat on the free OpenRouter pool (separate work) — the adapter fix is independent and ships on its own.