### PR TITLE
fix(adapters): strip double /v1 in openai-compatible endpoint URL

### DIFF
--- a/.changeset/openai-double-v1.md
+++ b/.changeset/openai-double-v1.md
@@ -1,0 +1,11 @@
+---
+"@agentskit/adapters": patch
+---
+
+Fix double `/v1` in the OpenAI-compatible endpoint URL. The request path was
+always built as `${baseUrl}/v1/chat/completions`, but several adapters declare
+their `baseUrl` already ending in `/v1` (openrouter `/api/v1`, together, mistral,
+fireworks, huggingface, vllm, lmstudio, llamacpp), producing
+`.../v1/v1/chat/completions` → HTTP 404 on every call. The base URL now has a
+trailing `/v1` stripped before the path is appended, so both conventions resolve
+correctly. (Latent because adapter tests mocked `fetch` without asserting the URL.)

--- a/packages/adapters/src/openai.ts
+++ b/packages/adapters/src/openai.ts
@@ -18,6 +18,11 @@ export interface OpenAIConfig {
 
 export function openai(config: OpenAIConfig): AdapterFactory {
   const { apiKey, model, baseUrl = 'https://api.openai.com', retry } = config
+  // Normalize: many compatible endpoints are declared WITH a trailing `/v1`
+  // (together, mistral, fireworks, openrouter `/api/v1`, …) while others are
+  // declared without it. We always append `/v1/chat/completions`, so strip a
+  // trailing `/v1` first to avoid a double `/v1/v1/...` (→ 404).
+  const apiRoot = baseUrl.replace(/\/v1\/?$/, '')
   // Auto: on for canonical OpenAI, off for every other compatible endpoint
   // where the param is a known source of 4xx surprises.
   // Match the canonical OpenAI host exactly — a substring/prefix check
@@ -60,7 +65,7 @@ export function openai(config: OpenAIConfig): AdapterFactory {
       if (includeUsage) body.stream_options = { include_usage: true }
 
       return createStreamSource(
-        (signal) => fetch(`${baseUrl}/v1/chat/completions`, {
+        (signal) => fetch(`${apiRoot}/v1/chat/completions`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/adapters/tests/openai-url.test.ts
+++ b/packages/adapters/tests/openai-url.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { openai } from '../src/openai'
+import { openrouter } from '../src/openrouter'
+import { together } from '../src/together'
+import type { AdapterFactory } from '@agentskit/core'
+
+let originalFetch: typeof globalThis.fetch
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+})
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function captureUrl(): { url?: string } {
+  const cap: { url?: string } = {}
+  globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+    cap.url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url
+    throw new Error('stub')
+  }) as typeof globalThis.fetch
+  return cap
+}
+
+async function drain(factory: AdapterFactory): Promise<void> {
+  const source = factory.createSource({
+    messages: [{ id: '1', role: 'user', content: 'hi', status: 'complete', createdAt: new Date(0) }],
+  })
+  const iter = source.stream()[Symbol.asyncIterator]()
+  try {
+    while (!(await iter.next()).done) {
+      /* drain */
+    }
+  } catch {
+    /* expected stub throw */
+  }
+}
+
+describe('openai-compatible endpoint URL', () => {
+  it('canonical OpenAI (no /v1 in baseUrl) → single /v1', async () => {
+    const cap = captureUrl()
+    await drain(openai({ apiKey: 'k', model: 'gpt-4o' }))
+    expect(cap.url).toBe('https://api.openai.com/v1/chat/completions')
+  })
+
+  it('baseUrl already ending in /v1 is not doubled', async () => {
+    const cap = captureUrl()
+    await drain(openai({ apiKey: 'k', model: 'm', baseUrl: 'https://example.test/v1' }))
+    expect(cap.url).toBe('https://example.test/v1/chat/completions')
+  })
+
+  it('openrouter (/api/v1) → single /v1, not /api/v1/v1', async () => {
+    const cap = captureUrl()
+    await drain(openrouter({ apiKey: 'k', model: 'meta-llama/llama-3.3-70b-instruct:free' }))
+    expect(cap.url).toBe('https://openrouter.ai/api/v1/chat/completions')
+    expect(cap.url).not.toContain('/v1/v1/')
+  })
+
+  it('together (/v1) → single /v1', async () => {
+    const cap = captureUrl()
+    await drain(together({ apiKey: 'k', model: 'x' }))
+    expect(cap.url).not.toContain('/v1/v1/')
+    expect(cap.url).toContain('/v1/chat/completions')
+  })
+})


### PR DESCRIPTION
## Problem

The OpenAI-compatible request path is always built as `${baseUrl}/v1/chat/completions`. Several adapters declare their `baseUrl` **already ending in `/v1`** — `openrouter` (`/api/v1`), `together`, `mistral`, `fireworks`, `huggingface`, `vllm`, `lmstudio`, `llamacpp` — so the real request goes to `.../v1/v1/chat/completions` → **HTTP 404 on every call**. These adapters were effectively non-functional.

Latent because adapter tests mock `fetch` without asserting the request URL.

## Fix

Strip a trailing `/v1` from `baseUrl` before appending the path. Both conventions (baseUrl with or without `/v1`) now resolve to a single `/v1/chat/completions`.

## Tests

`tests/openai-url.test.ts` asserts the final URL for canonical OpenAI, a `/v1`-suffixed baseUrl, `openrouter` (`/api/v1` → `/api/v1/chat/completions`, not `/v1/v1/`), and `together`. `4/4` pass.

## How it was found

Building a RAG docs-chat on the OpenRouter free pool: every model returned 404. Direct curl to the same model returned 429 (works) while the adapter hit the doubled path. With this fix the chain reaches the API and streams.