### PR TITLE
feat(cli): real Node fs/network adapters for the component subsystem (RFC-0006)

### DIFF
--- a/.changeset/cli-component-node-fs.md
+++ b/.changeset/cli-component-node-fs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add real Node.js fs/network adapters for the RFC-0006 component subsystem (`packages/cli/src/components/node-fs.ts`). Exports `nodeScanFs`, `nodeWriteFs`, `nodeConfigIo`, and `nodeFetch` — the concrete implementations of the injectable interfaces defined in `scan.ts`, `install.ts`, `config.ts`, and `fetch.ts`. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/node-fs.ts
+++ b/packages/cli/src/components/node-fs.ts
@@ -1,0 +1,95 @@
+/**
+ * Real Node.js filesystem and network adapters for the RFC-0006 component subsystem.
+ *
+ * This is the only module that touches `node:fs` or the network on behalf of the
+ * scanner, writer, and config I/O — every other module in `components/` accepts the
+ * injected interfaces so it stays unit-testable without touching disk.
+ *
+ * Proxy / custom-CA awareness is a documented follow-up; `nodeFetch` is intentionally
+ * minimal and delegates entirely to `globalThis.fetch`.
+ */
+import { dirname } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type { ConfigIo } from './config'
+import type { FetchLike } from './fetch'
+import type { WriteFs } from './install'
+import type { ScanFs } from './scan'
+
+/**
+ * `ScanFs` backed by the real Node.js filesystem.
+ * `readFile` returns `null` on ENOENT or any other read error rather than throwing.
+ */
+export function nodeScanFs(): ScanFs {
+  return {
+    readFile(path: string): string | null {
+      try {
+        return readFileSync(path, 'utf8')
+      } catch {
+        return null
+      }
+    },
+    exists(path: string): boolean {
+      return existsSync(path)
+    },
+  }
+}
+
+/**
+ * `WriteFs` backed by the real Node.js filesystem.
+ * `write` creates all ancestor directories before writing (equivalent to `mkdir -p`).
+ * `remove` is force/silent so it does not throw when the file is already absent
+ * (rollback paths call it after a partial write and must not double-fault).
+ */
+export function nodeWriteFs(): WriteFs {
+  return {
+    exists(path: string): boolean {
+      return existsSync(path)
+    },
+    write(path: string, content: string): void {
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileSync(path, content, 'utf8')
+    },
+    remove(path: string): void {
+      rmSync(path, { force: true })
+    },
+  }
+}
+
+/**
+ * `ConfigIo` backed by the real Node.js filesystem.
+ * `read` mirrors `nodeScanFs().readFile`; `write` mirrors `nodeWriteFs().write`
+ * (creates parent directories as needed).
+ */
+export function nodeConfigIo(): ConfigIo {
+  return {
+    read(path: string): string | null {
+      try {
+        return readFileSync(path, 'utf8')
+      } catch {
+        return null
+      }
+    },
+    write(path: string, content: string): void {
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileSync(path, content, 'utf8')
+    },
+  }
+}
+
+/**
+ * Minimal `FetchLike` that delegates to `globalThis.fetch`.
+ *
+ * Proxy / custom-CA support (e.g. `HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`) is a
+ * documented follow-up; wire an undici `ProxyAgent` here when that slice lands.
+ */
+export const nodeFetch: FetchLike = async (
+  url: string,
+  init?: { headers?: Record<string, string> },
+): Promise<{ ok: boolean; status: number; text: () => Promise<string> }> => {
+  const res = await globalThis.fetch(url, { headers: init?.headers })
+  return {
+    ok: res.ok,
+    status: res.status,
+    text: () => res.text(),
+  }
+}

