### PR TITLE
feat(ask-backend): F3 — MCP endpoint (RFC-0007)

### DIFF
--- a/.changeset/ask-backend-f3-mcp.md
+++ b/.changeset/ask-backend-f3-mcp.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a read-only MCP endpoint (`/mcp`) to the central Ask backend (RFC-0007 F3): JSON-RPC over POST exposing `list_corpora`, `search_docs`, and `ask` over the shared corpus registry. The `ask` tool reuses the warm ask handler and collapses its streamed `UiEvent` output into a single cited answer.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Docker build context for apps/ask-backend (context = repo root).
+# Keep it lean: deps + build artifacts are regenerated inside the image. Without
+# this the context is ~15 GB (node_modules + .git + every dist/.next/.turbo).
+**/node_modules
+.git
+.turbo
+**/.turbo
+**/dist
+**/.next
+**/.vercel
+**/coverage
+**/*.tsbuildinfo
+**/.DS_Store
+
+# Heavy app build outputs / fixtures not needed by the backend.
+**/storybook-static
+**/playwright-report
+**/test-results

--- a/apps/ask-backend/Dockerfile
+++ b/apps/ask-backend/Dockerfile
@@ -1,0 +1,42 @@
+# Central Ask backend (RFC-0007) — Docker build for Railway.
+#
+# Why Docker over Nixpacks: Nixpacks auto-ran `npm i`, which chokes on this
+# monorepo's `workspace:*` deps (EUNSUPPORTEDPROTOCOL). Docker gives us pnpm +
+# corepack and full control over the native ONNX runtime.
+#
+# Debian (bookworm) base — NOT alpine: onnxruntime-node ships a glibc native
+# binary; musl would fail to load it. Build context is the REPO ROOT (the backend
+# imports the docs app's source + the committed index via relative paths, so it
+# needs the whole workspace).
+FROM node:22-bookworm-slim
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=/pnpm:$PATH
+RUN corepack enable
+
+WORKDIR /app
+
+# CI=true so pnpm purges any stray node_modules non-interactively (no TTY in build).
+ENV CI=true
+
+# Whole workspace — the backend resolves `../../docs-next/lib/*` + the index at runtime.
+# (node_modules / .git / dist / caches are excluded via .dockerignore — deps are
+# installed and libs built fresh below.)
+COPY . .
+
+# Install all workspace deps, then build ONLY the libs the backend resolves to
+# `dist` (its dependency closure: adapters/core/rag/validation + rag's deps). The
+# Next apps are never built. `tsx` (a devDep) runs the backend's TS directly.
+RUN pnpm install --frozen-lockfile \
+ && pnpm exec turbo run build \
+      --filter='@agentskit/adapters...' \
+      --filter='@agentskit/rag...' \
+      --filter='@agentskit/validation...'
+
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+# The persistent process: the ONNX embedder + corpus index load once at boot and
+# stay warm. The container filesystem caches the model (no /tmp hack needed).
+CMD ["pnpm", "--filter", "@agentskit/ask-backend", "start"]

--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -12,12 +12,29 @@ corpora (akos/playbook).
 ## API
 
 ```
-POST /v1/ask?corpus=docs   { messages }  → NDJSON UiEvent stream (grounded, cited)
-GET  /v1/corpora                          → { corpora: [...] }
-GET  /health                              → ok
+POST /v1/ask?corpus=docs    { messages }       → NDJSON UiEvent stream (grounded, cited)
+POST /v1/search?corpus=docs { query, k? }      → { results: [...] }   (raw retrieval, no LLM)
+GET  /v1/corpora                               → { corpora: [...] }
+GET  /health                                   → ok
+ALL  /mcp                                       → MCP server (JSON-RPC over POST)
 ```
 
-(`/v1/search` + `/mcp` land in F1/F3.)
+### MCP
+
+`/mcp` is a read-only [MCP](https://modelcontextprotocol.io) server (JSON-RPC 2.0
+over POST, public `CORS *`) so agents query AgentsKit knowledge over the same corpus
+registry — same transport as the registry MCP. Tools:
+
+- `list_corpora()` → the knowledge bases this server answers over.
+- `search_docs({ corpus?, query, k? })` → relevant chunks + source paths (raw retrieval).
+- `ask({ corpus?, question })` → a grounded, cited answer (non-streaming; reuses the
+  warm ask handler and collapses its `UiEvent` stream into one markdown answer + sources).
+
+```bash
+curl -s -XPOST http://localhost:8080/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ask","arguments":{"question":"what memory backends are there?"}}}'
+```
 
 ## Run locally
 

