### PR TITLE
feat(integrations): GitHub PR review actions (line-level + batched)

### DIFF
--- a/.changeset/github-pr-review-actions.md
+++ b/.changeset/github-pr-review-actions.md
@@ -1,0 +1,6 @@
+---
+"@agentskit/integrations": minor
+"@agentskit/tools": minor
+---
+
+Add two GitHub pull-request review actions: `github_create_pr_review_comment` (a single line-level review comment, anchored to a commit + path + line) and `github_create_pr_review` (a batched review — APPROVE / REQUEST_CHANGES / COMMENT verdict, optional summary body, and any number of inline comments in one call). Both flow through the existing `github({ token })` tool factory automatically. Fills the gap where the GitHub integration could comment on issues but not post line-level PR review comments.

--- a/packages/integrations/src/services/github/actions.ts
+++ b/packages/integrations/src/services/github/actions.ts
@@ -71,4 +71,103 @@ export const githubCommentIssue = defineAction({
   },
 })
 
-export const githubActionsList = [githubSearchIssues, githubCreateIssue, githubCommentIssue]
+export const githubCreatePrReviewComment = defineAction({
+  name: 'github_create_pr_review_comment',
+  description:
+    'Post a single line-level review comment on a pull request. Anchored to a line in a specific commit; the line must be part of the diff.',
+  sideEffect: 'external',
+  sendCapability: 'pulls.createReviewComment',
+  schema: {
+    type: 'object',
+    properties: {
+      owner: { type: 'string' },
+      repo: { type: 'string' },
+      number: { type: 'number', description: 'Pull request number.' },
+      body: { type: 'string', description: 'Comment text (Markdown).' },
+      commit_id: { type: 'string', description: 'SHA of the commit to anchor the comment to (the PR head).' },
+      path: { type: 'string', description: 'File path relative to the repo root.' },
+      line: { type: 'number', description: 'Line number in the file (in the diff), 1-based.' },
+      side: { type: 'string', enum: ['LEFT', 'RIGHT'], description: 'Diff side; default RIGHT (the new version).' },
+      start_line: { type: 'number', description: 'For a multi-line comment, the first line of the range.' },
+      start_side: { type: 'string', enum: ['LEFT', 'RIGHT'] },
+    },
+    required: ['owner', 'repo', 'number', 'body', 'commit_id', 'path', 'line'],
+  },
+  async execute(args, { http }) {
+    const result = await http<{ id: number; html_url: string }>({
+      method: 'POST',
+      path: `/repos/${args.owner}/${args.repo}/pulls/${args.number}/comments`,
+      body: {
+        body: args.body,
+        commit_id: args.commit_id,
+        path: args.path,
+        line: args.line,
+        ...(args.side ? { side: args.side } : {}),
+        ...(args.start_line ? { start_line: args.start_line } : {}),
+        ...(args.start_side ? { start_side: args.start_side } : {}),
+      },
+    })
+    return { id: result.id, url: result.html_url }
+  },
+})
+
+export const githubCreatePrReview = defineAction({
+  name: 'github_create_pr_review',
+  description:
+    'Submit a pull-request review in one call: an overall verdict (APPROVE / REQUEST_CHANGES / COMMENT), an optional summary body, and any number of line-level inline comments.',
+  sideEffect: 'external',
+  sendCapability: 'pulls.createReview',
+  schema: {
+    type: 'object',
+    properties: {
+      owner: { type: 'string' },
+      repo: { type: 'string' },
+      number: { type: 'number', description: 'Pull request number.' },
+      event: {
+        type: 'string',
+        enum: ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'],
+        description: 'The review verdict.',
+      },
+      body: { type: 'string', description: 'Overall review summary (Markdown).' },
+      commit_id: { type: 'string', description: 'SHA the review applies to; defaults to the PR head.' },
+      comments: {
+        type: 'array',
+        description: 'Inline comments to attach to the review.',
+        items: {
+          type: 'object',
+          properties: {
+            path: { type: 'string' },
+            line: { type: 'number' },
+            side: { type: 'string', enum: ['LEFT', 'RIGHT'] },
+            start_line: { type: 'number' },
+            start_side: { type: 'string', enum: ['LEFT', 'RIGHT'] },
+            body: { type: 'string' },
+          },
+          required: ['path', 'line', 'body'],
+        },
+      },
+    },
+    required: ['owner', 'repo', 'number', 'event'],
+  },
+  async execute(args, { http }) {
+    const result = await http<{ id: number; html_url: string; state: string }>({
+      method: 'POST',
+      path: `/repos/${args.owner}/${args.repo}/pulls/${args.number}/reviews`,
+      body: {
+        event: args.event,
+        ...(args.body ? { body: args.body } : {}),
+        ...(args.commit_id ? { commit_id: args.commit_id } : {}),
+        ...(Array.isArray(args.comments) && args.comments.length ? { comments: args.comments } : {}),
+      },
+    })
+    return { id: result.id, url: result.html_url, state: result.state }
+  },
+})
+
+export const githubActionsList = [
+  githubSearchIssues,
+  githubCreateIssue,
+  githubCommentIssue,
+  githubCreatePrReviewComment,
+  githubCreatePrReview,
+]

