### PR TITLE
feat(cli): wire agentskit add to the component install flow (RFC-0006 D1)

### DIFF
--- a/.changeset/cli-add-command.md
+++ b/.changeset/cli-add-command.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: wire `agentskit add <name>` to the RFC-0006 component install flow (`packages/cli/src/commands/add-component.ts` + `add.ts`). The command now auto-detects components (scan → validate → fetch + checksum → transactional install via `addComponent`) and falls back to the agent path otherwise; adds `--registry`. Thin glue over the already-tested core. Not yet usable end-to-end (the `docs-chat` registry artifact + `agentskit init` are still to ship), so no release.

--- a/packages/cli/src/commands/add-component.ts
+++ b/packages/cli/src/commands/add-component.ts
@@ -1,0 +1,79 @@
+/**
+ * `agentskit add <name>` — component install path (RFC-0006 D1 auto-detect).
+ *
+ * Thin glue over `addComponent`: builds the real `node:fs`/network adapters, runs
+ * the transactional install, and prints the result. Detection is by trying to
+ * fetch a component manifest — if the id isn't a component in the registry
+ * (`fetch failed` / `not a component`), this returns `not-a-component` so the
+ * caller falls back to the agent path. All other failures (validation, checksum,
+ * path-escape) are real component errors and surface to the user.
+ */
+import { addComponent, type AddResult } from '../components/flow'
+import { nodeConfigIo, nodeFetch, nodeScanFs, nodeWriteFs } from '../components/node-fs'
+import { IntegrityError } from '../components/install'
+
+export interface ComponentAddOptions {
+  out?: string
+  force?: boolean
+  registry?: string
+}
+
+export type ComponentAddOutcome = 'installed' | 'not-a-component'
+
+/** True when the error means "this id is not a registry component" (→ try agent). */
+function isNotAComponent(err: unknown): boolean {
+  return err instanceof IntegrityError && /fetch failed|is not a component/i.test(err.message)
+}
+
+function printReport(result: AddResult): void {
+  const { id, version, installPath, framework, written, packages, env, warnings, configFromDisk } = result
+  const out = process.stdout
+  out.write(`\n✓ Installed ${id}@${version} → ${installPath}/  (${framework.uiBinding} × ${framework.metaFramework})\n`)
+  out.write(`  wrote ${written.length} file${written.length === 1 ? '' : 's'}\n`)
+
+  if (packages.length > 0) {
+    out.write(`\nInstall the packages it composes:\n  npm install ${packages.join(' ')}\n`)
+  }
+  const required = env.filter((e) => e.required)
+  if (required.length > 0) {
+    out.write(`\nRequired environment:\n`)
+    for (const e of required) out.write(`  ${e.name} — ${e.description}\n`)
+  }
+  if (warnings.length > 0) {
+    out.write(`\nWarnings:\n`)
+    for (const w of warnings) out.write(`  ⚠ ${w.message}\n`)
+  }
+  if (!configFromDisk) {
+    out.write(`\nTip: run \`agentskit init\` to commit .agentskit/components.json and skip the scan next time.\n`)
+  }
+  out.write('\n')
+}
+
+/**
+ * Attempt a component install for `name`. Returns `'installed'` on success,
+ * `'not-a-component'` when the id is not a registry component (caller should try
+ * the agent path). Throws on a genuine component install failure.
+ */
+export async function tryComponentAdd(
+  name: string,
+  options: ComponentAddOptions,
+): Promise<ComponentAddOutcome> {
+  try {
+    const result = await addComponent(
+      { identifier: name, outDir: options.out, force: options.force === true, registryBase: options.registry },
+      {
+        scanFs: nodeScanFs(),
+        io: nodeConfigIo(),
+        writeFs: nodeWriteFs(),
+        fetchImpl: nodeFetch,
+        now: () => new Date().toISOString(),
+        env: process.env,
+      },
+    )
+    printReport(result)
+    return 'installed'
+  } catch (err) {
+    if (isNotAComponent(err)) return 'not-a-component'
+    throw err
+  }
+}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,15 +1,17 @@
 import type { Command } from 'commander'
 import { addAgent, resolveSystemPrompt } from '../registry'
 import { runAgent } from '../run'
+import { tryComponentAdd } from './add-component'
 
 export function registerAddCommand(program: Command): void {
   program
-    .command('add <agent>')
+    .command('add <name>')
     .description(
-      'Add a ready-made agent from the AgentsKit registry (registry.agentskit.io). Copies the agent source into your project — you own the code. With --run, also executes it. e.g. `agentskit add research` or `agentskit add legal-contract-reviewer --run "review this NDA…" --provider ollama`.',
+      'Add a ready-made agent or UI component from the AgentsKit registry (registry.agentskit.io). Auto-detects which: a component is scanned/validated against your project and installed transactionally; an agent is copied into ./agents. You own the code. e.g. `agentskit add docs-chat` (component) or `agentskit add research --run "…"` (agent).',
     )
-    .option('--out <dir>', 'Directory to write the agent into (default: ./agents)')
+    .option('--out <dir>', 'Directory to install into (component: the port dir; agent: ./agents)')
     .option('-f, --force', 'Overwrite existing files')
+    .option('--registry <url>', 'Registry base URL override (component install)')
     .option('--run <task>', 'Run the agent on this task right after adding it')
     .option('--provider <provider>', 'Provider for --run (openai, anthropic, gemini, ollama, demo)', 'demo')
     .option('--model <model>', 'Model for --run')
@@ -20,6 +22,7 @@ export function registerAddCommand(program: Command): void {
         options: {
           out?: string
           force?: boolean
+          registry?: string
           run?: string
           provider: string
           model?: string
@@ -27,6 +30,15 @@ export function registerAddCommand(program: Command): void {
         },
       ) => {
         try {
+          // Auto-detect (RFC-0006 D1): try the component registry first; fall back
+          // to the agent path when the id is not a component.
+          const outcome = await tryComponentAdd(agent, {
+            out: options.out,
+            force: options.force,
+            registry: options.registry,
+          })
+          if (outcome === 'installed') return
+
           const result = await addAgent(agent, { outDir: options.out, force: options.force === true })
           process.stdout.write(`\nAdded "${result.agent.title}" → ${result.targetDir}/\n`)
           for (const f of result.written) process.stdout.write(`  wrote  ${f}\n`)


### PR DESCRIPTION
Final integration of RFC-0006 Rollout: `agentskit add` now installs **components**, not just agents.

## What
`agentskit add <name>` **auto-detects** (D1): tries the component registry first — scan → validate → fetch + checksum → transactional install via `addComponent` with the real `node:fs`/`fetch` adapters — and prints a report (files written, packages to install, required env, warnings, an `init` tip). Falls back to the existing agent path when the id isn't a component. Adds `--registry`.

Thin glue (`commands/add-component.ts` + `add.ts`) over the already-tested `addComponent` core (4 e2e tests) + `node-fs` adapters (11 tests). `commands/` is parity-gate-exempt, so no new test file; `tsc` + bare-throw clean.

## Status of the subsystem (now all in main)
types · scan · validate · config · install (path-guard + transactional) · fetch · sig (minisign) · marker (audit chain) · flow (orchestrator) · node-fs (adapters) · **this command**. 

Remaining for a real `agentskit add docs-chat`: publish the `docs-chat` component manifest + files in the `agentskit-registry` repo (the artifact the fetch client downloads), and `agentskit init` for zero-prompt config.