### PR TITLE
feat(cli): agentskit add orchestrator — the component install flow (RFC-0006)

### DIFF
--- a/.changeset/cli-component-flow.md
+++ b/.changeset/cli-component-flow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add the `agentskit add <component>` orchestrator (`packages/cli/src/components/flow.ts`, RFC-0006 install flow). `addComponent(options, deps)` wires the whole subsystem into one transactional install — scan → resolve config → fetch+verify manifest → validate → fetch+checksum files → path-guarded commit (rollback on failure) → write marker → append the tamper-evident audit chain. Pure orchestration over injected fs/network/clock adapters; the CLI command layer supplies real I/O + prompts. Fully unit-tested end-to-end. Not exported from the package entry yet — no public API change, no release.

--- a/packages/cli/src/components/flow.ts
+++ b/packages/cli/src/components/flow.ts
@@ -1,0 +1,178 @@
+/**
+ * `agentskit add <component>` orchestrator (RFC-0006 install flow).
+ *
+ * The capstone that wires the component subsystem into one transactional install:
+ *   scan → resolve config → fetch manifest → validate → fetch+verify files →
+ *   commit (path-guarded, rollback) → write marker → append audit chain.
+ *
+ * Pure orchestration over injected adapters (filesystem, network, clock) so the
+ * whole flow is unit-testable end-to-end with no real I/O. The CLI command layer
+ * supplies the real `node:fs`/`fetch` adapters and the interactive prompts; this
+ * module makes none of those decisions itself.
+ */
+import { join } from 'node:path'
+import type { FrameworkTarget, RegistryEnvVar } from './types'
+import { type ScanFs, scanProject } from './scan'
+import { type ConfigIo, CONFIG_PATH, resolveConfig, writeConfig } from './config'
+import { fetchManifest, fetchPortFiles, type FetchLike } from './fetch'
+import { validateInstall, type ValidationIssue } from './validate'
+import { type WriteFs, commitFiles, IntegrityError } from './install'
+import {
+  appendAudit,
+  buildInstalledComponent,
+  parseAuditLog,
+  serializeAuditLog,
+  upsertInstalled,
+} from './marker'
+
+/** Audit log path, relative to the project (or workspace package) root. */
+export const AUDIT_PATH = '.agentskit/install-log.jsonl'
+
+/** Injected adapters — real `node:fs`/`fetch` in the command, fakes in tests. */
+export interface AddDeps {
+  scanFs: ScanFs
+  /** Read/write for `components.json` and the audit log. */
+  io: ConfigIo
+  /** File install surface (write + remove for rollback). */
+  writeFs: WriteFs
+  /** Network. Defaults to global fetch. */
+  fetchImpl?: FetchLike
+  /** Injected clock → deterministic markers/audit. */
+  now: () => string
+  env?: Record<string, string | undefined>
+}
+
+export interface AddOptions {
+  identifier: string
+  root?: string
+  /** `--out` install dir override. Defaults to the port's `defaultTarget`. */
+  outDir?: string
+  /** Overwrite existing files instead of aborting on conflict. */
+  force?: boolean
+  /** `--registry` base override. */
+  registryBase?: string
+  /** Optional signed-manifest verifier (e.g. `makeSignatureVerifier(SHIPPED_KEY)`). */
+  signatureVerifier?: (manifestRaw: string, signatureRaw: string) => Promise<boolean>
+}
+
+export interface AddResult {
+  id: string
+  version: string
+  installPath: string
+  framework: FrameworkTarget
+  /** Absolute paths written. */
+  written: string[]
+  /** npm packages the component composes (install these). */
+  packages: string[]
+  /** Env the component needs. */
+  env: RegistryEnvVar[]
+  /** Non-blocking validation warnings (rate-limit, styling, …). */
+  warnings: ValidationIssue[]
+  /** Whether config came from a committed components.json (vs derived → suggest init). */
+  configFromDisk: boolean
+}
+
+/** Merge a project's declared dependency versions for the peer-range check. */
+function installedVersions(scanFs: ScanFs, root: string): Record<string, string> {
+  const raw = scanFs.readFile(join(root, 'package.json'))
+  if (raw == null) return {}
+  try {
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+    }
+    return { ...pkg.peerDependencies, ...pkg.devDependencies, ...pkg.dependencies }
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Install a component end-to-end. Throws {@link IntegrityError} (with the joined
+ * messages) when validation fails or any integrity check trips — leaving nothing
+ * written (commit is transactional). On success the marker + audit chain are
+ * persisted and an {@link AddResult} is returned for the command to print.
+ */
+export async function addComponent(options: AddOptions, deps: AddDeps): Promise<AddResult> {
+  const root = options.root ?? '.'
+
+  // 1 — scan + resolve config.
+  const scan = scanProject(deps.scanFs, root)
+  const { config, fromDisk } = resolveConfig(deps.io, scan, root)
+
+  // 2 — fetch + integrity/version-gate the manifest.
+  const { ref, component } = await fetchManifest(options.identifier, {
+    fetchImpl: deps.fetchImpl,
+    env: deps.env,
+    config,
+    registryBase: options.registryBase,
+    signatureVerifier: options.signatureVerifier,
+  })
+
+  // 3 — validate against the detected project (framework, peers, runtime, …).
+  const validation = validateInstall({
+    scan,
+    component,
+    installed: installedVersions(deps.scanFs, root),
+  })
+  if (!validation.ok || !validation.port) {
+    const errors = validation.issues.filter((i) => i.severity === 'error').map((i) => i.message)
+    throw new IntegrityError(`cannot install ${component.id}: ${errors.join('; ') || 'no compatible port'}`)
+  }
+  const port = validation.port
+
+  // 4 — fetch + checksum every port file.
+  const files = await fetchPortFiles(ref, port, { fetchImpl: deps.fetchImpl, env: deps.env, config })
+
+  // 5 — transactional, path-guarded commit.
+  const installPath = options.outDir ?? port.defaultTarget
+  const { written } = commitFiles(deps.writeFs, installPath, files, { force: options.force })
+
+  // 6 — record the marker on components.json.
+  const framework: FrameworkTarget = {
+    uiBinding: port.uiBinding,
+    metaFramework: scan.metaFramework === 'unknown' ? config.metaFramework : scan.metaFramework,
+  }
+  const now = deps.now()
+  const marker = buildInstalledComponent({
+    id: component.id,
+    framework,
+    installPath,
+    ref: ref.base,
+    version: component.version,
+    files,
+    now,
+  })
+  writeConfig(deps.io, upsertInstalled(config, marker), root)
+
+  // 7 — append the tamper-evident audit entry.
+  const auditPath = join(root, AUDIT_PATH)
+  const prev = parseAuditLog(deps.io.read(auditPath) ?? '')
+  const entry = appendAudit(prev, {
+    schemaVersion: 1,
+    eventType: 'install',
+    id: component.id,
+    version: component.version,
+    ref: ref.base,
+    files: files.map((f) => ({ path: f.path, sha256: marker.files[f.path]!.sha })),
+    manifestSigRef: options.signatureVerifier ? `${ref.itemId}.minisig` : '',
+    timestamp: now,
+  })
+  deps.io.write(auditPath, serializeAuditLog([...prev, entry]))
+
+  return {
+    id: component.id,
+    version: component.version,
+    installPath,
+    framework,
+    written,
+    packages: [...component.packages, ...(port.packages ?? [])],
+    env: component.env ?? [],
+    warnings: validation.issues.filter((i) => i.severity === 'warning'),
+    configFromDisk: fromDisk,
+  }
+}
+
+/** Re-export so the command can reference where config/audit live. */
+export { CONFIG_PATH }

--- a/packages/cli/tests/components-flow.test.ts
+++ b/packages/cli/tests/components-flow.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import { AUDIT_PATH, addComponent, type AddDeps } from '../src/components/flow'
+import { CONFIG_PATH } from '../src/components/config'
+import { sha256Hex, type FetchLike } from '../src/components/fetch'
+import { parseAuditLog, verifyAuditChain } from '../src/components/marker'
+import { IntegrityError, type WriteFs } from '../src/components/install'
+import { type ScanFs } from '../src/components/scan'
+import type { RegistryComponent } from '../src/components/types'
+
+const NOW = '2026-06-18T00:00:00.000Z'
+const BASE = 'https://registry.agentskit.io'
+const WIDGET = 'export const Widget = () => null'
+const GUARD = 'export const guard = true'
+
+function scanFs(pkg: Record<string, unknown>, dirs: string[] = ['app']): ScanFs {
+  const files: Record<string, string> = {
+    'package.json': JSON.stringify(pkg),
+    'tsconfig.json': '{}',
+  }
+  const dirSet = new Set(dirs)
+  return {
+    readFile: (p) => files[p] ?? null,
+    exists: (p) => p in files || dirSet.has(p),
+  }
+}
+
+/** ConfigIo + WriteFs backed by Maps, exposed for assertions. */
+function fakeIo() {
+  const files = new Map<string, string>()
+  const io = { files, read: (p: string) => files.get(p) ?? null, write: (p: string, c: string) => void files.set(p, c) }
+  return io
+}
+function fakeWriteFs() {
+  const files = new Map<string, string>()
+  const fs: WriteFs & { files: Map<string, string> } = {
+    files,
+    exists: (p) => files.has(p),
+    write: (p, c) => void files.set(p, c),
+    remove: (p) => void files.delete(p),
+  }
+  return fs
+}
+
+function fakeFetch(extra: Record<string, string> = {}): FetchLike {
+  const map: Record<string, string> = { [`${BASE}/r/docs-chat/widget.tsx`]: WIDGET, ...extra }
+  return async (url) => {
+    const body = map[url]
+    if (body == null) return { ok: false, status: 404, text: async () => 'nope' }
+    return { ok: true, status: 200, text: async () => body }
+  }
+}
+
+function manifest(over: Partial<RegistryComponent> = {}): string {
+  const m: RegistryComponent = {
+    $schema: 'x',
+    schemaVersion: 1,
+    kind: 'component',
+    id: 'docs-chat',
+    version: '1.2.0',
+    title: 'Ask the docs',
+    description: '',
+    category: 'chat',
+    frameworks: [{ uiBinding: 'react', metaFramework: 'next-app' }],
+    ports: {
+      react: {
+        uiBinding: 'react',
+        language: 'ts',
+        stylingMode: 'data-attrs-only',
+        streamingProtocol: 'ndjson',
+        defaultTarget: 'components/ask',
+        files: [
+          { path: 'widget.tsx', type: 'registry:component', sha256: sha256Hex(WIDGET) },
+          { path: 'lib/guard.ts', type: 'registry:lib', sha256: sha256Hex(GUARD), content: GUARD },
+        ],
+        server: {
+          delivery: 'bundled',
+          runtimeRequirement: 'nodejs',
+          embeddingBackend: 'onnx-node',
+          rateLimitBackend: 'memory',
+        },
+      },
+    },
+    packages: ['@agentskit/rag', '@agentskit/adapters'],
+    env: [{ name: 'OPENROUTER_API_KEY', description: 'key', required: true, scope: 'server' }],
+    ...over,
+  }
+  return JSON.stringify(m)
+}
+
+function deps(over: Partial<AddDeps> = {}): AddDeps {
+  return {
+    scanFs: scanFs({ dependencies: { next: '15.0.0', react: '19.0.0' }, devDependencies: { typescript: '5.0.0' } }),
+    io: fakeIo(),
+    writeFs: fakeWriteFs(),
+    fetchImpl: fakeFetch({ [`${BASE}/r/docs-chat.json`]: manifest() }),
+    now: () => NOW,
+    ...over,
+  }
+}
+
+describe('addComponent (end-to-end)', () => {
+  it('installs: commits files, writes the marker, appends the audit chain', async () => {
+    const d = deps()
+    const res = await addComponent({ identifier: 'docs-chat' }, d)
+
+    expect(res.id).toBe('docs-chat')
+    expect(res.version).toBe('1.2.0')
+    expect(res.installPath).toBe('components/ask')
+    expect(res.framework).toEqual({ uiBinding: 'react', metaFramework: 'next-app' })
+    expect(res.written).toHaveLength(2)
+    expect(res.packages).toEqual(['@agentskit/rag', '@agentskit/adapters'])
+    expect(res.env[0]?.name).toBe('OPENROUTER_API_KEY')
+    // serverless + memory limiter → a non-blocking warning surfaced.
+    expect(res.warnings.map((w) => w.code)).toContain('ratelimit-memory')
+    expect(res.configFromDisk).toBe(false)
+
+    // files actually written (content-verified by the flow).
+    const io = d.io as ReturnType<typeof fakeIo>
+    const wfs = d.writeFs as ReturnType<typeof fakeWriteFs>
+    expect([...wfs.files.values()]).toContain(WIDGET)
+    expect([...wfs.files.values()]).toContain(GUARD)
+
+    // marker recorded on components.json.
+    const config = JSON.parse(io.files.get(CONFIG_PATH)!)
+    expect(config.installed).toHaveLength(1)
+    expect(config.installed[0]).toMatchObject({ id: 'docs-chat', installPath: 'components/ask', version: '1.2.0' })
+    expect(config.installed[0].files['widget.tsx'].sha).toBe(sha256Hex(WIDGET))
+
+    // audit chain: one valid entry.
+    const log = parseAuditLog(io.files.get(AUDIT_PATH)!)
+    expect(log).toHaveLength(1)
+    expect(log[0]!.eventType).toBe('install')
+    expect(log[0]!.prevEntryHash).toBe('')
+    expect(verifyAuditChain(log).ok).toBe(true)
+  })
+
+  it('links a second install into the audit chain', async () => {
+    const io = fakeIo()
+    const d = deps({ io, writeFs: fakeWriteFs() })
+    await addComponent({ identifier: 'docs-chat' }, d)
+    // second install elsewhere via --out (avoids a file conflict).
+    await addComponent({ identifier: 'docs-chat', outDir: 'components/ask2' }, deps({ io, writeFs: fakeWriteFs() }))
+
+    const log = parseAuditLog(io.files.get(AUDIT_PATH)!)
+    expect(log).toHaveLength(2)
+    expect(log[1]!.prevEntryHash).not.toBe('')
+    expect(verifyAuditChain(log).ok).toBe(true)
+  })
+
+  it('aborts (nothing written) when validation fails — TS-only port into a JS project', async () => {
+    const d = deps({
+      scanFs: scanFs({ dependencies: { next: '15.0.0', react: '19.0.0' } }), // no typescript dep, no tsconfig handled below
+    })
+    // force JS: a scanFs without tsconfig.json.
+    const jsScan: ScanFs = {
+      readFile: (p) => (p === 'package.json' ? JSON.stringify({ dependencies: { next: '15.0.0', react: '19.0.0' } }) : null),
+      exists: (p) => p === 'app',
+    }
+    await expect(addComponent({ identifier: 'docs-chat' }, deps({ scanFs: jsScan }))).rejects.toThrow(IntegrityError)
+    const wfs = d.writeFs as ReturnType<typeof fakeWriteFs>
+    expect(wfs.files.size).toBe(0)
+  })
+
+  it('aborts on a tampered file (checksum mismatch)', async () => {
+    const tampered = fakeFetch({ [`${BASE}/r/docs-chat.json`]: manifest(), [`${BASE}/r/docs-chat/widget.tsx`]: 'HACKED' })
+    await expect(addComponent({ identifier: 'docs-chat' }, deps({ fetchImpl: tampered }))).rejects.toThrow(IntegrityError)
+  })
+})


### PR DESCRIPTION
Off `main`, independent. The capstone that ties the 8 component modules into one transactional install: `addComponent(options, deps)` — scan → resolveConfig → fetchManifest → validateInstall → fetchPortFiles (checksum) → commitFiles (path-guarded, rollback) → buildInstalledComponent + upsertInstalled + writeConfig → appendAudit (tamper-evident chain).

Pure orchestration over injected fs/network/clock adapters → unit-testable end-to-end. Throws `IntegrityError` leaving nothing written on any failure. 4 end-to-end tests (install + marker + audit, chain-link, validation abort, checksum-tamper abort). `tsc` + bare-throw clean.

The CLI command wiring (real-fs adapters #1029 + `kind` detect + prompts) lands next, on top of this + #1029.