### PR TITLE
feat(home): pill brand chips + theme-aware logos (fix light/dark)

### DIFF
--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -10,6 +10,7 @@ import {
   WorksWithSection,
 } from '@/components/home/showcases'
 import { Icon } from '@/components/home/icons'
+import { BrandIcon } from '@/components/home/brand-icon'
 import { counts, approx } from '@/lib/ecosystem-stats'
 
 export const metadata = {
@@ -160,17 +161,17 @@ function Hero() {
   )
 }
 
-// color override forces a visible fill for brands whose Simple Icons default is
-// near-black (invisible on the dark hero) — e.g. Angular (#0F0F11).
-const FRAMEWORKS: { slug: string; label: string; color?: string }[] = [
+// Theme-aware fills (Angular near-black, Deno/Bun invisible at one theme end)
+// are handled centrally in <BrandIcon> so these stay declarative.
+const FRAMEWORKS: { slug: string; label: string }[] = [
   { slug: 'react', label: 'React' },
   { slug: 'vuedotjs', label: 'Vue' },
   { slug: 'svelte', label: 'Svelte' },
   { slug: 'solid', label: 'Solid' },
-  { slug: 'angular', label: 'Angular', color: 'dd0031' },
+  { slug: 'angular', label: 'Angular' },
   { slug: 'nodedotjs', label: 'Node' },
-  { slug: 'deno', label: 'Deno', color: 'ffffff' },
-  { slug: 'bun', label: 'Bun', color: 'fbf0df' },
+  { slug: 'deno', label: 'Deno' },
+  { slug: 'bun', label: 'Bun' },
 ]
 
 /** Quiet static proof that the UI layer spans every framework. No animation. */
@@ -181,17 +182,7 @@ function HeroFrameworks() {
         Works with
       </span>
       {FRAMEWORKS.map((f) => (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          key={f.label}
-          src={`https://cdn.simpleicons.org/${f.slug}${f.color ? `/${f.color}` : ''}`}
-          alt={f.label}
-          title={f.label}
-          width={22}
-          height={22}
-          loading="lazy"
-          className="h-[22px] w-[22px]"
-        />
+        <BrandIcon key={f.label} slug={f.slug} label={f.label} size={22} imgClass="h-[22px] w-[22px]" />
       ))}
     </div>
   )

--- a/apps/docs-next/components/home/brand-icon.tsx
+++ b/apps/docs-next/components/home/brand-icon.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Theme-aware brand icon from Simple Icons. Brands whose default glyph is
+ * near-black (invisible in dark) or near-white (invisible in light) get a
+ * per-theme color override and render two <img> swapped via the `dark:` variant.
+ * Everything else renders a single brand-coloured icon (fine on both themes).
+ * Falls back to a monogram when the slug has no Simple Icons entry.
+ */
+const TINT: Record<string, { light?: string; dark?: string }> = {
+  // near-black default → light fill in dark theme
+  github: { dark: 'ffffff' },
+  openai: { dark: 'ffffff' },
+  x: { dark: 'ffffff' },
+  vercel: { dark: 'ffffff' },
+  notion: { dark: 'ffffff' },
+  anthropic: { dark: 'ffffff' },
+  elevenlabs: { dark: 'ffffff' },
+  caldotcom: { dark: 'ffffff' },
+  openrouter: { dark: 'ffffff' },
+  sentry: { dark: 'ffffff' },
+  framer: { dark: 'ffffff' },
+  // need both: invisible at one end of the spectrum on each theme
+  deno: { light: '000000', dark: 'ffffff' },
+  bun: { light: '1f2430', dark: 'fbf0df' },
+  // colored brand whose default is near-black: pin the brand red on both themes
+  angular: { light: 'dd0031', dark: 'dd0031' },
+}
+
+export function BrandIcon({
+  slug,
+  label,
+  size = 20,
+  imgClass = '',
+}: {
+  slug: string | null
+  label: string
+  size?: number
+  imgClass?: string
+}) {
+  const [failed, setFailed] = useState(false)
+  const monogram = label.replace(/[^a-zA-Z0-9]/g, '').charAt(0).toUpperCase() || '•'
+
+  if (failed || !slug) {
+    return (
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center justify-center font-mono font-bold text-ak-graphite"
+        style={{ width: size, height: size, fontSize: size * 0.7 }}
+      >
+        {monogram}
+      </span>
+    )
+  }
+
+  const url = (c?: string) => `https://cdn.simpleicons.org/${slug}${c ? `/${c}` : ''}`
+  const common = {
+    alt: '',
+    width: size,
+    height: size,
+    loading: 'lazy' as const,
+    onError: () => setFailed(true),
+    style: { width: size, height: size },
+  }
+  const tint = TINT[slug]
+
+  if (!tint) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={url()} {...common} className={`object-contain ${imgClass}`} />
+  }
+
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={url(tint.light)} {...common} className={`object-contain dark:hidden ${imgClass}`} />
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={url(tint.dark)} {...common} className={`hidden object-contain dark:block ${imgClass}`} />
+    </>
+  )
+}

