### PR TITLE
feat(cli): components.json builder + read/write (RFC-0006 D3 — init)

### DIFF
--- a/.changeset/cli-component-config.md
+++ b/.changeset/cli-component-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the `.agentskit/components.json` builder/reader/writer (`packages/cli/src/components/config.ts`, RFC-0006 D3). `buildConfig(scan)` derives a framework-idiomatic default config (uiBinding, metaFramework, aliases, per-meta server paths, styling, registries, pinned `$schema`); `serialize`/`parse`/`read`/`write`/`resolveConfig` round-trip it with injectable I/O. Fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/config.ts
+++ b/packages/cli/src/components/config.ts
@@ -1,0 +1,145 @@
+/**
+ * `.agentskit/components.json` — build / read / write (RFC-0006 D3).
+ *
+ * `agentskit init` writes this file once; every later `add` reads it and skips
+ * scanning. This module derives a sensible default `ComponentsConfig` from a
+ * {@link ProjectScan}, and (de)serializes it. Pure + injectable I/O so it is
+ * unit-testable; the interactive `init` command wires these together with prompts.
+ */
+import { join } from 'node:path'
+import type { ComponentsConfig, MetaFramework, ProjectScan } from './types'
+
+/** Where the config lives, relative to the project (or workspace package) root. */
+export const CONFIG_PATH = '.agentskit/components.json'
+
+/** Pinned, fetchable in v1 (the hosted registry URL becomes an alias later, D3). */
+export const SCHEMA_URL =
+  'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/v1/schema/components.json'
+
+export const DEFAULT_REGISTRY = 'https://registry.agentskit.io'
+
+/** Idiomatic server route directory per meta-framework. */
+const SERVER_DIR_BY_META: Record<MetaFramework, string> = {
+  'next-app': 'app/api',
+  'next-pages': 'pages/api',
+  remix: 'app/routes',
+  'tanstack-start': 'app/routes',
+  astro: 'src/pages/api',
+  sveltekit: 'src/routes/api',
+  nuxt: 'server/api',
+  'angular-ssr': 'src/server',
+  expo: 'server',
+  vite: 'server',
+  cra: 'server',
+  'angular-spa': 'server',
+  node: 'server',
+  none: 'server',
+}
+
+function joinPath(base: string, sub: string): string {
+  return base ? `${base}/${sub}` : sub
+}
+
+/**
+ * Derive a default {@link ComponentsConfig} from a scan. The values are
+ * best-effort, framework-idiomatic defaults the user can edit; `init` may override
+ * any of them via prompts. Falls back gracefully when the scan is `unknown`.
+ */
+export function buildConfig(scan: ProjectScan): ComponentsConfig {
+  const uiBinding = scan.uiBinding === 'unknown' ? 'react' : scan.uiBinding
+  const metaFramework = scan.metaFramework === 'unknown' ? 'none' : scan.metaFramework
+  const srcBase = scan.srcDir ?? ''
+
+  const componentsPath = joinPath(srcBase, 'components')
+  const libPath = joinPath(srcBase, 'lib')
+  // Next respects a `src/` dir for its router; prefix the server path when present.
+  const rawServer = SERVER_DIR_BY_META[metaFramework]
+  const serverPath =
+    srcBase && (metaFramework === 'next-app' || metaFramework === 'next-pages') && !rawServer.startsWith('src/')
+      ? joinPath(srcBase, rawServer)
+      : rawServer
+
+  const alias = scan.importAlias
+
+  return {
+    $schema: SCHEMA_URL,
+    schemaVersion: 1,
+    uiBinding,
+    metaFramework,
+    typescript: scan.typescript,
+    styling: {
+      mode: scan.styling.mode,
+      css: scan.styling.cssEntry ?? 'app/globals.css',
+      tailwindConfig: null,
+    },
+    aliases: {
+      // components + lib are import-aliased when the project has one; the server
+      // route is a framework-routed filesystem location, so it mirrors its path.
+      components: alias ? `${alias}/components` : `./${componentsPath}`,
+      lib: alias ? `${alias}/lib` : `./${libPath}`,
+      server: serverPath,
+    },
+    paths: {
+      root: scan.monorepo?.root ?? '.',
+      components: componentsPath,
+      lib: libPath,
+      server: serverPath,
+    },
+    registries: { default: DEFAULT_REGISTRY },
+  }
+}
+
+/** Serialize a config to pretty JSON (with a trailing newline, matching editors). */
+export function serializeConfig(config: ComponentsConfig): string {
+  return `${JSON.stringify(config, null, 2)}\n`
+}
+
+/** Parse + shallow-validate a config string. Returns `null` on malformed input. */
+export function parseConfig(raw: string): ComponentsConfig | null {
+  let data: unknown
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!data || typeof data !== 'object') return null
+  const c = data as Partial<ComponentsConfig>
+  if (typeof c.schemaVersion !== 'number' || !c.uiBinding || !c.metaFramework || !c.registries) {
+    return null
+  }
+  return c as ComponentsConfig
+}
+
+/** Injectable config I/O — `read` returns file contents or `null`; `write` persists. */
+export interface ConfigIo {
+  read: (path: string) => string | null
+  write: (path: string, content: string) => void
+}
+
+/** Read the committed config under `root`, or `null` when absent/malformed. */
+export function readConfig(io: ConfigIo, root = '.'): ComponentsConfig | null {
+  const raw = io.read(join(root, CONFIG_PATH))
+  return raw == null ? null : parseConfig(raw)
+}
+
+/** Write the config under `root`, returning the path written. */
+export function writeConfig(io: ConfigIo, config: ComponentsConfig, root = '.'): string {
+  const path = join(root, CONFIG_PATH)
+  io.write(path, serializeConfig(config))
+  return path
+}
+
+/**
+ * Resolve the effective config: the committed one when present (zero prompts),
+ * else a default derived from the scan. The boolean reports whether it was loaded
+ * from disk (vs. freshly derived → the caller should suggest running `init`).
+ */
+export function resolveConfig(
+  io: ConfigIo,
+  scan: ProjectScan,
+  root = '.',
+): { config: ComponentsConfig; fromDisk: boolean } {
+  const existing = readConfig(io, root)
+  if (existing) return { config: existing, fromDisk: true }
+  return { config: buildConfig(scan), fromDisk: false }
+}