--- a/packages/cli/tests/components-node-fs.test.ts
+++ b/packages/cli/tests/components-node-fs.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { nodeConfigIo, nodeFetch, nodeScanFs, nodeWriteFs } from '../src/components/node-fs'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'ak-nodefs-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('nodeScanFs', () => {
+  it('reads an existing file', () => {
+    const fs = nodeScanFs()
+    // write a file via nodeWriteFs so we can read it back
+    nodeWriteFs().write(join(root, 'pkg.json'), '{"name":"test"}')
+    expect(fs.readFile(join(root, 'pkg.json'))).toBe('{"name":"test"}')
+  })
+
+  it('returns null for a missing file', () => {
+    const fs = nodeScanFs()
+    expect(fs.readFile(join(root, 'does-not-exist.json'))).toBeNull()
+  })
+
+  it('exists returns true for a present file and false for a missing one', () => {
+    const fs = nodeScanFs()
+    nodeWriteFs().write(join(root, 'present.txt'), 'hi')
+    expect(fs.exists(join(root, 'present.txt'))).toBe(true)
+    expect(fs.exists(join(root, 'absent.txt'))).toBe(false)
+  })
+})
+
+describe('nodeWriteFs', () => {
+  it('creates nested directories and writes a file', () => {
+    const fs = nodeWriteFs()
+    const path = join(root, 'a', 'b', 'c', 'file.txt')
+    fs.write(path, 'hello nested')
+    expect(nodeScanFs().readFile(path)).toBe('hello nested')
+  })
+
+  it('overwrites an existing file', () => {
+    const fs = nodeWriteFs()
+    const path = join(root, 'file.txt')
+    fs.write(path, 'first')
+    fs.write(path, 'second')
+    expect(nodeScanFs().readFile(path)).toBe('second')
+  })
+
+  it('removes a file that exists', () => {
+    const fs = nodeWriteFs()
+    const path = join(root, 'gone.txt')
+    fs.write(path, 'bye')
+    expect(fs.exists(path)).toBe(true)
+    fs.remove(path)
+    expect(fs.exists(path)).toBe(false)
+  })
+
+  it('remove is silent when the file is already absent (force behaviour)', () => {
+    const fs = nodeWriteFs()
+    expect(() => fs.remove(join(root, 'never-existed.txt'))).not.toThrow()
+  })
+
+  it('exists returns correct values', () => {
+    const fs = nodeWriteFs()
+    const path = join(root, 'check.txt')
+    expect(fs.exists(path)).toBe(false)
+    fs.write(path, 'x')
+    expect(fs.exists(path)).toBe(true)
+  })
+})
+
+describe('nodeConfigIo', () => {
+  it('round-trips read/write with a nested path', () => {
+    const io = nodeConfigIo()
+    const path = join(root, '.agentskit', 'components.json')
+    const content = '{"schemaVersion":1}'
+    io.write(path, content)
+    expect(io.read(path)).toBe(content)
+  })
+
+  it('read returns null for a missing file', () => {
+    const io = nodeConfigIo()
+    expect(io.read(join(root, 'no-such-file.json'))).toBeNull()
+  })
+})
+
+describe('nodeFetch', () => {
+  it('is a function (network calls are not exercised in unit tests)', () => {
+    expect(typeof nodeFetch).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary

Adds `packages/cli/src/components/node-fs.ts` — the four concrete Node.js implementations of the injectable interfaces defined in the RFC-0006 component subsystem. Every other module in `components/` accepts injected interfaces and stays unit-testable with in-memory fakes; this file is the **only** place the subsystem touches `node:fs` or the network.

### Exports

| Export | Interface | Notes |
|---|---|---|
| `nodeScanFs()` | `ScanFs` | `readFile` returns `null` on ENOENT/any error (no throw); `exists` = `existsSync` |
| `nodeWriteFs()` | `WriteFs` | `write` does `mkdirSync(dirname, {recursive:true})` + `writeFileSync`; `remove` uses `rmSync({force:true})` for silent rollback |
| `nodeConfigIo()` | `ConfigIo` | `read` mirrors `nodeScanFs.readFile`; `write` mirrors `nodeWriteFs.write` (creates parent dirs) |
| `nodeFetch` | `FetchLike` | Thin wrapper over `globalThis.fetch`. Proxy/custom-CA support is a documented follow-up (one-line comment in source) |

### Tests (`packages/cli/tests/components-node-fs.test.ts`)

11 tests covering:
- `nodeScanFs` — read existing file, return `null` for missing, `exists` true/false
- `nodeWriteFs` — creates nested dirs, overwrites, removes, silent on missing remove, `exists` checks
- `nodeConfigIo` — round-trip read/write with nested path, `null` for missing
- `nodeFetch` — asserts it is a function (no live network calls in unit tests)

Real temp dir via `mkdtempSync` + `rmSync` cleanup in `afterEach`; no mocks.

## Test plan

- [ ] `pnpm --filter @agentskit/cli exec vitest run tests/components-node-fs.test.ts` — 11/11 pass
- [ ] `node scripts/check-no-bare-throw.mjs` — clean
- [ ] `pnpm --filter @agentskit/cli exec tsc --noEmit` — no errors in new files
- [ ] Only 3 files changed: `node-fs.ts`, `components-node-fs.test.ts`, `.changeset/cli-component-node-fs.md`