### PR TITLE
fix(ask-docs): ship onnxruntime native lib into the serverless function

### DIFF
--- a/apps/docs-next/lib/ask/handler.ts
+++ b/apps/docs-next/lib/ask/handler.ts
@@ -255,8 +255,11 @@ export function createAskHandler(config: AskConfig): (req: Request) => Promise<R
     } catch (err) {
       hooks.onError?.(err, { stage: 'retrieve' })
       console.error('[ask-docs] retrieval failed:', err)
+      // TEMP DIAGNOSTIC: surface the real error so we can see why retrieval fails
+      // in the serverless runtime (logs are truncated). Revert after diagnosis.
+      const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
       return singleEventStream(
-        [{ type: 'error', message: 'Could not search the docs right now. Please try again.' }],
+        [{ type: 'error', message: `Could not search the docs right now. [debug] ${detail.slice(0, 300)}` }],
         'unknown',
         cors,
       )

--- a/apps/docs-next/lib/ask/handler.ts
+++ b/apps/docs-next/lib/ask/handler.ts
@@ -255,11 +255,8 @@ export function createAskHandler(config: AskConfig): (req: Request) => Promise<R
     } catch (err) {
       hooks.onError?.(err, { stage: 'retrieve' })
       console.error('[ask-docs] retrieval failed:', err)
-      // TEMP DIAGNOSTIC: surface the real error so we can see why retrieval fails
-      // in the serverless runtime (logs are truncated). Revert after diagnosis.
-      const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
       return singleEventStream(
-        [{ type: 'error', message: `Could not search the docs right now. [debug] ${detail.slice(0, 300)}` }],
+        [{ type: 'error', message: 'Could not search the docs right now. Please try again.' }],
         'unknown',
         cors,
       )

--- a/apps/docs-next/next.config.mjs
+++ b/apps/docs-next/next.config.mjs
@@ -1,7 +1,10 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createMDX } from 'fumadocs-mdx/next'
 import { LEGACY_404_REDIRECTS } from './legacy-404-redirects.mjs'
 
 const withMDX = createMDX()
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..')
 
 /**
  * Redirects cover:
@@ -73,6 +76,21 @@ const config = {
   // "[ask-docs] retrieval failed". Keeping it external resolves it from
   // node_modules in the function (via output file tracing) at runtime instead.
   serverExternalPackages: ['@huggingface/transformers'],
+  // The ask-docs embedder uses onnxruntime-node, whose native `.so`/`.node`
+  // binaries are loaded via dlopen and therefore NOT picked up by Vercel's
+  // (static) output file tracing — the function then fails at query time with
+  // "libonnxruntime.so.1: cannot open shared object file". Force the Linux
+  // binaries into the function. `outputFileTracingRoot` points at the monorepo
+  // root so the pnpm store path resolves.
+  outputFileTracingRoot: repoRoot,
+  outputFileTracingIncludes: {
+    // Both relative forms — globs may resolve from the app dir or the tracing
+    // root depending on Next's monorepo handling; the non-matching one is a no-op.
+    '/api/ask-docs': [
+      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v*/linux/**/*',
+      './node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v*/linux/**/*',
+    ],
+  },
   async redirects() {
     // Legacy 404 fixes first — first match wins, so explicit per-URL rules
     // override the broad wildcard rules that used to chain into dead targets.


### PR DESCRIPTION
## Live prod hotfix #2 — root cause fully nailed + **verified on preview**

The first hotfix (`serverExternalPackages`) externalized transformers but the prod chat still errored. Surfaced the exact error via a temporary `[debug]` on a preview (read through a Vercel bypass token):

```
Failed to load external module @huggingface/transformers:
libonnxruntime.so.1: cannot open shared object file: No such file or directory
```

Vercel's **static** output file tracing can't see the native onnxruntime `.so`/`.node` (loaded via `dlopen`), so the function shipped without it.

## Fix (3 layers, all required)
1. `serverExternalPackages: ['@huggingface/transformers']` — don't bundle it.
2. **`outputFileTracingIncludes` + `outputFileTracingRoot`** (this PR) — force the Linux `onnxruntime-node` binaries (`libonnxruntime.so.1`, `onnxruntime_binding.node`) into the function; root = monorepo for the pnpm store path.
3. `env.cacheDir = '/tmp'` — the first-call model download can write.

## Verified
Tested the preview deploy via a bypass token: `POST /api/ask-docs` now **streams a real grounded, cited answer** (was "Could not search the docs"). The temporary `[debug]` surfacing was reverted in this same branch.

Keeps local **$0** ONNX embedding (vector-compatible with the committed index) — no new key, no remote service.