### PR TITLE
fix(observability): TS 6 build error in console-logger (TS2366)

### DIFF
--- a/packages/observability/src/console-logger.ts
+++ b/packages/observability/src/console-logger.ts
@@ -40,6 +40,9 @@ function formatHuman(event: AgentEvent): string {
     case 'error':
       return `[${timestamp()}] !! error: ${event.error.message}`
   }
+  // Fallback for any future AgentEvent variant (keeps the build green; TS 6 no
+  // longer treats the switch as exhaustively returning).
+  return `[${timestamp()}]    ${(event as AgentEvent).type}`
 }
 
 function formatJSON(event: AgentEvent): string {
@@ -68,6 +71,8 @@ function formatJSON(event: AgentEvent): string {
     case 'error':
       return JSON.stringify({ ...base, error: event.error.message })
   }
+  // Fallback for any future AgentEvent variant (keeps the build green).
+  return JSON.stringify(base)
 }
 
 export function consoleLogger(config: ConsoleLoggerConfig = {}): Observer {


### PR DESCRIPTION
## Fixes the red CI build

```
packages/observability build: src/console-logger.ts(11,42): error TS2366: Function lacks ending return statement…
packages/observability build: src/console-logger.ts(45,41): error TS2366: …
packages/observability build: Error: error occurred in dts build → Failed → Exit status 1
```

**Cause:** TypeScript 6.0.3 no longer treats the `switch (event.type)` over `AgentEvent` as exhaustively returning, so `formatHuman` / `formatJSON` fail the DTS build with TS2366.

**Fix:** add a trailing fallback `return` to both formatters. Keeps the build green and **future-proofs** for new `AgentEvent` variants (a new event type now degrades to a generic line instead of breaking the build).

## Validation
- `pnpm --filter @agentskit/observability build` → **CJS + DTS success** (was failing).
- Spot-checked `@agentskit/core`, `@agentskit/react`, `@agentskit/react-native` build clean standalone.

## Note (separate, infra)
Running the **parallel** monorepo build (`turbo` / `pnpm -r`) intermittently crashes tsup's DTS workers under concurrency (resource contention) — packages build fine individually. That's a CI runner concurrency concern, not a code error, and is out of scope here.