### PR TITLE
feat(runtime): invokeStructured + piiDenyValidator (agent substrate)

### DIFF
--- a/.changeset/agent-substrate-runtime.md
+++ b/.changeset/agent-substrate-runtime.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/runtime": minor
+---
+
+Add two agent-substrate primitives so registry/AKOS agents stop hand-rolling them: `invokeStructured({ adapter, tool, task, parse, skill? })` — first-class structured output (run a skill, force one `submit_*` tool call, read it from `result.toolCalls`, return the validated value); and `piiDenyValidator(opts?)` — a `Validator` that fails when output still contains PII, bridging `@agentskit/core/security`'s redactor into `createValidatorGuard` as a deterministic last-line gate.

--- a/apps/docs-next/content/docs/for-agents/runtime.mdx
+++ b/apps/docs-next/content/docs/for-agents/runtime.mdx
@@ -28,6 +28,8 @@ npm install @agentskit/runtime
 - `createChatTrigger({ adapter, agent, ... })` — unified inbound trigger for chat-surface bots (Slack / Teams / Discord / WhatsApp). Wraps a `ChatSurfaceAdapter` that normalizes provider events into a `ChatSurfaceEvent` discriminated union (`message` / `mention` / `reply` / `reaction` / `file_upload` / `installation`). Returns a framework-agnostic `WebhookHandler`.
 - `createQuotaTracker` + `withQuotas` — per-tool quota / blast-radius limits (count / cost / duration windows).
 - `createValidatorGuard` + built-in validators `denyPattern`, `lengthRange`, `isJson` — agent-insurance primitive that rejects tool args / outputs against allow/deny rules before they propagate.
