### PR TITLE
feat(cli): UI component install subsystem — scanner, validator, init, integrity, fetch (RFC-0006 step 2/3)

### DIFF
--- a/.changeset/cli-component-config.md
+++ b/.changeset/cli-component-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the `.agentskit/components.json` builder/reader/writer (`packages/cli/src/components/config.ts`, RFC-0006 D3). `buildConfig(scan)` derives a framework-idiomatic default config (uiBinding, metaFramework, aliases, per-meta server paths, styling, registries, pinned `$schema`); `serialize`/`parse`/`read`/`write`/`resolveConfig` round-trip it with injectable I/O. Fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/.changeset/cli-component-fetch.md
+++ b/.changeset/cli-component-fetch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the registry fetch client with per-file integrity (`packages/cli/src/components/fetch.ts`, RFC-0006 D9/D14). Resolves `name`/`@org/name`/URL identifiers to a registry base + item, authenticates private registries via `registryAuth` (env-var bearer, never argv), fetches the manifest (kind + schemaVersion gated) and each port file (inline or per-path), and verifies a SHA-256 over every file — aborting the whole install on any mismatch. The signed-manifest check is an injected `signatureVerifier` seam (minisign/Ed25519 primitive lands separately). Network is injectable; fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/.changeset/cli-component-install-guard.md
+++ b/.changeset/cli-component-install-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the path-containment guard + transactional file writer (`packages/cli/src/components/install.ts`, RFC-0006 D16/D10). `assertContained`/`isSafeRegistryPath` reject absolute paths and `..` traversal (closing the write-escape vector that valid checksums don't catch); `commitFiles` validates every path + collects all conflicts before writing any file, then rolls back on failure. `IntegrityError` is a typed error (bare-throw gate compliant). Fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/.changeset/cli-component-scanner.md
+++ b/.changeset/cli-component-scanner.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the project scanner (`packages/cli/src/components/scan.ts`, RFC-0006 D3/D4) — detects UI binding, meta-framework (incl. Next app vs pages, Angular SSR vs SPA, the no-server bundlers), package manager, TypeScript, src dir, import alias, styling, and monorepo signals from a project dir via an injectable filesystem. Pure + deterministic + fully unit-tested. Not exported from the package entry yet, so there is no public API change and no release.

--- a/.changeset/cli-component-validator.md
+++ b/.changeset/cli-component-validator.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the component install validator (`packages/cli/src/components/validate.ts`, RFC-0006 install-flow step 5). `validateInstall({ scan, component, installed })` resolves the port by `uiBinding` and checks framework-target support, peer version ranges (with a dependency-free range satisfier), runtime/embedding satisfiability, server-only env scope, TS/JS compatibility, styling, and serverless rate-limit durability — returning structured error/warning issues, never throwing. Fully unit-tested. Not exported from the package entry yet, so there is no public API change and no release.

--- a/packages/cli/src/components/config.ts
+++ b/packages/cli/src/components/config.ts
@@ -1,0 +1,145 @@
+/**
+ * `.agentskit/components.json` — build / read / write (RFC-0006 D3).
+ *
+ * `agentskit init` writes this file once; every later `add` reads it and skips
+ * scanning. This module derives a sensible default `ComponentsConfig` from a
+ * {@link ProjectScan}, and (de)serializes it. Pure + injectable I/O so it is
+ * unit-testable; the interactive `init` command wires these together with prompts.
+ */
+import { join } from 'node:path'
+import type { ComponentsConfig, MetaFramework, ProjectScan } from './types'
+
+/** Where the config lives, relative to the project (or workspace package) root. */
+export const CONFIG_PATH = '.agentskit/components.json'
+
+/** Pinned, fetchable in v1 (the hosted registry URL becomes an alias later, D3). */
+export const SCHEMA_URL =
+  'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/v1/schema/components.json'
+
+export const DEFAULT_REGISTRY = 'https://registry.agentskit.io'
+
+/** Idiomatic server route directory per meta-framework. */
+const SERVER_DIR_BY_META: Record<MetaFramework, string> = {
+  'next-app': 'app/api',
+  'next-pages': 'pages/api',
+  remix: 'app/routes',
+  'tanstack-start': 'app/routes',
+  astro: 'src/pages/api',
+  sveltekit: 'src/routes/api',
+  nuxt: 'server/api',
+  'angular-ssr': 'src/server',
+  expo: 'server',
+  vite: 'server',
+  cra: 'server',
+  'angular-spa': 'server',
+  node: 'server',
+  none: 'server',
+}
+
+function joinPath(base: string, sub: string): string {
+  return base ? `${base}/${sub}` : sub
+}
+
+/**
+ * Derive a default {@link ComponentsConfig} from a scan. The values are
+ * best-effort, framework-idiomatic defaults the user can edit; `init` may override
+ * any of them via prompts. Falls back gracefully when the scan is `unknown`.
+ */
+export function buildConfig(scan: ProjectScan): ComponentsConfig {
+  const uiBinding = scan.uiBinding === 'unknown' ? 'react' : scan.uiBinding
+  const metaFramework = scan.metaFramework === 'unknown' ? 'none' : scan.metaFramework
+  const srcBase = scan.srcDir ?? ''
+
+  const componentsPath = joinPath(srcBase, 'components')
+  const libPath = joinPath(srcBase, 'lib')
+  // Next respects a `src/` dir for its router; prefix the server path when present.
+  const rawServer = SERVER_DIR_BY_META[metaFramework]
+  const serverPath =
+    srcBase && (metaFramework === 'next-app' || metaFramework === 'next-pages') && !rawServer.startsWith('src/')
+      ? joinPath(srcBase, rawServer)
+      : rawServer
+
+  const alias = scan.importAlias
+
+  return {
+    $schema: SCHEMA_URL,
+    schemaVersion: 1,
+    uiBinding,
+    metaFramework,
+    typescript: scan.typescript,
+    styling: {
+      mode: scan.styling.mode,
+      css: scan.styling.cssEntry ?? 'app/globals.css',
+      tailwindConfig: null,
+    },
+    aliases: {
+      // components + lib are import-aliased when the project has one; the server
+      // route is a framework-routed filesystem location, so it mirrors its path.
+      components: alias ? `${alias}/components` : `./${componentsPath}`,
+      lib: alias ? `${alias}/lib` : `./${libPath}`,
+      server: serverPath,
+    },
+    paths: {
+      root: scan.monorepo?.root ?? '.',
+      components: componentsPath,
+      lib: libPath,
+      server: serverPath,
+    },
+    registries: { default: DEFAULT_REGISTRY },
+  }
+}
+
+/** Serialize a config to pretty JSON (with a trailing newline, matching editors). */
+export function serializeConfig(config: ComponentsConfig): string {
+  return `${JSON.stringify(config, null, 2)}\n`
+}
+
+/** Parse + shallow-validate a config string. Returns `null` on malformed input. */
+export function parseConfig(raw: string): ComponentsConfig | null {
+  let data: unknown
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!data || typeof data !== 'object') return null
+  const c = data as Partial<ComponentsConfig>
+  if (typeof c.schemaVersion !== 'number' || !c.uiBinding || !c.metaFramework || !c.registries) {
+    return null
+  }
+  return c as ComponentsConfig
+}
+
+/** Injectable config I/O — `read` returns file contents or `null`; `write` persists. */
+export interface ConfigIo {
+  read: (path: string) => string | null
+  write: (path: string, content: string) => void
+}
+
+/** Read the committed config under `root`, or `null` when absent/malformed. */
+export function readConfig(io: ConfigIo, root = '.'): ComponentsConfig | null {
+  const raw = io.read(join(root, CONFIG_PATH))
+  return raw == null ? null : parseConfig(raw)
+}
+
+/** Write the config under `root`, returning the path written. */
+export function writeConfig(io: ConfigIo, config: ComponentsConfig, root = '.'): string {
+  const path = join(root, CONFIG_PATH)
+  io.write(path, serializeConfig(config))
+  return path
+}
+
+/**
+ * Resolve the effective config: the committed one when present (zero prompts),
+ * else a default derived from the scan. The boolean reports whether it was loaded
+ * from disk (vs. freshly derived → the caller should suggest running `init`).
+ */
+export function resolveConfig(
+  io: ConfigIo,
+  scan: ProjectScan,
+  root = '.',
+): { config: ComponentsConfig; fromDisk: boolean } {
+  const existing = readConfig(io, root)
+  if (existing) return { config: existing, fromDisk: true }
+  return { config: buildConfig(scan), fromDisk: false }
+}

