### PR TITLE
feat(cli): project scanner for component install (RFC-0006 D3/D4)

### DIFF
--- a/.changeset/cli-component-scanner.md
+++ b/.changeset/cli-component-scanner.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the project scanner (`packages/cli/src/components/scan.ts`, RFC-0006 D3/D4) — detects UI binding, meta-framework (incl. Next app vs pages, Angular SSR vs SPA, the no-server bundlers), package manager, TypeScript, src dir, import alias, styling, and monorepo signals from a project dir via an injectable filesystem. Pure + deterministic + fully unit-tested. Not exported from the package entry yet, so there is no public API change and no release.

--- a/packages/cli/src/components/scan.ts
+++ b/packages/cli/src/components/scan.ts
@@ -1,0 +1,185 @@
+/**
+ * Project scanner (RFC-0006 D3/D4).
+ *
+ * Inspects a project directory and produces a {@link ProjectScan}: the UI binding,
+ * meta-framework, package manager, TypeScript flag, source dir, import alias,
+ * styling, and monorepo signals that `agentskit add` needs when there is no
+ * committed `.agentskit/components.json`. Pure + deterministic + dependency-light:
+ * all filesystem access goes through an injectable {@link ScanFs}, so it is fully
+ * unit-testable with an in-memory tree and never guesses silently — ambiguous
+ * signals resolve to `'unknown'`/`null` and surface later in validation.
+ */
+import { join } from 'node:path'
+import type {
+  MetaFramework,
+  PackageManager,
+  ProjectScan,
+  UiBinding,
+} from './types'
+
+/** The only filesystem surface the scanner needs. Injectable for tests. */
+export interface ScanFs {
+  /** Return the file contents, or `null` if it does not exist / can't be read. */
+  readFile: (path: string) => string | null
+  /** Whether a file or directory exists at `path`. */
+  exists: (path: string) => boolean
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+/** Merge all dependency buckets into one name→range map. */
+function allDeps(pkg: PackageJson | null): Record<string, string> {
+  if (!pkg) return {}
+  return { ...pkg.peerDependencies, ...pkg.devDependencies, ...pkg.dependencies }
+}
+
+function readJson<T>(fs: ScanFs, path: string): T | null {
+  const raw = fs.readFile(path)
+  if (raw == null) return null
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+function detectPackageManager(fs: ScanFs, root: string): PackageManager {
+  if (fs.exists(join(root, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fs.exists(join(root, 'bun.lockb')) || fs.exists(join(root, 'bun.lock'))) return 'bun'
+  if (fs.exists(join(root, 'yarn.lock'))) return 'yarn'
+  return 'npm'
+}
+
+/**
+ * UI binding from dependencies. Order matters: react-native and the various
+ * meta-framework UI libs must be checked before the bare `react`/`vue` they build
+ * on, so `expo`/`react-native` is never misread as plain `react`.
+ */
+function detectUiBinding(deps: Record<string, string>): UiBinding | 'unknown' {
+  const has = (name: string): boolean => name in deps
+  if (has('react-native') || has('expo')) return 'react-native'
+  if (has('@angular/core')) return 'angular'
+  if (has('svelte')) return 'svelte'
+  if (has('nuxt') || has('vue')) return 'vue'
+  if (has('solid-js')) return 'solid'
+  if (has('ink')) return 'ink'
+  if (has('react')) return 'react'
+  return 'unknown'
+}
+
+/**
+ * Meta-framework — decides WHERE a server file lands. Distinguishes app vs pages
+ * router (Next), SSR vs SPA (Angular), and the no-server bundlers (vite/cra).
+ */
+function detectMetaFramework(
+  fs: ScanFs,
+  root: string,
+  deps: Record<string, string>,
+  uiBinding: UiBinding | 'unknown',
+): MetaFramework | 'unknown' {
+  const has = (name: string): boolean => name in deps
+  const hasPrefix = (prefix: string): boolean => Object.keys(deps).some((d) => d.startsWith(prefix))
+
+  if (has('next')) {
+    // App Router when an `app/` (or `src/app/`) dir exists, else Pages Router.
+    if (fs.exists(join(root, 'app')) || fs.exists(join(root, 'src/app'))) return 'next-app'
+    return 'next-pages'
+  }
+  if (hasPrefix('@remix-run/')) return 'remix'
+  if (has('@tanstack/react-start') || has('@tanstack/start')) return 'tanstack-start'
+  if (has('@sveltejs/kit')) return 'sveltekit'
+  if (has('nuxt')) return 'nuxt'
+  if (has('astro')) return 'astro'
+  if (uiBinding === 'angular') {
+    return has('@angular/ssr') || has('@angular/platform-server') ? 'angular-ssr' : 'angular-spa'
+  }
+  if (has('expo')) return 'expo'
+  if (has('react-scripts')) return 'cra'
+  if (has('vite')) return 'vite'
+  if (uiBinding === 'ink') return 'node'
+  if (uiBinding === 'unknown') return 'unknown'
+  return 'none'
+}
+
+/** First `@/*`-style alias from tsconfig `compilerOptions.paths`, sans `/*`. */
+function detectImportAlias(fs: ScanFs, root: string): string | null {
+  const tsconfig = readJson<{ compilerOptions?: { paths?: Record<string, string[]> } }>(
+    fs,
+    join(root, 'tsconfig.json'),
+  )
+  const paths = tsconfig?.compilerOptions?.paths
+  if (!paths) return null
+  for (const key of Object.keys(paths)) {
+    // e.g. "@/*" → "@", "~/*" → "~". Skip exact (non-wildcard) mappings.
+    if (key.endsWith('/*')) return key.slice(0, -2)
+  }
+  return null
+}
+
+const CSS_ENTRY_CANDIDATES = [
+  'app/globals.css',
+  'app/global.css',
+  'src/app/globals.css',
+  'src/index.css',
+  'src/styles/globals.css',
+  'styles/globals.css',
+  'src/app.css',
+  'src/styles.css',
+]
+
+function detectStyling(
+  fs: ScanFs,
+  root: string,
+  deps: Record<string, string>,
+): ProjectScan['styling'] {
+  const tailwind =
+    'tailwindcss' in deps ||
+    fs.exists(join(root, 'tailwind.config.ts')) ||
+    fs.exists(join(root, 'tailwind.config.js')) ||
+    fs.exists(join(root, 'tailwind.config.cjs')) ||
+    fs.exists(join(root, 'tailwind.config.mjs'))
+  let cssEntry: string | null = null
+  for (const candidate of CSS_ENTRY_CANDIDATES) {
+    if (fs.exists(join(root, candidate))) {
+      cssEntry = candidate
+      break
+    }
+  }
+  return { mode: tailwind ? 'tailwind-preset' : 'data-attrs-only', cssEntry }
+}
+
+function detectMonorepo(fs: ScanFs, root: string): ProjectScan['monorepo'] {
+  if (fs.exists(join(root, 'pnpm-workspace.yaml'))) return { tool: 'pnpm', root }
+  if (fs.exists(join(root, 'turbo.json'))) return { tool: 'turbo', root }
+  if (fs.exists(join(root, 'nx.json'))) return { tool: 'nx', root }
+  return null
+}
+
+/**
+ * Scan `root` and return the detected {@link ProjectScan}. Never throws — a
+ * missing/unparseable `package.json` yields an all-`unknown`/default scan that the
+ * validator then reports, rather than a crash or a silent wrong guess.
+ */
+export function scanProject(fs: ScanFs, root = '.'): ProjectScan {
+  const pkg = readJson<PackageJson>(fs, join(root, 'package.json'))
+  const deps = allDeps(pkg)
+
+  const uiBinding = detectUiBinding(deps)
+  const metaFramework = detectMetaFramework(fs, root, deps, uiBinding)
+  const srcDir = fs.exists(join(root, 'src')) ? 'src' : null
+
+  return {
+    uiBinding,
+    metaFramework,
+    packageManager: detectPackageManager(fs, root),
+    typescript: fs.exists(join(root, 'tsconfig.json')),
+    srcDir,
+    importAlias: detectImportAlias(fs, root),
+    styling: detectStyling(fs, root, deps),
+    monorepo: detectMonorepo(fs, root),
+  }
+}

--- a/packages/cli/tests/components-scan.test.ts
+++ b/packages/cli/tests/components-scan.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { scanProject, type ScanFs } from '../src/components/scan'
+
+/**
+ * Build an in-memory {@link ScanFs} from a map of relative path → file contents
+ * plus a list of directory paths. Paths are relative to root `'.'` (the scanner's
+ * default), so e.g. `package.json` and `app` match the scanner's `join('.', …)`.
+ */
+function fakeFs(files: Record<string, string>, dirs: string[] = []): ScanFs {
+  const dirSet = new Set(dirs)
+  return {
+    readFile: (path) => (path in files ? files[path]! : null),
+    exists: (path) => path in files || dirSet.has(path),
+  }
+}
+
+function pkg(deps: Record<string, string>, dev: Record<string, string> = {}): string {
+  return JSON.stringify({ dependencies: deps, devDependencies: dev })
+}
+
+describe('scanProject', () => {
+  it('detects a Next.js App Router + React + pnpm + tailwind + alias + src', () => {
+    const fs = fakeFs(
+      {
+        'package.json': pkg({ next: '15.0.0', react: '19.0.0', tailwindcss: '3.4.0' }),
+        'pnpm-lock.yaml': '',
+        'tsconfig.json': JSON.stringify({ compilerOptions: { paths: { '@/*': ['./src/*'] } } }),
+        'app/globals.css': '',
+      },
+      ['app', 'src'],
+    )
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react')
+    expect(scan.metaFramework).toBe('next-app')
+    expect(scan.packageManager).toBe('pnpm')
+    expect(scan.typescript).toBe(true)
+    expect(scan.srcDir).toBe('src')
+    expect(scan.importAlias).toBe('@')
+    expect(scan.styling).toEqual({ mode: 'tailwind-preset', cssEntry: 'app/globals.css' })
+    expect(scan.monorepo).toBeNull()
+  })
+
+  it('detects Next Pages Router when there is no app/ dir', () => {
+    const fs = fakeFs({ 'package.json': pkg({ next: '14.0.0', react: '18.0.0' }) }, ['pages'])
+    expect(scanProject(fs).metaFramework).toBe('next-pages')
+  })
+
+  it('detects SvelteKit', () => {
+    const fs = fakeFs(
+      { 'package.json': pkg({ svelte: '5.0.0' }, { '@sveltejs/kit': '2.0.0' }), 'yarn.lock': '' },
+      [],
+    )
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('svelte')
+    expect(scan.metaFramework).toBe('sveltekit')
+    expect(scan.packageManager).toBe('yarn')
+  })
+
+  it('detects Nuxt as vue', () => {
+    const fs = fakeFs({ 'package.json': pkg({ nuxt: '3.13.0', vue: '3.5.0' }) })
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('vue')
+    expect(scan.metaFramework).toBe('nuxt')
+  })
+
+  it('distinguishes Angular SSR from SPA', () => {
+    const ssr = scanProject(
+      fakeFs({ 'package.json': pkg({ '@angular/core': '19.0.0', '@angular/ssr': '19.0.0' }) }),
+    )
+    expect(ssr.uiBinding).toBe('angular')
+    expect(ssr.metaFramework).toBe('angular-ssr')
+
+    const spa = scanProject(fakeFs({ 'package.json': pkg({ '@angular/core': '19.0.0' }) }))
+    expect(spa.metaFramework).toBe('angular-spa')
+  })
+
+  it('detects Expo / React Native (never misread as plain react)', () => {
+    const fs = fakeFs({ 'package.json': pkg({ expo: '52.0.0', react: '19.0.0', 'react-native': '0.76.0' }) })
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react-native')
+    expect(scan.metaFramework).toBe('expo')
+  })
+
+  it('detects a Vite + React SPA', () => {
+    const fs = fakeFs({ 'package.json': pkg({ react: '19.0.0' }, { vite: '6.0.0' }) }, ['src'])
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react')
+    expect(scan.metaFramework).toBe('vite')
+  })
+
+  it('detects Ink as a node target', () => {
+    const scan = scanProject(fakeFs({ 'package.json': pkg({ ink: '5.0.0', react: '18.0.0' }) }))
+    expect(scan.uiBinding).toBe('ink')
+    expect(scan.metaFramework).toBe('node')
+  })
+
+  it('detects a pnpm monorepo + tailwind via config file (not a dep)', () => {
+    const fs = fakeFs(
+      { 'package.json': pkg({ react: '19.0.0' }), 'pnpm-workspace.yaml': '', 'tailwind.config.ts': '' },
+      [],
+    )
+    const scan = scanProject(fs)
+    expect(scan.monorepo).toEqual({ tool: 'pnpm', root: '.' })
+    expect(scan.styling.mode).toBe('tailwind-preset')
+  })
+
+  it('falls back to unknown/defaults (no throw) when package.json is missing or invalid', () => {
+    const empty = scanProject(fakeFs({}))
+    expect(empty.uiBinding).toBe('unknown')
+    expect(empty.metaFramework).toBe('unknown')
+    expect(empty.packageManager).toBe('npm')
+    expect(empty.typescript).toBe(false)
+    expect(empty.srcDir).toBeNull()
+    expect(empty.importAlias).toBeNull()
+    expect(empty.styling).toEqual({ mode: 'data-attrs-only', cssEntry: null })
+    expect(empty.monorepo).toBeNull()
+
+    const broken = scanProject(fakeFs({ 'package.json': '{ not valid json' }))
+    expect(broken.uiBinding).toBe('unknown')
+  })
+})


### PR DESCRIPTION
**Stacked on #1018** (contract types). Second slice of RFC-0006 Rollout step 2.

## What
`scanProject(fs, root)` — the detection core behind `agentskit add`'s "identifies the app / framework" promise. Produces a `ProjectScan`:
- **uiBinding**: react / vue / svelte / solid / angular / react-native / ink (order-safe — Expo/RN never misread as plain react).
- **metaFramework** (decides where the server file lands): Next **app vs pages**, Angular **ssr vs spa**, sveltekit / nuxt / remix / tanstack-start / astro / expo / vite / cra / ink→node.
- packageManager (lockfile), typescript, srcDir, importAlias (tsconfig `paths`), styling (tailwind preset vs data-attrs-only + css entry), monorepo (pnpm/turbo/nx).

## Design
- **Injectable `ScanFs`** → pure, deterministic, fully unit-testable with an in-memory tree.
- **Never guesses silently** — ambiguous signals resolve to `unknown`/`null` and surface in validation. Missing/invalid `package.json` → all-unknown defaults, no throw.

## Tests
10 unit tests (Next app/pages, SvelteKit, Nuxt, Angular ssr/spa, Expo, Vite, Ink, pnpm monorepo + tailwind-config detection, missing/broken package.json). All green; `tsc` clean.

## Notes
- Not exported from the package entry yet → no public API change → empty changeset.
- Review base is #1018; rebases onto `main` once that merges.

Related: RFC #1014, #1018, #1016.