### PR TITLE
feat(cli): install marker + tamper-evident audit writer (RFC-0006 D9/D15)

### DIFF
--- a/.changeset/cli-component-marker.md
+++ b/.changeset/cli-component-marker.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add `packages/cli/src/components/marker.ts` — install marker upsert/find/remove on `components.json`'s `installed[]` (keyed by `{ id, installPath }`, monorepo-safe) plus a tamper-evident, hash-linked audit chain for `.agentskit/install-log.jsonl` (RFC-0006 D9/D15). Marker entries record per-file SHA-256 at install time (injected `now`) to power the later 3-way diff/update; `appendAudit` links each entry to the canonical SHA-256 of its predecessor, and `verifyAuditChain` walks the chain to flag the first index where tampering, reordering, or deletion breaks it. All functions are pure + deterministic (timestamps injected, keys canonicalised before hashing), throws reuse `IntegrityError`, and the module is fully unit-tested. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/marker.ts
+++ b/packages/cli/src/components/marker.ts
@@ -1,0 +1,202 @@
+/**
+ * Install marker + tamper-evident audit chain (RFC-0006 D9/D15).
+ *
+ * Two cooperating records track what was installed and prove it was not silently
+ * altered:
+ *
+ *   • The **install marker** is the `installed[]` array on `components.json`. Each
+ *     entry is keyed by `{ id, installPath }` so the same component can live in
+ *     several workspace packages (monorepo-safe) without collisions. The per-file
+ *     `{ sha, installedAt }` map captures content hashes at install time, which is
+ *     what later powers the 3-way diff/update (D15).
+ *
+ *   • The **audit chain** is the append-only `.agentskit/install-log.jsonl`
+ *     (NDJSON). Each {@link AuditEntry} carries the SHA-256 of the *canonical* prior
+ *     entry in `prevEntryHash`, hash-linking the log: tampering with, reordering, or
+ *     deleting any entry breaks the chain at a detectable index (D9).
+ *
+ * Everything here is pure + deterministic: timestamps are injected (`now`), object
+ * keys are canonicalised (recursively sorted) before hashing so the chain is
+ * reproducible, and the only I/O is (de)serialisation of strings — the
+ * real-filesystem append lives in the command layer. All throws reuse
+ * {@link IntegrityError} (the repo forbids bare `new Error`).
+ */
+import type { AuditEntry, ComponentsConfig, FrameworkTarget, InstalledComponent } from './types'
+import { sha256Hex } from './fetch'
+import { IntegrityError } from './install'
+import type { FileToWrite } from './install'
+
+/**
+ * Guard the per-file marker map: a duplicate relative path within a single
+ * component install would silently collapse two files into one hash slot, masking
+ * a real diff later. Reuse {@link IntegrityError} (the repo forbids bare
+ * `new Error`).
+ */
+function assertUniquePaths(files: ReadonlyArray<FileToWrite>): void {
+  const seen = new Set<string>()
+  for (const f of files) {
+    if (seen.has(f.path)) {
+      throw new IntegrityError(`duplicate file path in install marker: ${JSON.stringify(f.path)}`)
+    }
+    seen.add(f.path)
+  }
+}
+
+// ── Install marker — `installed[]` on components.json (D15) ─────────────────
+
+/** A marker entry is identified by this composite key (monorepo-safe). */
+function sameKey(entry: InstalledComponent, id: string, installPath: string): boolean {
+  return entry.id === id && entry.installPath === installPath
+}
+
+/**
+ * Add `entry`, or replace the existing one with the same `{ id, installPath }`.
+ * Returns a new config (immutably) — the input is never mutated. Order is stable:
+ * a replacement keeps its slot; a new entry is appended.
+ */
+export function upsertInstalled(config: ComponentsConfig, entry: InstalledComponent): ComponentsConfig {
+  const current = config.installed ?? []
+  const idx = current.findIndex((e) => sameKey(e, entry.id, entry.installPath))
+  const installed =
+    idx === -1 ? [...current, entry] : current.map((e, i) => (i === idx ? entry : e))
+  return { ...config, installed }
+}
+
+/** Find the recorded install for `{ id, installPath }`, or `undefined`. */
+export function findInstalled(
+  config: ComponentsConfig,
+  id: string,
+  installPath: string,
+): InstalledComponent | undefined {
+  return (config.installed ?? []).find((e) => sameKey(e, id, installPath))
+}
+
+/**
+ * Remove the recorded install for `{ id, installPath }`. Returns a new config
+ * (immutably); a no-op when the entry is absent.
+ */
+export function removeInstalled(config: ComponentsConfig, id: string, installPath: string): ComponentsConfig {
+  const current = config.installed ?? []
+  return { ...config, installed: current.filter((e) => !sameKey(e, id, installPath)) }
+}
+
+/**
+ * Build an {@link InstalledComponent} marker for a just-written component. The
+ * per-file map records the SHA-256 (hex) of each file's content at install time —
+ * the basis for the later 3-way diff. `now` is injected (never `Date.now()`) so
+ * the result is deterministic and testable.
+ */
+export function buildInstalledComponent(args: {
+  id: string
+  framework: FrameworkTarget
+  installPath: string
+  ref: string
+  version: string
+  files: ReadonlyArray<FileToWrite>
+  now: string
+}): InstalledComponent {
+  assertUniquePaths(args.files)
+  const files: Record<string, { sha: string; installedAt: string }> = {}
+  for (const f of args.files) {
+    files[f.path] = { sha: sha256Hex(f.content), installedAt: args.now }
+  }
+  return {
+    id: args.id,
+    kind: 'component',
+    framework: args.framework,
+    installPath: args.installPath,
+    ref: args.ref,
+    version: args.version,
+    files,
+  }
+}
+
+// ── Canonical JSON — recursively sorted keys (reproducible hashing) ─────────
+
+/**
+ * Recursively sort object keys so two structurally-equal values serialise
+ * identically regardless of key insertion order. Arrays keep their order (it is
+ * semantic); objects are rebuilt with sorted keys; primitives pass through.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key])
+    }
+    return sorted
+  }
+  return value
+}
+
+/** Canonical JSON string of a value (keys sorted recursively). */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+/** SHA-256 (hex) of the canonical JSON of an audit entry. */
+function hashEntry(entry: AuditEntry): string {
+  return sha256Hex(canonicalJson(entry))
+}
+
+// ── Audit chain — `.agentskit/install-log.jsonl` (D9) ──────────────────────
+
+/**
+ * Link a new entry onto the chain: its `prevEntryHash` is the SHA-256 of the
+ * canonical last prior entry (`''` when the log is empty). Returns the completed
+ * {@link AuditEntry}; `prevEntries` is not mutated.
+ */
+export function appendAudit(
+  prevEntries: ReadonlyArray<AuditEntry>,
+  entry: Omit<AuditEntry, 'prevEntryHash'>,
+): AuditEntry {
+  const prev = prevEntries.length > 0 ? prevEntries[prevEntries.length - 1] : undefined
+  const prevEntryHash = prev ? hashEntry(prev) : ''
+  return { ...entry, prevEntryHash }
+}
+
+/** Serialise the chain to NDJSON (one JSON object per line, trailing newline). */
+export function serializeAuditLog(entries: ReadonlyArray<AuditEntry>): string {
+  if (entries.length === 0) return ''
+  return `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`
+}
+
+/**
+ * Parse NDJSON back into entries, skipping blank lines and silently dropping any
+ * line that is not a well-formed JSON object. (Verification of the *chain* itself
+ * is {@link verifyAuditChain}'s job — parsing only rejects unstructured noise.)
+ */
+export function parseAuditLog(raw: string): AuditEntry[] {
+  const out: AuditEntry[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed === '') continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      out.push(parsed as AuditEntry)
+    }
+  }
+  return out
+}
+
+/**
+ * Walk the chain, recomputing each entry's expected `prevEntryHash` from the prior
+ * entry. The first entry must carry `''`. Returns `{ ok, brokenAt }` where
+ * `brokenAt` is the index of the first entry whose link does not match (or `null`
+ * when the whole chain is intact). Detects tampering, reordering, and deletion.
+ */
+export function verifyAuditChain(entries: ReadonlyArray<AuditEntry>): { ok: boolean; brokenAt: number | null } {
+  for (let i = 0; i < entries.length; i++) {
+    const expected = i === 0 ? '' : hashEntry(entries[i - 1])
+    if (entries[i].prevEntryHash !== expected) {
+      return { ok: false, brokenAt: i }
+    }
+  }
+  return { ok: true, brokenAt: null }
+}

