### PR TITLE
fix(ask-backend): bake embedding model into image (fixes 'search failed' at runtime)

### DIFF
--- a/apps/ask-backend/Dockerfile
+++ b/apps/ask-backend/Dockerfile
@@ -33,10 +33,18 @@ RUN pnpm install --frozen-lockfile \
       --filter='@agentskit/rag...' \
       --filter='@agentskit/validation...'
 
+# Bake the ONNX embedding model into the image at build time, into a stable cache
+# dir. Runtime then loads it locally — no HF download on boot, no cold-start race, no
+# network dependency, and no chance a transient first-load failure poisons the server.
+# `embed.ts` reads the same TRANSFORMERS_CACHE, so build + runtime agree on the path.
+# Run from the app dir so pnpm resolves `@huggingface/transformers` (hoisted there).
+ENV TRANSFORMERS_CACHE=/app/.transformers-cache
+RUN cd apps/ask-backend && node --input-type=module -e "import('@huggingface/transformers').then(async (t) => { t.env.cacheDir = process.env.TRANSFORMERS_CACHE; await t.pipeline('feature-extraction', 'Xenova/bge-small-en-v1.5'); console.log('embedding model baked into image'); })"
+
 ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
 
-# The persistent process: the ONNX embedder + corpus index load once at boot and
-# stay warm. The container filesystem caches the model (no /tmp hack needed).
+# The persistent process: the embedder loads the pre-baked model at boot and stays
+# warm; the corpus index loads once too. No runtime model download.
 CMD ["pnpm", "--filter", "@agentskit/ask-backend", "start"]

--- a/apps/docs-next/lib/rag/embed.ts
+++ b/apps/docs-next/lib/rag/embed.ts
@@ -43,10 +43,13 @@ async function getExtractor(): Promise<FeatureExtractor> {
   if (!extractorPromise) {
     extractorPromise = (async () => {
       const transformers = await import('@huggingface/transformers')
-      // Serverless functions have a read-only filesystem except for `/tmp`. The
-      // first call downloads the ONNX model from the HF hub and caches it; point
-      // that cache at the one writable dir, or the write fails and retrieval errors.
-      if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+      // Point the model cache at a writable, persistent dir. In the container image
+      // (RFC-0007 backend) the model is pre-baked here at build time via
+      // `TRANSFORMERS_CACHE`, so runtime never downloads. On Vercel/Lambda only
+      // `/tmp` is writable, so the first call downloads there.
+      if (process.env.TRANSFORMERS_CACHE) {
+        transformers.env.cacheDir = process.env.TRANSFORMERS_CACHE
+      } else if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
         transformers.env.cacheDir = '/tmp/.transformers-cache'
       }
       const extractor = (await transformers.pipeline(
@@ -54,7 +57,13 @@ async function getExtractor(): Promise<FeatureExtractor> {
         EMBED_MODEL,
       )) as unknown as FeatureExtractor
       return extractor
-    })()
+    })().catch((err) => {
+      // Never cache a rejected singleton — a transient first-load failure would
+      // otherwise poison the embedder for the whole process lifetime (fatal for a
+      // long-lived server). Reset so the next call retries.
+      extractorPromise = null
+      throw err
+    })
   }
   return extractorPromise
 }


### PR DESCRIPTION
**Re-landing the most important deploy fix** — it was on #1058's branch but that PR squash-merged with only the warmup commit, so this orphaned. Without it the deploy is healthy but the chat/search returns `search failed`.

## The runtime failure

```
[ask-backend] search failed: Error: Unable to get model file path or buffer.
  at getModelFile (@huggingface/transformers/.../transformers.node.mjs)
```

Two compounding bugs:
1. The embedder **downloaded the ONNX model on first use** at runtime → cold-start download raced the first request.
2. A transient first-load failure **cached a rejected `getExtractor()` singleton** → the embedder stayed broken for the whole process lifetime (Vercel hid this — fresh process per invocation).

## Fix
- **Bake the model into the image at build time** (`Dockerfile`: pre-download into a stable `TRANSFORMERS_CACHE=/app/.transformers-cache`, run from the app dir so pnpm resolves the dep). Runtime loads it locally — no download, no race, no network dependency. Build log prints `embedding model baked into image`.
- **`embed.ts`: never cache a rejected singleton** — reset on failure so it retries. Additive for Vercel (the `TRANSFORMERS_CACHE` branch only fires when set; Vercel still uses `/tmp`).

## Verified
Built the image (model baked), ran a **fresh** container, hit `/v1/search` immediately → returns results, **no model error, no download**. Boots ~2s, `/health` ok.

No changeset (apps are changeset-ignored).