### PR TITLE
feat(ask-backend): F0 — persistent Hono Ask backend (RFC-0007)

### DIFF
--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -1,0 +1,46 @@
+# @agentskit/ask-backend
+
+Central, **persistent** Ask backend (RFC-0007). A long-lived Hono server that loads
+the ONNX embedder + each corpus index **once at boot** and stays warm — no
+serverless cold-start, no native-binary tracing hacks — serving grounded, cited chat
+for every AgentsKit property over HTTP.
+
+One embedder + one $0 LLM pool + the shared guards serve **N corpora**, routed by a
+`corpus` query param. F0 serves `docs`; F1 adds `registry`; F2 wires the cross-repo
+corpora (akos/playbook).
+
+## API
+
+```
+POST /v1/ask?corpus=docs   { messages }  → NDJSON UiEvent stream (grounded, cited)
+GET  /v1/corpora                          → { corpora: [...] }
+GET  /health                              → ok
+```
+
+(`/v1/search` + `/mcp` land in F1/F3.)
+
+## Run locally
+
+```bash
+OPENROUTER_API_KEY=... pnpm --filter @agentskit/ask-backend dev
+# first request warms the model (~30 MB download to the local cache); then fast.
+curl -s -XPOST 'http://localhost:8080/v1/ask?corpus=docs' \
+  -H 'content-type: application/json' \
+  -d '{"messages":[{"role":"user","content":"what memory backends are there?"}]}'
+```
+
+## Design
+
+- Reuses the docs app's ask source directly (`createAskHandler`, retriever, guards,
+  embedder) via relative imports — **no shared lib** (RFC-0007 D5). The logic will
+  settle here permanently once the sites point their widgets at this backend (F4).
+- `createAskHandler` (RFC-0006 D5) is framework-neutral `(Request) => Response`, so
+  it mounts straight onto Hono.
+- Protection: CORS allow-list (`*.agentskit.io`), per-IP rate-limit (Upstash durable,
+  in-memory fallback), the triage/injection/scope guards, body cap. Secrets stay
+  server-side.
+
+## Deploy
+
+Railway (F1): persistent instance, `pnpm --filter @agentskit/ask-backend start`,
+`/health` healthcheck, custom domain `ask.agentskit.io`. Config lands in F1.

