### PR TITLE
feat(cli): path-containment guard + transactional writer (RFC-0006 D16/D10)

### DIFF
--- a/.changeset/cli-component-install-guard.md
+++ b/.changeset/cli-component-install-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the path-containment guard + transactional file writer (`packages/cli/src/components/install.ts`, RFC-0006 D16/D10). `assertContained`/`isSafeRegistryPath` reject absolute paths and `..` traversal (closing the write-escape vector that valid checksums don't catch); `commitFiles` validates every path + collects all conflicts before writing any file, then rolls back on failure. `IntegrityError` is a typed error (bare-throw gate compliant). Fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/install.ts
+++ b/packages/cli/src/components/install.ts
@@ -1,0 +1,130 @@
+/**
+ * Path-containment guard + transactional file writer (RFC-0006 D16/D10).
+ *
+ * `sha256` verifies file *content* and the signed manifest verifies the checksum
+ * list — but neither constrains *where* a file is written. A valid-checksum entry
+ * with `path: '../../.env'` would escape the target via `join`. D16 closes that:
+ * every registry path is validated (no absolute, no `..`) and every resolved
+ * destination is asserted to stay inside the target dir, on both the write and the
+ * diff-read paths.
+ *
+ * `commitFiles` adds the D10 transactional property at the unit level: validate
+ * ALL paths + collect ALL conflicts before writing ANY file, then write, rolling
+ * back everything written so far if any write fails. (The real-filesystem adapter
+ * layers the sibling temp-dir + atomic rename on top; the all-or-nothing semantics
+ * and the containment guard live here, fully testable.)
+ */
+import { isAbsolute, resolve, sep } from 'node:path'
+
+/** Raised on a path-traversal / unsafe-path / unresolved-conflict violation. */
+export class IntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IntegrityError'
+  }
+}
+
+/**
+ * Publish-time path validation: a registry file path must be relative and contain
+ * no `..` segment (and no empty/`.`-only segment). Pure predicate — the authoring
+ * tooling rejects a manifest that fails this; the CLI re-checks at install.
+ */
+export function isSafeRegistryPath(rel: string): boolean {
+  if (rel === '' || isAbsolute(rel)) return false
+  const segments = rel.split(/[/\\]/)
+  for (const s of segments) {
+    if (s === '' || s === '.' || s === '..') return false
+  }
+  return true
+}
+
+/**
+ * Resolve `rel` under `targetDir` and assert the result stays within it (D16).
+ * Throws {@link IntegrityError} on an unsafe path or an escape; otherwise returns
+ * the absolute destination. Use on every write AND every diff read.
+ */
+export function assertContained(targetDir: string, rel: string): string {
+  if (!isSafeRegistryPath(rel)) {
+    throw new IntegrityError(`unsafe registry path rejected: ${JSON.stringify(rel)}`)
+  }
+  const base = resolve(targetDir)
+  const dest = resolve(base, rel)
+  if (dest !== base && !dest.startsWith(base + sep)) {
+    throw new IntegrityError(`path escapes the target directory: ${JSON.stringify(rel)}`)
+  }
+  return dest
+}
+
+/** Minimal filesystem surface for the writer. Injectable for tests. */
+export interface WriteFs {
+  exists: (path: string) => boolean
+  /** Write `content`, creating parent directories as needed. */
+  write: (path: string, content: string) => void
+  /** Remove a file (used for rollback). */
+  remove: (path: string) => void
+}
+
+/** A file to install, with its path relative to the target directory. */
+export interface FileToWrite {
+  path: string
+  content: string
+}
+
+export interface CommitOptions {
+  /** Overwrite files that already exist. Default: abort on any conflict. */
+  force?: boolean
+}
+
+export interface CommitResult {
+  /** Absolute destinations written, in order. */
+  written: string[]
+}
+
+/**
+ * Install `files` into `targetDir` transactionally:
+ *   1. validate + contain every path (D16) — any failure aborts before any write;
+ *   2. collect ALL pre-existing conflicts — abort listing them unless `force`;
+ *   3. write; if any write throws, roll back everything written and rethrow.
+ *
+ * Never leaves a partially-written tree.
+ */
+export function commitFiles(
+  fs: WriteFs,
+  targetDir: string,
+  files: ReadonlyArray<FileToWrite>,
+  options: CommitOptions = {},
+): CommitResult {
+  // 1 — resolve + contain every destination first.
+  const planned = files.map((f) => ({ dest: assertContained(targetDir, f.path), content: f.content, rel: f.path }))
+
+  // 2 — collect all conflicts up front (no throw-on-first).
+  if (!options.force) {
+    const conflicts = planned.filter((p) => fs.exists(p.dest)).map((p) => p.rel)
+    if (conflicts.length > 0) {
+      throw new IntegrityError(
+        `refusing to overwrite ${conflicts.length} existing file(s) (use --force): ${conflicts.join(', ')}`,
+      )
+    }
+  }
+
+  // 3 — write, rolling back on any failure.
+  const written: string[] = []
+  try {
+    for (const p of planned) {
+      fs.write(p.dest, p.content)
+      written.push(p.dest)
+    }
+  } catch (err) {
+    for (const dest of written.reverse()) {
+      try {
+        fs.remove(dest)
+      } catch {
+        // best-effort rollback; surface the original error below
+      }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    throw new IntegrityError(`install failed and was rolled back (${written.length} file(s) removed): ${message}`)
+  }
+
+  return { written }
+}

--- a/packages/cli/tests/components-install.test.ts
+++ b/packages/cli/tests/components-install.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IntegrityError,
+  assertContained,
+  commitFiles,
+  isSafeRegistryPath,
+  type WriteFs,
+} from '../src/components/install'
+
+const TARGET = '/proj/components/ask'
+
+/** In-memory WriteFs backed by a Map. `failOn` makes a given dest throw on write. */
+function fakeFs(seed: Record<string, string> = {}, failOn?: string): WriteFs & { files: Map<string, string> } {
+  const files = new Map(Object.entries(seed))
+  return {
+    files,
+    exists: (p) => files.has(p),
+    write: (p, c) => {
+      if (p === failOn) throw new Error('disk full')
+      files.set(p, c)
+    },
+    remove: (p) => void files.delete(p),
+  }
+}
+
+describe('isSafeRegistryPath', () => {
+  it('accepts relative paths and rejects absolute / traversal / empty segments', () => {
+    expect(isSafeRegistryPath('a/b.ts')).toBe(true)
+    expect(isSafeRegistryPath('lib/ask/guard.ts')).toBe(true)
+    expect(isSafeRegistryPath('')).toBe(false)
+    expect(isSafeRegistryPath('/etc/passwd')).toBe(false)
+    expect(isSafeRegistryPath('../x')).toBe(false)
+    expect(isSafeRegistryPath('a/../b')).toBe(false)
+    expect(isSafeRegistryPath('a/./b')).toBe(false)
+    expect(isSafeRegistryPath('a//b')).toBe(false)
+  })
+})
+
+describe('assertContained (D16)', () => {
+  it('resolves a safe path inside the target', () => {
+    expect(assertContained(TARGET, 'a/b.ts')).toBe('/proj/components/ask/a/b.ts')
+  })
+
+  it('throws IntegrityError on traversal or absolute paths', () => {
+    expect(() => assertContained(TARGET, '../../.env')).toThrow(IntegrityError)
+    expect(() => assertContained(TARGET, '/etc/passwd')).toThrow(IntegrityError)
+    expect(() => assertContained(TARGET, 'ok/../../../etc')).toThrow(IntegrityError)
+  })
+})
+
+describe('commitFiles (D10 transactional)', () => {
+  it('writes every file under the target', () => {
+    const fs = fakeFs()
+    const res = commitFiles(fs, TARGET, [
+      { path: 'widget.tsx', content: 'a' },
+      { path: 'lib/guard.ts', content: 'b' },
+    ])
+    expect(res.written).toEqual(['/proj/components/ask/widget.tsx', '/proj/components/ask/lib/guard.ts'])
+    expect(fs.files.get('/proj/components/ask/lib/guard.ts')).toBe('b')
+  })
+
+  it('aborts on conflict (listing all) and writes nothing, unless --force', () => {
+    const fs = fakeFs({ '/proj/components/ask/widget.tsx': 'old' })
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'widget.tsx', content: 'new' },
+        { path: 'new.ts', content: 'x' },
+      ]),
+    ).toThrow(IntegrityError)
+    // nothing new written, original untouched
+    expect(fs.files.get('/proj/components/ask/widget.tsx')).toBe('old')
+    expect(fs.files.has('/proj/components/ask/new.ts')).toBe(false)
+
+    // force overwrites
+    const res = commitFiles(fs, TARGET, [{ path: 'widget.tsx', content: 'new' }], { force: true })
+    expect(res.written).toHaveLength(1)
+    expect(fs.files.get('/proj/components/ask/widget.tsx')).toBe('new')
+  })
+
+  it('writes nothing when any path is unsafe (validated before writing)', () => {
+    const fs = fakeFs()
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'ok.ts', content: 'a' },
+        { path: '../escape.ts', content: 'b' },
+      ]),
+    ).toThrow(IntegrityError)
+    expect(fs.files.size).toBe(0)
+  })
+
+  it('rolls back already-written files when a later write fails', () => {
+    const fs = fakeFs({}, '/proj/components/ask/second.ts')
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'first.ts', content: 'a' },
+        { path: 'second.ts', content: 'b' },
+      ]),
+    ).toThrow(IntegrityError)
+    // first.ts was written then rolled back → tree is clean
+    expect(fs.files.size).toBe(0)
+  })
+})


### PR DESCRIPTION
**Stacked on #1021** (init/config). Fifth slice — the security core of RFC-0006 Rollout step 3.

## What
`packages/cli/src/components/install.ts`:
- **D16 path containment** — `isSafeRegistryPath` (publish-time: reject absolute + `..` + empty/`.` segments) and `assertContained` (runtime: resolve under the target dir and assert it can't escape). Closes the write-escape vector (`path: '../../.env'`) that content `sha256` + a signed manifest do **not** catch. Applies on write **and** diff-read.
- **D10 transactional `commitFiles`** — validate every path + collect **all** conflicts before writing **any** file (abort unless `--force`), then write, **rolling back** everything on a mid-write failure. Never a partial tree.
- `IntegrityError` typed error (bare-throw gate compliant).

## Tests
7 unit tests (safe-path table, traversal/absolute throws, write-all, conflict-aborts-nothing, force-overwrite, unsafe-aborts-nothing, mid-write rollback). All green; bare-throw gate clean; `tsc` clean.

Stack: #1018 ← #1019 ← #1020 ← #1021 ← this. The real-fs adapter (sibling temp-dir + atomic rename) layers on top in the add-flow slice; the containment + all-or-nothing semantics live here.