### PR TITLE
feat(docs-chat): extensible triage rules + document the guardrails

### DIFF
--- a/apps/docs-next/content/docs/cookbook/ask-the-docs.mdx
+++ b/apps/docs-next/content/docs/cookbook/ask-the-docs.mdx
@@ -92,6 +92,36 @@ The floating chat is a headless, slotted component — open by default, branded 
 
 Generative UI (option buttons, forms, runnable code) activates with `ASK_RICH_UI=1` and a capable model — free models stay on reliable markdown text.
 
+## Guardrails (built in)
+
+Before any model call, a cheap **triage** runs — it saves your free-tier quota on
+trivia and blocks the obvious attacks:
+
+- **Greetings** ("hi", "oi") and **noise** ("test", empty, gibberish) → an instant
+  canned reply, no LLM.
+- **Prompt injection** ("ignore previous instructions", "reveal your system
+  prompt", "you are now…", "jailbreak") → a firm decline that never changes role
+  or leaks the prompt — no LLM.
+- Real questions (even one word like "memory") fall through.
+
+It's **additive and extensible** — keep the defenses, add your own:
+
+```ts
+import { triageMessage } from './lib/ask/guard'
+
+const triage = triageMessage(userText, {
+  greetings: ['salut', 'ciao'],
+  noise: ['blah'],
+  injectionPatterns: [/give me the raw config/i],
+  replies: { greeting: 'Hey! Ask me about our product docs.' },
+})
+if (triage.kind === 'canned') return stream(triage.reply) // skip the model
+```
+
+This sits on top of the other layers: client `system` messages are stripped, the
+retrieved context is fenced as **untrusted data**, and the grounded prompt keeps
+answers on-topic — defense-in-depth.
+
 ## Going further
 
 - **Durable rate limit** — front the route with Upstash (in-memory fallback for dev).

--- a/apps/docs-next/lib/ask/guard.ts
+++ b/apps/docs-next/lib/ask/guard.ts
@@ -164,34 +164,42 @@ const NOISE: ReadonlySet<string> = new Set([
   'asdf', 'qwerty', 'aaa', 'lorem ipsum', 'foo', 'bar',
 ])
 
-export function triageMessage(query: string): Triage {
+const DEFAULT_REPLIES = {
+  greeting:
+    '👋 Hi! I answer questions about **AgentsKit** straight from the docs. Try *“How do I create a runtime agent?”* or *“What memory backends are there?”*',
+  noise: 'I’m working ✓ — ask a real question about **AgentsKit** and I’ll answer from the docs.',
+  injection:
+    "I only answer questions about the **AgentsKit** documentation — I can’t change my instructions or role, or reveal my prompt. Ask me about agents, tools, skills, memory, RAG, or deploying.",
+} as const
+
+/**
+ * Extra triage rules a consumer can supply. All are MERGED with the built-ins —
+ * additive, so you keep the injection defenses and add your own greetings, noise
+ * words, injection patterns, or override the canned copy.
+ */
+export interface TriageRules {
+  greetings?: readonly string[]
+  noise?: readonly string[]
+  injectionPatterns?: readonly RegExp[]
+  replies?: Partial<typeof DEFAULT_REPLIES>
+}
+
+export function triageMessage(query: string, extra: TriageRules = {}): Triage {
+  const replies = { ...DEFAULT_REPLIES, ...extra.replies }
   const raw = query.trim()
   if (raw.length === 0) return { kind: 'canned', reply: 'Ask me anything about **AgentsKit** and I’ll answer from the docs.' }
 
-  if (INJECTION_PATTERNS.some((re) => re.test(raw))) {
-    return {
-      kind: 'canned',
-      reply:
-        "I only answer questions about the **AgentsKit** documentation — I can’t change my instructions or role, or reveal my prompt. Ask me about agents, tools, skills, memory, RAG, or deploying.",
-    }
-  }
+  const injection = [...INJECTION_PATTERNS, ...(extra.injectionPatterns ?? [])]
+  if (injection.some((re) => re.test(raw))) return { kind: 'canned', reply: replies.injection }
 
   const norm = raw.toLowerCase().replace(/[!?.…,~]+$/g, '').trim()
-  if (GREETINGS.has(norm)) {
-    return {
-      kind: 'canned',
-      reply:
-        '👋 Hi! I answer questions about **AgentsKit** straight from the docs. Try *“How do I create a runtime agent?”* or *“What memory backends are there?”*',
-    }
-  }
+  const greetings = new Set([...GREETINGS, ...(extra.greetings ?? [])])
+  if (greetings.has(norm)) return { kind: 'canned', reply: replies.greeting }
 
   // Pure noise / non-words / "test". Single real words (e.g. "memory") pass.
-  const isNoise = NOISE.has(norm) || /^[^a-zÀ-ſ]+$/i.test(norm) || norm.length < 2
-  if (isNoise) {
-    return {
-      kind: 'canned',
-      reply: 'I’m working ✓ — ask a real question about **AgentsKit** and I’ll answer from the docs.',
-    }
+  const noise = new Set([...NOISE, ...(extra.noise ?? [])])
+  if (noise.has(norm) || /^[^a-zÀ-ſ]+$/i.test(norm) || norm.length < 2) {
+    return { kind: 'canned', reply: replies.noise }
   }
 
   return { kind: 'ok' }


### PR DESCRIPTION
Follow-up to #1010 (which merged before this commit landed).

## What
- **Extensible triage** — `triageMessage(query, extra)` now accepts additive `TriageRules` (greetings / noise / injectionPatterns / reply overrides). Consumers keep the built-in prompt-injection defenses and layer their own on top.
- **Docs** — new "Guardrails (built in)" section in the Ask-the-docs cookbook recipe, documenting the pre-LLM triage (greetings/noise → canned, injection → firm decline, real questions fall through) and the extension example.

## Why
The guardrails should ship as part of the addable component, and consumers must be able to add their own rules without forking. The merge of #1010 carried the base `triageMessage` but not the extensibility or the docs.

## Scope
2 files: `apps/docs-next/lib/ask/guard.ts`, `apps/docs-next/content/docs/cookbook/ask-the-docs.mdx`. Additive only — no behavior change for existing callers.