### PR TITLE
feat(cli): minisign Ed25519 signature verification (RFC-0006 D9)

### DIFF
--- a/.changeset/cli-component-sig.md
+++ b/.changeset/cli-component-sig.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add minisign (Ed25519) signature verification (`packages/cli/src/components/sig.ts`, RFC-0006 D9) — implements the `signatureVerifier` seam the fetch client injects. Parses the minisign public-key + signature wire format, supports both legacy `Ed` (raw bytes) and prehashed `ED` (BLAKE2b-512) kinds, checks the key id, and verifies via `node:crypto` (no external binary). `makeSignatureVerifier(publicKey)` builds the `(manifestRaw, signatureRaw) => Promise<boolean>` the fetch client expects. Fully unit-tested with a generated keypair. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/sig.ts
+++ b/packages/cli/src/components/sig.ts
@@ -1,0 +1,125 @@
+/**
+ * Minisign signature verification (RFC-0006 D9).
+ *
+ * Implements the `signatureVerifier` seam the fetch client injects: verify a
+ * minisign (Ed25519) detached signature over the registry manifest, against a
+ * public key shipped with the CLI. Supports both minisign signature kinds —
+ * legacy `Ed` (signs the raw bytes) and prehashed `ED` (signs BLAKE2b-512 of the
+ * bytes) — and checks the key id matches before verifying.
+ *
+ * minisign wire format (the base64 payload on line 2 of each file):
+ *   public key:  algorithm[2 "Ed"] · key_id[8] · ed25519_public_key[32]   (42 bytes)
+ *   signature:   algorithm[2 "Ed"|"ED"] · key_id[8] · ed25519_signature[64] (74 bytes)
+ * Line 1 is the "untrusted comment". The signature file's trusted-comment global
+ * signature (lines 3–4) protects the comment only and is not needed to verify the
+ * payload, so it is ignored here.
+ *
+ * Uses only `node:crypto` (Ed25519 + blake2b512) — no external `minisign` binary.
+ */
+import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto'
+import { IntegrityError } from './install'
+
+export interface MinisignPublicKey {
+  algorithm: string
+  keyId: Buffer
+  publicKey: Buffer
+}
+
+export interface MinisignSignature {
+  algorithm: string
+  keyId: Buffer
+  signature: Buffer
+}
+
+/** The base64 payload of a minisign file is its second non-empty line. */
+function payloadLine(content: string): Buffer {
+  const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0)
+  if (lines.length < 2) throw new IntegrityError('malformed minisign file: missing payload line')
+  try {
+    return Buffer.from(lines[1]!.trim(), 'base64')
+  } catch {
+    throw new IntegrityError('malformed minisign file: payload is not valid base64')
+  }
+}
+
+export function parseMinisignPublicKey(content: string): MinisignPublicKey {
+  const buf = payloadLine(content)
+  if (buf.length !== 42) throw new IntegrityError(`malformed minisign public key: expected 42 bytes, got ${buf.length}`)
+  return {
+    algorithm: buf.subarray(0, 2).toString('latin1'),
+    keyId: buf.subarray(2, 10),
+    publicKey: buf.subarray(10, 42),
+  }
+}
+
+export function parseMinisignSignature(content: string): MinisignSignature {
+  const buf = payloadLine(content)
+  if (buf.length !== 74) throw new IntegrityError(`malformed minisign signature: expected 74 bytes, got ${buf.length}`)
+  return {
+    algorithm: buf.subarray(0, 2).toString('latin1'),
+    keyId: buf.subarray(2, 10),
+    signature: buf.subarray(10, 74),
+  }
+}
+
+/** Build an Ed25519 public KeyObject from the raw 32-byte key (via JWK OKP). */
+function ed25519PublicKey(raw: Buffer): ReturnType<typeof createPublicKey> {
+  return createPublicKey({
+    key: { kty: 'OKP', crv: 'Ed25519', x: raw.toString('base64url') },
+    format: 'jwk',
+  })
+}
+
+function verifyEd25519(message: Buffer, signature: Buffer, rawPublicKey: Buffer): boolean {
+  try {
+    return cryptoVerify(null, message, ed25519PublicKey(rawPublicKey), signature)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Verify a minisign signature over `message` against `publicKeyContent`. Returns
+ * false (never throws on a bad signature) when the key id mismatches, the
+ * algorithm is unknown, or the Ed25519 check fails. Throws {@link IntegrityError}
+ * only when a file is structurally malformed.
+ */
+export function verifyMinisign(
+  message: Buffer | string,
+  signatureContent: string,
+  publicKeyContent: string,
+): boolean {
+  const pub = parseMinisignPublicKey(publicKeyContent)
+  const sig = parseMinisignSignature(signatureContent)
+  if (!sig.keyId.equals(pub.keyId)) return false
+
+  const bytes = Buffer.isBuffer(message) ? message : Buffer.from(message, 'utf8')
+  let signed: Buffer
+  if (sig.algorithm === 'ED') {
+    // Prehashed: minisign signs BLAKE2b-512 of the file.
+    signed = createHash('blake2b512').update(bytes).digest()
+  } else if (sig.algorithm === 'Ed') {
+    // Legacy: signs the raw bytes.
+    signed = bytes
+  } else {
+    return false
+  }
+  return verifyEd25519(signed, sig.signature, pub.publicKey)
+}
+
+/**
+ * Build the `signatureVerifier` the fetch client expects, bound to a shipped
+ * public key. `(manifestRaw, signatureRaw) => Promise<boolean>`.
+ */
+export function makeSignatureVerifier(
+  publicKeyContent: string,
+): (manifestRaw: string, signatureRaw: string) => Promise<boolean> {
+  return async (manifestRaw, signatureRaw) => {
+    try {
+      return verifyMinisign(manifestRaw, signatureRaw, publicKeyContent)
+    } catch {
+      // A malformed signature/key is a verification failure, not a crash.
+      return false
+    }
+  }
+}

--- a/packages/cli/tests/components-sig.test.ts
+++ b/packages/cli/tests/components-sig.test.ts
@@ -1,0 +1,102 @@
+import { createHash, generateKeyPairSync, sign as cryptoSign, type KeyObject } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  makeSignatureVerifier,
+  parseMinisignPublicKey,
+  parseMinisignSignature,
+  verifyMinisign,
+} from '../src/components/sig'
+import { IntegrityError } from '../src/components/install'
+
+/** Raw 32-byte Ed25519 public key from a KeyObject. */
+function rawPublicKey(publicKey: KeyObject): Buffer {
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string }
+  return Buffer.from(jwk.x, 'base64url')
+}
+
+function pubContent(keyId: Buffer, raw: Buffer): string {
+  const payload = Buffer.concat([Buffer.from('Ed', 'latin1'), keyId, raw])
+  return `untrusted comment: minisign public key\n${payload.toString('base64')}\n`
+}
+
+function sigContent(algorithm: 'Ed' | 'ED', keyId: Buffer, signature: Buffer): string {
+  const payload = Buffer.concat([Buffer.from(algorithm, 'latin1'), keyId, signature])
+  return (
+    `untrusted comment: signature\n${payload.toString('base64')}\n` +
+    `trusted comment: timestamp\n${Buffer.alloc(64).toString('base64')}\n`
+  )
+}
+
+const KEY_ID = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])
+const MESSAGE = '{"id":"docs-chat","version":"1.0.0"}'
+
+function freshKey() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  return { publicKey, privateKey, raw: rawPublicKey(publicKey) }
+}
+
+describe('minisign parsing', () => {
+  it('round-trips public key and signature payloads', () => {
+    const { raw } = freshKey()
+    const pk = parseMinisignPublicKey(pubContent(KEY_ID, raw))
+    expect(pk.algorithm).toBe('Ed')
+    expect(pk.keyId.equals(KEY_ID)).toBe(true)
+    expect(pk.publicKey.equals(raw)).toBe(true)
+
+    const sg = parseMinisignSignature(sigContent('ED', KEY_ID, Buffer.alloc(64, 7)))
+    expect(sg.algorithm).toBe('ED')
+    expect(sg.signature.length).toBe(64)
+  })
+
+  it('throws IntegrityError on malformed input', () => {
+    expect(() => parseMinisignPublicKey('only one line')).toThrow(IntegrityError)
+    expect(() => parseMinisignPublicKey('comment\nnotbase64!!!@@@')).toThrow(IntegrityError)
+    expect(() => parseMinisignSignature(`comment\n${Buffer.alloc(10).toString('base64')}`)).toThrow(IntegrityError)
+  })
+})
+
+describe('verifyMinisign', () => {
+  it('verifies a legacy (Ed) signature over the raw bytes', () => {
+    const { privateKey, raw } = freshKey()
+    const signature = cryptoSign(null, Buffer.from(MESSAGE, 'utf8'), privateKey)
+    expect(verifyMinisign(MESSAGE, sigContent('Ed', KEY_ID, signature), pubContent(KEY_ID, raw))).toBe(true)
+  })
+
+  it('verifies a prehashed (ED) signature over blake2b-512', () => {
+    const { privateKey, raw } = freshKey()
+    const digest = createHash('blake2b512').update(Buffer.from(MESSAGE, 'utf8')).digest()
+    const signature = cryptoSign(null, digest, privateKey)
+    expect(verifyMinisign(MESSAGE, sigContent('ED', KEY_ID, signature), pubContent(KEY_ID, raw))).toBe(true)
+  })
+
+  it('rejects a tampered message, a wrong key id, and an unknown algorithm', () => {
+    const { privateKey, raw } = freshKey()
+    const signature = cryptoSign(null, Buffer.from(MESSAGE, 'utf8'), privateKey)
+    const pub = pubContent(KEY_ID, raw)
+
+    expect(verifyMinisign(`${MESSAGE} tampered`, sigContent('Ed', KEY_ID, signature), pub)).toBe(false)
+    const otherId = Buffer.from([9, 9, 9, 9, 9, 9, 9, 9])
+    expect(verifyMinisign(MESSAGE, sigContent('Ed', otherId, signature), pub)).toBe(false)
+    expect(verifyMinisign(MESSAGE, sigContent('Xx' as 'Ed', KEY_ID, signature), pub)).toBe(false)
+  })
+
+  it('rejects a signature from a different key', () => {
+    const signer = freshKey()
+    const attackerSig = cryptoSign(null, Buffer.from(MESSAGE, 'utf8'), signer.privateKey)
+    const victim = freshKey()
+    // Same key id framing but the published key is the victim's → must fail.
+    expect(verifyMinisign(MESSAGE, sigContent('Ed', KEY_ID, attackerSig), pubContent(KEY_ID, victim.raw))).toBe(false)
+  })
+})
+
+describe('makeSignatureVerifier (fetch seam)', () => {
+  it('returns a verifier that accepts valid and rejects invalid/malformed', async () => {
+    const { privateKey, raw } = freshKey()
+    const signature = cryptoSign(null, Buffer.from(MESSAGE, 'utf8'), privateKey)
+    const verify = makeSignatureVerifier(pubContent(KEY_ID, raw))
+
+    await expect(verify(MESSAGE, sigContent('Ed', KEY_ID, signature))).resolves.toBe(true)
+    await expect(verify(MESSAGE, 'garbage')).resolves.toBe(false)
+    await expect(verify('different manifest', sigContent('Ed', KEY_ID, signature))).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
Off `main`, independent (no stack). Fills the **`signatureVerifier` seam** the fetch client (#1025) injects — the crypto half of RFC-0006 D9 supply-chain integrity.

## What
`packages/cli/src/components/sig.ts`:
- Parses the **minisign wire format** — public key (`algorithm[2]·key_id[8]·ed25519_pubkey[32]`, 42B) and signature (`algorithm[2]·key_id[8]·ed25519_sig[64]`, 74B).
- Verifies both kinds: **legacy `Ed`** (signs raw bytes) and **prehashed `ED`** (signs BLAKE2b-512). Checks the key id matches before verifying.
- `node:crypto` only (Ed25519 + blake2b512) — **no external minisign binary**.
- `makeSignatureVerifier(publicKey)` → the `(manifestRaw, signatureRaw) => Promise<boolean>` the fetch client expects; malformed input → `false`, never a crash. `IntegrityError` only on structural malformation.

## Tests
7 unit tests with a **generated Ed25519 keypair** (framed into minisign format in-test): parse round-trip, legacy + prehashed verify, tamper / wrong-key-id / unknown-algo / different-key rejection, and the verifier seam. All green; bare-throw gate clean; sig.ts `tsc` clean.

## Wiring
Stays a ready primitive (not exported yet); the add-flow will call `makeSignatureVerifier(SHIPPED_KEY)` and pass it to `fetchManifest` once the registry publishes its key. No public API change → empty changeset.