--- a/apps/ask-backend/railway.json
+++ b/apps/ask-backend/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS",
-    "buildCommand": "corepack enable && pnpm install --frozen-lockfile"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/ask-backend/Dockerfile"
   },
   "deploy": {
     "startCommand": "pnpm --filter @agentskit/ask-backend start",

--- a/apps/ask-backend/src/mcp.ts
+++ b/apps/ask-backend/src/mcp.ts
@@ -1,0 +1,206 @@
+/**
+ * MCP endpoint for the central Ask backend (RFC-0007 F3).
+ *
+ * A hand-rolled JSON-RPC 2.0 server over POST (streamable-http), mirroring the
+ * registry MCP (`apps/registry/app/api/mcp`) so agents query AgentsKit knowledge
+ * with the same transport. Read-only, public, CORS `*` — it serves the same
+ * public docs knowledge the chat does, over the same corpus registry.
+ *
+ * Tools (over every registered corpus):
+ *   - list_corpora()                      → available knowledge bases
+ *   - search_docs({ corpus, query, k })   → relevant chunks + source paths (raw retrieval)
+ *   - ask({ corpus, question })           → a grounded, cited answer (non-streaming)
+ *
+ * `ask` reuses the per-corpus `createAskHandler` unchanged: it drives the handler
+ * with a one-shot request and collapses the NDJSON `UiEvent` stream into a single
+ * markdown answer + sources — MCP clients get one JSON result, not a stream.
+ */
+import type { RetrievedDocument, Retriever } from '@agentskit/core'
+import { decodeEvents } from '../../docs-next/lib/ask/protocol'
+
+/** A registered corpus: its retriever + the warm ask handler built over it. */
+export interface McpCorpus {
+  retriever: Retriever
+  handler: (req: Request) => Promise<Response>
+}
+
+const CORS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, OPTIONS',
+  'access-control-allow-headers': 'content-type, mcp-protocol-version',
+}
+
+const TOOLS = [
+  {
+    name: 'list_corpora',
+    description: 'List the AgentsKit knowledge bases this server can answer over.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'search_docs',
+    description:
+      'Retrieve the most relevant documentation chunks for a query (raw retrieval, no LLM). Returns content + source paths.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        corpus: { type: 'string', description: 'Knowledge base id (default "docs").' },
+        query: { type: 'string', description: 'The search query.' },
+        k: { type: 'integer', minimum: 1, maximum: 20, description: 'Max chunks (default 6).' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'ask',
+    description:
+      'Ask a question and get a grounded, cited answer synthesised from the corpus (non-streaming).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        corpus: { type: 'string', description: 'Knowledge base id (default "docs").' },
+        question: { type: 'string', description: 'The question to answer.' },
+      },
+      required: ['question'],
+    },
+  },
+]
+
+const text = (obj: unknown) => ({
+  content: [{ type: 'text', text: typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2) }],
+})
+const err = (m: string) => ({ isError: true, content: [{ type: 'text', text: m }] })
+
+function sourcePath(d: RetrievedDocument): string | undefined {
+  return (d.metadata as { path?: string } | undefined)?.path
+}
+function sourceTitle(d: RetrievedDocument): string | undefined {
+  return (d.metadata as { title?: string } | undefined)?.title
+}
+
+/** Drive the warm ask handler one-shot and collapse the stream into a final answer. */
+async function askOnce(
+  handler: (req: Request) => Promise<Response>,
+  question: string,
+): Promise<{ answer: string; sources: Array<{ title?: string; path?: string; anchor?: string }> }> {
+  const req = new Request('http://ask.local/v1/ask?corpus=mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ messages: [{ role: 'user', content: question }] }),
+  })
+  const res = await handler(req)
+  const body = await res.text()
+
+  let answer = ''
+  const sources: Array<{ title?: string; path?: string; anchor?: string }> = []
+  const { events } = decodeEvents(body.endsWith('\n') ? body : body + '\n')
+  for (const ev of events) {
+    if (ev.type === 'text') answer += ev.delta
+    else if (ev.type === 'tool' && ev.name === 'answer') {
+      const md = (ev.args as { markdown?: string }).markdown
+      if (typeof md === 'string') answer += md
+    } else if (ev.type === 'tool' && ev.name === 'cite') {
+      const cited = (ev.args as { sources?: Array<{ title?: string; path?: string; anchor?: string }> })
+        .sources
+      if (Array.isArray(cited)) sources.push(...cited)
+    } else if (ev.type === 'error') {
+      throw new Error(ev.message)
+    }
+  }
+  return { answer: answer.trim(), sources }
+}
+
+/** Build the MCP request handler over the given corpus registry. */
+export function createMcpHandler(corpora: Record<string, McpCorpus>) {
+  const DEFAULT = 'docs'
+
+  async function callTool(name: string, args: Record<string, unknown>) {
+    switch (name) {
+      case 'list_corpora':
+        return text({ corpora: Object.keys(corpora) })
+      case 'search_docs': {
+        const corpus = (args.corpus as string) ?? DEFAULT
+        const cor = corpora[corpus]
+        if (!cor) return err(`Unknown corpus: ${corpus}`)
+        const query = typeof args.query === 'string' ? args.query.trim() : ''
+        if (!query) return err('query is required')
+        const k = typeof args.k === 'number' ? Math.min(Math.max(1, args.k), 20) : 6
+        const docs = await cor.retriever.retrieve({ query, messages: [] })
+        return text({
+          results: docs.slice(0, k).map((d) => ({
+            content: d.content,
+            score: d.score,
+            path: sourcePath(d),
+            title: sourceTitle(d),
+          })),
+        })
+      }
+      case 'ask': {
+        const corpus = (args.corpus as string) ?? DEFAULT
+        const cor = corpora[corpus]
+        if (!cor) return err(`Unknown corpus: ${corpus}`)
+        const question = typeof args.question === 'string' ? args.question.trim() : ''
+        if (!question) return err('question is required')
+        const { answer, sources } = await askOnce(cor.handler, question)
+        return text({ answer, sources })
+      }
+      default:
+        return err(`Unknown tool: ${name}`)
+    }
+  }
+
+  async function handleRpc(msg: { id?: unknown; method?: string; params?: { name?: string; arguments?: Record<string, unknown> } }) {
+    const { id, method, params } = msg ?? {}
+    const reply = (result: unknown) => ({ jsonrpc: '2.0', id, result })
+    switch (method) {
+      case 'initialize':
+        return reply({
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'agentskit-ask', version: '1.0.0' },
+        })
+      case 'ping':
+        return reply({})
+      case 'tools/list':
+        return reply({ tools: TOOLS })
+      case 'tools/call':
+        try {
+          return reply(await callTool(params?.name ?? '', params?.arguments ?? {}))
+        } catch (e) {
+          return reply(err(e instanceof Error ? e.message : String(e)))
+        }
+      default:
+        if (typeof method === 'string' && method.startsWith('notifications/')) return null
+        return { jsonrpc: '2.0', id, error: { code: -32601, message: `Method not found: ${method}` } }
+    }
+  }
+
+  return async function mcp(req: Request): Promise<Response> {
+    if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS })
+    if (req.method === 'GET') {
+      return Response.json(
+        {
+          name: 'AgentsKit Ask MCP',
+          transport: 'streamable-http (JSON-RPC over POST)',
+          tools: TOOLS.map((t) => t.name),
+        },
+        { headers: CORS },
+      )
+    }
+    let payload: unknown
+    try {
+      payload = await req.json()
+    } catch {
+      return Response.json(
+        { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+        { status: 400, headers: CORS },
+      )
+    }
+    const out = Array.isArray(payload)
+      ? (await Promise.all(payload.map(handleRpc))).filter(Boolean)
+      : await handleRpc(payload as Parameters<typeof handleRpc>[0])
+    if (out == null || (Array.isArray(out) && out.length === 0)) {
+      return new Response(null, { status: 202, headers: CORS })
+    }
+    return Response.json(out, { headers: CORS })
+  }
+}

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -19,6 +19,7 @@ import type { JSONSchema7 } from 'json-schema'
 import type { RetrievedDocument, Retriever } from '@agentskit/core'
 import { createFallbackAdapter, openrouter } from '@agentskit/adapters'
 import { createAjvValidator } from '@agentskit/validation'