--- a/packages/cli/tests/components-config.test.ts
+++ b/packages/cli/tests/components-config.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONFIG_PATH,
+  DEFAULT_REGISTRY,
+  SCHEMA_URL,
+  buildConfig,
+  parseConfig,
+  readConfig,
+  resolveConfig,
+  serializeConfig,
+  writeConfig,
+  type ConfigIo,
+} from '../src/components/config'
+import type { ProjectScan } from '../src/components/types'
+
+function makeScan(over: Partial<ProjectScan> = {}): ProjectScan {
+  return {
+    uiBinding: 'react',
+    metaFramework: 'next-app',
+    packageManager: 'pnpm',
+    typescript: true,
+    srcDir: 'src',
+    importAlias: '@',
+    styling: { mode: 'tailwind-preset', cssEntry: 'src/app/globals.css' },
+    monorepo: null,
+    ...over,
+  }
+}
+
+/** In-memory ConfigIo backed by a Map. */
+function fakeIo(seed: Record<string, string> = {}): ConfigIo & { files: Map<string, string> } {
+  const files = new Map(Object.entries(seed))
+  return {
+    files,
+    read: (p) => files.get(p) ?? null,
+    write: (p, c) => void files.set(p, c),
+  }
+}
+
+describe('buildConfig', () => {
+  it('derives an aliased, src-prefixed Next App Router config', () => {
+    const c = buildConfig(makeScan())
+    expect(c.$schema).toBe(SCHEMA_URL)
+    expect(c.schemaVersion).toBe(1)
+    expect(c.uiBinding).toBe('react')
+    expect(c.metaFramework).toBe('next-app')
+    expect(c.typescript).toBe(true)
+    expect(c.aliases).toEqual({ components: '@/components', lib: '@/lib', server: 'src/app/api' })
+    expect(c.paths).toEqual({ root: '.', components: 'src/components', lib: 'src/lib', server: 'src/app/api' })
+    expect(c.styling).toEqual({ mode: 'tailwind-preset', css: 'src/app/globals.css', tailwindConfig: null })
+    expect(c.registries.default).toBe(DEFAULT_REGISTRY)
+  })
+
+  it('uses relative aliases + root-level paths when there is no alias or src', () => {
+    const c = buildConfig(makeScan({ importAlias: null, srcDir: null, metaFramework: 'next-pages' }))
+    expect(c.aliases).toEqual({ components: './components', lib: './lib', server: 'pages/api' })
+    expect(c.paths.components).toBe('components')
+    expect(c.paths.server).toBe('pages/api')
+  })
+
+  it('maps server dirs per meta-framework', () => {
+    expect(buildConfig(makeScan({ uiBinding: 'svelte', metaFramework: 'sveltekit', srcDir: null })).paths.server).toBe('src/routes/api')
+    expect(buildConfig(makeScan({ uiBinding: 'vue', metaFramework: 'nuxt', srcDir: null })).paths.server).toBe('server/api')
+  })
+
+  it('anchors root to the monorepo root', () => {
+    expect(buildConfig(makeScan({ monorepo: { tool: 'pnpm', root: '/repo' } })).paths.root).toBe('/repo')
+  })
+
+  it('falls back to react/none for an unknown scan', () => {
+    const c = buildConfig(makeScan({ uiBinding: 'unknown', metaFramework: 'unknown' }))
+    expect(c.uiBinding).toBe('react')
+    expect(c.metaFramework).toBe('none')
+  })
+})
+
+describe('serialize / parse', () => {
+  it('round-trips through serialize → parse', () => {
+    const c = buildConfig(makeScan())
+    const parsed = parseConfig(serializeConfig(c))
+    expect(parsed).toEqual(c)
+  })
+
+  it('rejects malformed or incomplete configs', () => {
+    expect(parseConfig('{ not json')).toBeNull()
+    expect(parseConfig('null')).toBeNull()
+    expect(parseConfig(JSON.stringify({ uiBinding: 'react' }))).toBeNull() // no schemaVersion/registries
+  })
+})
+
+describe('read / write / resolve', () => {
+  it('writes then reads the config under the root', () => {
+    const io = fakeIo()
+    const c = buildConfig(makeScan())
+    const written = writeConfig(io, c)
+    expect(written).toBe(CONFIG_PATH)
+    expect(readConfig(io)).toEqual(c)
+  })
+
+  it('resolveConfig prefers the committed file, else derives from the scan', () => {
+    const c = buildConfig(makeScan())
+    const onDisk = fakeIo({ [CONFIG_PATH]: serializeConfig(c) })
+    expect(resolveConfig(onDisk, makeScan())).toEqual({ config: c, fromDisk: true })
+
+    const empty = fakeIo()
+    const resolved = resolveConfig(empty, makeScan({ metaFramework: 'next-pages' }))
+    expect(resolved.fromDisk).toBe(false)
+    expect(resolved.config.metaFramework).toBe('next-pages')
+  })
+})


### PR DESCRIPTION
**Stacked on #1020** (validator). Fourth slice of RFC-0006 Rollout step 2 — the `init`/config foundation.

## What
`packages/cli/src/components/config.ts` — the `.agentskit/components.json` contract in code:
- **`buildConfig(scan)`** derives a framework-idiomatic default: aliases (components/lib import-aliased, server mirrors its route path), **per-meta server paths** (next app/pages, sveltekit `src/routes/api`, nuxt `server/api`, remix `app/routes`, …), styling, registries, and the **pinned `$schema`** raw-GitHub URL (D3 — fetchable day one).
- **`serialize`/`parse`/`read`/`write`/`resolveConfig`** — round-trip with injectable I/O. `resolveConfig` prefers the committed file (zero prompts) else derives from the scan and flags `fromDisk:false` so the caller can suggest `init`.

## Tests
9 unit tests (aliased+src Next, relative no-src, per-meta server dirs, monorepo root, unknown fallback, serialize↔parse round-trip, malformed rejection, read/write/resolve). All green; `tsc` clean. Empty changeset (not exported yet).

Stack: #1018 ← #1019 ← #1020 ← this. The interactive `init` command (prompts) wires these in the add-flow slice.