--- a/packages/cli/src/components/fetch.ts
+++ b/packages/cli/src/components/fetch.ts
@@ -1,0 +1,198 @@
+/**
+ * Registry fetch client with per-file integrity (RFC-0006 D9/D14).
+ *
+ * Resolves a component identifier (`name` / `@org/name` / `https://…`) to a
+ * registry base + item id, fetches the manifest at the pinned ref, and fetches
+ * each port file (inline content or per-path), verifying a SHA-256 over every file
+ * and aborting the WHOLE install on any mismatch. Private registries authenticate
+ * via `components.json` `registryAuth` (base URL → env var name) — never an argv
+ * token. The signed-manifest check is an injected `signatureVerifier` seam (the
+ * minisign/Ed25519 primitive lands in its own slice, tested against a real key).
+ *
+ * Network access is injected (`FetchLike`) so the whole client is unit-testable
+ * with no real requests.
+ */
+import { createHash } from 'node:crypto'
+import type { ComponentPort, ComponentsConfig, RegistryComponent } from './types'
+import { IntegrityError, type FileToWrite } from './install'
+
+/** Highest registry `schemaVersion` this CLI understands. */
+export const SUPPORTED_SCHEMA_VERSION = 1
+
+export const DEFAULT_REGISTRY = 'https://registry.agentskit.io'
+
+export interface FetchResponseLike {
+  ok: boolean
+  status: number
+  text: () => Promise<string>
+}
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<FetchResponseLike>
+
+/** A resolved registry location for one item. */
+export interface RegistryRef {
+  base: string
+  itemId: string
+}
+
+export interface ResolveOptions {
+  /** `--registry` override (highest precedence). */
+  registryBase?: string
+}
+
+/**
+ * Resolve an identifier to a {@link RegistryRef} (D9):
+ *   - `https://…/r/foo.json` → that URL's directory as base, `foo` as the item;
+ *   - `@org/name` → `config.registries[org]` as base, `name` as the item;
+ *   - `name` → the default registry (`--registry` > `registries.default`).
+ */
+export function resolveIdentifier(
+  identifier: string,
+  config: Pick<ComponentsConfig, 'registries'> | undefined,
+  options: ResolveOptions = {},
+): RegistryRef {
+  const registries = config?.registries ?? {}
+
+  if (/^https?:\/\//.test(identifier)) {
+    // Direct URL to a manifest: strip `/r/<id>.json` (or any trailing file) → base.
+    const m = identifier.match(/^(.*?)\/r\/([^/]+?)(?:\.json)?$/)
+    if (m) return { base: m[1]!, itemId: m[2]! }
+    const url = new URL(identifier)
+    const id = url.pathname.split('/').filter(Boolean).pop()?.replace(/\.json$/, '') ?? identifier
+    return { base: `${url.origin}`, itemId: id }
+  }
+
+  if (identifier.startsWith('@')) {
+    const slash = identifier.indexOf('/')
+    if (slash < 0) throw new IntegrityError(`invalid namespaced identifier: ${identifier}`)
+    const org = identifier.slice(1, slash)
+    const name = identifier.slice(slash + 1)
+    const base = registries[org]
+    if (!base) throw new IntegrityError(`unknown registry namespace "@${org}" — add it to components.json registries`)
+    return { base, itemId: name }
+  }
+
+  const base = options.registryBase ?? registries.default ?? DEFAULT_REGISTRY
+  return { base, itemId: identifier }
+}
+
+/**
+ * Authorization header for a private registry: `registryAuth` maps a base URL to
+ * the ENV VAR NAME holding its bearer token (D9 — secret never in the file, never
+ * in argv). Returns `{}` when no match or the env var is unset.
+ */
+export function resolveAuthHeader(
+  base: string,
+  config: Pick<ComponentsConfig, 'registryAuth'> | undefined,
+  env: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const map = config?.registryAuth
+  if (!map) return {}
+  for (const [registryBase, envVar] of Object.entries(map)) {
+    if (base.startsWith(registryBase)) {
+      const token = env[envVar]
+      if (token) return { authorization: `Bearer ${token}` }
+    }
+  }
+  return {}
+}
+
+/** Lowercase hex SHA-256 of a string. */
+export function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex')
+}
+
+/** Throw {@link IntegrityError} listing every file whose content fails its sha256. */
+export function verifyChecksums(files: ReadonlyArray<{ path: string; content: string; sha256: string }>): void {
+  const bad = files.filter((f) => sha256Hex(f.content) !== f.sha256).map((f) => f.path)
+  if (bad.length > 0) {
+    throw new IntegrityError(`checksum mismatch — install aborted for ${bad.length} file(s): ${bad.join(', ')}`)
+  }
+}
+
+export interface FetchOptions extends ResolveOptions {
+  fetchImpl?: FetchLike
+  env?: Record<string, string | undefined>
+  config?: Pick<ComponentsConfig, 'registries' | 'registryAuth'>
+  /**
+   * Optional signed-manifest verifier (D9). Receives the raw manifest JSON and the
+   * raw signature; returns whether it is valid. When provided, a manifest that
+   * fails verification aborts the fetch. The minisign signature path is
+   * `<manifest-url>.minisig`.
+   */
+  signatureVerifier?: (manifestRaw: string, signatureRaw: string) => Promise<boolean>
+}
+
+function manifestUrl(ref: RegistryRef): string {
+  return `${ref.base}/r/${ref.itemId}.json`
+}
+function fileUrl(ref: RegistryRef, path: string): string {
+  return `${ref.base}/r/${ref.itemId}/${path}`
+}
+
+async function getText(fetchImpl: FetchLike, url: string, headers: Record<string, string>): Promise<string> {
+  const res = await fetchImpl(url, { headers })
+  if (!res.ok) throw new IntegrityError(`fetch failed (${res.status}) for ${url}`)
+  return res.text()
+}
+
+/** Fetch + parse + integrity/version-gate the component manifest. */
+export async function fetchManifest(identifier: string, options: FetchOptions = {}): Promise<{
+  ref: RegistryRef
+  component: RegistryComponent
+}> {
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike)
+  const ref = resolveIdentifier(identifier, options.config, options)
+  const headers = resolveAuthHeader(ref.base, options.config, options.env)
+
+  const raw = await getText(fetchImpl, manifestUrl(ref), headers)
+
+  if (options.signatureVerifier) {
+    const sig = await getText(fetchImpl, `${manifestUrl(ref)}.minisig`, headers)
+    const ok = await options.signatureVerifier(raw, sig)
+    if (!ok) throw new IntegrityError(`manifest signature verification failed for ${ref.itemId}`)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new IntegrityError(`manifest is not valid JSON for ${ref.itemId}`)
+  }
+  const component = parsed as RegistryComponent
+  if (component?.kind !== 'component') {
+    throw new IntegrityError(`"${ref.itemId}" is not a component (kind=${String((component as { kind?: string })?.kind)})`)
+  }
+  if (typeof component.schemaVersion !== 'number' || component.schemaVersion > SUPPORTED_SCHEMA_VERSION) {
+    throw new IntegrityError(
+      `"${ref.itemId}" needs a newer CLI (schemaVersion ${component.schemaVersion} > ${SUPPORTED_SCHEMA_VERSION})`,
+    )
+  }
+  return { ref, component }
+}
+
+/**
+ * Fetch a port's files — inline `content` when present, else per-path — verify the
+ * SHA-256 of every file, and return them ready for `commitFiles`. Aborts the whole
+ * set on any mismatch (D14/D9). `target` overrides are preserved on each file.
+ */
+export async function fetchPortFiles(
+  ref: RegistryRef,
+  port: ComponentPort,
+  options: FetchOptions = {},
+): Promise<FileToWrite[]> {
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike)
+  const headers = resolveAuthHeader(ref.base, options.config, options.env)
+
+  const resolved = await Promise.all(
+    port.files.map(async (f) => {
+      const content = f.content ?? (await getText(fetchImpl, fileUrl(ref, f.path), headers))
+      return { path: f.path, content, sha256: f.sha256 }
+    }),
+  )
+
+  verifyChecksums(resolved)
+  return resolved.map((f) => ({ path: f.path, content: f.content }))
+}