--- a/apps/ask-backend/package.json
+++ b/apps/ask-backend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agentskit/ask-backend",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Central AgentsKit Ask backend (RFC-0007) — a persistent Hono server that runs the embedder + RAG + grounded chat once, warm, for every corpus. Reuses the docs app's ask source; the sites call it over HTTP.",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "workspace:*",
+    "@agentskit/core": "workspace:*",
+    "@agentskit/rag": "workspace:*",
+    "@huggingface/transformers": "^4.2.0",
+    "@hono/node-server": "^1.13.7",
+    "@upstash/ratelimit": "^2.0.5",
+    "@upstash/redis": "^1.34.3",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -1,0 +1,114 @@
+/**
+ * Central AgentsKit Ask backend (RFC-0007) — a persistent Hono server.
+ *
+ * The whole point vs. Vercel serverless: this is a long-lived process, so the ONNX
+ * embedder + each corpus index load ONCE at boot and stay warm — no cold start, no
+ * native-binary tracing hacks. One embedder + one LLM pool + the shared guards serve
+ * N per-property corpora, routed by a `corpus` query param.
+ *
+ * F0 reuses the docs app's ask source directly (no shared lib, per the author) and
+ * serves the `docs` corpus. F1 adds `registry`; F2 wires the cross-repo corpora.
+ *
+ * Env: OPENROUTER_API_KEY (required), ASK_CORS_ORIGINS, ASK_RICH_UI, PORT,
+ * UPSTASH_REDIS_REST_URL/_TOKEN (durable rate-limit; in-memory fallback otherwise).
+ */
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import type { RetrievedDocument, Retriever } from '@agentskit/core'
+import { createFallbackAdapter, openrouter } from '@agentskit/adapters'
+// Reuse the docs app's ask source (relative — no shared package, RFC-0007 D5).
+import { createAskHandler } from '../../docs-next/lib/ask/handler'
+import { createDocsRetriever, formatCitedContext } from '../../docs-next/lib/rag/retrieve'
+import { FREE_MODELS } from '../../docs-next/lib/openrouter'
+import { docsAssistant } from '../../docs-next/lib/ask/skill'
+import { UI_TOOLS } from '../../docs-next/lib/ask/protocol'
+import { rateLimit } from '../../docs-next/lib/ask/rate-limit'
+
+const apiKey = process.env.OPENROUTER_API_KEY
+if (!apiKey) {
+  console.error('[ask-backend] OPENROUTER_API_KEY is required')
+  process.exit(1)
+}
+
+/** Shared $0 free-model fallback chain — one adapter for every corpus. */
+const adapter = createFallbackAdapter(
+  FREE_MODELS.map((model) => ({
+    id: model,
+    adapter: openrouter({ apiKey, model, retry: { maxAttempts: 2, baseDelayMs: 400 } }),
+  })),
+)
+
+/** A registered knowledge base: its retriever + grounding config. */
+interface Corpus {
+  retriever: Retriever
+  systemPrompt: string
+  temperature?: number
+  formatContext: (docs: RetrievedDocument[]) => string
+}
+
+/**
+ * The corpus registry. F0 = `docs`. F1 adds `registry` (in-repo). F2 adds the
+ * cross-repo corpora (akos/playbook) once their indexes are reachable. The embedder
+ * + adapter + guards are shared; only the retriever + prompt differ per corpus.
+ */
+const corpora: Record<string, Corpus> = {
+  docs: {
+    retriever: createDocsRetriever(),
+    systemPrompt: docsAssistant.systemPrompt,
+    temperature: docsAssistant.temperature,
+    formatContext: (docs) => formatCitedContext(docs).context,
+  },
+}
+
+function clientIp(req: Request): string {
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  )
+}
+
+/** Build a warm `createAskHandler` per corpus (shared adapter/guards/limiter). */
+const handlers: Record<string, (req: Request) => Promise<Response>> = {}
+for (const [id, c] of Object.entries(corpora)) {
+  handlers[id] = createAskHandler({
+    retriever: c.retriever,
+    adapter,
+    systemPrompt: c.systemPrompt,
+    temperature: c.temperature,
+    uiTools: UI_TOOLS,
+    richUi: process.env.ASK_RICH_UI === '1',
+    modelLabel: FREE_MODELS[0],
+    formatContext: c.formatContext,
+    rateLimiter: async (req) => rateLimit(clientIp(req)),
+  })
+}
+
+// Warm the model + every corpus index at boot — the persistent-process payoff.
+for (const c of Object.values(corpora)) {
+  void Promise.resolve(c.retriever.retrieve({ query: 'warmup', messages: [] })).catch(() => {})
+}
+
+const app = new Hono()
+
+const origins = (
+  process.env.ASK_CORS_ORIGINS ??
+  'https://www.agentskit.io,https://agentskit.io,https://registry.agentskit.io,http://localhost:3000'
+).split(',')
+app.use('/v1/*', cors({ origin: origins, allowMethods: ['POST', 'GET', 'OPTIONS'] }))
+
+app.get('/health', (c) => c.text('ok'))
+app.get('/v1/corpora', (c) => c.json({ corpora: Object.keys(corpora) }))
+
+app.post('/v1/ask', (c) => {
+  const corpus = c.req.query('corpus') ?? 'docs'
+  const handler = handlers[corpus]
+  if (!handler) return c.json({ error: `unknown corpus "${corpus}"` }, 400)
+  return handler(c.req.raw)
+})
+
+const port = Number(process.env.PORT ?? 8080)
+serve({ fetch: app.fetch, port }, () => {
+  console.log(`[ask-backend] listening on :${port} — corpora: ${Object.keys(corpora).join(', ')}`)
+})

--- a/apps/ask-backend/tsconfig.json
+++ b/apps/ask-backend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,43 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/ask-backend:
+    dependencies:
+      '@agentskit/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@agentskit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentskit/rag':
+        specifier: workspace:*
+        version: link:../../packages/rag
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.26)
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
+      '@upstash/ratelimit':
+        specifier: ^2.0.5
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.34.3
+        version: 1.38.0
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.26
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/docs-next:
     dependencies:
       '@agentskit/adapters':
@@ -2132,6 +2169,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
@@ -5566,6 +5609,10 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -9012,6 +9059,10 @@ snapshots:
       protobufjs: 7.6.4
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tokenizers@0.1.3': {}
@@ -12441,6 +12492,8 @@ snapshots:
       hermes-estree: 0.36.0
 
   highlight.js@10.7.3: {}
+
+  hono@4.12.26: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
**RFC-0007 F0** (#1039) — scaffold the central persistent Ask backend. **No shared lib** (per the author): `apps/ask-backend` reuses the docs app's ask source via relative imports.

## What
A long-lived **Hono** server that loads the ONNX embedder + corpus index **once at boot** and stays warm — no serverless cold-start, no native-binary tracing hacks (the whole point vs. the Vercel route).

- **Corpus registry** (F0 = `docs`; F1 adds `registry`; F2 the cross-repo akos/playbook). One embedder + one $0 LLM pool + shared guards; only the retriever + prompt differ per corpus.
- **API**: `POST /v1/ask?corpus=docs` (NDJSON UiEvent stream, grounded+cited), `GET /v1/corpora`, `GET /health`.
- **Protection**: CORS `*.agentskit.io`, per-IP rate-limit (Upstash durable + in-memory fallback), the triage/injection/scope guards, body cap; secrets server-side.
- `createAskHandler` (RFC-0006 D5) mounts onto Hono unchanged.

## Status
`tsc` clean; reuses docs-next source cleanly (no lib). docs-next's Vercel route stays live + unchanged. Local run needs `OPENROUTER_API_KEY`. **F1** = Railway deploy + `registry` corpus + `/v1/search` + repoint the widget.