### PR TITLE
feat(docs): point Ask widget at the central backend (ask.agentskit.io) — RFC-0007 F1

### DIFF
--- a/apps/docs-next/.env.production
+++ b/apps/docs-next/.env.production
@@ -1,0 +1,4 @@
+# Route the Ask-the-docs widget to the central persistent backend (RFC-0007 F1).
+# Public URL, no secret — NEXT_PUBLIC_* is inlined at build time. When unset the
+# widget falls back to the in-repo Vercel route (/api/ask-docs).
+NEXT_PUBLIC_ASK_ENDPOINT=https://ask.agentskit.io/v1/ask?corpus=docs


### PR DESCRIPTION
The central Ask backend is **live and verified** at `https://ask.agentskit.io` (RFC-0007). This repoints the docs Ask widget at it.

## Change
`apps/docs-next/.env.production`:
```
NEXT_PUBLIC_ASK_ENDPOINT=https://ask.agentskit.io/v1/ask?corpus=docs
```
The widget (`useAskChat.ts`) already reads this and falls back to the in-repo `/api/ask-docs` route when unset. Public URL, no secret; `NEXT_PUBLIC_*` is inlined at build, so merging triggers a Vercel rebuild that picks it up.

## Verified live (against the deployed backend)
- `GET /health` → `ok`
- `POST /v1/search?corpus=docs` → real doc chunks (200)
- `POST /v1/ask?corpus=docs` → streamed grounded answer + `cite` sources (identical NDJSON `UiEvent` protocol as the Vercel route)

CORS: the docs origin `https://www.agentskit.io` is in the backend's allow-list. No changeset (app).

After merge: Vercel redeploys docs → the live widget hits the warm persistent backend (no serverless cold-start / native-binary load). The `/api/ask-docs` route stays as fallback until F4.