+import { createMcpHandler } from './mcp'
 // Reuse the docs app's ask source (relative — no shared package, RFC-0007 D5).
 import { createAskHandler } from '../../docs-next/lib/ask/handler'
 import { createDocsRetriever, formatCitedContext } from '../../docs-next/lib/rag/retrieve'
@@ -155,6 +156,16 @@ app.post('/v1/search', async (c) => {
     return c.json({ error: 'search failed' }, 500)
   }
 })
+
+// MCP endpoint (RFC-0007 F3) — read-only JSON-RPC over POST, public (CORS `*`),
+// over the same corpus registry. Reuses each corpus's retriever (search_docs) and
+// warm ask handler (ask). Its own CORS handling, so it sits outside `/v1/*`.
+const mcp = createMcpHandler(
+  Object.fromEntries(
+    Object.entries(corpora).map(([id, c]) => [id, { retriever: c.retriever, handler: handlers[id] }]),
+  ),
+)
+app.all('/mcp', (c) => mcp(c.req.raw))
 
 const port = Number(process.env.PORT ?? 8080)
 serve({ fetch: app.fetch, port }, () => {

--- a/rfcs/0007-central-ask-backend.md
+++ b/rfcs/0007-central-ask-backend.md
@@ -163,8 +163,10 @@ retriever; everything else (guards, adapter, citations) is shared config.
   where the backend pulls it (committed artifact or fetch-on-boot); register those
   corpora; their widgets point at `ask.agentskit.io/v1/ask?corpus=<their>`. (registry
   knowledge = the agents in `agentskit-registry`, not the site pages.)
-- **F3 — MCP**: `/mcp` with `list_corpora` / `search_docs` / `ask`; document it for
-  agents (and cross-link from the registry MCP).
+- **F3 — MCP** ✓: `/mcp` with `list_corpora` / `search_docs` / `ask` — a read-only
+  JSON-RPC server (same transport as the registry MCP), over the shared corpus
+  registry. `ask` reuses the warm handler and collapses the `UiEvent` stream into one
+  cited answer. (Cross-link from the registry MCP once the domain is live.)
 - **F4 — retire serverless routes**: remove the per-property Vercel `/api/ask-docs`
   routes (or leave a thin proxy); the backend is the single source.
 


### PR DESCRIPTION
## RFC-0007 F3 — MCP endpoint on the central Ask backend

Adds `/mcp` to `apps/ask-backend`: a read-only **JSON-RPC 2.0 over POST** server (streamable-http), public (`CORS *`), over the **shared corpus registry**. Same transport as the registry MCP (`apps/registry/app/api/mcp`) so agents query AgentsKit knowledge identically.

### Tools
- `list_corpora()` → knowledge bases this server answers over.
- `search_docs({ corpus?, query, k? })` → relevant chunks + source paths (raw retrieval, no LLM — reuses the corpus retriever).
- `ask({ corpus?, question })` → grounded, cited answer (**non-streaming**: reuses the warm `createAskHandler` and collapses its `UiEvent` stream into one markdown answer + sources).

### Notes
- No new dep, no shared lib (RFC-0007 D5) — `createMcpHandler(corpora)` lives in the backend app, built from the same `corpora` + `handlers` maps already wired for `/v1/*`.
- `/mcp` carries its own CORS (public read-only), so it sits outside the `/v1/*` allow-list.
- Typecheck clean; all 17 quality gates pass. Local e2e (`ask`) needs the model download + `OPENROUTER_API_KEY`, exercised on the Railway deploy.

Phases: F0 ✓ → F1 ✓ → **F3 ✓** → F2 (cross-repo corpora) → F4 (retire serverless). F3 done ahead of F2 since it's unblocked.