### PR TITLE
ci: AI code review on PRs (self-hosted, claude -p, advisory)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,29 @@
+# AI code review on every PR — runs LOCALLY on a self-hosted runner via `claude -p`
+# (subscription, no per-call API cost). Advisory: posts a review, never blocks.
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # SECURITY: only PRs from branches in this repo (maintainers). Fork PRs are
+    # skipped — never run untrusted fork code on the self-hosted runner.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
+    steps:
+      - name: Add claude to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: AgentsKit-io/code-review-cli@main
+        with:
+          provider: 'claude-cli' # local claude -p — no API cost
+          claude-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          max-files: '25'
+          # advisory by default (posts only). To gate merges:
+          # fail-on-block: 'true'
+          # block: 'high'


### PR DESCRIPTION
Runs the [AgentsKit code-review agent](https://github.com/AgentsKit-io/code-review-cli) on every PR — **locally on a self-hosted runner via `claude -p`** (subscription, no per-call API cost). **Advisory**: posts an inline + summary review, never fails the check.

## Safety

- `if: github.event.pull_request.head.repo.full_name == github.repository` — **only non-fork PRs** (branches in this repo). Fork PRs are skipped so untrusted fork code never executes on the self-hosted runner.
- Only `run:` step is a static `PATH` echo; no untrusted input is interpolated into a shell.

## Requires

- A self-hosted runner online (label `self-hosted`) — registered.
- Secret `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) at repo or org level.

Tune `max-files` / `block`; flip `fail-on-block: 'true'` later to gate merges. This PR itself (a same-repo branch) will be reviewed by the agent once merged + on its next push.