### PR TITLE
fix(ink): strip ANSI from progress duration in plain mode

### DIFF
--- a/.changeset/progress-observer-plain-duration.md
+++ b/.changeset/progress-observer-plain-duration.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/ink": patch
+---
+
+Fix `createProgressObserver`: the stage-duration segment (e.g. `(1.2s)`) carried raw ANSI escape codes even in `plain` mode, leaving `\x1b[2m…\x1b[0m` in non-TTY/CI logs. The duration now uses the same plain-aware codes as the rest of the line.

--- a/packages/ink/src/progress-observer.ts
+++ b/packages/ink/src/progress-observer.ts
@@ -67,12 +67,14 @@ export function createProgressObserver(options: ProgressObserverOptions = {}): O
       stop()
       const sym = event.status === 'ok' ? '✓' : event.status === 'error' ? '⛔' : '–'
       const color = event.status === 'ok' ? C.green : event.status === 'error' ? C.red : C.yellow
-      const time = event.durationMs ? ` ${C.dim}(${(event.durationMs / 1000).toFixed(1)}s)${C.reset}` : ''
       const cr = plain ? '' : '\r'
       const clr = plain ? '' : '\x1b[K' // clear to EOL so a long spinner line leaves no leftover chars
       const c = plain ? '' : color
       const r = plain ? '' : C.reset
       const d = plain ? '' : C.dim
+      // Build `time` from the plain-aware codes too — otherwise the duration keeps
+      // raw ANSI in non-TTY/CI logs, defeating the whole point of `plain`.
+      const time = event.durationMs ? ` ${d}(${(event.durationMs / 1000).toFixed(1)}s)${r}` : ''
       write(`${cr}  ${c}${sym}${r} ${label} ${d}${event.detail ?? ''}${r}${time}${clr}\n`)
     },
   }

--- a/packages/ink/tests/progress-observer.test.ts
+++ b/packages/ink/tests/progress-observer.test.ts
@@ -19,4 +19,18 @@ describe('createProgressObserver', () => {
     expect(text).toContain('⛔')
     expect(text).not.toContain('llm:start')
   })
+
+  it('emits no ANSI escapes in plain mode — including around the duration', () => {
+    const out: string[] = []
+    const obs = createProgressObserver({ write: (s) => out.push(s), plain: true })
+
+    obs.on({ type: 'progress', label: 'classify', status: 'start' })
+    obs.on({ type: 'progress', label: 'classify', status: 'ok', detail: 'done', durationMs: 1200 })
+
+    const text = out.join('')
+    // The duration used to carry raw \x1b[2m … \x1b[0m even in plain mode.
+    expect(text).toContain('(1.2s)')
+    // eslint-disable-next-line no-control-regex
+    expect(text).not.toMatch(/\x1b\[/)
+  })
 })


### PR DESCRIPTION
## Bug

`createProgressObserver` builds most of its output line from `plain`-aware codes (color/dim/reset all collapse to `''` when `plain`), **but the duration segment hard-coded the escapes**:

```ts
const time = event.durationMs ? ` ${C.dim}(${…}s)${C.reset}` : ''
```

So in non-TTY / CI logs — exactly where `plain` auto-engages — every resolved line still got raw `\x1b[2m(1.2s)\x1b[0m`. Defeats the purpose of plain mode (clean piped logs).

Caught dogfooding: a nightly cron writes the renderer to a `cron.log` and the durations came out as `[2m(33.2s)[0m`.

## Fix

Build `time` from the same plain-aware `d`/`r` locals as the rest of the line. One-line reorder. Added a test asserting plain output contains **no** `\x1b[` escapes (would fail before this change).

## Validation

`vitest run packages/ink/tests/progress-observer.test.ts` — 2/2 pass. Changeset: `@agentskit/ink` patch.