--- a/packages/cli/src/components/install.ts
+++ b/packages/cli/src/components/install.ts
@@ -1,0 +1,130 @@
+/**
+ * Path-containment guard + transactional file writer (RFC-0006 D16/D10).
+ *
+ * `sha256` verifies file *content* and the signed manifest verifies the checksum
+ * list — but neither constrains *where* a file is written. A valid-checksum entry
+ * with `path: '../../.env'` would escape the target via `join`. D16 closes that:
+ * every registry path is validated (no absolute, no `..`) and every resolved
+ * destination is asserted to stay inside the target dir, on both the write and the
+ * diff-read paths.
+ *
+ * `commitFiles` adds the D10 transactional property at the unit level: validate
+ * ALL paths + collect ALL conflicts before writing ANY file, then write, rolling
+ * back everything written so far if any write fails. (The real-filesystem adapter
+ * layers the sibling temp-dir + atomic rename on top; the all-or-nothing semantics
+ * and the containment guard live here, fully testable.)
+ */
+import { isAbsolute, resolve, sep } from 'node:path'
+
+/** Raised on a path-traversal / unsafe-path / unresolved-conflict violation. */
+export class IntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IntegrityError'
+  }
+}
+
+/**
+ * Publish-time path validation: a registry file path must be relative and contain
+ * no `..` segment (and no empty/`.`-only segment). Pure predicate — the authoring
+ * tooling rejects a manifest that fails this; the CLI re-checks at install.
+ */
+export function isSafeRegistryPath(rel: string): boolean {
+  if (rel === '' || isAbsolute(rel)) return false
+  const segments = rel.split(/[/\\]/)
+  for (const s of segments) {
+    if (s === '' || s === '.' || s === '..') return false
+  }
+  return true
+}
+
+/**
+ * Resolve `rel` under `targetDir` and assert the result stays within it (D16).
+ * Throws {@link IntegrityError} on an unsafe path or an escape; otherwise returns
+ * the absolute destination. Use on every write AND every diff read.
+ */
+export function assertContained(targetDir: string, rel: string): string {
+  if (!isSafeRegistryPath(rel)) {
+    throw new IntegrityError(`unsafe registry path rejected: ${JSON.stringify(rel)}`)
+  }
+  const base = resolve(targetDir)
+  const dest = resolve(base, rel)
+  if (dest !== base && !dest.startsWith(base + sep)) {
+    throw new IntegrityError(`path escapes the target directory: ${JSON.stringify(rel)}`)
+  }
+  return dest
+}
+
+/** Minimal filesystem surface for the writer. Injectable for tests. */
+export interface WriteFs {
+  exists: (path: string) => boolean
+  /** Write `content`, creating parent directories as needed. */
+  write: (path: string, content: string) => void
+  /** Remove a file (used for rollback). */
+  remove: (path: string) => void
+}
+
+/** A file to install, with its path relative to the target directory. */
+export interface FileToWrite {
+  path: string
+  content: string
+}
+
+export interface CommitOptions {
+  /** Overwrite files that already exist. Default: abort on any conflict. */
+  force?: boolean
+}
+
+export interface CommitResult {
+  /** Absolute destinations written, in order. */
+  written: string[]
+}
+
+/**
+ * Install `files` into `targetDir` transactionally:
+ *   1. validate + contain every path (D16) — any failure aborts before any write;
+ *   2. collect ALL pre-existing conflicts — abort listing them unless `force`;
+ *   3. write; if any write throws, roll back everything written and rethrow.
+ *
+ * Never leaves a partially-written tree.
+ */
+export function commitFiles(
+  fs: WriteFs,
+  targetDir: string,
+  files: ReadonlyArray<FileToWrite>,
+  options: CommitOptions = {},
+): CommitResult {
+  // 1 — resolve + contain every destination first.
+  const planned = files.map((f) => ({ dest: assertContained(targetDir, f.path), content: f.content, rel: f.path }))
+
+  // 2 — collect all conflicts up front (no throw-on-first).
+  if (!options.force) {
+    const conflicts = planned.filter((p) => fs.exists(p.dest)).map((p) => p.rel)
+    if (conflicts.length > 0) {
+      throw new IntegrityError(
+        `refusing to overwrite ${conflicts.length} existing file(s) (use --force): ${conflicts.join(', ')}`,
+      )
+    }
+  }
+
+  // 3 — write, rolling back on any failure.
+  const written: string[] = []
+  try {
+    for (const p of planned) {
+      fs.write(p.dest, p.content)
+      written.push(p.dest)
+    }
+  } catch (err) {
+    for (const dest of written.reverse()) {
+      try {
+        fs.remove(dest)
+      } catch {
+        // best-effort rollback; surface the original error below
+      }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    throw new IntegrityError(`install failed and was rolled back (${written.length} file(s) removed): ${message}`)
+  }
+
+  return { written }
+}

--- a/packages/cli/src/components/scan.ts
+++ b/packages/cli/src/components/scan.ts
@@ -1,0 +1,185 @@
+/**
+ * Project scanner (RFC-0006 D3/D4).
+ *
+ * Inspects a project directory and produces a {@link ProjectScan}: the UI binding,
+ * meta-framework, package manager, TypeScript flag, source dir, import alias,
+ * styling, and monorepo signals that `agentskit add` needs when there is no
+ * committed `.agentskit/components.json`. Pure + deterministic + dependency-light:
+ * all filesystem access goes through an injectable {@link ScanFs}, so it is fully
+ * unit-testable with an in-memory tree and never guesses silently — ambiguous
+ * signals resolve to `'unknown'`/`null` and surface later in validation.
+ */
+import { join } from 'node:path'
+import type {
+  MetaFramework,
+  PackageManager,
+  ProjectScan,
+  UiBinding,
+} from './types'
+
+/** The only filesystem surface the scanner needs. Injectable for tests. */
+export interface ScanFs {
+  /** Return the file contents, or `null` if it does not exist / can't be read. */
+  readFile: (path: string) => string | null
+  /** Whether a file or directory exists at `path`. */
+  exists: (path: string) => boolean
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+/** Merge all dependency buckets into one name→range map. */
+function allDeps(pkg: PackageJson | null): Record<string, string> {
+  if (!pkg) return {}
+  return { ...pkg.peerDependencies, ...pkg.devDependencies, ...pkg.dependencies }
+}
+
+function readJson<T>(fs: ScanFs, path: string): T | null {
+  const raw = fs.readFile(path)
+  if (raw == null) return null
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+function detectPackageManager(fs: ScanFs, root: string): PackageManager {
+  if (fs.exists(join(root, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fs.exists(join(root, 'bun.lockb')) || fs.exists(join(root, 'bun.lock'))) return 'bun'
+  if (fs.exists(join(root, 'yarn.lock'))) return 'yarn'
+  return 'npm'
+}
+
+/**
+ * UI binding from dependencies. Order matters: react-native and the various
+ * meta-framework UI libs must be checked before the bare `react`/`vue` they build
+ * on, so `expo`/`react-native` is never misread as plain `react`.
+ */
+function detectUiBinding(deps: Record<string, string>): UiBinding | 'unknown' {
+  const has = (name: string): boolean => name in deps
+  if (has('react-native') || has('expo')) return 'react-native'
+  if (has('@angular/core')) return 'angular'
+  if (has('svelte')) return 'svelte'
+  if (has('nuxt') || has('vue')) return 'vue'
+  if (has('solid-js')) return 'solid'
+  if (has('ink')) return 'ink'
+  if (has('react')) return 'react'
+  return 'unknown'
+}
+
+/**
+ * Meta-framework — decides WHERE a server file lands. Distinguishes app vs pages
+ * router (Next), SSR vs SPA (Angular), and the no-server bundlers (vite/cra).
+ */
+function detectMetaFramework(
+  fs: ScanFs,
+  root: string,
+  deps: Record<string, string>,
+  uiBinding: UiBinding | 'unknown',
+): MetaFramework | 'unknown' {
+  const has = (name: string): boolean => name in deps
+  const hasPrefix = (prefix: string): boolean => Object.keys(deps).some((d) => d.startsWith(prefix))
+
+  if (has('next')) {
+    // App Router when an `app/` (or `src/app/`) dir exists, else Pages Router.
+    if (fs.exists(join(root, 'app')) || fs.exists(join(root, 'src/app'))) return 'next-app'
+    return 'next-pages'
+  }
+  if (hasPrefix('@remix-run/')) return 'remix'
+  if (has('@tanstack/react-start') || has('@tanstack/start')) return 'tanstack-start'
+  if (has('@sveltejs/kit')) return 'sveltekit'
+  if (has('nuxt')) return 'nuxt'
+  if (has('astro')) return 'astro'
+  if (uiBinding === 'angular') {
+    return has('@angular/ssr') || has('@angular/platform-server') ? 'angular-ssr' : 'angular-spa'
+  }
+  if (has('expo')) return 'expo'
+  if (has('react-scripts')) return 'cra'
+  if (has('vite')) return 'vite'
+  if (uiBinding === 'ink') return 'node'
+  if (uiBinding === 'unknown') return 'unknown'
+  return 'none'
+}
+
+/** First `@/*`-style alias from tsconfig `compilerOptions.paths`, sans `/*`. */
+function detectImportAlias(fs: ScanFs, root: string): string | null {
+  const tsconfig = readJson<{ compilerOptions?: { paths?: Record<string, string[]> } }>(
+    fs,
+    join(root, 'tsconfig.json'),
+  )
+  const paths = tsconfig?.compilerOptions?.paths
+  if (!paths) return null
+  for (const key of Object.keys(paths)) {
+    // e.g. "@/*" → "@", "~/*" → "~". Skip exact (non-wildcard) mappings.
+    if (key.endsWith('/*')) return key.slice(0, -2)
+  }
+  return null
+}
+
+const CSS_ENTRY_CANDIDATES = [
+  'app/globals.css',
+  'app/global.css',
+  'src/app/globals.css',
+  'src/index.css',
+  'src/styles/globals.css',
+  'styles/globals.css',
+  'src/app.css',
+  'src/styles.css',
+]
+
+function detectStyling(
+  fs: ScanFs,
+  root: string,
+  deps: Record<string, string>,
+): ProjectScan['styling'] {
+  const tailwind =
+    'tailwindcss' in deps ||
+    fs.exists(join(root, 'tailwind.config.ts')) ||
+    fs.exists(join(root, 'tailwind.config.js')) ||
+    fs.exists(join(root, 'tailwind.config.cjs')) ||
+    fs.exists(join(root, 'tailwind.config.mjs'))
+  let cssEntry: string | null = null
+  for (const candidate of CSS_ENTRY_CANDIDATES) {
+    if (fs.exists(join(root, candidate))) {
+      cssEntry = candidate
+      break
+    }
+  }
+  return { mode: tailwind ? 'tailwind-preset' : 'data-attrs-only', cssEntry }
+}
+
+function detectMonorepo(fs: ScanFs, root: string): ProjectScan['monorepo'] {
+  if (fs.exists(join(root, 'pnpm-workspace.yaml'))) return { tool: 'pnpm', root }
+  if (fs.exists(join(root, 'turbo.json'))) return { tool: 'turbo', root }
+  if (fs.exists(join(root, 'nx.json'))) return { tool: 'nx', root }
+  return null
+}
+
+/**
+ * Scan `root` and return the detected {@link ProjectScan}. Never throws — a
+ * missing/unparseable `package.json` yields an all-`unknown`/default scan that the
+ * validator then reports, rather than a crash or a silent wrong guess.
+ */
+export function scanProject(fs: ScanFs, root = '.'): ProjectScan {
+  const pkg = readJson<PackageJson>(fs, join(root, 'package.json'))
+  const deps = allDeps(pkg)
+
+  const uiBinding = detectUiBinding(deps)
+  const metaFramework = detectMetaFramework(fs, root, deps, uiBinding)
+  const srcDir = fs.exists(join(root, 'src')) ? 'src' : null
+
+  return {
+    uiBinding,
+    metaFramework,
+    packageManager: detectPackageManager(fs, root),
+    typescript: fs.exists(join(root, 'tsconfig.json')),
+    srcDir,
+    importAlias: detectImportAlias(fs, root),
+    styling: detectStyling(fs, root, deps),
+    monorepo: detectMonorepo(fs, root),
+  }
+}

--- a/packages/cli/src/components/validate.ts
+++ b/packages/cli/src/components/validate.ts
@@ -1,0 +1,207 @@
+/**
+ * Component install validator (RFC-0006 install-flow step 5; D4/D5/D11/D12).
+ *
+ * Given a {@link ProjectScan} and a {@link RegistryComponent}, decide whether the
+ * component can be installed into this project — BEFORE any file is written. It
+ * resolves the port by `uiBinding`, then checks: framework-target support, peer
+ * version ranges, runtime/embedding satisfiability, server-only env scope, TS/JS
+ * compatibility, styling, and serverless rate-limit durability. Pure + deterministic;
+ * returns structured issues (never throws) so the CLI can print them and a
+ * `--dry-run`/`--yes` flow can branch on `ok`.
+ */
+import type { ComponentPort, MetaFramework, ProjectScan, RegistryComponent } from './types'
+
+export type ValidationSeverity = 'error' | 'warning'
+
+export interface ValidationIssue {
+  severity: ValidationSeverity
+  code: string
+  message: string
+}
+
+export interface ValidationResult {
+  /** True when there are no `error`-severity issues. */
+  ok: boolean
+  /** The resolved port for the detected `uiBinding`, when one exists. */
+  port?: ComponentPort
+  issues: ValidationIssue[]
+}
+
+export interface ValidateInput {
+  scan: ProjectScan
+  component: RegistryComponent
+  /** Installed dependency versions (name → version) from the project package.json. */
+  installed?: Record<string, string>
+}
+
+/** Meta-frameworks with no Node server runtime (pure client / device). */
+const NO_NODE_SERVER: ReadonlySet<MetaFramework> = new Set([
+  'expo',
+  'vite',
+  'cra',
+  'angular-spa',
+  'none',
+])
+
+/** Meta-frameworks commonly deployed serverless (per-instance limiter is unsafe). */
+const SERVERLESS_CAPABLE: ReadonlySet<MetaFramework> = new Set([
+  'next-app',
+  'next-pages',
+  'remix',
+  'tanstack-start',
+  'sveltekit',
+  'nuxt',
+])
+
+interface Semver {
+  major: number
+  minor: number
+  patch: number
+}
+
+/** Parse `1.2.3` / `v1.2.3` / `1.2` (prerelease + build stripped). `null` if unparseable. */
+function parseVersion(input: string): Semver | null {
+  const cleaned = input.trim().replace(/^[v=]+/, '').split(/[-+]/)[0] ?? ''
+  const parts = cleaned.split('.')
+  if (parts.length === 0 || parts[0] === '') return null
+  const nums = parts.map((p) => Number.parseInt(p, 10))
+  if (nums.some((n) => Number.isNaN(n))) return null
+  return { major: nums[0] ?? 0, minor: nums[1] ?? 0, patch: nums[2] ?? 0 }
+}
+
+function cmp(a: Semver, b: Semver): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch
+}
+
+/**
+ * Minimal range satisfier — the subset peerRanges actually use: `*`/empty, exact,
+ * comparators (`>=`,`>`,`<=`,`<`,`=`), caret (`^`), tilde (`~`), and `workspace:*`
+ * (always satisfied — the version is repo-owner-controlled, RFC-0006 D11). A `||`
+ * union is supported by splitting. Unknown forms fail OPEN (treated as satisfied)
+ * so an unrecognised range never wrongly blocks an install.
+ */
+export function satisfiesRange(version: string, range: string): boolean {
+  const r = range.trim()
+  if (r === '' || r === '*' || r === 'x' || r.startsWith('workspace:')) return true
+  if (r.includes('||')) return r.split('||').some((part) => satisfiesRange(version, part))
+
+  const v = parseVersion(version)
+  if (!v) return true // can't parse installed version → don't block
+
+  const m = r.match(/^(>=|<=|>|<|=|\^|~)?\s*(.+)$/)
+  if (!m) return true
+  const op = m[1] ?? '='
+  const target = parseVersion(m[2]!)
+  if (!target) return true
+
+  switch (op) {
+    case '>=':
+      return cmp(v, target) >= 0
+    case '>':
+      return cmp(v, target) > 0
+    case '<=':
+      return cmp(v, target) <= 0
+    case '<':
+      return cmp(v, target) < 0
+    case '^': {
+      // Compatible within the leftmost non-zero version segment.
+      if (cmp(v, target) < 0) return false
+      if (target.major > 0) return v.major === target.major
+      if (target.minor > 0) return v.major === 0 && v.minor === target.minor
+      return v.major === 0 && v.minor === 0 && v.patch === target.patch
+    }
+    case '~':
+      // Same major.minor, patch >=.
+      return v.major === target.major && v.minor === target.minor && cmp(v, target) >= 0
+    default:
+      return cmp(v, target) === 0
+  }
+}
+
+export function validateInstall(input: ValidateInput): ValidationResult {
+  const { scan, component, installed = {} } = input
+  const issues: ValidationIssue[] = []
+  const err = (code: string, message: string) => issues.push({ severity: 'error', code, message })
+  const warn = (code: string, message: string) => issues.push({ severity: 'warning', code, message })
+
+  const supported = Object.keys(component.ports)
+
+  // ── Framework-target support (D4). ─────────────────────────────────────────
+  if (scan.uiBinding === 'unknown') {
+    err('framework-unknown', `Could not detect the UI framework. ${component.id} supports: ${supported.join(', ')}.`)
+    return { ok: false, issues }
+  }
+  const port = component.ports[scan.uiBinding]
+  if (!port) {
+    err(
+      'binding-unsupported',
+      `${component.id} has no "${scan.uiBinding}" port. Supported bindings: ${supported.join(', ')}.`,
+    )
+    return { ok: false, issues }
+  }
+  // The declared (uiBinding, metaFramework) pair must be shipped.
+  const pairShipped = component.frameworks.some(
+    (t) => t.uiBinding === scan.uiBinding && (scan.metaFramework === 'unknown' || t.metaFramework === scan.metaFramework),
+  )
+  if (scan.metaFramework !== 'unknown' && !pairShipped) {
+    err(
+      'target-unsupported',
+      `${component.id} does not ship a ${scan.uiBinding} × ${scan.metaFramework} target.`,
+    )
+  }
+
+  // ── Peer ranges (D11): port-level overrides component-level. ───────────────
+  const peerRanges = { ...component.peerRanges, ...port.peerRanges }
+  for (const [name, range] of Object.entries(peerRanges)) {
+    const have = installed[name]
+    if (have == null) continue // not yet installed — will be added; don't block
+    if (!satisfiesRange(have, range)) {
+      err('peer-mismatch', `${name}@${have} does not satisfy required ${range}.`)
+    }
+  }
+
+  // ── Runtime + embedding satisfiability (D5/D6). ────────────────────────────
+  const server = port.server
+  if (server) {
+    const noServer = NO_NODE_SERVER.has(scan.metaFramework as MetaFramework)
+    if (server.runtimeRequirement === 'nodejs' && noServer && server.delivery === 'bundled') {
+      err(
+        'runtime-unsatisfiable',
+        `${scan.metaFramework} has no Node server, but this port needs a bundled Node handler. Use a hosted endpoint instead.`,
+      )
+    }
+    if (server.embeddingBackend === 'onnx-node' && noServer) {
+      err(
+        'embedding-unsatisfiable',
+        `The onnx-node embedder needs a Node runtime; ${scan.metaFramework} can't run it. Use a BYO/api-remote embedder.`,
+      )
+    }
+    // Server-only secret would land in a client bundle (D5 env scope).
+    if (noServer && server.delivery === 'bundled') {
+      for (const e of component.env ?? []) {
+        if (e.scope === 'server' && e.required) {
+          err('env-client-leak', `Server-only env "${e.name}" can't be bundled into a client-only ${scan.metaFramework} target.`)
+        }
+      }
+    }
+    // Durable rate-limit on serverless (D5).
+    if (server.rateLimitBackend === 'memory' && SERVERLESS_CAPABLE.has(scan.metaFramework as MetaFramework)) {
+      warn(
+        'ratelimit-memory',
+        `In-memory rate-limit is per-instance and ineffective on serverless ${scan.metaFramework}. Set UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN for a durable limiter.`,
+      )
+    }
+  }
+
+  // ── TS / JS compatibility (D12). ───────────────────────────────────────────
+  if (port.language === 'ts' && !scan.typescript) {
+    err('language-ts-only', `${component.id}'s ${scan.uiBinding} port is TypeScript-only, but this is a JavaScript project.`)
+  }
+
+  // ── Styling (D8). ──────────────────────────────────────────────────────────
+  if (port.stylingMode === 'tailwind-preset' && scan.styling.mode !== 'tailwind-preset') {
+    warn('styling-tailwind', `This port expects Tailwind, which wasn't detected. The component still renders via its --ak-* tokens; wire the preset manually.`)
+  }
+
+  return { ok: !issues.some((i) => i.severity === 'error'), port, issues }
+}

--- a/packages/cli/tests/components-config.test.ts
+++ b/packages/cli/tests/components-config.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONFIG_PATH,
+  DEFAULT_REGISTRY,
+  SCHEMA_URL,
+  buildConfig,
+  parseConfig,
+  readConfig,
+  resolveConfig,
+  serializeConfig,
+  writeConfig,
+  type ConfigIo,
+} from '../src/components/config'
+import type { ProjectScan } from '../src/components/types'
+
+function makeScan(over: Partial<ProjectScan> = {}): ProjectScan {
+  return {
+    uiBinding: 'react',
+    metaFramework: 'next-app',
+    packageManager: 'pnpm',
+    typescript: true,
+    srcDir: 'src',
+    importAlias: '@',
+    styling: { mode: 'tailwind-preset', cssEntry: 'src/app/globals.css' },
+    monorepo: null,
+    ...over,
+  }
+}
+
+/** In-memory ConfigIo backed by a Map. */
+function fakeIo(seed: Record<string, string> = {}): ConfigIo & { files: Map<string, string> } {
+  const files = new Map(Object.entries(seed))
+  return {
+    files,
+    read: (p) => files.get(p) ?? null,
+    write: (p, c) => void files.set(p, c),
+  }
+}
+
+describe('buildConfig', () => {
+  it('derives an aliased, src-prefixed Next App Router config', () => {
+    const c = buildConfig(makeScan())
+    expect(c.$schema).toBe(SCHEMA_URL)
+    expect(c.schemaVersion).toBe(1)
+    expect(c.uiBinding).toBe('react')
+    expect(c.metaFramework).toBe('next-app')
+    expect(c.typescript).toBe(true)
+    expect(c.aliases).toEqual({ components: '@/components', lib: '@/lib', server: 'src/app/api' })
+    expect(c.paths).toEqual({ root: '.', components: 'src/components', lib: 'src/lib', server: 'src/app/api' })
+    expect(c.styling).toEqual({ mode: 'tailwind-preset', css: 'src/app/globals.css', tailwindConfig: null })
+    expect(c.registries.default).toBe(DEFAULT_REGISTRY)
+  })
+
+  it('uses relative aliases + root-level paths when there is no alias or src', () => {
+    const c = buildConfig(makeScan({ importAlias: null, srcDir: null, metaFramework: 'next-pages' }))
+    expect(c.aliases).toEqual({ components: './components', lib: './lib', server: 'pages/api' })
+    expect(c.paths.components).toBe('components')
+    expect(c.paths.server).toBe('pages/api')
+  })
+
+  it('maps server dirs per meta-framework', () => {
+    expect(buildConfig(makeScan({ uiBinding: 'svelte', metaFramework: 'sveltekit', srcDir: null })).paths.server).toBe('src/routes/api')
+    expect(buildConfig(makeScan({ uiBinding: 'vue', metaFramework: 'nuxt', srcDir: null })).paths.server).toBe('server/api')
+  })
+
+  it('anchors root to the monorepo root', () => {
+    expect(buildConfig(makeScan({ monorepo: { tool: 'pnpm', root: '/repo' } })).paths.root).toBe('/repo')
+  })
+
+  it('falls back to react/none for an unknown scan', () => {
+    const c = buildConfig(makeScan({ uiBinding: 'unknown', metaFramework: 'unknown' }))
+    expect(c.uiBinding).toBe('react')
+    expect(c.metaFramework).toBe('none')
+  })
+})
+
+describe('serialize / parse', () => {
+  it('round-trips through serialize → parse', () => {
+    const c = buildConfig(makeScan())
+    const parsed = parseConfig(serializeConfig(c))
+    expect(parsed).toEqual(c)
+  })
+
+  it('rejects malformed or incomplete configs', () => {
+    expect(parseConfig('{ not json')).toBeNull()
+    expect(parseConfig('null')).toBeNull()
+    expect(parseConfig(JSON.stringify({ uiBinding: 'react' }))).toBeNull() // no schemaVersion/registries
+  })
+})
+
+describe('read / write / resolve', () => {
+  it('writes then reads the config under the root', () => {
+    const io = fakeIo()
+    const c = buildConfig(makeScan())
+    const written = writeConfig(io, c)
+    expect(written).toBe(CONFIG_PATH)
+    expect(readConfig(io)).toEqual(c)
+  })
+
+  it('resolveConfig prefers the committed file, else derives from the scan', () => {
+    const c = buildConfig(makeScan())
+    const onDisk = fakeIo({ [CONFIG_PATH]: serializeConfig(c) })
+    expect(resolveConfig(onDisk, makeScan())).toEqual({ config: c, fromDisk: true })
+
+    const empty = fakeIo()
+    const resolved = resolveConfig(empty, makeScan({ metaFramework: 'next-pages' }))
+    expect(resolved.fromDisk).toBe(false)
+    expect(resolved.config.metaFramework).toBe('next-pages')
+  })
+})

--- a/packages/cli/tests/components-fetch.test.ts
+++ b/packages/cli/tests/components-fetch.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fetchManifest,
+  fetchPortFiles,
+  resolveAuthHeader,
+  resolveIdentifier,
+  sha256Hex,
+  verifyChecksums,
+  type FetchLike,
+} from '../src/components/fetch'
+import { IntegrityError } from '../src/components/install'
+import type { ComponentPort, RegistryComponent } from '../src/components/types'
+
+const registries = { default: 'https://registry.agentskit.io', acme: 'https://acme.internal/ak' }
+
+/** Fake FetchLike from a url → body map (missing url → 404). */
+function fakeFetch(map: Record<string, string>): FetchLike {
+  return async (url) => {
+    const body = map[url]
+    if (body == null) return { ok: false, status: 404, text: async () => 'not found' }
+    return { ok: true, status: 200, text: async () => body }
+  }
+}
+
+function makePort(files: ComponentPort['files']): ComponentPort {
+  return {
+    uiBinding: 'react',
+    language: 'ts',
+    stylingMode: 'data-attrs-only',
+    streamingProtocol: 'ndjson',
+    files,
+    defaultTarget: 'components/ask',
+  }
+}
+
+function manifest(over: Partial<RegistryComponent> = {}): RegistryComponent {
+  return {
+    $schema: 'x',
+    schemaVersion: 1,
+    kind: 'component',
+    id: 'docs-chat',
+    version: '1.0.0',
+    title: 'Ask the docs',
+    description: '',
+    category: 'chat',
+    frameworks: [{ uiBinding: 'react', metaFramework: 'next-app' }],
+    ports: { react: makePort([]) },
+    packages: [],
+    ...over,
+  }
+}
+
+describe('resolveIdentifier', () => {
+  it('resolves bare / namespaced / URL identifiers', () => {
+    expect(resolveIdentifier('docs-chat', { registries })).toEqual({
+      base: 'https://registry.agentskit.io',
+      itemId: 'docs-chat',
+    })
+    expect(resolveIdentifier('@acme/chat', { registries })).toEqual({
+      base: 'https://acme.internal/ak',
+      itemId: 'chat',
+    })
+    expect(resolveIdentifier('https://reg.example.com/v1/r/docs-chat.json', { registries })).toEqual({
+      base: 'https://reg.example.com/v1',
+      itemId: 'docs-chat',
+    })
+    expect(resolveIdentifier('docs-chat', { registries }, { registryBase: 'https://mirror.local' })).toEqual({
+      base: 'https://mirror.local',
+      itemId: 'docs-chat',
+    })
+  })
+
+  it('throws on an unknown namespace', () => {
+    expect(() => resolveIdentifier('@nope/chat', { registries })).toThrow(IntegrityError)
+  })
+})
+
+describe('resolveAuthHeader', () => {
+  it('injects a bearer token from the mapped env var, else nothing', () => {
+    const config = { registryAuth: { 'https://acme.internal/ak': 'ACME_TOKEN' } }
+    expect(resolveAuthHeader('https://acme.internal/ak', config, { ACME_TOKEN: 'sek' })).toEqual({
+      authorization: 'Bearer sek',
+    })
+    expect(resolveAuthHeader('https://acme.internal/ak', config, {})).toEqual({})
+    expect(resolveAuthHeader('https://registry.agentskit.io', config, { ACME_TOKEN: 'sek' })).toEqual({})
+  })
+})
+
+describe('checksums', () => {
+  it('passes matching and aborts on mismatch', () => {
+    expect(() =>
+      verifyChecksums([{ path: 'a', content: 'hi', sha256: sha256Hex('hi') }]),
+    ).not.toThrow()
+    expect(() =>
+      verifyChecksums([{ path: 'a', content: 'hi', sha256: 'deadbeef' }]),
+    ).toThrow(IntegrityError)
+  })
+})
+
+describe('fetchManifest', () => {
+  const base = 'https://registry.agentskit.io'
+  const url = `${base}/r/docs-chat.json`
+
+  it('fetches, parses, and version-gates', async () => {
+    const fetchImpl = fakeFetch({ [url]: JSON.stringify(manifest()) })
+    const { ref, component } = await fetchManifest('docs-chat', { fetchImpl, config: { registries } })
+    expect(ref.itemId).toBe('docs-chat')
+    expect(component.kind).toBe('component')
+  })
+
+  it('rejects a non-component, a too-new schema, and a 404', async () => {
+    const agent = fakeFetch({ [url]: JSON.stringify({ kind: 'agent', schemaVersion: 1 }) })
+    await expect(fetchManifest('docs-chat', { fetchImpl: agent, config: { registries } })).rejects.toThrow(IntegrityError)
+
+    const future = fakeFetch({ [url]: JSON.stringify(manifest({ schemaVersion: 99 })) })
+    await expect(fetchManifest('docs-chat', { fetchImpl: future, config: { registries } })).rejects.toThrow(/newer CLI/)
+
+    await expect(fetchManifest('docs-chat', { fetchImpl: fakeFetch({}), config: { registries } })).rejects.toThrow(IntegrityError)
+  })
+
+  it('enforces the signature seam when provided', async () => {
+    const fetchImpl = fakeFetch({ [url]: JSON.stringify(manifest()), [`${url}.minisig`]: 'SIG' })
+    await expect(
+      fetchManifest('docs-chat', { fetchImpl, config: { registries }, signatureVerifier: async () => false }),
+    ).rejects.toThrow(/signature verification failed/)
+    const ok = await fetchManifest('docs-chat', {
+      fetchImpl,
+      config: { registries },
+      signatureVerifier: async (raw, sig) => raw.includes('docs-chat') && sig === 'SIG',
+    })
+    expect(ok.component.id).toBe('docs-chat')
+  })
+})
+
+describe('fetchPortFiles', () => {
+  const ref = { base: 'https://registry.agentskit.io', itemId: 'docs-chat' }
+
+  it('uses inline content, fetches the rest, and verifies every checksum', async () => {
+    const fetchImpl = fakeFetch({ [`${ref.base}/r/docs-chat/widget.tsx`]: 'WIDGET' })
+    const port = makePort([
+      { path: 'lib.ts', type: 'registry:lib', sha256: sha256Hex('INLINE'), content: 'INLINE' },
+      { path: 'widget.tsx', type: 'registry:component', sha256: sha256Hex('WIDGET') },
+    ])
+    const files = await fetchPortFiles(ref, port, { fetchImpl })
+    expect(files).toEqual([
+      { path: 'lib.ts', content: 'INLINE' },
+      { path: 'widget.tsx', content: 'WIDGET' },
+    ])
+  })
+
+  it('aborts the whole set on a tampered file', async () => {
+    const fetchImpl = fakeFetch({ [`${ref.base}/r/docs-chat/widget.tsx`]: 'TAMPERED' })
+    const port = makePort([{ path: 'widget.tsx', type: 'registry:component', sha256: sha256Hex('ORIGINAL') }])
+    await expect(fetchPortFiles(ref, port, { fetchImpl })).rejects.toThrow(IntegrityError)
+  })
+})

--- a/packages/cli/tests/components-install.test.ts
+++ b/packages/cli/tests/components-install.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IntegrityError,
+  assertContained,
+  commitFiles,
+  isSafeRegistryPath,
+  type WriteFs,
+} from '../src/components/install'
+
+const TARGET = '/proj/components/ask'
+
+/** In-memory WriteFs backed by a Map. `failOn` makes a given dest throw on write. */
+function fakeFs(seed: Record<string, string> = {}, failOn?: string): WriteFs & { files: Map<string, string> } {
+  const files = new Map(Object.entries(seed))
+  return {
+    files,
+    exists: (p) => files.has(p),
+    write: (p, c) => {
+      if (p === failOn) throw new Error('disk full')
+      files.set(p, c)
+    },
+    remove: (p) => void files.delete(p),
+  }
+}
+
+describe('isSafeRegistryPath', () => {
+  it('accepts relative paths and rejects absolute / traversal / empty segments', () => {
+    expect(isSafeRegistryPath('a/b.ts')).toBe(true)
+    expect(isSafeRegistryPath('lib/ask/guard.ts')).toBe(true)
+    expect(isSafeRegistryPath('')).toBe(false)
+    expect(isSafeRegistryPath('/etc/passwd')).toBe(false)
+    expect(isSafeRegistryPath('../x')).toBe(false)
+    expect(isSafeRegistryPath('a/../b')).toBe(false)
+    expect(isSafeRegistryPath('a/./b')).toBe(false)
+    expect(isSafeRegistryPath('a//b')).toBe(false)
+  })
+})
+
+describe('assertContained (D16)', () => {
+  it('resolves a safe path inside the target', () => {
+    expect(assertContained(TARGET, 'a/b.ts')).toBe('/proj/components/ask/a/b.ts')
+  })
+
+  it('throws IntegrityError on traversal or absolute paths', () => {
+    expect(() => assertContained(TARGET, '../../.env')).toThrow(IntegrityError)
+    expect(() => assertContained(TARGET, '/etc/passwd')).toThrow(IntegrityError)
+    expect(() => assertContained(TARGET, 'ok/../../../etc')).toThrow(IntegrityError)
+  })
+})
+
+describe('commitFiles (D10 transactional)', () => {
+  it('writes every file under the target', () => {
+    const fs = fakeFs()
+    const res = commitFiles(fs, TARGET, [
+      { path: 'widget.tsx', content: 'a' },
+      { path: 'lib/guard.ts', content: 'b' },
+    ])
+    expect(res.written).toEqual(['/proj/components/ask/widget.tsx', '/proj/components/ask/lib/guard.ts'])
+    expect(fs.files.get('/proj/components/ask/lib/guard.ts')).toBe('b')
+  })
+
+  it('aborts on conflict (listing all) and writes nothing, unless --force', () => {
+    const fs = fakeFs({ '/proj/components/ask/widget.tsx': 'old' })
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'widget.tsx', content: 'new' },
+        { path: 'new.ts', content: 'x' },
+      ]),
+    ).toThrow(IntegrityError)
+    // nothing new written, original untouched
+    expect(fs.files.get('/proj/components/ask/widget.tsx')).toBe('old')
+    expect(fs.files.has('/proj/components/ask/new.ts')).toBe(false)
+
+    // force overwrites
+    const res = commitFiles(fs, TARGET, [{ path: 'widget.tsx', content: 'new' }], { force: true })
+    expect(res.written).toHaveLength(1)
+    expect(fs.files.get('/proj/components/ask/widget.tsx')).toBe('new')
+  })
+
+  it('writes nothing when any path is unsafe (validated before writing)', () => {
+    const fs = fakeFs()
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'ok.ts', content: 'a' },
+        { path: '../escape.ts', content: 'b' },
+      ]),
+    ).toThrow(IntegrityError)
+    expect(fs.files.size).toBe(0)
+  })
+
+  it('rolls back already-written files when a later write fails', () => {
+    const fs = fakeFs({}, '/proj/components/ask/second.ts')
+    expect(() =>
+      commitFiles(fs, TARGET, [
+        { path: 'first.ts', content: 'a' },
+        { path: 'second.ts', content: 'b' },
+      ]),
+    ).toThrow(IntegrityError)
+    // first.ts was written then rolled back → tree is clean
+    expect(fs.files.size).toBe(0)
+  })
+})

