### PR TITLE
fix(ask-docs): render canned 'answer' replies + unblock example-rag-chat lint

### DIFF
--- a/apps/docs-next/components/docs/ask/registry/define-ui-tool.tsx
+++ b/apps/docs-next/components/docs/ask/registry/define-ui-tool.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ComponentType, ReactNode } from 'react'
-import { UI_TOOL_NAMES } from '@/lib/ask/protocol'
+import { RENDERABLE_TOOL_NAMES } from '@/lib/ask/protocol'
 
 /**
  * Generative-UI tool registry — the anti-injection render boundary.
@@ -86,7 +86,7 @@ export function createRegistry(tools: ReadonlyArray<UiTool<unknown>>): UiToolReg
   const components: Record<string, ComponentType<UiToolProps<unknown>>> = {}
 
   for (const tool of tools) {
-    if (!UI_TOOL_NAMES.has(tool.name)) {
+    if (!RENDERABLE_TOOL_NAMES.has(tool.name)) {
       // eslint-disable-next-line no-console
       console.warn(
         `[ask-registry] tool "${tool.name}" is not in UI_TOOL_NAMES; dropped from registry.`,
@@ -97,11 +97,11 @@ export function createRegistry(tools: ReadonlyArray<UiTool<unknown>>): UiToolReg
   }
 
   function has(name: string): boolean {
-    return UI_TOOL_NAMES.has(name) && name in components
+    return RENDERABLE_TOOL_NAMES.has(name) && name in components
   }
 
   function render(name: string, args: unknown, ctx: UiToolContext): ReactNode {
-    if (!UI_TOOL_NAMES.has(name)) {
+    if (!RENDERABLE_TOOL_NAMES.has(name)) {
       // eslint-disable-next-line no-console
       console.warn(`[ask-registry] blocked non-allow-listed tool "${name}".`)
       return null

--- a/apps/docs-next/lib/ask/protocol.ts
+++ b/apps/docs-next/lib/ask/protocol.ts
@@ -167,6 +167,16 @@ export function isUiTool(name: string): boolean {
   return UI_TOOL_NAMES.has(name)
 }
 
+/**
+ * Names the WIDGET may render — a superset of `UI_TOOL_NAMES`. The server emits
+ * `answer` itself for triage / off-topic-decline replies (canned, no model call),
+ * so the render boundary must allow it even though it is NOT advertised to the
+ * model. Injection-safe: the route forwards *model* tool-calls only via `isUiTool`
+ * (which excludes `answer`), so a model can never produce an `answer` event — only
+ * the trusted server can.
+ */
+export const RENDERABLE_TOOL_NAMES = new Set([...UI_TOOL_NAMES, 'answer'])
+
 // ── Streaming wire protocol (NDJSON: one JSON object per line) ───────────────
 
 export type UiEvent =

--- a/apps/example-rag-chat/src/vite-env.d.ts
+++ b/apps/example-rag-chat/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/example-rag-chat/tsconfig.json
+++ b/apps/example-rag-chat/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["vite/client"]
-  },
   "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
Two fixes:

1. **Canned replies render nothing** — "hi"/"test"/"oi" etc. The server answers those via a fast `answer` tool event (no model call), but the widget's render boundary gated on `UI_TOOL_NAMES`, which excludes `answer` (so the model can't call it) → `createRegistry` dropped the renderer → nothing showed. Fix: `RENDERABLE_TOOL_NAMES = UI_TOOL_NAMES + 'answer'`; gate render on it. Injection-safe (the route forwards model tool-calls only via `isUiTool`, no `answer`).

2. **example-rag-chat lint** (unrelated, was blocking the shared gate) — vite 8 broke `tsconfig "types": ["vite/client"]` (TS2688); switch to the canonical `src/vite-env.d.ts` reference so `?raw`/CSS module decls resolve.