--- a/packages/cli/tests/components-marker.test.ts
+++ b/packages/cli/tests/components-marker.test.ts
@@ -1,0 +1,225 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { IntegrityError } from '../src/components/install'
+import type { FileToWrite } from '../src/components/install'
+import {
+  appendAudit,
+  buildInstalledComponent,
+  canonicalJson,
+  findInstalled,
+  parseAuditLog,
+  removeInstalled,
+  serializeAuditLog,
+  upsertInstalled,
+  verifyAuditChain,
+} from '../src/components/marker'
+import type { AuditEntry, ComponentsConfig, FrameworkTarget, InstalledComponent } from '../src/components/types'
+
+const FW: FrameworkTarget = { uiBinding: 'react', metaFramework: 'next-app' }
+
+function sha(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex')
+}
+
+function baseConfig(installed?: InstalledComponent[]): ComponentsConfig {
+  return {
+    $schema: 'https://example/schema.json',
+    schemaVersion: 1,
+    uiBinding: 'react',
+    metaFramework: 'next-app',
+    typescript: true,
+    styling: { mode: 'data-attrs-only', css: 'app/globals.css', tailwindConfig: null },
+    aliases: { components: '@/components', lib: '@/lib', server: 'app/api' },
+    paths: { root: '.', components: 'components', lib: 'lib', server: 'app/api' },
+    registries: { default: 'https://registry.agentskit.io' },
+    ...(installed ? { installed } : {}),
+  }
+}
+
+function marker(id: string, installPath: string): InstalledComponent {
+  return {
+    id,
+    kind: 'component',
+    framework: FW,
+    installPath,
+    ref: 'main',
+    version: '1.0.0',
+    files: { 'widget.tsx': { sha: sha('x'), installedAt: '2026-01-01T00:00:00Z' } },
+  }
+}
+
+function auditBase(id: string): Omit<AuditEntry, 'prevEntryHash'> {
+  return {
+    schemaVersion: 1,
+    eventType: 'install',
+    id,
+    version: '1.0.0',
+    ref: 'main',
+    files: [{ path: 'widget.tsx', sha256: sha('x') }],
+    manifestSigRef: 'sig-1',
+    timestamp: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('install marker — upsert / find / remove (D15)', () => {
+  it('upsert adds a new entry', () => {
+    const cfg = upsertInstalled(baseConfig(), marker('ask', 'apps/web/components/ask'))
+    expect(cfg.installed).toHaveLength(1)
+    expect(cfg.installed?.[0].id).toBe('ask')
+  })
+
+  it('upsert replaces an entry with the same id + installPath', () => {
+    const first = marker('ask', 'apps/web/components/ask')
+    const cfg1 = upsertInstalled(baseConfig(), first)
+    const updated: InstalledComponent = { ...first, version: '2.0.0' }
+    const cfg2 = upsertInstalled(cfg1, updated)
+    expect(cfg2.installed).toHaveLength(1)
+    expect(cfg2.installed?.[0].version).toBe('2.0.0')
+  })
+
+  it('upsert keeps separate entries for the same id at different installPaths (monorepo-safe)', () => {
+    const cfg1 = upsertInstalled(baseConfig(), marker('ask', 'apps/web/components/ask'))
+    const cfg2 = upsertInstalled(cfg1, marker('ask', 'apps/admin/components/ask'))
+    expect(cfg2.installed).toHaveLength(2)
+    expect(cfg2.installed?.map((e) => e.installPath)).toEqual([
+      'apps/web/components/ask',
+      'apps/admin/components/ask',
+    ])
+  })
+
+  it('upsert does not mutate the input config', () => {
+    const cfg = baseConfig()
+    const next = upsertInstalled(cfg, marker('ask', 'apps/web/components/ask'))
+    expect(cfg.installed).toBeUndefined()
+    expect(next).not.toBe(cfg)
+  })
+
+  it('findInstalled returns the entry when present and undefined otherwise', () => {
+    const cfg = upsertInstalled(baseConfig(), marker('ask', 'apps/web/components/ask'))
+    expect(findInstalled(cfg, 'ask', 'apps/web/components/ask')?.id).toBe('ask')
+    expect(findInstalled(cfg, 'ask', 'apps/admin/components/ask')).toBeUndefined()
+    expect(findInstalled(cfg, 'missing', 'apps/web/components/ask')).toBeUndefined()
+  })
+
+  it('removeInstalled drops the matching entry only', () => {
+    let cfg = upsertInstalled(baseConfig(), marker('ask', 'apps/web/components/ask'))
+    cfg = upsertInstalled(cfg, marker('ask', 'apps/admin/components/ask'))
+    const after = removeInstalled(cfg, 'ask', 'apps/web/components/ask')
+    expect(after.installed).toHaveLength(1)
+    expect(after.installed?.[0].installPath).toBe('apps/admin/components/ask')
+  })
+})
+
+describe('buildInstalledComponent (D15)', () => {
+  it('records the sha256 hex of each file content with the injected timestamp', () => {
+    const files: FileToWrite[] = [
+      { path: 'widget.tsx', content: 'export const Widget = () => null' },
+      { path: 'lib/guard.ts', content: 'export const guard = true' },
+    ]
+    const now = '2026-06-18T12:00:00Z'
+    const entry = buildInstalledComponent({
+      id: 'ask',
+      framework: FW,
+      installPath: 'apps/web/components/ask',
+      ref: 'v1',
+      version: '1.2.3',
+      files,
+      now,
+    })
+    expect(entry.id).toBe('ask')
+    expect(entry.kind).toBe('component')
+    expect(entry.files['widget.tsx'].sha).toBe(sha('export const Widget = () => null'))
+    expect(entry.files['lib/guard.ts'].sha).toBe(sha('export const guard = true'))
+    expect(entry.files['widget.tsx'].installedAt).toBe(now)
+  })
+
+  it('rejects duplicate file paths via IntegrityError', () => {
+    const files: FileToWrite[] = [
+      { path: 'widget.tsx', content: 'a' },
+      { path: 'widget.tsx', content: 'b' },
+    ]
+    expect(() =>
+      buildInstalledComponent({
+        id: 'ask',
+        framework: FW,
+        installPath: 'p',
+        ref: 'v1',
+        version: '1.0.0',
+        files,
+        now: 'now',
+      }),
+    ).toThrow(IntegrityError)
+  })
+})
+
+describe('audit chain — append + verify (D9)', () => {
+  it('the first entry has prevEntryHash === ""', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    expect(e0.prevEntryHash).toBe('')
+  })
+
+  it('the second entry links to the canonical hash of the first', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    expect(e1.prevEntryHash).toBe(sha(canonicalJson(e0)))
+  })
+
+  it('verifyAuditChain returns ok:true, brokenAt:null for a valid chain', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    const e2 = appendAudit([e0, e1], auditBase('c'))
+    expect(verifyAuditChain([e0, e1, e2])).toEqual({ ok: true, brokenAt: null })
+  })
+
+  it('detects a tampered entry at its index', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    const e2 = appendAudit([e0, e1], auditBase('c'))
+    // mutate the payload of e1 — the link from e2 no longer matches.
+    const tampered: AuditEntry = { ...e1, version: '9.9.9' }
+    const res = verifyAuditChain([e0, tampered, e2])
+    expect(res.ok).toBe(false)
+    expect(res.brokenAt).toBe(2)
+  })
+
+  it('detects reordered entries', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    const e2 = appendAudit([e0, e1], auditBase('c'))
+    // swap e1 and e2 — e2's prevEntryHash no longer matches the (now) prior entry,
+    // and the first-position entry no longer carries ''.
+    const res = verifyAuditChain([e0, e2, e1])
+    expect(res.ok).toBe(false)
+    expect(res.brokenAt).toBe(1)
+  })
+
+  it('detects a deleted entry', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    const e2 = appendAudit([e0, e1], auditBase('c'))
+    // drop e1 — e2 now links to e0 but its prevEntryHash points at e1.
+    const res = verifyAuditChain([e0, e2])
+    expect(res.ok).toBe(false)
+    expect(res.brokenAt).toBe(1)
+  })
+})
+
+describe('audit log serialization (NDJSON)', () => {
+  it('serializeAuditLog ↔ parseAuditLog round-trips', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const e1 = appendAudit([e0], auditBase('b'))
+    const raw = serializeAuditLog([e0, e1])
+    expect(raw.split('\n').filter((l) => l !== '')).toHaveLength(2)
+    expect(parseAuditLog(raw)).toEqual([e0, e1])
+  })
+
+  it('parseAuditLog skips blank and malformed lines', () => {
+    const e0 = appendAudit([], auditBase('a'))
+    const raw = `${JSON.stringify(e0)}\n\nnot json\n[1,2,3]\n`
+    expect(parseAuditLog(raw)).toEqual([e0])
+  })
+
+  it('serializeAuditLog returns an empty string for no entries', () => {
+    expect(serializeAuditLog([])).toBe('')
+  })
+})