+- `piiDenyValidator(opts?)` — a `Validator` that fails when the output still contains PII (bridges `@agentskit/core/security`'s redactor into the guard chain); a deterministic last-line gate for redaction/export agents instead of trusting the prompt.
+- `invokeStructured({ adapter, tool, task, parse, skill? })` — first-class structured output: run a skill that must call one `submit_*` tool, read it back from `result.toolCalls`, return the validated value. Replaces the hand-rolled "offer one tool, find the call, parse args" boilerplate every pipeline agent writes.
 
 ## Minimal example
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,6 @@
 export { createRuntime } from './runner'
+export { invokeStructured } from './structured'
+export { piiDenyValidator } from './pii-validator'
 export { createSharedContext } from './shared-context'
 export type { SharedContext, ReadonlySharedContext } from './shared-context'
 export type { RuntimeConfig, RunOptions, RunResult, DelegateConfig } from './types'

--- a/packages/runtime/src/pii-validator.ts
+++ b/packages/runtime/src/pii-validator.ts
@@ -1,0 +1,32 @@
+import { createPIIRedactor, type PIIRule } from '@agentskit/core/security'
+import type { Validator, ValidatorAction } from './validator-guard'
+
+/**
+ * A `Validator` that FAILS when the agent's output still contains PII — the bridge
+ * between `@agentskit/core/security`'s redactor and the `createValidatorGuard` chain.
+ * Use it as a deterministic last-line gate on agents that must not leak PII
+ * (redaction, summarization, anything exporting cross-tenant), instead of trusting
+ * the system prompt to do it.
+ *
+ * ```ts
+ * import { createValidatorGuard, piiDenyValidator } from '@agentskit/runtime'
+ * const guard = createValidatorGuard({ validators: [piiDenyValidator()] })
+ * ```
+ *
+ * Default `onFail: 'block'` — a PII leak is not something to silently retry past.
+ */
+export function piiDenyValidator(
+  opts: { rules?: PIIRule[]; name?: string; onFail?: ValidatorAction } = {},
+): Validator {
+  const redactor = createPIIRedactor({ rules: opts.rules })
+  return {
+    name: opts.name ?? 'pii-deny',
+    check: ({ output }) => {
+      const { hits } = redactor.redact(output)
+      if (hits.length === 0) return { ok: true }
+      const summary = hits.map((h) => `${h.rule}×${h.count}`).join(', ')
+      return { ok: false, reason: `output contains PII (${summary})` }
+    },
+    onFail: opts.onFail ?? 'block',
+  }
+}

--- a/packages/runtime/src/structured.ts
+++ b/packages/runtime/src/structured.ts
@@ -1,0 +1,49 @@
+import type { AdapterFactory, ChatMemory, Observer, SkillDefinition, ToolCall, ToolDefinition } from '@agentskit/core'
+import { createRuntime } from './runner'
+
+/**
+ * Run a skill that must produce STRUCTURED output, and return it validated — the
+ * first-class version of the pattern every pipeline agent hand-rolls (offer one
+ * `submit_*` tool, run, read it back from `result.toolCalls`, parse).
+ *
+ * The model's only job is to call `tool` once; `execute` just acknowledges. The
+ * `parse` callback validates the args (e.g. `(a) => MySchema.parse(a)` with Zod) so
+ * this stays dependency-free — the runtime never imports Zod.
+ *
+ * ```ts
+ * const cls = await invokeStructured({
+ *   adapter, skill: classifier, task,
+ *   tool: submitClassificationTool,
+ *   parse: (args) => Classification.parse(args),
+ * })
+ * ```
+ */
+export async function invokeStructured<T>(opts: {
+  adapter: AdapterFactory
+  /** The submit tool the skill must call exactly once. */
+  tool: ToolDefinition
+  task: string
+  /** Validate + shape the tool args (throws on invalid). */
+  parse: (args: Record<string, unknown>) => T
+  skill?: SkillDefinition
+  /** Extra tools available during the run (besides `tool`). */
+  tools?: ToolDefinition[]
+  memory?: ChatMemory
+  observers?: Observer[]
+  onConfirm?: (toolCall: ToolCall) => boolean | Promise<boolean>
+  maxSteps?: number
+  signal?: AbortSignal
+}): Promise<T> {
+  const runtime = createRuntime({
+    adapter: opts.adapter,
+    tools: [opts.tool, ...(opts.tools ?? [])],
+    memory: opts.memory,
+    observers: opts.observers,
+    onConfirm: opts.onConfirm,
+    maxSteps: opts.maxSteps ?? 3,
+  })
+  const result = await runtime.run(opts.task, { skill: opts.skill, signal: opts.signal })
+  const call = result.toolCalls.find((c) => c.name === opts.tool.name)
+  if (!call) throw new Error(`invokeStructured: ${opts.skill?.name ?? 'agent'} did not call ${opts.tool.name}`)
+  return opts.parse(call.args)
+}

--- a/packages/runtime/src/structured.ts
+++ b/packages/runtime/src/structured.ts
@@ -1,4 +1,5 @@
 import type { AdapterFactory, ChatMemory, Observer, SkillDefinition, ToolCall, ToolDefinition } from '@agentskit/core'
+import { RuntimeError } from '@agentskit/core'
 import { createRuntime } from './runner'
 
 /**
@@ -44,6 +45,10 @@ export async function invokeStructured<T>(opts: {
   })
   const result = await runtime.run(opts.task, { skill: opts.skill, signal: opts.signal })
   const call = result.toolCalls.find((c) => c.name === opts.tool.name)
-  if (!call) throw new Error(`invokeStructured: ${opts.skill?.name ?? 'agent'} did not call ${opts.tool.name}`)
+  if (!call)
+    throw new RuntimeError({
+      code: 'AK_STRUCTURED_NO_TOOL_CALL',
+      message: `invokeStructured: ${opts.skill?.name ?? 'agent'} did not call ${opts.tool.name}`,
+    })
   return opts.parse(call.args)
 }

--- a/packages/runtime/tests/agent-substrate.test.ts
+++ b/packages/runtime/tests/agent-substrate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { AdapterFactory, ToolDefinition } from '@agentskit/core'
-import { invokeStructured, piiDenyValidator } from '../src/index'
+import { invokeStructured } from '../src/structured'
+import { piiDenyValidator } from '../src/pii-validator'
 
 // Minimal inline mock adapter — avoids a cross-package dep on @agentskit/adapters.
 type Chunk = Record<string, unknown>

--- a/packages/runtime/tests/agent-substrate.test.ts
+++ b/packages/runtime/tests/agent-substrate.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import type { AdapterFactory, ToolDefinition } from '@agentskit/core'
+import { invokeStructured, piiDenyValidator } from '../src/index'
+
+// Minimal inline mock adapter — avoids a cross-package dep on @agentskit/adapters.
+type Chunk = Record<string, unknown>
+function mock(chunks: Chunk[]): AdapterFactory {
+  return {
+    capabilities: { streaming: false, tools: true },
+    createSource: () => ({
+      // eslint-disable-next-line @typescript-eslint/require-await
+      stream: async function* () {
+        for (const c of chunks) yield c as never
+      },
+      abort: () => {},
+    }),
+  } as unknown as AdapterFactory
+}
+
+describe('piiDenyValidator', () => {
+  it('fails when output contains PII, passes when clean', async () => {
+    const v = piiDenyValidator()
+    const dirty = await v.check({ attempt: 0, output: 'reach me at jane@doe.com or 555-123-4567' })
+    expect(dirty).toMatchObject({ ok: false })
+    expect((dirty as { reason: string }).reason).toMatch(/email|phone/)
+    expect(await v.check({ attempt: 0, output: 'no identifiers here' })).toMatchObject({ ok: true })
+    expect(v.onFail).toBe('block')
+  })
+})
+
+describe('invokeStructured', () => {
+  const submit: ToolDefinition = { name: 'submit_x', description: 'submit', execute: async () => 'recorded' }
+  const adapter = mock([
+    { type: 'tool_call', toolCall: { id: 't', name: 'submit_x', args: JSON.stringify({ n: '42', label: 'ok' }) } },
+    { type: 'done' },
+  ])
+
+  it('runs a skill, reads back the submit tool args, and returns parsed output', async () => {
+    const out = await invokeStructured({
+      adapter,
+      tool: submit,
+      task: 'do it',
+      parse: (a) => ({ n: Number(a.n), label: String(a.label) }),
+    })
+    expect(out).toEqual({ n: 42, label: 'ok' })
+  })
+
+  it('throws if the skill never calls the submit tool', async () => {
+    const silent = mock([{ type: 'text', content: 'no tool call' }, { type: 'done' }])
+    await expect(
+      invokeStructured({ adapter: silent, tool: submit, task: 'x', parse: (a) => a }),
+    ).rejects.toThrow(/did not call submit_x/)
+  })
+})

--- a/packages/runtime/tests/agent-substrate.test.ts
+++ b/packages/runtime/tests/agent-substrate.test.ts
@@ -1,21 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import type { AdapterFactory, ToolDefinition } from '@agentskit/core'
+import type { AdapterFactory, StreamChunk, ToolDefinition } from '@agentskit/core'
 import { invokeStructured } from '../src/structured'
 import { piiDenyValidator } from '../src/pii-validator'
 
 // Minimal inline mock adapter — avoids a cross-package dep on @agentskit/adapters.
-type Chunk = Record<string, unknown>
-function mock(chunks: Chunk[]): AdapterFactory {
-  return {
+// Typed against AdapterFactory + StreamChunk so it stays in sync with the real
+// contract (no `as unknown` escape hatch).
+function mock(chunks: StreamChunk[]): AdapterFactory {
+  const factory: AdapterFactory = {
     capabilities: { streaming: false, tools: true },
     createSource: () => ({
       // eslint-disable-next-line @typescript-eslint/require-await
       stream: async function* () {
-        for (const c of chunks) yield c as never
+        yield* chunks
       },
       abort: () => {},
     }),
-  } as unknown as AdapterFactory
+  }
+  return factory
 }
 
 describe('piiDenyValidator', () => {
@@ -26,6 +28,15 @@ describe('piiDenyValidator', () => {
     expect((dirty as { reason: string }).reason).toMatch(/email|phone/)
     expect(await v.check({ attempt: 0, output: 'no identifiers here' })).toMatchObject({ ok: true })
     expect(v.onFail).toBe('block')
+  })
+
+  it('uses the documented defaults and honors overrides', () => {
+    const def = piiDenyValidator()
+    expect(def.name).toBe('pii-deny')
+    expect(def.onFail).toBe('block')
+    const custom = piiDenyValidator({ name: 'no-pii', onFail: 'retry' })
+    expect(custom.name).toBe('no-pii')
+    expect(custom.onFail).toBe('retry')
   })
 })
 
@@ -51,5 +62,24 @@ describe('invokeStructured', () => {
     await expect(
       invokeStructured({ adapter: silent, tool: submit, task: 'x', parse: (a) => a }),
     ).rejects.toThrow(/did not call submit_x/)
+  })
+
+  it('surfaces a parse failure on malformed submit args rather than returning garbage', async () => {
+    const bad = mock([
+      { type: 'tool_call', toolCall: { id: 't', name: 'submit_x', args: JSON.stringify({ n: 'not-a-number' }) } },
+      { type: 'done' },
+    ])
+    await expect(
+      invokeStructured({
+        adapter: bad,
+        tool: submit,
+        task: 'x',
+        parse: (a) => {
+          const n = Number(a.n)
+          if (Number.isNaN(n)) throw new Error('n is not a number')
+          return { n }
+        },
+      }),
+    ).rejects.toThrow(/not a number/)
   })
 })


### PR DESCRIPTION
P0 substrate, part 2 (part 1 = #1050 core). Two primitives the registry/AKOS agents repeatedly hand-roll or lack:

- **`invokeStructured({ adapter, tool, task, parse, skill? })`** — first-class structured output. Runs a skill that must call one `submit_*` tool, reads it back from `result.toolCalls`, returns the validated value. The `parse` callback keeps Zod out of the runtime. This is the exact boilerplate `code-review` and `knowledge-promoter` each re-implement.
- **`piiDenyValidator(opts?)`** — a `Validator` that fails when the output still contains PII, bridging `@agentskit/core/security`'s `createPIIRedactor` into the `createValidatorGuard` chain. A deterministic last-line gate for redaction/export agents instead of trusting the system prompt.

Tests 3/3; for-agents coverage updated; changeset `@agentskit/runtime` minor. Additive.