### PR TITLE
fix(ask-backend): bind 0.0.0.0 + log bind address (Railway healthcheck)

### DIFF
--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -214,7 +214,11 @@ const mcp = createMcpHandler(
 )
 app.all('/mcp', (c) => mcp(c.req.raw))
 
+// Bind 0.0.0.0 explicitly — Railway's healthcheck reaches the container over its
+// private network, so listening only on localhost/::1 would fail the check.
 const port = Number(process.env.PORT ?? 8080)
-serve({ fetch: app.fetch, port }, () => {
-  console.log(`[ask-backend] listening on :${port} — corpora: ${Object.keys(corpora).join(', ')}`)
+serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, (info) => {
+  console.log(
+    `[ask-backend] listening on ${info.address}:${info.port} — corpora: ${Object.keys(corpora).join(', ')}`,
+  )
 })


### PR DESCRIPTION
Railway deploy reached **Build ✓ Deploy ✓** but **Healthcheck ✗** on `/health`.

Two hardening changes so the healthcheck can reach the container:
- **Bind `0.0.0.0` explicitly** in `serve()`. Railway hits `/health` over its private network; listening only on localhost/`::1` fails the check. (Local Docker worked because `-p` maps to the published port, masking the bind host.)
- **Log the actual bind address + port** at boot, so the deploy log shows where it's listening.

> NOTE: the most likely root cause of *this* failure is a missing `OPENROUTER_API_KEY` env var — the server calls `process.exit(1)` at boot without it, so the container never serves `/health`. This PR removes the binding as a *second* possible cause and makes boot diagnosable from the log. Confirm the var is set in Railway → Variables.

No changeset (app — all `apps/` are changeset-ignored).