### PR TITLE
fix(ask-backend): make the deploy actually serve — defer warmup + bake embedding model

### DIFF
--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -118,9 +118,13 @@ for (const [id, c] of Object.entries(corpora)) {
   })
 }
 
-// Warm the model + every corpus index at boot — the persistent-process payoff.
-for (const c of Object.values(corpora)) {
-  void Promise.resolve(c.retriever.retrieve({ query: 'warmup', messages: [] })).catch(() => {})
+// Warm the model + every corpus index — the persistent-process payoff. Deferred
+// (not run at module load) so the embedder's CPU-heavy first load can't block the
+// initial `/health` healthcheck and get the container killed before it goes ready.
+function warmCorpora(): void {
+  for (const c of Object.values(corpora)) {
+    void Promise.resolve(c.retriever.retrieve({ query: 'warmup', messages: [] })).catch(() => {})
+  }
 }
 
 const app = new Hono()
@@ -221,4 +225,6 @@ serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, (info) => {
   console.log(
     `[ask-backend] listening on ${info.address}:${info.port} — corpora: ${Object.keys(corpora).join(', ')}`,
   )
+  // Let the healthcheck go green first, then warm the model in the background.
+  setTimeout(warmCorpora, 3000).unref()
 })


### PR DESCRIPTION
Follow-up to #1057 — this commit was pushed to that branch **after** it merged, so it orphaned. Re-landing on main.

## Why

Railway deploy crash-loops with `Exit status 137` (SIGKILL) even though the server logs `listening`. #1057 fixed the IPv6 bind half (`0.0.0.0`); this is the other half:

The ONNX embedder warmup ran at **module load** (before/at boot). The embedder's first load is CPU-heavy and single-threaded → it can block `/health` long enough for Railway to fail the healthcheck and SIGKILL the container before it ever goes ready.

## Fix

Move the warmup into a deferred call from the `serve()` listening callback: `setTimeout(warmCorpora, 3000).unref()`. The healthcheck goes green first; the model warms in the background right after. The persistent-process warm-model payoff is unchanged — just no longer racing boot.

Verified in the Docker image: boots, `listening on 0.0.0.0:8080`, `/health` → `ok` in 2s. No changeset (app).