### PR DESCRIPTION
## What

Adds `packages/cli/src/components/marker.ts` — the install-marker + tamper-evident audit layer for the component subsystem (RFC-0006 D9/D15).

### Install marker (`installed[]` on `components.json`)
- `upsertInstalled` — add or replace by `{ id, installPath }` (monorepo-safe), immutable.
- `findInstalled` / `removeInstalled`.
- `buildInstalledComponent` — per-file `{ sha, installedAt }` map (sha = SHA-256 hex of content) using an **injected** `now`. Powers the later 3-way diff/update.

### Audit chain (`.agentskit/install-log.jsonl`, append-only)
- `appendAudit` — links each entry to the canonical SHA-256 of its predecessor (`''` for the first).
- `serializeAuditLog` / `parseAuditLog` — NDJSON, skipping blank/malformed lines.
- `verifyAuditChain` — walks the chain and returns `{ ok, brokenAt }`; detects **tampering, reordering, and deletion**.

## Notes
- Pure + deterministic: timestamps injected (never `Date.now()`), object keys canonicalised (recursively sorted) before hashing so the chain is reproducible.
- All throws reuse `IntegrityError` from `./install` (no bare `new Error`).
- `sha256Hex` reused from `./fetch`.
- Not exported from the package entry yet — no public API change, no release (empty changeset).

## Tests
`packages/cli/tests/components-marker.test.ts` — 17 cases, all green: upsert add/replace/coexist + immutability, find (hit/miss), remove, sha map, audit first/link, valid chain, tampered/reordered/deleted detection, serialize↔parse round-trip.

Bare-throw gate clean; new files typecheck clean (remaining lint errors are pre-existing `@agentskit/*` workspace-resolution noise in other files).