--- a/packages/cli/tests/components-scan.test.ts
+++ b/packages/cli/tests/components-scan.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { scanProject, type ScanFs } from '../src/components/scan'
+
+/**
+ * Build an in-memory {@link ScanFs} from a map of relative path → file contents
+ * plus a list of directory paths. Paths are relative to root `'.'` (the scanner's
+ * default), so e.g. `package.json` and `app` match the scanner's `join('.', …)`.
+ */
+function fakeFs(files: Record<string, string>, dirs: string[] = []): ScanFs {
+  const dirSet = new Set(dirs)
+  return {
+    readFile: (path) => (path in files ? files[path]! : null),
+    exists: (path) => path in files || dirSet.has(path),
+  }
+}
+
+function pkg(deps: Record<string, string>, dev: Record<string, string> = {}): string {
+  return JSON.stringify({ dependencies: deps, devDependencies: dev })
+}
+
+describe('scanProject', () => {
+  it('detects a Next.js App Router + React + pnpm + tailwind + alias + src', () => {
+    const fs = fakeFs(
+      {
+        'package.json': pkg({ next: '15.0.0', react: '19.0.0', tailwindcss: '3.4.0' }),
+        'pnpm-lock.yaml': '',
+        'tsconfig.json': JSON.stringify({ compilerOptions: { paths: { '@/*': ['./src/*'] } } }),
+        'app/globals.css': '',
+      },
+      ['app', 'src'],
+    )
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react')
+    expect(scan.metaFramework).toBe('next-app')
+    expect(scan.packageManager).toBe('pnpm')
+    expect(scan.typescript).toBe(true)
+    expect(scan.srcDir).toBe('src')
+    expect(scan.importAlias).toBe('@')
+    expect(scan.styling).toEqual({ mode: 'tailwind-preset', cssEntry: 'app/globals.css' })
+    expect(scan.monorepo).toBeNull()
+  })
+
+  it('detects Next Pages Router when there is no app/ dir', () => {
+    const fs = fakeFs({ 'package.json': pkg({ next: '14.0.0', react: '18.0.0' }) }, ['pages'])
+    expect(scanProject(fs).metaFramework).toBe('next-pages')
+  })
+
+  it('detects SvelteKit', () => {
+    const fs = fakeFs(
+      { 'package.json': pkg({ svelte: '5.0.0' }, { '@sveltejs/kit': '2.0.0' }), 'yarn.lock': '' },
+      [],
+    )
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('svelte')
+    expect(scan.metaFramework).toBe('sveltekit')
+    expect(scan.packageManager).toBe('yarn')
+  })
+
+  it('detects Nuxt as vue', () => {
+    const fs = fakeFs({ 'package.json': pkg({ nuxt: '3.13.0', vue: '3.5.0' }) })
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('vue')
+    expect(scan.metaFramework).toBe('nuxt')
+  })
+
+  it('distinguishes Angular SSR from SPA', () => {
+    const ssr = scanProject(
+      fakeFs({ 'package.json': pkg({ '@angular/core': '19.0.0', '@angular/ssr': '19.0.0' }) }),
+    )
+    expect(ssr.uiBinding).toBe('angular')
+    expect(ssr.metaFramework).toBe('angular-ssr')
+
+    const spa = scanProject(fakeFs({ 'package.json': pkg({ '@angular/core': '19.0.0' }) }))
+    expect(spa.metaFramework).toBe('angular-spa')
+  })
+
+  it('detects Expo / React Native (never misread as plain react)', () => {
+    const fs = fakeFs({ 'package.json': pkg({ expo: '52.0.0', react: '19.0.0', 'react-native': '0.76.0' }) })
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react-native')
+    expect(scan.metaFramework).toBe('expo')
+  })
+
+  it('detects a Vite + React SPA', () => {
+    const fs = fakeFs({ 'package.json': pkg({ react: '19.0.0' }, { vite: '6.0.0' }) }, ['src'])
+    const scan = scanProject(fs)
+    expect(scan.uiBinding).toBe('react')
+    expect(scan.metaFramework).toBe('vite')
+  })
+
+  it('detects Ink as a node target', () => {
+    const scan = scanProject(fakeFs({ 'package.json': pkg({ ink: '5.0.0', react: '18.0.0' }) }))
+    expect(scan.uiBinding).toBe('ink')
+    expect(scan.metaFramework).toBe('node')
+  })
+
+  it('detects a pnpm monorepo + tailwind via config file (not a dep)', () => {
+    const fs = fakeFs(
+      { 'package.json': pkg({ react: '19.0.0' }), 'pnpm-workspace.yaml': '', 'tailwind.config.ts': '' },
+      [],
+    )
+    const scan = scanProject(fs)
+    expect(scan.monorepo).toEqual({ tool: 'pnpm', root: '.' })
+    expect(scan.styling.mode).toBe('tailwind-preset')
+  })
+
+  it('falls back to unknown/defaults (no throw) when package.json is missing or invalid', () => {
+    const empty = scanProject(fakeFs({}))
+    expect(empty.uiBinding).toBe('unknown')
+    expect(empty.metaFramework).toBe('unknown')
+    expect(empty.packageManager).toBe('npm')
+    expect(empty.typescript).toBe(false)
+    expect(empty.srcDir).toBeNull()
+    expect(empty.importAlias).toBeNull()
+    expect(empty.styling).toEqual({ mode: 'data-attrs-only', cssEntry: null })
+    expect(empty.monorepo).toBeNull()
+
+    const broken = scanProject(fakeFs({ 'package.json': '{ not valid json' }))
+    expect(broken.uiBinding).toBe('unknown')
+  })
+})

