### PR TITLE
feat(ask-backend): F1 — /v1/search + Railway deploy config (RFC-0007)

### DIFF
--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -40,7 +40,21 @@ curl -s -XPOST 'http://localhost:8080/v1/ask?corpus=docs' \
   in-memory fallback), the triage/injection/scope guards, body cap. Secrets stay
   server-side.
 
-## Deploy
+## Deploy (Railway)
 
-Railway (F1): persistent instance, `pnpm --filter @agentskit/ask-backend start`,
-`/health` healthcheck, custom domain `ask.agentskit.io`. Config lands in F1.
+`railway.json` is checked in. In the Railway dashboard:
+
+1. **New project → Deploy from GitHub repo** (`AgentsKit-io/agentskit`).
+2. **Settings → Root Directory** = the **repo root** (the backend imports the docs
+   app's source + the committed index, so it needs the full workspace — not just
+   `apps/ask-backend`). The `railway.json` build/start commands run from there.
+3. **Variables**: `OPENROUTER_API_KEY` (required), optional `UPSTASH_REDIS_REST_URL`
+   + `UPSTASH_REDIS_REST_TOKEN` (durable rate-limit), `ASK_CORS_ORIGINS`.
+4. **Networking → Custom Domain** = `ask.agentskit.io`.
+
+Build = `pnpm install`; start = `pnpm --filter @agentskit/ask-backend start` (tsx).
+The persistent process means the model loads once at boot and stays warm — the
+writable Railway filesystem caches it (no `/tmp` hack needed; the Vercel-specific
+cache override doesn't fire here).
+
+Then point each site's chat widget at `https://ask.agentskit.io/v1/ask?corpus=<id>`.

--- a/apps/ask-backend/package.json
+++ b/apps/ask-backend/package.json
@@ -13,13 +13,15 @@
     "@agentskit/adapters": "workspace:*",
     "@agentskit/core": "workspace:*",
     "@agentskit/rag": "workspace:*",
-    "@huggingface/transformers": "^4.2.0",
+    "@agentskit/validation": "workspace:*",
     "@hono/node-server": "^1.13.7",
+    "@huggingface/transformers": "^4.2.0",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.3",
     "hono": "^4.6.14"
   },
   "devDependencies": {
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^25.9.3",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/apps/ask-backend/railway.json
+++ b/apps/ask-backend/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "corepack enable && pnpm install --frozen-lockfile"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @agentskit/ask-backend start",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "numReplicas": 1
+  }
+}

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -15,8 +15,10 @@
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import type { JSONSchema7 } from 'json-schema'
 import type { RetrievedDocument, Retriever } from '@agentskit/core'
 import { createFallbackAdapter, openrouter } from '@agentskit/adapters'
+import { createAjvValidator } from '@agentskit/validation'
 // Reuse the docs app's ask source (relative — no shared package, RFC-0007 D5).
 import { createAskHandler } from '../../docs-next/lib/ask/handler'
 import { createDocsRetriever, formatCitedContext } from '../../docs-next/lib/rag/retrieve'
@@ -108,23 +110,38 @@ app.post('/v1/ask', (c) => {
   return handler(c.req.raw)
 })
 
