### PR TITLE
feat(docs-chat): request-time index import (RFC-0006 D6)

### DIFF
--- a/apps/docs-next/lib/ask/guard.ts
+++ b/apps/docs-next/lib/ask/guard.ts
@@ -23,9 +23,11 @@
  * `sanitizeMessages` strips any client-supplied system role (we inject our own
  * grounded prompt) and caps both history length and per-message size.
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
 import type { EmbedFn, Message } from '@agentskit/core'
 import { embed as defaultEmbed } from '../rag/embed'
-import snapshot from '../ask-index/index.json'
 
 interface IndexRecord {
   embedding: number[]
@@ -62,14 +64,27 @@ function cosine(a: number[], b: number[]): number {
 }
 
 /**
+ * Load the committed index from disk on first call; cached thereafter.
+ * Using readFileSync with a runtime-resolved path keeps the 20 MB JSON out of
+ * the module-load graph (RFC-0006 D6 — cold-start / bundle optimisation).
+ */
+function loadIndexRecords(): IndexRecord[] {
+  const dir = dirname(fileURLToPath(import.meta.url))
+  const indexPath = join(dir, '../ask-index/index.json')
+  const raw = readFileSync(indexPath, 'utf8')
+  return (JSON.parse(raw) as IndexSnapshot).records ?? []
+}
+
+/**
  * Mean of all chunk embeddings, re-normalized. Computed once from the committed
- * index. Returns `undefined` when the index is empty (→ guard fails open).
+ * index (loaded lazily on first call). Returns `undefined` when the index is
+ * empty (→ guard fails open).
  */
 let cachedCentroid: number[] | null | undefined
 function corpusCentroid(): number[] | undefined {
   if (cachedCentroid !== undefined) return cachedCentroid ?? undefined
 
-  const records = (snapshot as unknown as IndexSnapshot).records ?? []
+  const records = loadIndexRecords()
   if (records.length === 0) {
     cachedCentroid = null
     return undefined

--- a/apps/docs-next/lib/ask/guard.ts
+++ b/apps/docs-next/lib/ask/guard.ts
@@ -23,9 +23,6 @@
  * `sanitizeMessages` strips any client-supplied system role (we inject our own
  * grounded prompt) and caps both history length and per-message size.
  */
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { join, dirname } from 'node:path'
 import type { EmbedFn, Message } from '@agentskit/core'
 import { embed as defaultEmbed } from '../rag/embed'
 
@@ -64,15 +61,14 @@ function cosine(a: number[], b: number[]): number {
 }
 
 /**
- * Load the committed index from disk on first call; cached thereafter.
- * Using readFileSync with a runtime-resolved path keeps the 20 MB JSON out of
- * the module-load graph (RFC-0006 D6 — cold-start / bundle optimisation).
+ * Load the committed index on first call; cached thereafter. The dynamic
+ * `import()` makes the JSON a lazily-loaded chunk — kept out of the module-load
+ * graph (RFC-0006 D6 cold-start win) while still bundled + shipped by the builder
+ * (no serverless file-resolution risk, unlike an `fs` read).
  */
-function loadIndexRecords(): IndexRecord[] {
-  const dir = dirname(fileURLToPath(import.meta.url))
-  const indexPath = join(dir, '../ask-index/index.json')
-  const raw = readFileSync(indexPath, 'utf8')
-  return (JSON.parse(raw) as IndexSnapshot).records ?? []
+async function loadIndexRecords(): Promise<IndexRecord[]> {
+  const mod = (await import('../ask-index/index.json')) as { default: IndexSnapshot }
+  return mod.default.records ?? []
 }
 
 /**
@@ -81,10 +77,10 @@ function loadIndexRecords(): IndexRecord[] {
  * empty (→ guard fails open).
  */
 let cachedCentroid: number[] | null | undefined
-function corpusCentroid(): number[] | undefined {
+async function corpusCentroid(): Promise<number[] | undefined> {
   if (cachedCentroid !== undefined) return cachedCentroid ?? undefined
 
-  const records = loadIndexRecords()
+  const records = await loadIndexRecords()
   if (records.length === 0) {
     cachedCentroid = null
     return undefined
@@ -123,7 +119,7 @@ export async function checkScope(query: string, options: ScopeOptions = {}): Pro
   const text = query.trim()
   if (text.length === 0) return { inScope: false, reason: 'empty query' }
 
-  const centroid = corpusCentroid()
+  const centroid = await corpusCentroid()
   if (!centroid) return { inScope: true }
 
   const threshold = options.threshold ?? ON_TOPIC_THRESHOLD

--- a/apps/docs-next/lib/rag/retrieve.ts
+++ b/apps/docs-next/lib/rag/retrieve.ts
@@ -12,13 +12,10 @@
  * The returned `Retriever` caps its output at ~3k tokens of cited context so
  * the prompt budget stays bounded regardless of how many chunks match.
  *
- * RFC-0006 D6: the 20 MB index.json is loaded lazily on first retrieval and
- * cached in-process, so it is NOT part of the module-load graph. Serverless
- * cold-start and bundle size are unaffected.
+ * RFC-0006 D6: the ~20 MB index.json is loaded lazily on first retrieval (via a
+ * dynamic import → a separate, on-demand chunk) and cached in-process, so it is
+ * NOT part of the module-load graph and does not inflate serverless cold-start.
  */
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { join, dirname } from 'node:path'
 import type {
   EmbedFn,
   RetrievedDocument,
@@ -51,17 +48,15 @@ interface IndexSnapshot {
 let cachedSnapshot: IndexSnapshot | undefined
 
 /**
- * Load the committed index from disk on first call; return the cached copy
- * thereafter. Using readFileSync with a path resolved from import.meta.url
- * ensures bundlers cannot inline the JSON at build time — it is read at Node
- * runtime, not at module-parse time.
+ * Load the committed index on first call; return the cached copy thereafter. The
+ * dynamic `import()` makes the JSON a lazily-loaded chunk: the builder still
+ * bundles and ships it (so there is no runtime file-resolution risk, unlike an
+ * `fs` read in a serverless function), but it is not parsed at module init.
  */
-function loadSnapshot(): IndexSnapshot {
+async function loadSnapshot(): Promise<IndexSnapshot> {
   if (cachedSnapshot) return cachedSnapshot
-  const dir = dirname(fileURLToPath(import.meta.url))
-  const indexPath = join(dir, '../ask-index/index.json')
-  const raw = readFileSync(indexPath, 'utf8')
-  cachedSnapshot = JSON.parse(raw) as IndexSnapshot
+  const mod = (await import('../ask-index/index.json')) as { default: IndexSnapshot }
+  cachedSnapshot = mod.default
   return cachedSnapshot
 }
 
@@ -150,40 +145,43 @@ export function createDocsRetriever(options: DocsRetrieverOptions = {}): Retriev
   const maxChars = options.maxContextChars ?? MAX_CONTEXT_CHARS
 
   // Defer index access into the async retrieve path so createDocsRetriever()
-  // itself remains synchronous. RAG + hybrid retriever are built on first call
-  // and reused via closured references.
-  let base: Retriever | undefined
+  // itself remains synchronous. RAG + hybrid retriever are built once on the
+  // first call and reused via the cached promise.
+  let basePromise: Promise<Retriever> | undefined
 
-  function ensureRetriever(): Retriever {
-    if (base) return base
-    const data = loadSnapshot()
-    const store = createInMemoryVectorStore(data.records)
-    const rag = createRAG({
-      embed,
-      store,
-      // Inputs are pre-chunked; keep the query-side splitter inert.
-      chunkSize: 1_000_000,
-      chunkOverlap: 0,
-      topK: CANDIDATE_POOL,
-    })
-    base = options.vectorOnly
-      ? rag
-      : createHybridRetriever(rag, {
-          candidatePool: CANDIDATE_POOL,
-          topK: TOP_K,
-          // Semantic-heavier: keyword-matchy recipe/example siblings were
-          // out-ranking the canonical leaf page at #1. Leaning on the vector score
-          // promotes the conceptual page — measured MRR 0.546 → 0.678 with
-          // recall@6 unchanged at 98% (eval: lib/ask/eval/retrieval.ts).
-          vectorWeight: 0.85,
-          bm25Weight: 0.15,
-        })
-    return base
+  function ensureRetriever(): Promise<Retriever> {
+    if (basePromise) return basePromise
+    basePromise = (async () => {
+      const data = await loadSnapshot()
+      const store = createInMemoryVectorStore(data.records)
+      const rag = createRAG({
+        embed,
+        store,
+        // Inputs are pre-chunked; keep the query-side splitter inert.
+        chunkSize: 1_000_000,
+        chunkOverlap: 0,
+        topK: CANDIDATE_POOL,
+      })
+      return options.vectorOnly
+        ? rag
+        : createHybridRetriever(rag, {
+            candidatePool: CANDIDATE_POOL,
+            topK: TOP_K,
+            // Semantic-heavier: keyword-matchy recipe/example siblings were
+            // out-ranking the canonical leaf page at #1. Leaning on the vector score
+            // promotes the conceptual page — measured MRR 0.546 → 0.678 with
+            // recall@6 unchanged at 98% (eval: lib/ask/eval/retrieval.ts).
+            vectorWeight: 0.85,
+            bm25Weight: 0.15,
+          })
+    })()
+    return basePromise
   }
 
   return {
     async retrieve(request) {
-      const docs = await ensureRetriever().retrieve(request)
+      const retriever = await ensureRetriever()
+      const docs = await retriever.retrieve(request)
       return boundByChars(docs, maxChars)
     },
   }

--- a/apps/docs-next/lib/rag/retrieve.ts
+++ b/apps/docs-next/lib/rag/retrieve.ts
@@ -11,7 +11,14 @@
  *
  * The returned `Retriever` caps its output at ~3k tokens of cited context so
  * the prompt budget stays bounded regardless of how many chunks match.
+ *
+ * RFC-0006 D6: the 20 MB index.json is loaded lazily on first retrieval and
+ * cached in-process, so it is NOT part of the module-load graph. Serverless
+ * cold-start and bundle size are unaffected.
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
 import type {
   EmbedFn,
   RetrievedDocument,
@@ -23,8 +30,6 @@ import type {
 import { createRAG, createHybridRetriever } from '@agentskit/rag'
 import { embed as defaultEmbed } from './embed'
 import type { DocChunkMetadata } from './ingest'
-// Committed snapshot — bundled at build time so the route needs no FS read.
-import snapshot from '../ask-index/index.json'
 
 interface IndexRecord {
   id: string
@@ -40,6 +45,24 @@ interface IndexSnapshot {
   dim: number
   count: number
   records: IndexRecord[]
+}
+
+/** Lazily-loaded snapshot — populated on first retrieve() call, then reused. */
+let cachedSnapshot: IndexSnapshot | undefined
+
+/**
+ * Load the committed index from disk on first call; return the cached copy
+ * thereafter. Using readFileSync with a path resolved from import.meta.url
+ * ensures bundlers cannot inline the JSON at build time — it is read at Node
+ * runtime, not at module-parse time.
+ */
+function loadSnapshot(): IndexSnapshot {
+  if (cachedSnapshot) return cachedSnapshot
+  const dir = dirname(fileURLToPath(import.meta.url))
+  const indexPath = join(dir, '../ask-index/index.json')
+  const raw = readFileSync(indexPath, 'utf8')
+  cachedSnapshot = JSON.parse(raw) as IndexSnapshot
+  return cachedSnapshot
 }
 
 /** ~4 chars per token; cap cited context near 3k tokens (~12k chars). */
@@ -117,38 +140,50 @@ function boundByChars(docs: RetrievedDocument[], maxChars: number): RetrievedDoc
  * Build the docs `Retriever` over the committed index. Returns a bounded,
  * reranked set of cited chunks. Plug straight into `createRuntime({ retriever })`
  * or any `useChat` retriever slot.
+ *
+ * The index is loaded lazily on the first `retrieve()` call (RFC-0006 D6): the
+ * 20 MB JSON is not part of the module-load graph and does not inflate cold-start
+ * or bundle size. All retrieval behaviour is unchanged.
  */
 export function createDocsRetriever(options: DocsRetrieverOptions = {}): Retriever {
-  const data = snapshot as unknown as IndexSnapshot
   const embed = options.embed ?? defaultEmbed
   const maxChars = options.maxContextChars ?? MAX_CONTEXT_CHARS
 
-  const store = createInMemoryVectorStore(data.records)
-  const rag = createRAG({
-    embed,
-    store,
-    // Inputs are pre-chunked; keep the query-side splitter inert.
-    chunkSize: 1_000_000,
-    chunkOverlap: 0,
-    topK: CANDIDATE_POOL,
-  })
+  // Defer index access into the async retrieve path so createDocsRetriever()
+  // itself remains synchronous. RAG + hybrid retriever are built on first call
+  // and reused via closured references.
+  let base: Retriever | undefined
 
-  const base: Retriever = options.vectorOnly
-    ? rag
-    : createHybridRetriever(rag, {
-        candidatePool: CANDIDATE_POOL,
-        topK: TOP_K,
-        // Semantic-heavier: keyword-matchy recipe/example siblings were
-        // out-ranking the canonical leaf page at #1. Leaning on the vector score
-        // promotes the conceptual page — measured MRR 0.546 → 0.678 with
-        // recall@6 unchanged at 98% (eval: lib/ask/eval/retrieval.ts).
-        vectorWeight: 0.85,
-        bm25Weight: 0.15,
-      })
+  function ensureRetriever(): Retriever {
+    if (base) return base
+    const data = loadSnapshot()
+    const store = createInMemoryVectorStore(data.records)
+    const rag = createRAG({
+      embed,
+      store,
+      // Inputs are pre-chunked; keep the query-side splitter inert.
+      chunkSize: 1_000_000,
+      chunkOverlap: 0,
+      topK: CANDIDATE_POOL,
+    })
+    base = options.vectorOnly
+      ? rag
+      : createHybridRetriever(rag, {
+          candidatePool: CANDIDATE_POOL,
+          topK: TOP_K,
+          // Semantic-heavier: keyword-matchy recipe/example siblings were
+          // out-ranking the canonical leaf page at #1. Leaning on the vector score
+          // promotes the conceptual page — measured MRR 0.546 → 0.678 with
+          // recall@6 unchanged at 98% (eval: lib/ask/eval/retrieval.ts).
+          vectorWeight: 0.85,
+          bm25Weight: 0.15,
+        })
+    return base
+  }
 
   return {
     async retrieve(request) {
-      const docs = await base.retrieve(request)
+      const docs = await ensureRetriever().retrieve(request)
       return boundByChars(docs, maxChars)
     },
   }


### PR DESCRIPTION
## Summary

- Replace `import snapshot from '../ask-index/index.json'` in both `retrieve.ts` and `guard.ts` with a `node:fs` `readFileSync` loader that reads the 20 MB index on **first use** and caches it in-process.
- Path resolved via `fileURLToPath(import.meta.url)` + `node:path` so bundlers cannot trace-and-inline it at build time.
- Lazy init in `retrieve.ts`: the RAG/hybrid retriever is built inside `ensureRetriever()`, called on the first `retrieve()` invocation; `createDocsRetriever()` remains synchronous.
- Lazy init in `guard.ts`: `loadIndexRecords()` is called inside `corpusCentroid()` on first scope check; cached-centroid memoisation is fully preserved; fail-open behaviour unchanged.

## Behaviour

Behaviour is **identical** — same records shape, same cosine + BM25 hybrid reranking, same `ON_TOPIC_THRESHOLD`, same fail-open centroid guard. The only change is *when* the JSON is parsed: request-time instead of module-load time.

## Type check

`tsc --noEmit` clean for both changed files. Pre-existing unrelated type errors in `highlighter.ts`, `RunResult.tsx`, `rate-limit.ts`, and `embed.ts` are unchanged from `main`.