--- a/apps/docs-next/components/home/logo-marquee.tsx
+++ b/apps/docs-next/components/home/logo-marquee.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { motion, useReducedMotion } from 'motion/react'
-import { useState } from 'react'
 import { brandSlug } from '@/lib/brand-slugs'
+import { BrandIcon } from './brand-icon'
 
 export interface MarqueeItem {
   id: string
@@ -10,30 +10,10 @@ export interface MarqueeItem {
 }
 
 function Logo({ item }: { item: MarqueeItem }) {
-  const [failed, setFailed] = useState(false)
-  const slug = brandSlug(item.id)
-  const monogram = item.label.replace(/[^a-zA-Z0-9]/g, '').charAt(0).toUpperCase() || '•'
   return (
-    <span className="inline-flex shrink-0 items-center gap-2.5 pr-3">
-      <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-ak-foam/90">
-        {!failed ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={`https://cdn.simpleicons.org/${slug}`}
-            alt=""
-            width={20}
-            height={20}
-            loading="lazy"
-            onError={() => setFailed(true)}
-            className="h-5 w-5"
-          />
-        ) : (
-          <span aria-hidden="true" className="font-mono text-xs font-bold text-ak-midnight">
-            {monogram}
-          </span>
-        )}
-      </span>
-      <span className="font-mono text-sm text-ak-graphite">{item.label}</span>
+    <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-ak-border bg-ak-surface px-3.5 py-2">
+      <BrandIcon slug={brandSlug(item.id)} label={item.label} size={18} imgClass="h-[18px] w-[18px]" />
+      <span className="whitespace-nowrap font-mono text-sm text-ak-graphite">{item.label}</span>
     </span>
   )
 }


### PR DESCRIPTION
## What
Brings the registry's marquee chip pattern to the AgentsKit home and fixes brand logos that broke under light/dark.

### Marquee — pill chips
The "works with everything" marquee rendered each logo in a filled light square (`bg-ak-foam`) with the name beside it — looked wrong in light mode. Now each item is a **bordered pill with the logo + name together**, on theme-aware tokens (`border-ak-border` / `bg-ak-surface`).

### Theme-aware logos — new `<BrandIcon>`
Centralizes Simple Icons fetching with per-theme color overrides and a monogram fallback:
- Near-black brands (GitHub, OpenAI, xAI, Vercel, Notion, Anthropic, Sentry, …) get a light fill in dark theme instead of vanishing.
- **Hero "Works with" row fixed**: Deno (was hardcoded `/ffffff`) disappeared in light mode; Bun (`/fbf0df`) was illegible in light. Both now swap color per theme. Angular's red fill also moved into `BrandIcon`.

## Notes
- Dark mode is class-based (`.dark`); icons swap via the `dark:` variant (two `<img>`, one per theme).
- `tsc --noEmit` clean.

## Verify
Toggle light/dark on the home page: hero framework row (Deno/Bun legible both ways) + the integrations/providers marquee (pills, logos visible both themes).