--- a/packages/cli/tests/components-validate.test.ts
+++ b/packages/cli/tests/components-validate.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { satisfiesRange, validateInstall } from '../src/components/validate'
+import type { ComponentPort, ProjectScan, RegistryComponent } from '../src/components/types'
+
+function makePort(over: Partial<ComponentPort> = {}): ComponentPort {
+  return {
+    uiBinding: 'react',
+    language: 'ts',
+    stylingMode: 'data-attrs-only',
+    streamingProtocol: 'ndjson',
+    files: [],
+    defaultTarget: 'components/ask',
+    server: {
+      delivery: 'bundled',
+      runtimeRequirement: 'nodejs',
+      embeddingBackend: 'onnx-node',
+      rateLimitBackend: 'external-required',
+    },
+    ...over,
+  }
+}
+
+function makeComponent(over: Partial<RegistryComponent> = {}): RegistryComponent {
+  return {
+    $schema: 'x',
+    schemaVersion: 1,
+    kind: 'component',
+    id: 'docs-chat',
+    version: '1.0.0',
+    title: 'Ask the docs',
+    description: '',
+    category: 'chat',
+    frameworks: [{ uiBinding: 'react', metaFramework: 'next-app' }],
+    ports: { react: makePort() },
+    packages: [],
+    env: [],
+    ...over,
+  }
+}
+
+function makeScan(over: Partial<ProjectScan> = {}): ProjectScan {
+  return {
+    uiBinding: 'react',
+    metaFramework: 'next-app',
+    packageManager: 'pnpm',
+    typescript: true,
+    srcDir: 'src',
+    importAlias: '@',
+    styling: { mode: 'data-attrs-only', cssEntry: null },
+    monorepo: null,
+    ...over,
+  }
+}
+
+const codes = (r: { issues: { code: string }[] }) => r.issues.map((i) => i.code)
+
+describe('satisfiesRange', () => {
+  it('handles the subset peerRanges use', () => {
+    expect(satisfiesRange('2.1.0', '>=2')).toBe(true)
+    expect(satisfiesRange('1.9.0', '>=2')).toBe(false)
+    expect(satisfiesRange('1.4.2', '^1.2.0')).toBe(true)
+    expect(satisfiesRange('2.0.0', '^1.2.0')).toBe(false)
+    expect(satisfiesRange('1.2.9', '~1.2.0')).toBe(true)
+    expect(satisfiesRange('1.3.0', '~1.2.0')).toBe(false)
+    expect(satisfiesRange('3.0.0', '*')).toBe(true)
+    expect(satisfiesRange('1.0.0', 'workspace:*')).toBe(true)
+    expect(satisfiesRange('2.0.0', '1.x || >=2')).toBe(true)
+    expect(satisfiesRange('1.2.3', '1.2.3')).toBe(true)
+  })
+})
+
+describe('validateInstall', () => {
+  it('passes a supported react × next-app target', () => {
+    const r = validateInstall({ scan: makeScan(), component: makeComponent() })
+    expect(r.ok).toBe(true)
+    expect(r.issues).toHaveLength(0)
+    expect(r.port).toBeDefined()
+  })
+
+  it('errors on an undetected framework', () => {
+    const r = validateInstall({ scan: makeScan({ uiBinding: 'unknown' }), component: makeComponent() })
+    expect(r.ok).toBe(false)
+    expect(codes(r)).toContain('framework-unknown')
+  })
+
+  it('errors when the binding has no port', () => {
+    const r = validateInstall({ scan: makeScan({ uiBinding: 'vue', metaFramework: 'nuxt' }), component: makeComponent() })
+    expect(r.ok).toBe(false)
+    expect(codes(r)).toContain('binding-unsupported')
+  })
+
+  it('errors when the (binding, meta) pair is not shipped', () => {
+    const r = validateInstall({ scan: makeScan({ metaFramework: 'remix' }), component: makeComponent() })
+    expect(codes(r)).toContain('target-unsupported')
+  })
+
+  it('errors on a peer-range mismatch but accepts workspace + uninstalled', () => {
+    const component = makeComponent({ peerRanges: { '@agentskit/react': '>=2' } })
+    expect(validateInstall({ scan: makeScan(), component, installed: { '@agentskit/react': '1.9.0' } }).ok).toBe(false)
+    expect(validateInstall({ scan: makeScan(), component, installed: { '@agentskit/react': '2.1.0' } }).ok).toBe(true)
+    // workspace: + not-yet-installed both pass.
+    expect(validateInstall({ scan: makeScan(), component, installed: { '@agentskit/react': 'workspace:*' } }).ok).toBe(true)
+    expect(validateInstall({ scan: makeScan(), component, installed: {} }).ok).toBe(true)
+  })
+
+  it('errors when a Node/onnx port targets a server-less framework', () => {
+    const component = makeComponent({
+      frameworks: [{ uiBinding: 'react', metaFramework: 'vite' }],
+      ports: { react: makePort() },
+    })
+    const r = validateInstall({ scan: makeScan({ metaFramework: 'vite' }), component })
+    expect(r.ok).toBe(false)
+    expect(codes(r)).toEqual(expect.arrayContaining(['runtime-unsatisfiable', 'embedding-unsatisfiable']))
+  })
+
+  it('errors when a server-only secret would land in a client bundle', () => {
+    const component = makeComponent({
+      frameworks: [{ uiBinding: 'react', metaFramework: 'vite' }],
+      ports: { react: makePort({ server: { delivery: 'bundled', runtimeRequirement: 'none', embeddingBackend: 'none', rateLimitBackend: 'memory' } }) },
+      env: [{ name: 'OPENROUTER_API_KEY', description: '', required: true, scope: 'server' }],
+    })
+    const r = validateInstall({ scan: makeScan({ metaFramework: 'vite' }), component })
+    expect(codes(r)).toContain('env-client-leak')
+  })
+
+  it('warns on memory rate-limit for serverless, ts-only on JS, and missing tailwind', () => {
+    const ratelimit = validateInstall({
+      scan: makeScan(),
+      component: makeComponent({ ports: { react: makePort({ server: { delivery: 'bundled', runtimeRequirement: 'nodejs', embeddingBackend: 'onnx-node', rateLimitBackend: 'memory' } }) } }),
+    })
+    expect(ratelimit.ok).toBe(true)
+    expect(codes(ratelimit)).toContain('ratelimit-memory')
+
+    const jsProject = validateInstall({ scan: makeScan({ typescript: false }), component: makeComponent() })
+    expect(jsProject.ok).toBe(false)
+    expect(codes(jsProject)).toContain('language-ts-only')
+
+    const tailwind = validateInstall({
+      scan: makeScan(),
+      component: makeComponent({ ports: { react: makePort({ stylingMode: 'tailwind-preset' }) } }),
+    })
+    expect(tailwind.ok).toBe(true)
+    expect(codes(tailwind)).toContain('styling-tailwind')
+  })
+})


