### PR TITLE
fix(ask-backend): normalize CORS origins + log allow-list (widget was CORS-blocked)

### DIFF
--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -129,10 +129,17 @@ function warmCorpora(): void {
 
 const app = new Hono()
 
+// Parse the CORS allow-list defensively: trim each entry and strip a trailing slash
+// (an `Origin` header never has one, so `https://x/` would silently never match), and
+// drop empties. Log the effective list so a misconfigured ASK_CORS_ORIGINS is visible.
 const origins = (
   process.env.ASK_CORS_ORIGINS ??
   'https://www.agentskit.io,https://agentskit.io,https://registry.agentskit.io,http://localhost:3000'
-).split(',')
+)
+  .split(',')
+  .map((o) => o.trim().replace(/\/+$/, ''))
+  .filter(Boolean)
+console.log('[ask-backend] CORS allow-origins:', origins.join(', ') || '(none!)')
 app.use('/v1/*', cors({ origin: origins, allowMethods: ['POST', 'GET', 'OPTIONS'] }))
 
 // Reject oversized bodies up front on every compute route (cheap pre-parse guard).


### PR DESCRIPTION
## Symptom
The live docs widget can't reach the backend: every response is missing `access-control-allow-origin`, so the browser blocks the fetch (curl works — it ignores CORS). Tested all four default origins against the deployed backend → **all MISSING**:

```
Origin https://www.agentskit.io      → allow-origin: <MISSING>
Origin https://agentskit.io          → allow-origin: <MISSING>
Origin https://registry.agentskit.io → allow-origin: <MISSING>
Origin http://localhost:3000         → allow-origin: <MISSING>
```

Even defaults fail → the effective allow-list doesn't contain these exact strings (likely `ASK_CORS_ORIGINS` set with spaces / a trailing slash / wrong values).

## Fix
Parse the allow-list defensively in `server.ts`:
- `trim()` each entry (a space after a comma → leading-space origin → never matches)
- strip trailing `/` (an `Origin` header never has one, so `https://x/` silently never matches)
- drop empties
- **log the effective allow-list at boot** so a misconfigured `ASK_CORS_ORIGINS` is visible

## Also needed (ops)
Check `ASK_CORS_ORIGINS` on Railway — fix it to exact comma-separated origins (no spaces/trailing slash) or unset it to use the default. The new boot log (`[ask-backend] CORS allow-origins: …`) confirms what's loaded.

No changeset (app).