--- a/packages/integrations/tests/dev.test.ts
+++ b/packages/integrations/tests/dev.test.ts
@@ -31,6 +31,33 @@ describe('github', () => {
     expect(await run(tools.find((t) => t.name === 'github_create_issue')!, { owner: 'o', repo: 'r', title: 'x' })).toEqual({ number: 2, url: 'iu' })
     expect(await run(tools.find((t) => t.name === 'github_comment_issue')!, { owner: 'o', repo: 'r', number: 1, body: 'b' })).toEqual({ id: 9, url: 'cu' })
   })
+
+  it('PR review comment + batched PR review hit the pulls endpoints', async () => {
+    let path = ''; let body: Record<string, unknown> = {}
+    const fetch = fakeFetch((u, init) => {
+      path = u; body = JSON.parse(String(init.body ?? '{}'))
+      if (u.includes('/reviews')) return json({ id: 7, html_url: 'ru', state: 'CHANGES_REQUESTED' })
+      return json({ id: 5, html_url: 'pcu' })
+    })
+    const tools = toToolDefinitions(githubIntegration, { credential: 'gh', fetch })
+
+    const comment = tools.find((t) => t.name === 'github_create_pr_review_comment')!
+    expect(await run(comment, { owner: 'o', repo: 'r', number: 3, body: 'fix', commit_id: 'abc', path: 'a.ts', line: 12 }))
+      .toEqual({ id: 5, url: 'pcu' })
+    expect(path).toContain('/repos/o/r/pulls/3/comments')
+    expect(body).toMatchObject({ body: 'fix', commit_id: 'abc', path: 'a.ts', line: 12 })
+    expect(body).not.toHaveProperty('side') // omitted when not passed
+
+    const review = tools.find((t) => t.name === 'github_create_pr_review')!
+    expect(
+      await run(review, {
+        owner: 'o', repo: 'r', number: 3, event: 'REQUEST_CHANGES', body: 'summary',
+        comments: [{ path: 'a.ts', line: 12, body: 'inline' }],
+      }),
+    ).toEqual({ id: 7, url: 'ru', state: 'CHANGES_REQUESTED' })
+    expect(path).toContain('/repos/o/r/pulls/3/reviews')
+    expect(body).toMatchObject({ event: 'REQUEST_CHANGES', body: 'summary', comments: [{ path: 'a.ts', line: 12, body: 'inline' }] })
+  })
 })
 
 describe('github-actions', () => {

--- a/packages/tools/tests/integrations.test.ts
+++ b/packages/tools/tests/integrations.test.ts
@@ -72,8 +72,18 @@ describe('github', () => {
     expect(capture.url).toContain('/repos/a/b/issues/3/comments')
   })
 
-  it('github() returns all three tools', () => {
-    expect(github({ token: 't' })).toHaveLength(3)
+  it('github() returns the full action set', () => {
+    const names = github({ token: 't' }).map((t) => t.name)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'github_search_issues',
+        'github_create_issue',
+        'github_comment_issue',
+        'github_create_pr_review_comment',
+        'github_create_pr_review',
+      ]),
+    )
+    expect(names).toHaveLength(5)
   })
 })
 


### PR DESCRIPTION
## What

Adds two actions to the GitHub integration (`@agentskit/integrations`), surfaced automatically through `github({ token })` in `@agentskit/tools`:

- **`github_create_pr_review_comment`** — a single line-level review comment, anchored to `commit_id` + `path` + `line` (with optional `side` and multi-line `start_line`/`start_side`). `POST /repos/:o/:r/pulls/:n/comments`.
- **`github_create_pr_review`** — a batched review in one call: an `event` verdict (`APPROVE`/`REQUEST_CHANGES`/`COMMENT`), an optional summary `body`, and any number of inline `comments`. `POST /repos/:o/:r/pulls/:n/reviews`.

## Why

The integration could open + comment on **issues** but had no way to post **line-level PR review comments**. This is a prerequisite for the upcoming `code-review` registry agent's inline reporter — but it's an isolated, additive fill of a real gap, useful on its own.

## Notes

- Both register via `githubActionsList`, so existing `github({ token })` consumers get them with no wiring change.
- Not new public exports (internal action consts aggregated into `githubIntegration`), so no for-agents doc change.
- Tests cover both endpoints, the pulls path, and optional-arg omission. Full integrations suite: 113 pass.

Changeset: `@agentskit/integrations` + `@agentskit/tools` minor.