### PR TITLE
docs(rfc): 0006 — UI component registry & shadcn-style `agentskit add`

### DIFF
--- a/rfcs/0006-ui-component-registry.md
+++ b/rfcs/0006-ui-component-registry.md
@@ -1,0 +1,252 @@
+# RFC 0006 — UI component registry & shadcn-style `agentskit add`
+
+- **Status**: Proposed
+- **Date**: 2026-06-18
+- **Author**: @EmersonBraun
+- **Related issues**: —
+- **Related RFCs**: [0002](./0002-agent-registry-and-ecosystem-cohesion.md) (Agent Registry), [0004](./0004-framework-binding-stability.md) (Framework binding stability)
+- **Related PRs**: #1010 (Ask-the-docs chat — the first component), #1013 (extensible guardrails), registry repo (AgentsKit-io/agentskit-registry)
+
+## Summary
+
+Extend the existing shadcn-style `agentskit add` so it can install **UI components**
+(starting with the Ask-the-docs chat), not just **agents**. A single command
+`agentskit add <name>` scans the target project, detects its framework, validates
+compatibility, asks where to place the files, copies framework-correct source the
+user owns, and leaves it ready to use. The chat is the flagship: the goal is the
+market-standard, plug-and-play "drop an AI chat into any app" command, across
+React, Next, Svelte, Vue, Angular, React Native, and Ink.
+
+This RFC defines the **contracts** only (registry schema, scanner, per-framework
+port, add/validate flow). No implementation lands until the design is accepted.
+
+## Motivation
+
+The Ask-the-docs chat (RFC-0010 work, PR #1010) is the strongest live proof of
+AgentsKit — grounded RAG, $0 free-tier, cited, generative-UI, guardrails. But
+today it is:
+
+- **React-only** — the composite widget exists for React; the primitives exist
+  for svelte/solid/ink (full) and vue/angular/react-native (partial), but the
+  composite chat is not ported.
+- **Not installable as a component** — `agentskit add` (RFC-0002) copies
+  *agents* (`createDocsChatAgent` → `./agents/<id>/`). There is no UI-component
+  path, no project scan, no framework detection, no placement prompt.
+
+shadcn proved the pattern that wins adoption: *scan → validate → ask → copy →
+ready*, with the user owning the source. AgentsKit already has the registry
+client, the hosted-index + raw-GitHub fetch, and a line-diff updater (RFC-0002).
+This RFC reuses all of it and adds the UI-component shape on top.
+
+The chat is the "last mile" for UI the way ready agents are the last mile for
+runtime: each install pulls real downloads of the base packages it composes
+(`@agentskit/react|svelte|…`, `@agentskit/rag`, `@agentskit/adapters`).
+
+## Current state
+
+The registry client (`packages/cli/src/registry.ts`) already provides:
+
+- `RegistryAgent` schema: `{ id, title, description, category, packages, env,
+  files, sources, skill }`
+- `fetchAgent(id)` — hosted `registry.agentskit.io/r/<id>.json` first, raw-GitHub
+  `registry/<id>/` fallback
+- `addAgent(id, { outDir, force })` — writes `sources` into `./agents/<id>/`,
+  refuses to clobber without `--force`
+- `diffAgent(id)` + `lineDiff` — keep a copied item in sync (shadcn-style update)
+
+`packages/cli/src/commands/add.ts` exposes `add <agent>` with `--out`, `--force`,
+`--run`, `--provider/--model/--api-key`.
+
+What is missing for components: a component schema variant, a project scanner, a
+validator, an interactive placement step, and per-framework source variants.
+
+## Decisions (locked for this RFC)
+
+1. **One command, auto-detect.** Keep a single `agentskit add <name>`. The CLI
+   fetches the registry item and branches on its `kind` (`agent` | `component`).
+   No second verb. (Chosen over a separate `agentskit ui add`.)
+2. **RFC-first.** Contracts here are the deliverable; implementation follows in
+   linked PRs once accepted. No component ports or scanner code land under this
+   RFC.
+3. **Reuse RFC-0002 infrastructure.** Same registry repo, same hosted-index +
+   raw-GitHub fetch, same "user owns the source" + line-diff update. Components
+   are a new item shape in the *same* registry, not a new system.
+
+## Proposal
+
+### 1. Registry item schema — `kind` discriminator
+
+Promote the registry item to a tagged union. Agents keep their exact current
+shape (back-compatible: a missing `kind` defaults to `'agent'`).
+
+```ts
+type RegistryItem = RegistryAgent | RegistryComponent
+
+interface RegistryComponent {
+  kind: 'component'
+  id: string                       // 'docs-chat'
+  title: string
+  description: string
+  category: string                 // 'chat' | 'input' | …
+
+  /** Frameworks this component ships a port for. */
+  frameworks: Framework[]          // ['react','next','svelte','vue','angular','react-native','ink']
+
+  /** Per-framework file sets. The scanner picks the matching entry. */
+  ports: Record<Framework, ComponentPort>
+
+  /** npm deps common to every port (per-port deps add to these). */
+  packages: string[]              // ['@agentskit/rag','@agentskit/adapters']
+  env?: RegistryEnvVar[]          // e.g. OPENROUTER_API_KEY (required)
+}
+
+interface ComponentPort {
+  /** Files relative to the chosen install dir; sources inlined like agents. */
+  files: string[]
+  sources: RegistryFile[]         // { path, content }[]
+  /** Extra npm deps for this framework only. */
+  packages?: string[]
+  devPackages?: string[]
+  /** Other registry items this port needs (resolved + installed first). */
+  registryDependencies?: string[]
+  /** Default install dir, framework-idiomatic; overridable by scan/prompt/--out. */
+  defaultTarget: string           // react: 'components/ask', angular: 'src/app/ask'
+  /** Styling requirements the validator checks/applies. */
+  styling?: {
+    tailwind?: boolean
+    cssVars?: string[]            // '--ak-*' tokens the component expects
+    globalCss?: RegistryFile      // optional css to append (e.g. keyframes)
+  }
+}
+```
+
+`RegistryFile` (`{ path, content }`) and `RegistryEnvVar` are reused verbatim.
+
+### 2. Project scanner contract
+
+A pure, dependency-light module that inspects the cwd and returns a `ProjectScan`.
+No network, no writes. Tested with an injectable fs (mirrors the registry client's
+`fetchImpl`/`writeFileImpl` style).
+
+```ts
+interface ProjectScan {
+  framework: Framework | 'unknown'   // from deps: next, react, svelte, @angular/core, react-native, ink…
+  packageManager: 'npm' | 'pnpm' | 'yarn' | 'bun'   // from lockfile
+  typescript: boolean                // tsconfig.json present
+  srcDir: string | null              // 'src' if present, else project root
+  importAlias: string | null         // from tsconfig "paths" (e.g. '@/*' → '@')
+  styling: { tailwind: boolean; cssEntry: string | null }
+  appRouter?: boolean                // Next: app/ vs pages/
+}
+```
+
+Detection rules (deterministic, documented in the implementation PR):
+framework from `package.json` deps → lockfile → tsconfig → styling. Ambiguous or
+missing signals resolve to `'unknown'`/`null` and surface in the validator, never
+a silent guess.
+
+### 3. Validator + add/validate flow
+
+`agentskit add <name>`:
+
+1. **Fetch** the item (hosted → raw fallback, existing path).
+2. **Branch on `kind`.** `agent` → today's `addAgent` (unchanged). `component` →
+   continue.
+3. **Scan** the project (§2).
+4. **Validate**:
+   - `scan.framework` ∈ `component.frameworks`? If not → fail with the list of
+     supported frameworks and the detected one. No partial install.
+   - styling: if the port needs tailwind and the scan finds none → warn + print
+     the manual step (do not hard-fail; the component still renders with the
+     `--ak-*` tokens documented).
+   - env: list required `env` vars the user must set.
+5. **Resolve placement**: `--out` > interactive prompt (default =
+   `port.defaultTarget`, joined under `scan.srcDir`/alias). `--yes` skips the
+   prompt and takes the default (CI-friendly).
+6. **Resolve `registryDependencies`** recursively, install those components first.
+7. **Write** `port.sources` (refuse to clobber without `--force`, existing rule);
+   append `styling.globalCss` if present.
+8. **Report**: files written, `npm/pnpm/yarn install <packages>`, required env,
+   and a one-line "ready" usage snippet for the detected framework.
+
+`agentskit add <name> --dry-run` prints the plan (framework, target, files, deps)
+without writing — the scan/validate output as a preview.
+
+### 4. Per-framework port contract
+
+Each component publishes a `ComponentPort` per supported framework. A port is
+**self-contained and idiomatic**: it composes that framework's `@agentskit/*`
+binding (`useChat` for react/vue/solid/svelte, the Ink components for terminal),
+uses only `data-ak-*` + `--ak-*` tokens (headless, no hardcoded colors — matches
+the framework convention in CLAUDE.md), and ships no styles beyond the optional
+`globalCss`.
+
+Port parity is **declared, not implied**: a component lists only the frameworks
+it actually ships. `docs-chat` ships `react` + `next` first (the live widget);
+svelte/vue/angular/react-native/ink are added as ports land, each gated by the
+binding's stability tier (RFC-0004). The CLI never offers a framework a component
+hasn't shipped.
+
+### 5. Update path
+
+`agentskit diff <name>` / update already exists for agents (`diffAgent` +
+`lineDiff`). For components it diffs against the **active port** at the recorded
+install dir. The install writes a tiny `.agentskit/components.json` marker
+(`{ id, framework, target }`) so update knows which port and where, without
+re-scanning.
+
+## The chat as the flagship
+
+`docs-chat` is the first and reference component. Its port files are the existing
+React widget set, refactored to be registry-portable:
+
+- `ask-widget.tsx` (headless compound shell), `useAskChat`, `Markdown`,
+  `registry` (allow-listed generative-UI render boundary)
+- `lib/ask/guard.ts` (the extensible triage + scope guard from #1013),
+  `lib/rag/*` (retriever + cited context), `lib/openrouter.ts` (free pool)
+- `app/api/ask-docs/route.ts` as a framework-appropriate server handler (Next
+  route handler for the `next` port; documented adapter for others)
+- `globalCss`: the `--ak-*` keyframes (loading dots, AI shimmer)
+
+Everything the user installs is theirs to edit — including the guardrail rules,
+which `triageMessage(query, extra)` already accepts additively.
+
+## Alternatives considered
+
+- **Separate `agentskit ui add` namespace** — rejected per decision §1; one verb,
+  auto-detect is simpler for users and keeps RFC-0002's surface.
+- **A `@agentskit/registry` CLI package** — rejected by RFC-0002 already; extend
+  the existing CLI.
+- **Ship the chat as an installable npm package** — rejected: violates the "user
+  owns the source / shadcn-style" principle that makes the components forkable
+  and the guardrails extensible.
+- **Per-framework `create-*` scaffolds instead of `add`** — rejected: scaffolds
+  start new projects; `add` drops into existing ones, which is the adoption case.
+
+## Open questions
+
+1. **Server-side portability.** The chat's grounding route is a Next handler.
+   For non-Next React (Vite) and other frameworks, do we ship a framework-neutral
+   request handler the user mounts, or per-framework server adapters? (Leaning:
+   one neutral `handleAskRequest(req)` core + thin per-framework mounts.)
+2. **Embedding at install vs runtime.** The committed ONNX index (`gen-ask-index`)
+   is docs-specific. The component should ship the *indexer script* + an empty
+   index, not a corpus. Confirm the install copies the script and documents
+   "run it against your docs", not a prebuilt index.
+3. **Marker file location.** `.agentskit/components.json` vs per-component
+   frontmatter. (Leaning: single `.agentskit/components.json`.)
+4. **Framework rollout order** after react/next: svelte + vue (full `useChat`),
+   then angular + react-native (partial bindings — gated by RFC-0004), ink last.
+
+## Rollout (once accepted)
+
+1. **Contracts** — land `RegistryComponent` + scanner + validator types in the
+   CLI (no ports yet), behind the existing `add` command.
+2. **React/Next port** — make `docs-chat` registry-portable; first end-to-end
+   `agentskit add docs-chat` into a fresh Next app.
+3. **Scanner + interactive flow** — detection, validation, placement prompt,
+   `--dry-run`/`--yes`.
+4. **Second framework** (svelte) — proves the port contract generalizes.
+5. **Remaining ports** — vue, angular, react-native, ink, each gated by binding
+   stability (RFC-0004).
+6. Graduate the stable contracts (item schema, scanner) to an ADR.

--- a/rfcs/0006-ui-component-registry.md
+++ b/rfcs/0006-ui-component-registry.md
@@ -1,7 +1,7 @@
 # RFC 0006 — UI component registry & shadcn-style `agentskit add`
 
 - **Status**: Proposed
-- **Version**: 3 (v2 → v3 after a 6-lens consensus review — closes 2 BLOCKERs + the `AskConfig` cluster; see Changelog)
+- **Version**: 3.1 (v3 consensus review + all product calls resolved — 0 open questions; see Changelog)
 - **Date**: 2026-06-18
 - **Author**: @EmersonBraun
 - **Related issues**: —
@@ -216,9 +216,10 @@ The install therefore:
 
 1. Copies an **indexer** (`agentskit ask index ./docs`) and an **empty** index
    stub — never AgentsKit's corpus.
-2. Declares `embeddingBackend` (D5). `onnx-node` for Node servers;
-   `api-remote` (call an embedding API) for edge/RN/serverless without ONNX;
-   `browser-wasm` only where WASM SIMD is available.
+2. Declares `embeddingBackend` (D5). **`onnx-node` is the launch default** for Node
+   servers ($0, local). `api-remote` (a **BYO** embed fn / API via `AskConfig.embed`)
+   serves edge/RN/serverless without ONNX — no bundled paid provider; `browser-wasm`
+   only where WASM SIMD is available. Edge/RN ports are deferred (see Open questions).
 3. Loads the index at request time (not module-load) for large corpora, to keep
    serverless cold-start small.
 4. Prints a "run the indexer before first use" step in the ready output.
@@ -512,33 +513,41 @@ false** — resolved before the `react × next-app` port ships (Rollout step 4).
 - **Silent `kind` default to `'agent'`** — rejected (D1): explicit + validated.
 - **Single coarse `framework`** — rejected (D4): can't place server files.
 
-## Open questions (genuine product calls — need your decision)
+## Open questions
 
-1. **Launch framework breadth.** Ship `react×next-app` first and expand, or block
-   the GA announcement until `sveltekit` + `nuxt` also ship? (Recommendation:
-   ship react/next first; each later port gated by RFC-0004 binding stability.)
-2. **Default embedding for `hosted`/edge ports** — bundle a small `api-remote`
-   embedder (which provider?) or require the user to supply one?
-3. **Telemetry** — default off, opt-in `agentskit add --telemetry`? (Recommendation:
-   off by default.) The wire contract is already `ObservabilityHooks` (D5) — this OQ
-   is only the default + provider, not the surface.
+**None — all resolved (v3.1).** The RFC has zero open items; implementation can
+begin.
 
-**Resolved in v3** (were open in v2): signing = **minisign Ed25519**, cosign
-deferred (D9). `$schema` = a **versioned raw-GitHub tag URL**, hosted
-`registry.agentskit.io` becomes an alias once live (D3/D11) — so standing up hosting
-is no longer a blocker for Rollout step 1; it can follow on its own timeline.
+Resolved product calls:
+
+1. **Launch breadth** → ship **`react × next-app` first**, expand port-by-port (each
+   gated by RFC-0004 binding stability).
+2. **Edge/RN/hosted embedding** → **`onnx-node` now** for Node ports ($0, local);
+   edge/RN/`hosted` ports are deferred and, when they land, take a **BYO embedder
+   via `AskConfig.embed`** (no bundled paid provider, preserves the $0 default).
+3. **Telemetry** → **off by default**, opt-in `agentskit add --telemetry`; the wire
+   contract is `ObservabilityHooks` (D5), no-op until enabled.
+
+Resolved earlier (v3): signing = **minisign Ed25519** (cosign deferred, D9);
+`$schema` = **versioned raw-GitHub tag URL** with the hosted URL as a later alias
+(D3/D11) — hosting is not a blocker for kickoff.
 
 ## Rollout (once accepted)
 
-1. **Contracts** — land `RegistryComponent` + `FrameworkTarget` + scanner +
-   validator + `components.json` + `init` (no ports yet).
-2. **Integrity layer** — pinned refs, per-file sha256, signed (minisign) manifest +
+Kickoff = **step 1 (D8)** per the locked decision — it's a self-contained refactor
+of the existing chat, needs no registry, and unblocks every later port.
+
+1. **D8 portability refactor (KICKOFF)** of the chat — extract the server core to
+   `createAskHandler(AskConfig)` (define `AskConfig` + `ObservabilityHooks`), make
+   the widget headless (no `className`/`next/*`/brand import; slotted `linkComponent`,
+   inlined logo), **dynamic (request-time) index import**, and land the
+   `check:registry-headless` gate wired into `pnpm check:quality-gates`.
+2. **Contracts** — `RegistryComponent` + `FrameworkTarget` + scanner + validator +
+   `components.json` + `init` (no ports yet).
+3. **Integrity layer** — pinned refs, per-file sha256, signed (minisign) manifest +
    `keys.json` rotation, configurable/auth'd registry, **path-containment guard
    (D16) on write and diff read**, transactional install, tamper-evident marker +
    audit.
-3. **D8 portability refactor** of the chat — `check:registry-headless` must pass
-   before the `react × next-app` port merges; server core extraction to
-   `createAskHandler(AskConfig)`; **dynamic (request-time) index import**.
 4. **react × next-app port** — first end-to-end `agentskit add docs-chat`.
 5. **Scanner + interactive flow** — detection, validation, placement, `--dry-run`/
    `--yes`, PM execution.
@@ -549,6 +558,10 @@ is no longer a blocker for Rollout step 1; it can follow on its own timeline.
 
 ## Changelog
 
+- **v3.1** — all 3 product calls resolved → **0 open questions**: launch
+  `react × next-app` first; `onnx-node` now + BYO embedder (`AskConfig.embed`) for
+  edge/RN later; telemetry off-by-default opt-in. Rollout reordered: **D8 is the
+  implementation kickoff**. Ready to implement.
 - **v3** — 6-lens consensus review (53 agents). Closed both BLOCKERs:
   **ports-map key grammar** locked to `uiBinding` alone (D4/Schema) and a
   **path-containment guard** added (new D16, on write + diff read, publish-time

--- a/rfcs/0006-ui-component-registry.md
+++ b/rfcs/0006-ui-component-registry.md
@@ -1,6 +1,7 @@
 # RFC 0006 — UI component registry & shadcn-style `agentskit add`
 
 - **Status**: Proposed
+- **Version**: 2 (v1 → v2 hardened after adversarial enterprise review — see Changelog)
 - **Date**: 2026-06-18
 - **Author**: @EmersonBraun
 - **Related issues**: —
@@ -9,244 +10,388 @@
 
 ## Summary
 
-Extend the existing shadcn-style `agentskit add` so it can install **UI components**
-(starting with the Ask-the-docs chat), not just **agents**. A single command
-`agentskit add <name>` scans the target project, detects its framework, validates
-compatibility, asks where to place the files, copies framework-correct source the
-user owns, and leaves it ready to use. The chat is the flagship: the goal is the
-market-standard, plug-and-play "drop an AI chat into any app" command, across
-React, Next, Svelte, Vue, Angular, React Native, and Ink.
+Extend the existing shadcn-style `agentskit add` so it installs **UI components**
+(starting with the Ask-the-docs chat), not just **agents**. `agentskit init`
+writes a project config (`.agentskit/components.json`) once; thereafter
+`agentskit add <name>` reads it, validates compatibility, copies framework-correct
+source the user owns, installs deps, and leaves the component ready — including its
+**server handler** where one is needed.
 
-This RFC defines the **contracts** only (registry schema, scanner, per-framework
-port, add/validate flow). No implementation lands until the design is accepted.
+The chat is the flagship: the bar is **enterprise-grade, market-standard,
+plug-and-play** — verifiable supply-chain integrity, transactional installs,
+private-registry support, TS/JS parity, multi-framework + multi-backend, across
+React/Next/Remix/TanStack, SvelteKit, Nuxt/Vue, Angular, React Native (Expo), and
+Ink.
+
+This RFC defines the **contracts** only. No implementation lands until accepted.
+v2 closes the blockers found in review; the **Resolved decisions** section is the
+core, **Open questions** now holds only genuine product calls.
 
 ## Motivation
 
-The Ask-the-docs chat (RFC-0010 work, PR #1010) is the strongest live proof of
-AgentsKit — grounded RAG, $0 free-tier, cited, generative-UI, guardrails. But
-today it is:
+The Ask-the-docs chat (#1010, #1013) is AgentsKit's strongest live proof —
+grounded RAG, $0 free-tier, cited, generative-UI, guardrails. But it is React-only
+and not installable as a component: `agentskit add` (RFC-0002) copies *agents*
+into `./agents/<id>/`; there is no UI path, no project scan, no framework
+detection, no placement, no server-handler delivery, no integrity verification.
 
-- **React-only** — the composite widget exists for React; the primitives exist
-  for svelte/solid/ink (full) and vue/angular/react-native (partial), but the
-  composite chat is not ported.
-- **Not installable as a component** — `agentskit add` (RFC-0002) copies
-  *agents* (`createDocsChatAgent` → `./agents/<id>/`). There is no UI-component
-  path, no project scan, no framework detection, no placement prompt.
+shadcn/ui proved the pattern that wins adoption — *init → scan → validate → copy →
+ready*, user owns the source. AgentsKit already has the registry client, the
+hosted-index + raw-GitHub fetch, and a line-diff updater. v2 reuses that and adds
+the contracts an enterprise flagship requires. Each install also pulls real
+downloads of the base packages the component composes.
 
-shadcn proved the pattern that wins adoption: *scan → validate → ask → copy →
-ready*, with the user owning the source. AgentsKit already has the registry
-client, the hosted-index + raw-GitHub fetch, and a line-diff updater (RFC-0002).
-This RFC reuses all of it and adds the UI-component shape on top.
+## Resolved decisions (locked)
 
-The chat is the "last mile" for UI the way ready agents are the last mile for
-runtime: each install pulls real downloads of the base packages it composes
-(`@agentskit/react|svelte|…`, `@agentskit/rag`, `@agentskit/adapters`).
+> v1 deferred too much. These are now decided. Each maps to a review blocker.
 
-## Current state
+### D1. One verb, explicit `kind`, auto-detect
 
-The registry client (`packages/cli/src/registry.ts`) already provides:
+Keep a single `agentskit add <name>`. Registry items carry an **explicit**
+`kind: 'agent' | 'component'` (no silent default — a missing/unknown kind is a
+publish-time validation error, not an implicit agent). The CLI branches on `kind`.
+No separate `ui add`.
 
-- `RegistryAgent` schema: `{ id, title, description, category, packages, env,
-  files, sources, skill }`
-- `fetchAgent(id)` — hosted `registry.agentskit.io/r/<id>.json` first, raw-GitHub
-  `registry/<id>/` fallback
-- `addAgent(id, { outDir, force })` — writes `sources` into `./agents/<id>/`,
-  refuses to clobber without `--force`
-- `diffAgent(id)` + `lineDiff` — keep a copied item in sync (shadcn-style update)
+### D2. RFC-first; reuse RFC-0002 infra
 
-`packages/cli/src/commands/add.ts` exposes `add <agent>` with `--out`, `--force`,
-`--run`, `--provider/--model/--api-key`.
+Contracts here are the deliverable. Components are a new item shape in the **same**
+registry (same repo, same hosted-index + raw-GitHub fallback, same user-owns-source
++ line-diff update) — not a new system.
 
-What is missing for components: a component schema variant, a project scanner, a
-validator, an interactive placement step, and per-framework source variants.
+### D3. `agentskit init` + `components.json` (the shadcn contract)
 
-## Decisions (locked for this RFC)
+`agentskit init` writes `.agentskit/components.json` once (committed to the repo).
+Every `add` reads it first and **skips scanning/prompts**; it scans only when the
+file is absent (and warns to run `init`). CI (`--yes`) trusts this file rather than
+re-detecting.
 
-1. **One command, auto-detect.** Keep a single `agentskit add <name>`. The CLI
-   fetches the registry item and branches on its `kind` (`agent` | `component`).
-   No second verb. (Chosen over a separate `agentskit ui add`.)
-2. **RFC-first.** Contracts here are the deliverable; implementation follows in
-   linked PRs once accepted. No component ports or scanner code land under this
-   RFC.
-3. **Reuse RFC-0002 infrastructure.** Same registry repo, same hosted-index +
-   raw-GitHub fetch, same "user owns the source" + line-diff update. Components
-   are a new item shape in the *same* registry, not a new system.
+```jsonc
+{
+  "$schema": "https://registry.agentskit.io/schema/components.json",
+  "schemaVersion": 1,
+  "uiBinding": "react",
+  "metaFramework": "next-app",
+  "typescript": true,
+  "rsc": true,
+  "styling": { "mode": "data-attrs-only", "css": "app/global.css", "tailwindConfig": null },
+  "aliases": { "components": "@/components", "lib": "@/lib", "server": "@/app/api" },
+  "paths": { "root": ".", "components": "components", "lib": "lib", "server": "app/api" },
+  "registries": { "default": "https://registry.agentskit.io" },
+  "linkComponent": null
+}
+```
 
-## Proposal
+In a monorepo `paths.*` anchor to a workspace package (`packages/ui/src/…`),
+resolved relative to the config file, not cwd. `init` detects `pnpm-workspace.yaml`
+/ `turbo.json` / `nx.json` and prompts for the target package.
 
-### 1. Registry item schema — `kind` discriminator
+### D4. Two-level framework model (so the server file lands correctly)
 
-Promote the registry item to a tagged union. Agents keep their exact current
-shape (back-compatible: a missing `kind` defaults to `'agent'`).
+`framework` was too coarse to know **where** a server route goes. Split it:
 
 ```ts
-type RegistryItem = RegistryAgent | RegistryComponent
+type UiBinding =
+  | 'react' | 'svelte' | 'vue' | 'solid' | 'angular' | 'react-native' | 'ink'
+
+type MetaFramework =
+  | 'next-app' | 'next-pages' | 'remix' | 'tanstack-start' | 'astro'
+  | 'sveltekit' | 'nuxt' | 'angular-ssr' | 'expo'
+  | 'vite' | 'cra' | 'angular-spa' | 'node' | 'none'
+
+interface FrameworkTarget { uiBinding: UiBinding; metaFramework: MetaFramework }
+```
+
+The scanner produces **both**. UI files key on `uiBinding`; server files key on
+`metaFramework`. The CLI never offers a `(uiBinding, metaFramework)` pair a
+component hasn't shipped.
+
+### D5. Server-handler delivery contract (resolves v1 open Q1)
+
+Every component that needs a backend ships a framework-neutral core plus thin
+per-meta-framework mounts. The core is a **Web-standard handler**:
+
+```ts
+// shipped, framework-agnostic — user owns it
+export function createAskHandler(config: AskConfig): (req: Request) => Promise<Response>
+```
+
+Per-`metaFramework` mount files adapt it (Next route handler, SvelteKit
+`+server.ts`, Nuxt `server/api/*.post.ts`, Remix `action`, Express middleware for
+`angular-ssr`, a local Node server for `ink`). The `ComponentPort.server` field
+declares delivery:
+
+```ts
+interface PortServer {
+  delivery: 'bundled' | 'hosted' | 'local'
+  //  bundled → server file(s) installed (Next/SvelteKit/Nuxt/Remix/Express)
+  //  hosted  → no server here; user points at a deployed endpoint (RN, pure SPA)
+  //  local   → a local Node server script is installed (Ink/CLI)
+  serverTargetByMeta?: Partial<Record<MetaFramework, string>>
+  runtimeRequirement: 'nodejs' | 'edge-compatible' | 'none'
+  embeddingBackend: 'onnx-node' | 'api-remote' | 'browser-wasm' | 'none'
+  endpointEnvVar?: string  // for hosted/local: e.g. AGENTSKIT_ASK_ENDPOINT
+}
+```
+
+The validator refuses an install whose `runtimeRequirement`/`embeddingBackend` the
+detected target can't satisfy (e.g. `onnx-node` on `expo`/edge) — with a concrete
+message and the supported alternative, never a silent broken install.
+
+### D6. Embedding + index portability (resolves v1 open Q2)
+
+The committed ONNX index is **corpus-specific** (AgentsKit docs) and Node-only.
+The install therefore:
+
+1. Copies an **indexer** (`agentskit ask index ./docs`) and an **empty** index
+   stub — never AgentsKit's corpus.
+2. Declares `embeddingBackend` (D5). `onnx-node` for Node servers;
+   `api-remote` (call an embedding API) for edge/RN/serverless without ONNX;
+   `browser-wasm` only where WASM SIMD is available.
+3. Loads the index at request time (not module-load) for large corpora, to keep
+   serverless cold-start small.
+4. Prints a "run the indexer before first use" step in the ready output.
+
+### D7. Streaming protocol negotiation
+
+The server speaks **NDJSON by default and SSE on `Accept: text/event-stream`**.
+`ComponentPort.streamingProtocol: 'ndjson' | 'sse' | 'both'`. Angular (`HttpClient`)
+and older React Native ports default to `sse`/`both` (cleaner to consume than
+`ReadableStream` reader). Client port code matches its declared protocol.
+
+### D8. Styling neutrality (enforced, not aspirational)
+
+Review found the current widget uses ~40 hardcoded Tailwind classes, `next/link`,
+and an app-local `AnimatedLogo` import — it is not actually headless. The
+portability refactor is **gate-enforced** before any port ships:
+
+- **No `className` / hardcoded color in installed source.** Visual state via
+  `data-ak-*` only. `ComponentPort.stylingMode: 'data-attrs-only' | 'tailwind-preset'`.
+- Tokens ship as **plain CSS** (`--ak-*`) plus a structured `cssVars` block
+  (`{ light?, dark? }`) the CLI **merges** into the project's CSS entry — not a
+  wholesale append. Keyframes ship as `styling.css: RegistryFile[]`.
+- Cross-app imports are **inlined** (the logo) or **slotted** (`linkComponent`
+  prop, default `<a>`) so non-Next ports work.
+
+### D9. Supply-chain integrity (enterprise trust)
+
+- **Pinned refs in production**: fetch from `/refs/tags/v<semver>/`, not `main`.
+  `main` only behind an explicit `--channel preview`.
+- **Per-file `sha256`** in the item manifest; the CLI verifies every file after
+  fetch and **aborts the whole install** on mismatch.
+- **Signed index manifest** (minisign/cosign detached signature) so the checksum
+  list itself can't be poisoned; CLI verifies the signature against a shipped
+  public key before trusting checksums.
+- **Configurable / private registry**: resolution order `--registry` →
+  `AGENTSKIT_REGISTRY_URL` → `components.json` `registries` map → default.
+  Identifier forms: `name`, `@org/name` (namespaced via the map), `https://…`.
+- **Proxy/CA aware** fetch (`HTTPS_PROXY`/`NO_PROXY`/`NODE_EXTRA_CA_CERTS`) with an
+  actionable error when blocked.
+- **Audit**: append `.agentskit/install-log.jsonl` (id, version, ref, files+sha,
+  timestamp) — the artifact a future `agentskit audit` consumes.
+
+### D10. Transactional, idempotent install
+
+- **Stage → verify → atomic commit.** Write to a temp dir, verify all files +
+  checksums, then move as one step. Any pre-commit failure → delete temp, roll back
+  partially-written files, report "rolled back N files." Never leave a dirty tree.
+- **Idempotent**: identical content → silent no-op. Modified-by-user + no `--update`
+  → skip with notice. Conflicts collected up front and resolved **per file**
+  (interactive prompt, or `--overwrite` for the set) — never the current
+  throw-on-first-conflict.
+- **Secrets never via argv** — drop `--api-key`; read keys from env only.
+- **`--yes`** suppresses every prompt and exits non-zero (never hangs) on any
+  blocker.
+- **Runs the package manager** (`scan.packageManager add …`), not just prints it;
+  prompts unless `--yes`. Generates/append `.env.example` for required env.
+
+### D11. Versioning + machine-verifiable schema
+
+- Registry items carry `schemaVersion` and a semver `version`; CLI refuses a
+  `schemaVersion` it predates.
+- `ComponentPort.peerRanges: Record<string,string>` (e.g. `@agentskit/react: ">=2"`);
+  validator checks installed versions and blocks on mismatch.
+- All registry JSON + `components.json` carry `$schema` for editor/CI validation.
+
+### D12. TS ↔ JS parity
+
+`ComponentPort.language: 'ts' | 'js' | 'both'`. For `both`, parallel sources; else
+a type-strip + extension-rename transform at install when `scan.typescript ===
+false`. A TS-only component refuses to install into a JS project with a clear
+message rather than writing broken `.tsx`.
+
+### D13. Per-file targets + file types
+
+`RegistryFile` gains `target?` and `type` so a component's client file, server
+route, hook, lib, css, and test each land in the right place:
+
+```ts
+type RegistryFileType =
+  | 'registry:component' | 'registry:hook' | 'registry:lib'
+  | 'registry:route' | 'registry:page' | 'registry:css' | 'registry:test'
+
+interface RegistryFile {
+  path: string
+  type: RegistryFileType
+  sha256: string
+  target?: string        // overrides defaultTarget for this file
+  language?: 'ts' | 'js'
+  content?: string        // optional inline; else fetched per-file by `path` (D14)
+}
+```
+
+### D14. Per-file fetch, not monolithic inline
+
+Components fetch files **individually** (cacheable, small metadata, cheap `diff`)
+rather than inlining all content in one JSON like agents do. The item manifest
+lists files + `sha256`; content is fetched per path. Agents keep their current
+inline shape (back-compatible).
+
+### D15. Marker, update, list (shadcn-grade sync)
+
+`.agentskit/components.json` `installed[]` entries, keyed by `{ id, installPath }`
+(monorepo-safe), each recording `ref`, `version`, and a per-file
+`{ sha, installedAt }` map. This enables **3-way diff**:
+`local==installed` → safe update; `local!=installed && upstream!=installed` →
+conflict, show diff + prompt; `local!=installed && upstream==installed` → skip.
+Commands: `agentskit diff <name>`, `agentskit update <name>`, `agentskit
+components list` (all installed + sync status). `registryDependencies` resolve via
+topological sort with **cycle detection** and a depth cap; dedup by `id` against
+the marker.
+
+## Schema (consolidated)
+
+```ts
+type RegistryItem = RegistryAgent | RegistryComponent  // discriminated on `kind`
 
 interface RegistryComponent {
+  $schema: string
+  schemaVersion: number
   kind: 'component'
-  id: string                       // 'docs-chat'
+  id: string
+  version: string                    // semver
   title: string
   description: string
-  category: string                 // 'chat' | 'input' | …
-
-  /** Frameworks this component ships a port for. */
-  frameworks: Framework[]          // ['react','next','svelte','vue','angular','react-native','ink']
-
-  /** Per-framework file sets. The scanner picks the matching entry. */
-  ports: Record<Framework, ComponentPort>
-
-  /** npm deps common to every port (per-port deps add to these). */
-  packages: string[]              // ['@agentskit/rag','@agentskit/adapters']
-  env?: RegistryEnvVar[]          // e.g. OPENROUTER_API_KEY (required)
+  category: string                   // 'chat' | …
+  frameworks: FrameworkTarget[]      // declared, not implied
+  ports: Record<string, ComponentPort>  // key = `${uiBinding}:${metaFramework}` or `${uiBinding}`
+  packages: string[]                 // common npm deps
+  peerRanges?: Record<string, string>
+  env?: RegistryEnvVar[]
 }
 
 interface ComponentPort {
-  /** Files relative to the chosen install dir; sources inlined like agents. */
-  files: string[]
-  sources: RegistryFile[]         // { path, content }[]
-  /** Extra npm deps for this framework only. */
+  uiBinding: UiBinding
+  language: 'ts' | 'js' | 'both'
+  stylingMode: 'data-attrs-only' | 'tailwind-preset'
+  streamingProtocol: 'ndjson' | 'sse' | 'both'
+  files: RegistryFile[]
+  testFiles?: RegistryFile[]
   packages?: string[]
   devPackages?: string[]
-  /** Other registry items this port needs (resolved + installed first). */
+  peerRanges?: Record<string, string>
   registryDependencies?: string[]
-  /** Default install dir, framework-idiomatic; overridable by scan/prompt/--out. */
-  defaultTarget: string           // react: 'components/ask', angular: 'src/app/ask'
-  /** Styling requirements the validator checks/applies. */
+  defaultTarget: string
+  server?: PortServer
   styling?: {
-    tailwind?: boolean
-    cssVars?: string[]            // '--ak-*' tokens the component expects
-    globalCss?: RegistryFile      // optional css to append (e.g. keyframes)
+    cssVars?: { light?: Record<string, string>; dark?: Record<string, string> }
+    css?: RegistryFile[]             // keyframes / token files, merged not appended
   }
 }
-```
 
-`RegistryFile` (`{ path, content }`) and `RegistryEnvVar` are reused verbatim.
-
-### 2. Project scanner contract
-
-A pure, dependency-light module that inspects the cwd and returns a `ProjectScan`.
-No network, no writes. Tested with an injectable fs (mirrors the registry client's
-`fetchImpl`/`writeFileImpl` style).
-
-```ts
-interface ProjectScan {
-  framework: Framework | 'unknown'   // from deps: next, react, svelte, @angular/core, react-native, ink…
-  packageManager: 'npm' | 'pnpm' | 'yarn' | 'bun'   // from lockfile
-  typescript: boolean                // tsconfig.json present
-  srcDir: string | null              // 'src' if present, else project root
-  importAlias: string | null         // from tsconfig "paths" (e.g. '@/*' → '@')
-  styling: { tailwind: boolean; cssEntry: string | null }
-  appRouter?: boolean                // Next: app/ vs pages/
+interface RegistryEnvVar {
+  name: string
+  description: string
+  required?: boolean
+  scope?: 'server' | 'client' | 'build'   // server-only keys never bundled client-side
 }
 ```
 
-Detection rules (deterministic, documented in the implementation PR):
-framework from `package.json` deps → lockfile → tsconfig → styling. Ambiguous or
-missing signals resolve to `'unknown'`/`null` and surface in the validator, never
-a silent guess.
+`ProjectScan` (when `components.json` absent): `{ uiBinding, metaFramework,
+packageManager, typescript, srcDir, importAlias, styling:{mode,cssEntry},
+monorepo:{tool,root}|null }`. Ambiguous signals resolve to `unknown`/`null` and
+surface in validation — never a silent guess.
 
-### 3. Validator + add/validate flow
+## Install flow (enterprise)
 
-`agentskit add <name>`:
-
-1. **Fetch** the item (hosted → raw fallback, existing path).
-2. **Branch on `kind`.** `agent` → today's `addAgent` (unchanged). `component` →
-   continue.
-3. **Scan** the project (§2).
-4. **Validate**:
-   - `scan.framework` ∈ `component.frameworks`? If not → fail with the list of
-     supported frameworks and the detected one. No partial install.
-   - styling: if the port needs tailwind and the scan finds none → warn + print
-     the manual step (do not hard-fail; the component still renders with the
-     `--ak-*` tokens documented).
-   - env: list required `env` vars the user must set.
-5. **Resolve placement**: `--out` > interactive prompt (default =
-   `port.defaultTarget`, joined under `scan.srcDir`/alias). `--yes` skips the
-   prompt and takes the default (CI-friendly).
-6. **Resolve `registryDependencies`** recursively, install those components first.
-7. **Write** `port.sources` (refuse to clobber without `--force`, existing rule);
-   append `styling.globalCss` if present.
-8. **Report**: files written, `npm/pnpm/yarn install <packages>`, required env,
-   and a one-line "ready" usage snippet for the detected framework.
-
-`agentskit add <name> --dry-run` prints the plan (framework, target, files, deps)
-without writing — the scan/validate output as a preview.
-
-### 4. Per-framework port contract
-
-Each component publishes a `ComponentPort` per supported framework. A port is
-**self-contained and idiomatic**: it composes that framework's `@agentskit/*`
-binding (`useChat` for react/vue/solid/svelte, the Ink components for terminal),
-uses only `data-ak-*` + `--ak-*` tokens (headless, no hardcoded colors — matches
-the framework convention in CLAUDE.md), and ships no styles beyond the optional
-`globalCss`.
-
-Port parity is **declared, not implied**: a component lists only the frameworks
-it actually ships. `docs-chat` ships `react` + `next` first (the live widget);
-svelte/vue/angular/react-native/ink are added as ports land, each gated by the
-binding's stability tier (RFC-0004). The CLI never offers a framework a component
-hasn't shipped.
-
-### 5. Update path
-
-`agentskit diff <name>` / update already exists for agents (`diffAgent` +
-`lineDiff`). For components it diffs against the **active port** at the recorded
-install dir. The install writes a tiny `.agentskit/components.json` marker
-(`{ id, framework, target }`) so update knows which port and where, without
-re-scanning.
+1. **Load config** (`components.json`); else scan + warn to run `init`.
+2. **Resolve identifier + registry** (D9): `name` / `@org/name` / URL → base URL.
+3. **Fetch item manifest** at the pinned ref; verify signature + `schemaVersion`.
+4. **Branch on `kind`** — `agent` → today's path (unchanged). `component` → on.
+5. **Validate** (D4/D5/D6/D11/D12): framework-target supported; `peerRanges`;
+   `runtimeRequirement` + `embeddingBackend` satisfiable; styling mode; env scope
+   (block a server-only key resolving into a client bundle); TS/JS.
+6. **Resolve `registryDependencies`** — topo sort, cycle-detect, dedup vs marker.
+7. **Plan**. `--dry-run [--json]` prints the full structured plan (files+targets,
+   deps, env, conflicts) using the **same pipeline** and exits — no writes.
+8. **Fetch files**, verify each `sha256`.
+9. **Stage → atomic commit** (D10); conflicts resolved per file.
+10. **Merge** `cssVars` into the CSS entry; write/append `.env.example`.
+11. **Write/update marker** + audit log (D9/D15) atomically.
+12. **Install packages** via the detected PM (prompt unless `--yes`).
+13. **Ready output** — per-framework usage snippet, required env, "run the indexer"
+    (D6), endpoint setup for `hosted`/`local`.
 
 ## The chat as the flagship
 
-`docs-chat` is the first and reference component. Its port files are the existing
-React widget set, refactored to be registry-portable:
-
-- `ask-widget.tsx` (headless compound shell), `useAskChat`, `Markdown`,
-  `registry` (allow-listed generative-UI render boundary)
-- `lib/ask/guard.ts` (the extensible triage + scope guard from #1013),
-  `lib/rag/*` (retriever + cited context), `lib/openrouter.ts` (free pool)
-- `app/api/ask-docs/route.ts` as a framework-appropriate server handler (Next
-  route handler for the `next` port; documented adapter for others)
-- `globalCss`: the `--ak-*` keyframes (loading dots, AI shimmer)
-
-Everything the user installs is theirs to edit — including the guardrail rules,
-which `triageMessage(query, extra)` already accepts additively.
+`docs-chat` is the reference component. First port = `react` × `next-app` (the
+live widget), shipped only **after** the D8 portability refactor (no `className`,
+inlined logo, slotted link, server core extracted to `createAskHandler`). Files:
+the headless compound shell + `useAskChat` + `Markdown` + allow-listed
+generative-UI registry (client); `createAskHandler` + the Next mount + guardrails
+(`lib/ask/guard.ts`, extensible per #1013) + retriever + free-pool adapter
+(server); the indexer + empty index stub; merged `--ak-*` tokens/keyframes.
+Everything is the user's to edit, including the guardrail rules.
 
 ## Alternatives considered
 
-- **Separate `agentskit ui add` namespace** — rejected per decision §1; one verb,
-  auto-detect is simpler for users and keeps RFC-0002's surface.
-- **A `@agentskit/registry` CLI package** — rejected by RFC-0002 already; extend
-  the existing CLI.
-- **Ship the chat as an installable npm package** — rejected: violates the "user
-  owns the source / shadcn-style" principle that makes the components forkable
-  and the guardrails extensible.
-- **Per-framework `create-*` scaffolds instead of `add`** — rejected: scaffolds
-  start new projects; `add` drops into existing ones, which is the adoption case.
+- **Separate `agentskit ui add`** — rejected (D1): one verb + explicit `kind`.
+- **`@agentskit/registry` CLI package** — rejected by RFC-0002; extend the CLI.
+- **Ship the chat as an npm package** — rejected: breaks user-owns-source / forkable
+  guardrails.
+- **Inline all file content (agent model) for components** — rejected (D14):
+  bloats the index, defeats per-file caching and cheap diff.
+- **Silent `kind` default to `'agent'`** — rejected (D1): explicit + validated.
+- **Single coarse `framework`** — rejected (D4): can't place server files.
 
-## Open questions
+## Open questions (genuine product calls — need your decision)
 
-1. **Server-side portability.** The chat's grounding route is a Next handler.
-   For non-Next React (Vite) and other frameworks, do we ship a framework-neutral
-   request handler the user mounts, or per-framework server adapters? (Leaning:
-   one neutral `handleAskRequest(req)` core + thin per-framework mounts.)
-2. **Embedding at install vs runtime.** The committed ONNX index (`gen-ask-index`)
-   is docs-specific. The component should ship the *indexer script* + an empty
-   index, not a corpus. Confirm the install copies the script and documents
-   "run it against your docs", not a prebuilt index.
-3. **Marker file location.** `.agentskit/components.json` vs per-component
-   frontmatter. (Leaning: single `.agentskit/components.json`.)
-4. **Framework rollout order** after react/next: svelte + vue (full `useChat`),
-   then angular + react-native (partial bindings — gated by RFC-0004), ink last.
+1. **Launch framework breadth.** Ship `react×next-app` first and expand, or block
+   the GA announcement until `sveltekit` + `nuxt` also ship? (Recommendation:
+   ship react/next first; each later port gated by RFC-0004 binding stability.)
+2. **Signing toolchain.** minisign (tiny, simple) vs cosign/Sigstore (heavier,
+   ecosystem-standard, keyless OIDC). (Recommendation: minisign now, cosign later.)
+3. **Stand up `registry.agentskit.io` (hosted + signed) now**, or run on
+   tag-pinned raw-GitHub + checksums until volume justifies hosting?
+4. **Default embedding for `hosted`/edge ports** — bundle a small `api-remote`
+   embedder (which provider?) or require the user to supply one?
+5. **Telemetry** — default off, opt-in `agentskit add --telemetry`? (Recommendation:
+   off by default.)
 
 ## Rollout (once accepted)
 
-1. **Contracts** — land `RegistryComponent` + scanner + validator types in the
-   CLI (no ports yet), behind the existing `add` command.
-2. **React/Next port** — make `docs-chat` registry-portable; first end-to-end
-   `agentskit add docs-chat` into a fresh Next app.
-3. **Scanner + interactive flow** — detection, validation, placement prompt,
-   `--dry-run`/`--yes`.
-4. **Second framework** (svelte) — proves the port contract generalizes.
-5. **Remaining ports** — vue, angular, react-native, ink, each gated by binding
-   stability (RFC-0004).
-6. Graduate the stable contracts (item schema, scanner) to an ADR.
+1. **Contracts** — land `RegistryComponent` + `FrameworkTarget` + scanner +
+   validator + `components.json` + `init` (no ports yet).
+2. **Integrity layer** — pinned refs, per-file sha256, signed manifest, configurable
+   registry, transactional install, marker + audit.
+3. **D8 portability refactor** of the chat (headless gate, server core extraction).
+4. **react × next-app port** — first end-to-end `agentskit add docs-chat`.
+5. **Scanner + interactive flow** — detection, validation, placement, `--dry-run`/
+   `--yes`, PM execution.
+6. **Second meta-framework (sveltekit)** — proves the port + server contract.
+7. **Remaining ports** — remix/tanstack, nuxt/vue, angular(-ssr/-spa), expo, ink —
+   each gated by binding stability (RFC-0004).
+8. Graduate the stable contracts (item schema, scanner, `components.json`) to an ADR.
+
+## Changelog
+
+- **v2** — closed enterprise-review blockers: `init`/`components.json` (D3),
+  two-level framework model (D4), server-handler delivery + neutral
+  `createAskHandler` (D5), embedding/index portability (D6), streaming negotiation
+  (D7), enforced styling neutrality (D8), supply-chain integrity — pinned refs,
+  per-file checksums, signed manifest, private registries, proxy/CA, audit (D9),
+  transactional/idempotent install + PM execution + secrets-not-in-argv (D10),
+  versioning + `$schema` (D11), TS/JS parity (D12), per-file targets/types (D13),
+  per-file fetch (D14), monorepo-safe marker + 3-way diff + `list` + cycle-safe
+  deps (D15). Open questions reduced to product calls.
+- **v1** — initial proposal: one-verb auto-detect, component schema, scanner,
+  per-framework ports, basic add/validate flow.

--- a/rfcs/0006-ui-component-registry.md
+++ b/rfcs/0006-ui-component-registry.md
@@ -1,7 +1,7 @@
 # RFC 0006 — UI component registry & shadcn-style `agentskit add`
 
 - **Status**: Proposed
-- **Version**: 2 (v1 → v2 hardened after adversarial enterprise review — see Changelog)
+- **Version**: 3 (v2 → v3 after a 6-lens consensus review — closes 2 BLOCKERs + the `AskConfig` cluster; see Changelog)
 - **Date**: 2026-06-18
 - **Author**: @EmersonBraun
 - **Related issues**: —
@@ -24,8 +24,9 @@ React/Next/Remix/TanStack, SvelteKit, Nuxt/Vue, Angular, React Native (Expo), an
 Ink.
 
 This RFC defines the **contracts** only. No implementation lands until accepted.
-v2 closes the blockers found in review; the **Resolved decisions** section is the
-core, **Open questions** now holds only genuine product calls.
+Two review rounds (v2, then a 6-lens consensus pass for v3) closed every BLOCKER;
+the **Resolved decisions** section is the core, **Open questions** now holds only
+genuine product calls.
 
 ## Motivation
 
@@ -37,8 +38,8 @@ detection, no placement, no server-handler delivery, no integrity verification.
 
 shadcn/ui proved the pattern that wins adoption — *init → scan → validate → copy →
 ready*, user owns the source. AgentsKit already has the registry client, the
-hosted-index + raw-GitHub fetch, and a line-diff updater. v2 reuses that and adds
-the contracts an enterprise flagship requires. Each install also pulls real
+hosted-index + raw-GitHub fetch, and a line-diff updater. This RFC reuses that and
+adds the contracts an enterprise flagship requires. Each install also pulls real
 downloads of the base packages the component composes.
 
 ## Resolved decisions (locked)
@@ -67,7 +68,10 @@ re-detecting.
 
 ```jsonc
 {
-  "$schema": "https://registry.agentskit.io/schema/components.json",
+  // v1 $schema is a versioned raw-GitHub tag URL so it resolves the day it ships,
+  // before registry.agentskit.io hosting exists; the hosted URL becomes an alias
+  // (redirect) once live, so no committed components.json ever needs to change it.
+  "$schema": "https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/v1/schema/components.json",
   "schemaVersion": 1,
   "uiBinding": "react",
   "metaFramework": "next-app",
@@ -77,6 +81,10 @@ re-detecting.
   "aliases": { "components": "@/components", "lib": "@/lib", "server": "@/app/api" },
   "paths": { "root": ".", "components": "components", "lib": "lib", "server": "app/api" },
   "registries": { "default": "https://registry.agentskit.io" },
+  // Private/enterprise registries: map a registry base URL → the ENV VAR NAME that
+  // holds its bearer token. The secret never lives in the committed file; the CLI
+  // injects `Authorization: Bearer <resolved-env>` for matching fetches.
+  "registryAuth": { "https://artifactory.acme.internal/agentskit": "ACME_REGISTRY_TOKEN" },
   "linkComponent": null
 }
 ```
@@ -84,6 +92,11 @@ re-detecting.
 In a monorepo `paths.*` anchor to a workspace package (`packages/ui/src/…`),
 resolved relative to the config file, not cwd. `init` detects `pnpm-workspace.yaml`
 / `turbo.json` / `nx.json` and prompts for the target package.
+
+The CLI reads the top-level `schemaVersion` and applies **forward-only**
+migrations, preserving unknown fields; `agentskit init --upgrade` rewrites the file
+to the current format. (Air-gapped/offline validators supply a local copy of the
+`$schema` file.)
 
 ### D4. Two-level framework model (so the server file lands correctly)
 
@@ -101,9 +114,14 @@ type MetaFramework =
 interface FrameworkTarget { uiBinding: UiBinding; metaFramework: MetaFramework }
 ```
 
-The scanner produces **both**. UI files key on `uiBinding`; server files key on
-`metaFramework`. The CLI never offers a `(uiBinding, metaFramework)` pair a
-component hasn't shipped.
+The scanner produces **both**. **The `ports` map is keyed by `uiBinding` alone**;
+the correct server mount file within a port is selected by
+`server.serverTargetByMeta[metaFramework]` (D5). The CLI builds the lookup key as
+`scan.uiBinding` and rejects the install if `ports` has no matching key. A
+publish-time validator rejects any `ports` key that is not a bare `UiBinding`
+literal (the compound `${uiBinding}:${metaFramework}` form is **not** allowed — it
+was ambiguous and is removed). The CLI never offers a
+`(uiBinding, metaFramework)` pair a component hasn't shipped.
 
 ### D5. Server-handler delivery contract (resolves v1 open Q1)
 
@@ -115,7 +133,40 @@ per-meta-framework mounts. The core is a **Web-standard handler**:
 export function createAskHandler(config: AskConfig): (req: Request) => Promise<Response>
 ```
 
-Per-`metaFramework` mount files adapt it (Next route handler, SvelteKit
+`AskConfig` is the runtime contract every mount wraps. It carries the **security
+envelope**, a **pluggable rate-limiter**, and **observability hooks** — so the four
+runtime concerns (handler security, rate-limit extensibility, telemetry, structured
+429/decline events) are one type, not per-port reinvention:
+
+```ts
+interface AskConfig {
+  retriever: Retriever
+  adapter: Adapter                       // free-pool fallback chain, etc.
+  // — security envelope (explicit defaults; locked in production) —
+  security?: {
+    rateLimit?: { windowSec: number; max: number }   // default 60s / 10 req, in-memory
+    bearerToken?: string                  // optional shared-secret auth
+    corsOrigins?: string[]                // default ['*'] in dev, MUST be set in prod
+    maxBodyBytes?: number                 // default 32_768
+  }
+  // — pluggable limiter; default = the in-memory limiter (process-local, see note) —
+  rateLimiter?: (req: Request) => Promise<{ ok: boolean; retryAfterSec?: number }>
+  // — observability; default no-op, each emits one structured JSON line —
+  hooks?: ObservabilityHooks
+}
+
+interface ObservabilityHooks {
+  onRateLimit?(ip: string, retryAfterSec: number): void
+  onScopeDecline?(ip: string, reason: string, queryHash: string): void
+  onError?(err: unknown, ctx: { stage: string }): void
+}
+```
+
+> The default `rateLimiter` is **process-local** — correct for a single Node
+> server, ineffective across serverless cold-starts / replicas. Ports declare this
+> via `PortServer.rateLimitBackend` and the installer warns (below).
+
+Per-`metaFramework` mount files adapt the handler (Next route handler, SvelteKit
 `+server.ts`, Nuxt `server/api/*.post.ts`, Remix `action`, Express middleware for
 `angular-ssr`, a local Node server for `ink`). The `ComponentPort.server` field
 declares delivery:
@@ -129,13 +180,34 @@ interface PortServer {
   serverTargetByMeta?: Partial<Record<MetaFramework, string>>
   runtimeRequirement: 'nodejs' | 'edge-compatible' | 'none'
   embeddingBackend: 'onnx-node' | 'api-remote' | 'browser-wasm' | 'none'
-  endpointEnvVar?: string  // for hosted/local: e.g. AGENTSKIT_ASK_ENDPOINT
+  rateLimitBackend: 'memory' | 'external-required'  // serverless-capable ⇒ warn if 'memory'
+  endpointEnvVar?: string       // hosted/local server-side endpoint, e.g. AGENTSKIT_ASK_ENDPOINT
+  clientEndpointProp?: string   // the hook/component prop that receives the runtime endpoint URL
+  securityHeaders?: Record<string, string>  // advisory CSP etc. (see D8/flagship)
+  bundleSizeKb?: number         // optional cold-start budget tooling can assert
 }
 ```
 
 The validator refuses an install whose `runtimeRequirement`/`embeddingBackend` the
 detected target can't satisfy (e.g. `onnx-node` on `expo`/edge) — with a concrete
 message and the supported alternative, never a silent broken install.
+
+**`serverTargetByMeta` is authoritative** for the matched `metaFramework`;
+`components.json` `paths.server` is the project default applied **only** when
+`serverTargetByMeta` has no entry for the detected `metaFramework`. When both are
+set and disagree, the installer emits a non-blocking warning so the developer
+reconciles consciously.
+
+**Client endpoint injection.** `endpointEnvVar` is server-side. Ports whose client
+must reach a runtime/deployed endpoint (Remix resource routes, TanStack Start, pure
+SPA, `angular-spa`, Expo — anything not served from a predictable
+`NEXT_PUBLIC_*`-style build var) MUST declare `clientEndpointProp` (the hook /
+component prop, e.g. `endpointUrl`; a `configureAskChat({ endpoint })` factory is an
+acceptable equivalent) and print a usage snippet passing it.
+
+**`delivery: 'local'`** runtime lifecycle (process management, port resolution,
+health-check, SIGTERM propagation) is **out of scope** for this RFC and must be
+specified as a `LocalServerSpec` before the Ink port (Rollout step 7) ships.
 
 ### D6. Embedding + index portability (resolves v1 open Q2)
 
@@ -172,28 +244,78 @@ portability refactor is **gate-enforced** before any port ships:
 - Cross-app imports are **inlined** (the logo) or **slotted** (`linkComponent`
   prop, default `<a>`) so non-Next ports work.
 
+**Enforcement** is a named gate, not a comment: `check:registry-headless`
+(`scripts/check-registry-headless.mjs`) grep/AST-fails on `className=`, hardcoded
+color literals, `next/*` imports, and `@/components/brand/*` imports in
+`registry:component` / `registry:route` **source** files (authoring-time, in the
+registry repo — not installed output). It is wired into `pnpm
+check:quality-gates` and is a **merge precondition** for the first port.
+
+#### D8a. CSS-merge contract (deterministic, diff-able)
+
+"Merge `cssVars` into the CSS entry" has one machine-readable algorithm so two CLI
+implementations produce identical output and the D15 3-way diff for CSS has a
+foundation:
+
+- **Selectors**: `light` tokens → `:root`; `dark` tokens →
+  `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`.
+- **Block markers**: each installed block is delimited by
+  `/* agentskit:<id>:start */ … /* agentskit:<id>:end */` so it can be located,
+  replaced, or removed idempotently.
+- **Conflict policy**: duplicate `--ak-*` token names → last-writer-wins with a
+  `--verbose` warning.
+- **Keyframes** are namespaced `ak-<componentId>-<name>` to avoid collisions.
+
 ### D9. Supply-chain integrity (enterprise trust)
 
 - **Pinned refs in production**: fetch from `/refs/tags/v<semver>/`, not `main`.
   `main` only behind an explicit `--channel preview`.
 - **Per-file `sha256`** in the item manifest; the CLI verifies every file after
   fetch and **aborts the whole install** on mismatch.
-- **Signed index manifest** (minisign/cosign detached signature) so the checksum
-  list itself can't be poisoned; CLI verifies the signature against a shipped
-  public key before trusting checksums.
+- **Signed index manifest** — a **minisign** detached signature (Ed25519) so the
+  checksum list itself can't be poisoned; the CLI verifies it against a shipped
+  Ed25519 public key embedded in the CLI binary before trusting checksums. (cosign/
+  Sigstore keyless is deferred to a future ADR — it has no shipped key and needs
+  outbound TLS to Fulcio/Rekor, which breaks air-gapped installs.)
+- **Key distribution + rotation**: the CLI ships a bootstrap key; at install it
+  fetches `keys.json` listing active keys (`kid` + `publicKey` + `validFrom` +
+  optional `validUntil`). The signed manifest carries a `kid`. Two keys overlap for
+  a rotation window (**≥ 30 days**); the CLI **warns** (not blocks) as the active
+  key nears expiry.
 - **Configurable / private registry**: resolution order `--registry` →
   `AGENTSKIT_REGISTRY_URL` → `components.json` `registries` map → default.
   Identifier forms: `name`, `@org/name` (namespaced via the map), `https://…`.
+  Private-registry credentials resolve **only** via `components.json` `registryAuth`
+  (base URL → env-var name) + env — a `--registry-token` argv flag is **prohibited**
+  for the same reason `--api-key` is (D10).
 - **Proxy/CA aware** fetch (`HTTPS_PROXY`/`NO_PROXY`/`NODE_EXTRA_CA_CERTS`) with an
   actionable error when blocked.
-- **Audit**: append `.agentskit/install-log.jsonl` (id, version, ref, files+sha,
-  timestamp) — the artifact a future `agentskit audit` consumes.
+- **Audit**: append `.agentskit/install-log.jsonl`, an **append-only, tamper-evident**
+  chain. Each entry:
+  ```ts
+  interface AuditEntry {
+    schemaVersion: 1
+    eventType: 'install' | 'update' | 'remove' | 'rollback'
+    id: string; version: string; ref: string
+    files: Array<{ path: string; sha256: string }>
+    manifestSigRef: string            // correlates to the verified signed manifest
+    prevEntryHash: string             // sha256 of the canonical prior entry ('' for first)
+    timestamp: string
+  }
+  ```
+  A future `agentskit audit` walks the `prevEntryHash` chain and fails on any
+  gap/mismatch. (Retention window, HMAC, and the `audit` command itself are deferred
+  to a follow-on ADR.)
 
 ### D10. Transactional, idempotent install
 
 - **Stage → verify → atomic commit.** Write to a temp dir, verify all files +
   checksums, then move as one step. Any pre-commit failure → delete temp, roll back
   partially-written files, report "rolled back N files." Never leave a dirty tree.
+  The staging temp dir is a **sibling of the target** (`target/../.agentskit-tmp-<uuid>/`),
+  not `os.tmpdir()`, so `rename(2)` stays atomic (same filesystem); on `EXDEV` the
+  CLI falls back to copy-then-delete and warns atomicity is best-effort. (The npm/
+  pnpm/Yarn pattern.)
 - **Idempotent**: identical content → silent no-op. Modified-by-user + no `--update`
   → skip with notice. Conflicts collected up front and resolved **per file**
   (interactive prompt, or `--overwrite` for the set) — never the current
@@ -209,8 +331,15 @@ portability refactor is **gate-enforced** before any port ships:
 - Registry items carry `schemaVersion` and a semver `version`; CLI refuses a
   `schemaVersion` it predates.
 - `ComponentPort.peerRanges: Record<string,string>` (e.g. `@agentskit/react: ">=2"`);
-  validator checks installed versions and blocks on mismatch.
-- All registry JSON + `components.json` carry `$schema` for editor/CI validation.
+  validator checks installed versions and blocks on mismatch. **Port-level overrides
+  component-level** for the same key (more-specific wins); `peerRanges` from all
+  resolved `registryDependency` ports are collected into **one** set and conflicts
+  surfaced in aggregate at the dry-run (step 7), not on first hit. The validator
+  treats any resolved version beginning with `workspace:` as **always-satisfying**
+  (the version is repo-owner-controlled and guaranteed present — avoids false-blocks
+  for monorepo contributors).
+- All registry JSON + `components.json` carry `$schema` (a versioned raw-GitHub tag
+  URL in v1; hosted alias later — see D3) for editor/CI validation.
 
 ### D12. TS ↔ JS parity
 
@@ -230,7 +359,7 @@ type RegistryFileType =
   | 'registry:route' | 'registry:page' | 'registry:css' | 'registry:test'
 
 interface RegistryFile {
-  path: string
+  path: string           // publish-time validated: no absolute paths, no `..` segments (D16)
   type: RegistryFileType
   sha256: string
   target?: string        // overrides defaultTarget for this file
@@ -258,6 +387,19 @@ components list` (all installed + sync status). `registryDependencies` resolve v
 topological sort with **cycle detection** and a depth cap; dedup by `id` against
 the marker.
 
+### D16. Path containment (no write-escape)
+
+`sha256` verifies content, the signed manifest verifies the checksum list, and
+stage→atomic-commit verifies completeness — but none constrain **where** a file is
+written. A valid-checksum entry with `path: '../../.env'` would escape the target
+via `path.join`. Therefore:
+
+- For every file, after `dest = join(targetDir, file.path)` the CLI MUST assert
+  `path.resolve(dest).startsWith(path.resolve(targetDir) + path.sep)` and throw
+  `IntegrityError` otherwise. **The same guard applies on the `diff` read path.**
+- `RegistryFile.path` is **publish-time validated** to reject absolute paths and any
+  `..` segment.
+
 ## Schema (consolidated)
 
 ```ts
@@ -273,7 +415,7 @@ interface RegistryComponent {
   description: string
   category: string                   // 'chat' | …
   frameworks: FrameworkTarget[]      // declared, not implied
-  ports: Record<string, ComponentPort>  // key = `${uiBinding}:${metaFramework}` or `${uiBinding}`
+  ports: Record<UiBinding, ComponentPort>  // key = uiBinding alone; server file picked via server.serverTargetByMeta[metaFramework] (D4)
   packages: string[]                 // common npm deps
   peerRanges?: Record<string, string>
   env?: RegistryEnvVar[]
@@ -317,19 +459,30 @@ surface in validation — never a silent guess.
 2. **Resolve identifier + registry** (D9): `name` / `@org/name` / URL → base URL.
 3. **Fetch item manifest** at the pinned ref; verify signature + `schemaVersion`.
 4. **Branch on `kind`** — `agent` → today's path (unchanged). `component` → on.
-5. **Validate** (D4/D5/D6/D11/D12): framework-target supported; `peerRanges`;
-   `runtimeRequirement` + `embeddingBackend` satisfiable; styling mode; env scope
-   (block a server-only key resolving into a client bundle); TS/JS.
-6. **Resolve `registryDependencies`** — topo sort, cycle-detect, dedup vs marker.
+5. **Validate** (D4/D5/D6/D11/D12/D16): lookup key = `scan.uiBinding`, reject if no
+   matching port; framework-target supported; `peerRanges`; `runtimeRequirement` +
+   `embeddingBackend` satisfiable; styling mode; env scope (block a server-only key
+   resolving into a client bundle); TS/JS. **Warn** (non-blocking) when
+   `paths.server` disagrees with `serverTargetByMeta[metaFramework]`, and when a
+   serverless-capable `metaFramework` ships `rateLimitBackend: 'memory'` (naming
+   `UPSTASH_REDIS_REST_URL` / `_TOKEN` + a setup link).
+6. **Resolve `registryDependencies`** — topo sort, cycle-detect, dedup vs marker;
+   collect all port `peerRanges` into one set (D11).
 7. **Plan**. `--dry-run [--json]` prints the full structured plan (files+targets,
-   deps, env, conflicts) using the **same pipeline** and exits — no writes.
-8. **Fetch files**, verify each `sha256`.
-9. **Stage → atomic commit** (D10); conflicts resolved per file.
-10. **Merge** `cssVars` into the CSS entry; write/append `.env.example`.
-11. **Write/update marker** + audit log (D9/D15) atomically.
+   deps, env, conflicts, aggregate peer-range conflicts) using the **same pipeline**
+   and exits — no writes.
+8. **Fetch files**, verify each `sha256`; assert path containment (D16) before any
+   write.
+9. **Stage → atomic commit** (D10), path-containment re-checked; conflicts resolved
+   per file.
+10. **Merge** `cssVars` into the CSS entry per the D8a algorithm; write/append
+    `.env.example`.
+11. **Write/update marker** + tamper-evident audit entry (D9/D15) atomically.
 12. **Install packages** via the detected PM (prompt unless `--yes`).
 13. **Ready output** — per-framework usage snippet, required env, "run the indexer"
-    (D6), endpoint setup for `hosted`/`local`.
+    (D6); for non-Next/`hosted` ports a snippet passing `clientEndpointProp`; a CSP
+    notice when `embeddingBackend === 'browser-wasm'` or a web-worker backend is used
+    (required `worker-src blob:` / scoped `connect-src`).
 
 ## The chat as the flagship
 
@@ -341,6 +494,12 @@ generative-UI registry (client); `createAskHandler` + the Next mount + guardrail
 (`lib/ask/guard.ts`, extensible per #1013) + retriever + free-pool adapter
 (server); the indexer + empty index stub; merged `--ak-*` tokens/keyframes.
 Everything is the user's to edit, including the guardrail rules.
+
+The flagship's default `webWorkerBackend` (runnable snippets) spawns a worker via
+blob URL with `fetch` access. Bundled handlers MUST document the required
+`Content-Security-Policy` directives (`worker-src blob:`, scoped `connect-src`), and
+any `WebWorkerBackend` option exposes `allowNetwork: boolean` **defaulting to
+false** — resolved before the `react × next-app` port ships (Rollout step 4).
 
 ## Alternatives considered
 
@@ -358,22 +517,28 @@ Everything is the user's to edit, including the guardrail rules.
 1. **Launch framework breadth.** Ship `react×next-app` first and expand, or block
    the GA announcement until `sveltekit` + `nuxt` also ship? (Recommendation:
    ship react/next first; each later port gated by RFC-0004 binding stability.)
-2. **Signing toolchain.** minisign (tiny, simple) vs cosign/Sigstore (heavier,
-   ecosystem-standard, keyless OIDC). (Recommendation: minisign now, cosign later.)
-3. **Stand up `registry.agentskit.io` (hosted + signed) now**, or run on
-   tag-pinned raw-GitHub + checksums until volume justifies hosting?
-4. **Default embedding for `hosted`/edge ports** — bundle a small `api-remote`
+2. **Default embedding for `hosted`/edge ports** — bundle a small `api-remote`
    embedder (which provider?) or require the user to supply one?
-5. **Telemetry** — default off, opt-in `agentskit add --telemetry`? (Recommendation:
-   off by default.)
+3. **Telemetry** — default off, opt-in `agentskit add --telemetry`? (Recommendation:
+   off by default.) The wire contract is already `ObservabilityHooks` (D5) — this OQ
+   is only the default + provider, not the surface.
+
+**Resolved in v3** (were open in v2): signing = **minisign Ed25519**, cosign
+deferred (D9). `$schema` = a **versioned raw-GitHub tag URL**, hosted
+`registry.agentskit.io` becomes an alias once live (D3/D11) — so standing up hosting
+is no longer a blocker for Rollout step 1; it can follow on its own timeline.
 
 ## Rollout (once accepted)
 
 1. **Contracts** — land `RegistryComponent` + `FrameworkTarget` + scanner +
    validator + `components.json` + `init` (no ports yet).
-2. **Integrity layer** — pinned refs, per-file sha256, signed manifest, configurable
-   registry, transactional install, marker + audit.
-3. **D8 portability refactor** of the chat (headless gate, server core extraction).
+2. **Integrity layer** — pinned refs, per-file sha256, signed (minisign) manifest +
+   `keys.json` rotation, configurable/auth'd registry, **path-containment guard
+   (D16) on write and diff read**, transactional install, tamper-evident marker +
+   audit.
+3. **D8 portability refactor** of the chat — `check:registry-headless` must pass
+   before the `react × next-app` port merges; server core extraction to
+   `createAskHandler(AskConfig)`; **dynamic (request-time) index import**.
 4. **react × next-app port** — first end-to-end `agentskit add docs-chat`.
 5. **Scanner + interactive flow** — detection, validation, placement, `--dry-run`/
    `--yes`, PM execution.
@@ -384,6 +549,22 @@ Everything is the user's to edit, including the guardrail rules.
 
 ## Changelog
 
+- **v3** — 6-lens consensus review (53 agents). Closed both BLOCKERs:
+  **ports-map key grammar** locked to `uiBinding` alone (D4/Schema) and a
+  **path-containment guard** added (new D16, on write + diff read, publish-time
+  `..`/abs-path rejection). Resolved the **`AskConfig` cluster** — defined
+  `AskConfig` + `ObservabilityHooks` (security envelope, pluggable `rateLimiter`,
+  telemetry hooks) in D5, collapsing 5 findings into one. Also: `rateLimitBackend` /
+  `clientEndpointProp` / `securityHeaders` / `bundleSizeKb` on `PortServer`;
+  `serverTargetByMeta` vs `paths.server` precedence; **D8a** CSS-merge algorithm;
+  D8 enforcement gate `check:registry-headless`; minisign Ed25519 + `keys.json`
+  rotation, cosign deferred (resolves a v2 contradiction); `registryAuth` + a
+  `--registry-token` ban; sibling temp-dir + EXDEV fallback (D10); tamper-evident
+  audit-chain schema (D9); per-file `peerRanges` merge order + `workspace:`
+  always-satisfy; `$schema` pinned to a versioned raw-GitHub URL (unblocks Rollout);
+  web-worker CSP/`allowNetwork`; `components.json` forward-migration;
+  `LocalServerSpec` (Ink) scoped out explicitly. Open questions down to 3 product
+  calls. Readiness per panel: 62→ (after these) no remaining BLOCKER.
 - **v2** — closed enterprise-review blockers: `init`/`components.json` (D3),
   two-level framework model (D4), server-handler delivery + neutral
   `createAskHandler` (D5), embedding/index portability (D6), streaming negotiation

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -27,3 +27,4 @@ An RFC may grow into an ADR once the decision is committed and implemented.
 | [0003](./0003-oss-akos-boundary.md) | OSS / AKOS product boundary | Accepted |
 | [0004](./0004-framework-binding-stability.md) | Framework binding stability (beta → stable) | Proposed |
 | [0005](./0005-agent-progress-events.md) | Agent progress events + headless progress renderer | Proposed |
+| [0006](./0006-ui-component-registry.md) | UI component registry & shadcn-style `agentskit add` | Proposed |


### PR DESCRIPTION
## RFC 0006 — Proposed (v3)

shadcn-style, enterprise-grade `agentskit add <name>` for UI components — the Ask-the-docs chat as flagship, plug-and-play across react/next/remix/tanstack/sveltekit/nuxt/vue/angular/react-native/ink.

### Hardening trail
- **v1** — one-verb auto-detect, component schema, scanner, per-framework ports.
- **v2** — closed first-round enterprise blockers: `init`/`components.json`, two-level framework model, server-handler delivery, embedding/index portability, supply-chain integrity, transactional install, versioning, TS/JS parity, per-file targets, marker/diff/list.
- **v3** — **6-lens consensus review (53-agent workflow: independent reviews → adversarial gap verification → architect consensus)**. Closed both remaining BLOCKERs and the `AskConfig` cluster.

### v3 closes (consensus verdict: no remaining BLOCKER)
- **BLOCKER** ports-map key locked to `uiBinding` alone (server file selected via `serverTargetByMeta[metaFramework]`) — was ambiguous.
- **BLOCKER** new **D16 path-containment** guard (write + diff read; publish-time reject of abs paths / `..`) — closes a write-escape vector that valid checksums don't catch.
- **AskConfig cluster** — defined `AskConfig` + `ObservabilityHooks` (security envelope, pluggable `rateLimiter`, telemetry hooks); collapsed 5 findings into one type.
- PortServer: `rateLimitBackend` / `clientEndpointProp` / `securityHeaders` / `bundleSizeKb`; `serverTargetByMeta` vs `paths.server` precedence.
- D8a deterministic CSS-merge algorithm; D8 `check:registry-headless` enforcement gate.
- Supply-chain: minisign Ed25519 + `keys.json` rotation (cosign deferred — resolves a v2 contradiction); `registryAuth` + `--registry-token` ban; tamper-evident audit chain; sibling temp-dir + EXDEV fallback.
- `peerRanges` merge order + `workspace:` always-satisfy; `$schema` pinned to a versioned URL (unblocks rollout); web-worker CSP/`allowNetwork`; `components.json` forward-migration; `LocalServerSpec` (Ink) explicitly scoped out.

Open questions reduced to **3 product calls**: launch framework breadth, edge/`hosted` embedder, telemetry default.

Related: #1010, #1013, RFC-0002, RFC-0004.