### PR TITLE
feat(cli): registry fetch client with per-file integrity (RFC-0006 D9/D14)

### DIFF
--- a/.changeset/cli-component-fetch.md
+++ b/.changeset/cli-component-fetch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the registry fetch client with per-file integrity (`packages/cli/src/components/fetch.ts`, RFC-0006 D9/D14). Resolves `name`/`@org/name`/URL identifiers to a registry base + item, authenticates private registries via `registryAuth` (env-var bearer, never argv), fetches the manifest (kind + schemaVersion gated) and each port file (inline or per-path), and verifies a SHA-256 over every file — aborting the whole install on any mismatch. The signed-manifest check is an injected `signatureVerifier` seam (minisign/Ed25519 primitive lands separately). Network is injectable; fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/fetch.ts
+++ b/packages/cli/src/components/fetch.ts
@@ -1,0 +1,198 @@
+/**
+ * Registry fetch client with per-file integrity (RFC-0006 D9/D14).
+ *
+ * Resolves a component identifier (`name` / `@org/name` / `https://…`) to a
+ * registry base + item id, fetches the manifest at the pinned ref, and fetches
+ * each port file (inline content or per-path), verifying a SHA-256 over every file
+ * and aborting the WHOLE install on any mismatch. Private registries authenticate
+ * via `components.json` `registryAuth` (base URL → env var name) — never an argv
+ * token. The signed-manifest check is an injected `signatureVerifier` seam (the
+ * minisign/Ed25519 primitive lands in its own slice, tested against a real key).
+ *
+ * Network access is injected (`FetchLike`) so the whole client is unit-testable
+ * with no real requests.
+ */
+import { createHash } from 'node:crypto'
+import type { ComponentPort, ComponentsConfig, RegistryComponent } from './types'
+import { IntegrityError, type FileToWrite } from './install'
+
+/** Highest registry `schemaVersion` this CLI understands. */
+export const SUPPORTED_SCHEMA_VERSION = 1
+
+export const DEFAULT_REGISTRY = 'https://registry.agentskit.io'
+
+export interface FetchResponseLike {
+  ok: boolean
+  status: number
+  text: () => Promise<string>
+}
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<FetchResponseLike>
+
+/** A resolved registry location for one item. */
+export interface RegistryRef {
+  base: string
+  itemId: string
+}
+
+export interface ResolveOptions {
+  /** `--registry` override (highest precedence). */
+  registryBase?: string
+}
+
+/**
+ * Resolve an identifier to a {@link RegistryRef} (D9):
+ *   - `https://…/r/foo.json` → that URL's directory as base, `foo` as the item;
+ *   - `@org/name` → `config.registries[org]` as base, `name` as the item;
+ *   - `name` → the default registry (`--registry` > `registries.default`).
+ */
+export function resolveIdentifier(
+  identifier: string,
+  config: Pick<ComponentsConfig, 'registries'> | undefined,
+  options: ResolveOptions = {},
+): RegistryRef {
+  const registries = config?.registries ?? {}
+
+  if (/^https?:\/\//.test(identifier)) {
+    // Direct URL to a manifest: strip `/r/<id>.json` (or any trailing file) → base.
+    const m = identifier.match(/^(.*?)\/r\/([^/]+?)(?:\.json)?$/)
+    if (m) return { base: m[1]!, itemId: m[2]! }
+    const url = new URL(identifier)
+    const id = url.pathname.split('/').filter(Boolean).pop()?.replace(/\.json$/, '') ?? identifier
+    return { base: `${url.origin}`, itemId: id }
+  }
+
+  if (identifier.startsWith('@')) {
+    const slash = identifier.indexOf('/')
+    if (slash < 0) throw new IntegrityError(`invalid namespaced identifier: ${identifier}`)
+    const org = identifier.slice(1, slash)
+    const name = identifier.slice(slash + 1)
+    const base = registries[org]
+    if (!base) throw new IntegrityError(`unknown registry namespace "@${org}" — add it to components.json registries`)
+    return { base, itemId: name }
+  }
+
+  const base = options.registryBase ?? registries.default ?? DEFAULT_REGISTRY
+  return { base, itemId: identifier }
+}
+
+/**
+ * Authorization header for a private registry: `registryAuth` maps a base URL to
+ * the ENV VAR NAME holding its bearer token (D9 — secret never in the file, never
+ * in argv). Returns `{}` when no match or the env var is unset.
+ */
+export function resolveAuthHeader(
+  base: string,
+  config: Pick<ComponentsConfig, 'registryAuth'> | undefined,
+  env: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const map = config?.registryAuth
+  if (!map) return {}
+  for (const [registryBase, envVar] of Object.entries(map)) {
+    if (base.startsWith(registryBase)) {
+      const token = env[envVar]
+      if (token) return { authorization: `Bearer ${token}` }
+    }
+  }
+  return {}
+}
+
+/** Lowercase hex SHA-256 of a string. */
+export function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex')
+}
+
+/** Throw {@link IntegrityError} listing every file whose content fails its sha256. */
+export function verifyChecksums(files: ReadonlyArray<{ path: string; content: string; sha256: string }>): void {
+  const bad = files.filter((f) => sha256Hex(f.content) !== f.sha256).map((f) => f.path)
+  if (bad.length > 0) {
+    throw new IntegrityError(`checksum mismatch — install aborted for ${bad.length} file(s): ${bad.join(', ')}`)
+  }
+}
+
+export interface FetchOptions extends ResolveOptions {
+  fetchImpl?: FetchLike
+  env?: Record<string, string | undefined>
+  config?: Pick<ComponentsConfig, 'registries' | 'registryAuth'>
+  /**
+   * Optional signed-manifest verifier (D9). Receives the raw manifest JSON and the
+   * raw signature; returns whether it is valid. When provided, a manifest that
+   * fails verification aborts the fetch. The minisign signature path is
+   * `<manifest-url>.minisig`.
+   */
+  signatureVerifier?: (manifestRaw: string, signatureRaw: string) => Promise<boolean>
+}
+
+function manifestUrl(ref: RegistryRef): string {
+  return `${ref.base}/r/${ref.itemId}.json`
+}
+function fileUrl(ref: RegistryRef, path: string): string {
+  return `${ref.base}/r/${ref.itemId}/${path}`
+}
+
+async function getText(fetchImpl: FetchLike, url: string, headers: Record<string, string>): Promise<string> {
+  const res = await fetchImpl(url, { headers })
+  if (!res.ok) throw new IntegrityError(`fetch failed (${res.status}) for ${url}`)
+  return res.text()
+}
+
+/** Fetch + parse + integrity/version-gate the component manifest. */
+export async function fetchManifest(identifier: string, options: FetchOptions = {}): Promise<{
+  ref: RegistryRef
+  component: RegistryComponent
+}> {
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike)
+  const ref = resolveIdentifier(identifier, options.config, options)
+  const headers = resolveAuthHeader(ref.base, options.config, options.env)
+
+  const raw = await getText(fetchImpl, manifestUrl(ref), headers)
+
+  if (options.signatureVerifier) {
+    const sig = await getText(fetchImpl, `${manifestUrl(ref)}.minisig`, headers)
+    const ok = await options.signatureVerifier(raw, sig)
+    if (!ok) throw new IntegrityError(`manifest signature verification failed for ${ref.itemId}`)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new IntegrityError(`manifest is not valid JSON for ${ref.itemId}`)
+  }
+  const component = parsed as RegistryComponent
+  if (component?.kind !== 'component') {
+    throw new IntegrityError(`"${ref.itemId}" is not a component (kind=${String((component as { kind?: string })?.kind)})`)
+  }
+  if (typeof component.schemaVersion !== 'number' || component.schemaVersion > SUPPORTED_SCHEMA_VERSION) {
+    throw new IntegrityError(
+      `"${ref.itemId}" needs a newer CLI (schemaVersion ${component.schemaVersion} > ${SUPPORTED_SCHEMA_VERSION})`,
+    )
+  }
+  return { ref, component }
+}
+
+/**
+ * Fetch a port's files — inline `content` when present, else per-path — verify the
+ * SHA-256 of every file, and return them ready for `commitFiles`. Aborts the whole
+ * set on any mismatch (D14/D9). `target` overrides are preserved on each file.
+ */
+export async function fetchPortFiles(
+  ref: RegistryRef,
+  port: ComponentPort,
+  options: FetchOptions = {},
+): Promise<FileToWrite[]> {
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike)
+  const headers = resolveAuthHeader(ref.base, options.config, options.env)
+
+  const resolved = await Promise.all(
+    port.files.map(async (f) => {
+      const content = f.content ?? (await getText(fetchImpl, fileUrl(ref, f.path), headers))
+      return { path: f.path, content, sha256: f.sha256 }
+    }),
+  )
+
+  verifyChecksums(resolved)
+  return resolved.map((f) => ({ path: f.path, content: f.content }))
+}