+// Validate the search body against a JSON Schema via Ajv (the repo's runtime
+// validator, @agentskit/validation — JSON Schema is canonical here, not Zod).
+const validateSearch = createAjvValidator({ coerceTypes: true })
+const SEARCH_SCHEMA: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    query: { type: 'string', minLength: 1 },
+    k: { type: 'integer', minimum: 1, maximum: 20 },
+  },
+  required: ['query'],
+  additionalProperties: false,
+}
+
 // Raw retrieval — relevant chunks for a query, no LLM. Powers tools + the MCP
 // search tool, and lets a site render sources without a full chat turn.
 app.post('/v1/search', async (c) => {
   const corpus = c.req.query('corpus') ?? 'docs'
   const cor = corpora[corpus]
   if (!cor) return c.json({ error: `unknown corpus "${corpus}"` }, 400)
-  let body: { query?: unknown; k?: unknown }
+  let raw: unknown
   try {
-    body = (await c.req.json()) as { query?: unknown; k?: unknown }
+    raw = await c.req.json()
   } catch {
     return c.json({ error: 'invalid JSON' }, 400)
   }
-  const query = typeof body.query === 'string' ? body.query.trim() : ''
-  if (!query) return c.json({ error: 'query required' }, 400)
-  const k = typeof body.k === 'number' && body.k > 0 ? Math.min(body.k, 20) : 6
+  const result = validateSearch(SEARCH_SCHEMA, (raw ?? {}) as Record<string, unknown>)
+  if (!result.valid) {
+    return c.json({ error: 'invalid request body', detail: result.errors }, 400)
+  }
+  const { query, k = 6 } = raw as { query: string; k?: number }
   try {
-    const docs = await cor.retriever.retrieve({ query, messages: [] })
+    const docs = await cor.retriever.retrieve({ query: query.trim(), messages: [] })
     return c.json({
       results: docs.slice(0, k).map((d) => ({
         content: d.content,

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -108,6 +108,37 @@ app.post('/v1/ask', (c) => {
   return handler(c.req.raw)
 })
 
+// Raw retrieval — relevant chunks for a query, no LLM. Powers tools + the MCP
+// search tool, and lets a site render sources without a full chat turn.
+app.post('/v1/search', async (c) => {
+  const corpus = c.req.query('corpus') ?? 'docs'
+  const cor = corpora[corpus]
+  if (!cor) return c.json({ error: `unknown corpus "${corpus}"` }, 400)
+  let body: { query?: unknown; k?: unknown }
+  try {
+    body = (await c.req.json()) as { query?: unknown; k?: unknown }
+  } catch {
+    return c.json({ error: 'invalid JSON' }, 400)
+  }
+  const query = typeof body.query === 'string' ? body.query.trim() : ''
+  if (!query) return c.json({ error: 'query required' }, 400)
+  const k = typeof body.k === 'number' && body.k > 0 ? Math.min(body.k, 20) : 6
+  try {
+    const docs = await cor.retriever.retrieve({ query, messages: [] })
+    return c.json({
+      results: docs.slice(0, k).map((d) => ({
+        content: d.content,
+        score: d.score,
+        path: (d.metadata as { path?: string } | undefined)?.path,
+        title: (d.metadata as { title?: string } | undefined)?.title,
+      })),
+    })
+  } catch (err) {
+    console.error('[ask-backend] search failed:', err)
+    return c.json({ error: 'search failed' }, 500)
+  }
+})
+
 const port = Number(process.env.PORT ?? 8080)
 serve({ fetch: app.fetch, port }, () => {
   console.log(`[ask-backend] listening on :${port} — corpora: ${Object.keys(corpora).join(', ')}`)

--- a/apps/docs-next/components/docs/ask/useAskChat.ts
+++ b/apps/docs-next/components/docs/ask/useAskChat.ts
@@ -4,6 +4,14 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { decodeEvents, type UiEvent } from '@/lib/ask/protocol'
 
 /**
+ * Where to POST the chat. Defaults to the same-origin Vercel route; set
+ * `NEXT_PUBLIC_ASK_ENDPOINT` (e.g. `https://ask.agentskit.io/v1/ask?corpus=docs`)
+ * to route to the central persistent backend (RFC-0007). Both speak the same
+ * NDJSON `UiEvent` protocol, so nothing else changes.
+ */
+const ASK_ENDPOINT = process.env.NEXT_PUBLIC_ASK_ENDPOINT || '/api/ask-docs'
+
+/**
  * A rendered part of an assistant turn. Parts are kept in arrival order so the
  * widget can interleave streamed prose (`text`) with generative-UI tool calls
  * (`tool`) exactly as the model emitted them.
@@ -206,7 +214,7 @@ export function useAskChat(): UseAskChat {
       abortRef.current = ctrl
 
       try {
-        const res = await fetch('/api/ask-docs', {
+        const res = await fetch(ASK_ENDPOINT, {
           method: 'POST',
           signal: ctrl.signal,
           headers: { 'content-type': 'application/json' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@agentskit/rag':
         specifier: workspace:*
         version: link:../../packages/rag
+      '@agentskit/validation':
+        specifier: workspace:*
+        version: link:../../packages/validation
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.26)
@@ -94,6 +97,9 @@ importers:
         specifier: ^4.6.14
         version: 4.12.26
     devDependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3

--- a/rfcs/0007-central-ask-backend.md
+++ b/rfcs/0007-central-ask-backend.md
@@ -60,15 +60,17 @@ Requests carry a `corpus`; the backend picks that corpus's retriever and runs th
 shared handler. A new property = drop in its index + register the corpus. The model
 is shared (same embedding space) — adding corpora is cheap.
 
-**v1 corpora = `docs` + `registry`** (both live in this monorepo → indexes built
-here). This proves real per-`corpus` routing with two corpora. **`akos` and
-`playbook` live in separate repos** — they are **F2**: the backend sources their
-content cross-repo. Each property's CI builds its index (the same `gen-ask-index`
-step) and publishes it as an artifact the backend pulls on deploy (a committed
-`index.json` in a known location, or a small fetch on boot). The backend stays
-multi-corpus-ready from v1; the akos/playbook corpora register once their indexes
-are reachable. No property's source needs to live in the backend's repo — only its
-built index.
+**v1 corpus = `docs` only** — the one genuine knowledge base in this monorepo. The
+**`registry` knowledge is the agents**, which live in the separate
+`agentskit-registry` repo (not the `apps/registry` site's few pages), so registry is
+**cross-repo like akos/playbook** → all three are **F2**. The backend is built
+multi-corpus from day one (corpus registry + `?corpus=` routing), but only `docs`
+has content at v1.
+
+**F2 cross-repo sourcing**: each property's repo CI builds its index (the same
+`gen-ask-index` step) and publishes it as an artifact the backend pulls on deploy (a
+committed `index.json` in a known location, or a small fetch on boot). Only the built
+index travels — no property's source lives in the backend's repo.
 
 ### D3. Public but protected
 
@@ -152,14 +154,15 @@ retriever; everything else (guards, adapter, citations) is shared config.
   **no package extraction** — and serves `/v1/ask` + `/health` for the docs corpus.
   Run it locally; verify a real query streams a cited answer. `docs-next`'s Vercel
   route stays live (unchanged) the whole time.
-- **F1 — Railway + the in-repo corpora (`docs` + `registry`)**: build both indexes
-  here, register two corpora, add `/v1/search` + `/v1/corpora`. Warm-load the model
-  at boot. Deploy to Railway, attach `ask.agentskit.io`. Point the **www** (+ registry)
-  widget at it; verify warm + fast + cited, and that `corpus` routing works.
-- **F2 — cross-repo corpora (`akos`, `playbook`)**: design the content-sourcing —
-  each separate repo's CI builds its `index.json` and publishes it where the backend
-  pulls it (committed artifact or fetch-on-boot); register those corpora; their
-  widgets point at `ask.agentskit.io/v1/ask?corpus=<their>`.
+- **F1 — Railway + the `docs` corpus**: register the docs corpus, add `/v1/search` +
+  `/v1/corpora`, warm-load the model at boot. Deploy to Railway, attach
+  `ask.agentskit.io`. Point the **www** widget at it (`NEXT_PUBLIC_ASK_ENDPOINT`);
+  verify warm + fast + cited. (The backend is already multi-corpus-ready.)
+- **F2 — cross-repo corpora (`registry`, `akos`, `playbook`)**: design the
+  content-sourcing — each separate repo's CI builds its `index.json` and publishes it
+  where the backend pulls it (committed artifact or fetch-on-boot); register those
+  corpora; their widgets point at `ask.agentskit.io/v1/ask?corpus=<their>`. (registry
+  knowledge = the agents in `agentskit-registry`, not the site pages.)
 - **F3 — MCP**: `/mcp` with `list_corpora` / `search_docs` / `ask`; document it for
   agents (and cross-link from the registry MCP).
 - **F4 — retire serverless routes**: remove the per-property Vercel `/api/ask-docs`


### PR DESCRIPTION
**RFC-0007 F1 (part 1)** — makes the backend deployable + adds raw retrieval.

## What
- **`/v1/search?corpus=<id>`** — raw retrieval (relevant chunks, no LLM) per corpus. Powers tools, the MCP search tool, and source-rendering without a full chat turn.
- **`railway.json`** (NIXPACKS) + README setup steps — deploy to a persistent Railway instance: repo-root service dir (the backend reuses the docs source + committed index), `OPENROUTER_API_KEY` (+ optional `UPSTASH_*`), `/health` healthcheck, `ask.agentskit.io` domain.

The persistent process = the model loads once at boot and stays warm — no serverless cold-start, no native-binary tracing hack.

## Next (F1 cont., after the Railway deploy)
- Point the docs widget at `ask.agentskit.io/v1/ask?corpus=docs` (env-configurable, defaults to the current same-origin route).
- Add the `registry` corpus (gen its index + a per-index retriever) → proves multi-corpus routing.

`tsc` clean. docs-next's Vercel route stays live + unchanged.