### PR DESCRIPTION
Consolidates the 5 CLI component slices onto current `main` after #1018 (contract types) merged. The original stacked PRs (#1019–#1023) broke when the squash-merge of #1018 deleted their base branch — re-based here as one clean, reviewable series of 5 commits.

## Commits (RFC-0006 Rollout step 2/3)
1. **Project scanner** (`scan.ts`, D3/D4) — detect uiBinding × metaFramework (Next app/pages, Angular ssr/spa, sveltekit/nuxt/remix/tanstack/expo/vite/ink…), pkg manager, TS, alias, styling, monorepo. Injectable fs.
2. **Validator** (`validate.ts`, step 5) — framework-target support, peer ranges (dep-free satisfier), runtime/embedding satisfiability, server-env-scope, TS/JS, rate-limit. Structured issues.
3. **`components.json`** (`config.ts`, D3) — `buildConfig(scan)` + serialize/parse/read/write/resolve.
4. **Path-guard + transactional writer** (`install.ts`, D16/D10) — reject `..`/abs, `assertContained`, all-or-nothing `commitFiles` with rollback, `IntegrityError`.
5. **Fetch client** (`fetch.ts`, D9/D14) — identifier/registry/auth resolution, per-file sha256 verify, manifest kind/version gate, signature seam.

## Quality
- **44 unit tests** across the 5 modules, all green; `tsc` clean; bare-throw gate clean.
- Pure + injectable I/O throughout (no network/fs in tests). Not exported from the package entry yet → no public API change, empty (no-release) changesets.

Supersedes #1019, #1020, #1021, #1022, #1023.