--- a/packages/cli/tests/components-fetch.test.ts
+++ b/packages/cli/tests/components-fetch.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fetchManifest,
+  fetchPortFiles,
+  resolveAuthHeader,
+  resolveIdentifier,
+  sha256Hex,
+  verifyChecksums,
+  type FetchLike,
+} from '../src/components/fetch'
+import { IntegrityError } from '../src/components/install'
+import type { ComponentPort, RegistryComponent } from '../src/components/types'
+
+const registries = { default: 'https://registry.agentskit.io', acme: 'https://acme.internal/ak' }
+
+/** Fake FetchLike from a url → body map (missing url → 404). */
+function fakeFetch(map: Record<string, string>): FetchLike {
+  return async (url) => {
+    const body = map[url]
+    if (body == null) return { ok: false, status: 404, text: async () => 'not found' }
+    return { ok: true, status: 200, text: async () => body }
+  }
+}
+
+function makePort(files: ComponentPort['files']): ComponentPort {
+  return {
+    uiBinding: 'react',
+    language: 'ts',
+    stylingMode: 'data-attrs-only',
+    streamingProtocol: 'ndjson',
+    files,
+    defaultTarget: 'components/ask',
+  }
+}
+
+function manifest(over: Partial<RegistryComponent> = {}): RegistryComponent {
+  return {
+    $schema: 'x',
+    schemaVersion: 1,
+    kind: 'component',
+    id: 'docs-chat',
+    version: '1.0.0',
+    title: 'Ask the docs',
+    description: '',
+    category: 'chat',
+    frameworks: [{ uiBinding: 'react', metaFramework: 'next-app' }],
+    ports: { react: makePort([]) },
+    packages: [],
+    ...over,
+  }
+}
+
+describe('resolveIdentifier', () => {
+  it('resolves bare / namespaced / URL identifiers', () => {
+    expect(resolveIdentifier('docs-chat', { registries })).toEqual({
+      base: 'https://registry.agentskit.io',
+      itemId: 'docs-chat',
+    })
+    expect(resolveIdentifier('@acme/chat', { registries })).toEqual({
+      base: 'https://acme.internal/ak',
+      itemId: 'chat',
+    })
+    expect(resolveIdentifier('https://reg.example.com/v1/r/docs-chat.json', { registries })).toEqual({
+      base: 'https://reg.example.com/v1',
+      itemId: 'docs-chat',
+    })
+    expect(resolveIdentifier('docs-chat', { registries }, { registryBase: 'https://mirror.local' })).toEqual({
+      base: 'https://mirror.local',
+      itemId: 'docs-chat',
+    })
+  })
+
+  it('throws on an unknown namespace', () => {
+    expect(() => resolveIdentifier('@nope/chat', { registries })).toThrow(IntegrityError)
+  })
+})
+
+describe('resolveAuthHeader', () => {
+  it('injects a bearer token from the mapped env var, else nothing', () => {
+    const config = { registryAuth: { 'https://acme.internal/ak': 'ACME_TOKEN' } }
+    expect(resolveAuthHeader('https://acme.internal/ak', config, { ACME_TOKEN: 'sek' })).toEqual({
+      authorization: 'Bearer sek',
+    })
+    expect(resolveAuthHeader('https://acme.internal/ak', config, {})).toEqual({})
+    expect(resolveAuthHeader('https://registry.agentskit.io', config, { ACME_TOKEN: 'sek' })).toEqual({})
+  })
+})
+
+describe('checksums', () => {
+  it('passes matching and aborts on mismatch', () => {
+    expect(() =>
+      verifyChecksums([{ path: 'a', content: 'hi', sha256: sha256Hex('hi') }]),
+    ).not.toThrow()
+    expect(() =>
+      verifyChecksums([{ path: 'a', content: 'hi', sha256: 'deadbeef' }]),
+    ).toThrow(IntegrityError)
+  })
+})
+
+describe('fetchManifest', () => {
+  const base = 'https://registry.agentskit.io'
+  const url = `${base}/r/docs-chat.json`
+
+  it('fetches, parses, and version-gates', async () => {
+    const fetchImpl = fakeFetch({ [url]: JSON.stringify(manifest()) })
+    const { ref, component } = await fetchManifest('docs-chat', { fetchImpl, config: { registries } })
+    expect(ref.itemId).toBe('docs-chat')
+    expect(component.kind).toBe('component')
+  })
+
+  it('rejects a non-component, a too-new schema, and a 404', async () => {
+    const agent = fakeFetch({ [url]: JSON.stringify({ kind: 'agent', schemaVersion: 1 }) })
+    await expect(fetchManifest('docs-chat', { fetchImpl: agent, config: { registries } })).rejects.toThrow(IntegrityError)
+
+    const future = fakeFetch({ [url]: JSON.stringify(manifest({ schemaVersion: 99 })) })
+    await expect(fetchManifest('docs-chat', { fetchImpl: future, config: { registries } })).rejects.toThrow(/newer CLI/)
+
+    await expect(fetchManifest('docs-chat', { fetchImpl: fakeFetch({}), config: { registries } })).rejects.toThrow(IntegrityError)
+  })
+
+  it('enforces the signature seam when provided', async () => {
+    const fetchImpl = fakeFetch({ [url]: JSON.stringify(manifest()), [`${url}.minisig`]: 'SIG' })
+    await expect(
+      fetchManifest('docs-chat', { fetchImpl, config: { registries }, signatureVerifier: async () => false }),
+    ).rejects.toThrow(/signature verification failed/)
+    const ok = await fetchManifest('docs-chat', {
+      fetchImpl,
+      config: { registries },
+      signatureVerifier: async (raw, sig) => raw.includes('docs-chat') && sig === 'SIG',
+    })
+    expect(ok.component.id).toBe('docs-chat')
+  })
+})
+
+describe('fetchPortFiles', () => {
+  const ref = { base: 'https://registry.agentskit.io', itemId: 'docs-chat' }
+
+  it('uses inline content, fetches the rest, and verifies every checksum', async () => {
+    const fetchImpl = fakeFetch({ [`${ref.base}/r/docs-chat/widget.tsx`]: 'WIDGET' })
+    const port = makePort([
+      { path: 'lib.ts', type: 'registry:lib', sha256: sha256Hex('INLINE'), content: 'INLINE' },
+      { path: 'widget.tsx', type: 'registry:component', sha256: sha256Hex('WIDGET') },
+    ])
+    const files = await fetchPortFiles(ref, port, { fetchImpl })
+    expect(files).toEqual([
+      { path: 'lib.ts', content: 'INLINE' },
+      { path: 'widget.tsx', content: 'WIDGET' },
+    ])
+  })
+
+  it('aborts the whole set on a tampered file', async () => {
+    const fetchImpl = fakeFetch({ [`${ref.base}/r/docs-chat/widget.tsx`]: 'TAMPERED' })
+    const port = makePort([{ path: 'widget.tsx', type: 'registry:component', sha256: sha256Hex('ORIGINAL') }])
+    await expect(fetchPortFiles(ref, port, { fetchImpl })).rejects.toThrow(IntegrityError)
+  })
+})


