### PR TITLE
fix(ask-docs): keep @huggingface/transformers external in serverless (prod retrieval broken)

### DIFF
--- a/apps/docs-next/lib/rag/embed.ts
+++ b/apps/docs-next/lib/rag/embed.ts
@@ -42,8 +42,14 @@ let extractorPromise: Promise<FeatureExtractor> | null = null
 async function getExtractor(): Promise<FeatureExtractor> {
   if (!extractorPromise) {
     extractorPromise = (async () => {
-      const { pipeline } = await import('@huggingface/transformers')
-      const extractor = (await pipeline(
+      const transformers = await import('@huggingface/transformers')
+      // Serverless functions have a read-only filesystem except for `/tmp`. The
+      // first call downloads the ONNX model from the HF hub and caches it; point
+      // that cache at the one writable dir, or the write fails and retrieval errors.
+      if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+        transformers.env.cacheDir = '/tmp/.transformers-cache'
+      }
+      const extractor = (await transformers.pipeline(
         'feature-extraction',
         EMBED_MODEL,
       )) as unknown as FeatureExtractor

--- a/apps/docs-next/next.config.mjs
+++ b/apps/docs-next/next.config.mjs
@@ -67,6 +67,12 @@ const DOC_REDIRECTS = [
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // The Ask-the-docs route runs `@huggingface/transformers` (ONNX) in-process for
+  // local query embeddings. It MUST NOT be bundled into the serverless function —
+  // bundling its onnxruntime backend breaks it at runtime, surfacing as
+  // "[ask-docs] retrieval failed". Keeping it external resolves it from
+  // node_modules in the function (via output file tracing) at runtime instead.
+  serverExternalPackages: ['@huggingface/transformers'],
   async redirects() {
     // Legacy 404 fixes first — first match wins, so explicit per-URL rules
     // override the broad wildcard rules that used to chain into dead targets.


### PR DESCRIPTION
## Live production hotfix
`www.agentskit.io` Ask-the-docs chat returns `{"type":"error","message":"Could not search the docs right now."}` on every real query.

## Root cause (confirmed via Vercel prod runtime logs)
`[ask-docs] retrieval failed` — Next was **bundling `@huggingface/transformers`** (no `serverExternalPackages` in `next.config.mjs`) into the serverless function, which breaks its onnxruntime backend at query time. `checkScope` embeds too but **fails open** (caught) → masked there; `retrieve` doesn't catch the embed → surfaces as the retrieval error. Confirmed the error contained `"Cannot"` but **not** `"records"` → ruled out the index dynamic-import; it's the embed.

## Fix
1. `serverExternalPackages: ['@huggingface/transformers']` → Next resolves it from `node_modules` at runtime (output file tracing) instead of bundling it.
2. `env.cacheDir = '/tmp/.transformers-cache'` on Vercel/Lambda → the first-call model download can write (serverless FS is read-only except `/tmp`).

The standard transformers.js-in-Next serverless fix. Will verify on the production redeploy via runtime logs after merge.