### PR DESCRIPTION
**Stacked on #1022** (path-guard). Sixth slice — the network + integrity half of RFC-0006 Rollout step 3.

## What
`packages/cli/src/components/fetch.ts`:
- **`resolveIdentifier`** — `name` → default/`--registry`; `@org/name` → `registries[org]`; `https://…/r/x.json` → URL base. Unknown namespace throws.
- **`resolveAuthHeader`** — private registries authenticate via `components.json` `registryAuth` (base URL → env-var name → `Bearer`); secret never in the file, never in argv (D9).
- **`sha256Hex` / `verifyChecksums`** — per-file SHA-256; any mismatch aborts the whole set.
- **`fetchManifest`** — fetch + parse, gate on `kind === 'component'` and `schemaVersion ≤ SUPPORTED`; injected **`signatureVerifier` seam** (a manifest failing it aborts).
- **`fetchPortFiles`** — inline `content` or per-path fetch, verify every checksum, return `FileToWrite[]` for `commitFiles`.

## Scope note
The minisign/Ed25519 signature **primitive** is intentionally a separate slice (it needs a real published key + signature vectors to test against). Here it's a verified injected seam, so the integrity chain (per-file sha256 + version/kind gate + signed-manifest hook) is complete and the crypto lands testably next.

## Tests
9 unit tests, network injected (no real requests): identifier/auth resolution, checksum pass/abort, manifest parse/version-gate/404, signature seam enforce, inline+fetched files with tamper-abort. All green; `tsc` clean.

Stack: #1018 ← #1019 ← #1020 ← #1021 ← #1022 ← this.