### PR TITLE
feat(ask): support Redis URL rate limiting

### DIFF
--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -83,8 +83,10 @@ In the Railway dashboard:
 1. **New project → Deploy from GitHub repo** (`AgentsKit-io/agentskit`).
 2. **Settings → Root Directory** = **leave empty / repo root** (do NOT set it to
    `apps/ask-backend`). Railway picks up `/railway.json` → Dockerfile builder.
-3. **Variables**: `OPENROUTER_API_KEY` (required), optional `UPSTASH_REDIS_REST_URL`
-   + `UPSTASH_REDIS_REST_TOKEN` (durable rate-limit), `ASK_CORS_ORIGINS`.
+3. **Variables**: `OPENROUTER_API_KEY` (required), optional `REDIS_URL` /
+   `ASK_REDIS_URL` (durable rate-limit over Redis protocol; use `?family=0` for
+   Railway private networking when needed), optional `UPSTASH_REDIS_REST_URL` +
+   `UPSTASH_REDIS_REST_TOKEN` fallback, `ASK_CORS_ORIGINS`.
 4. **Networking → Custom Domain** = `ask.agentskit.io`.
 
 The Dockerfile installs the workspace + builds the backend's lib closure; start =

--- a/apps/ask-backend/package.json
+++ b/apps/ask-backend/package.json
@@ -18,7 +18,8 @@
     "@huggingface/transformers": "^4.2.0",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.3",
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "redis": "^6.0.0"
   },
   "devDependencies": {
     "@types/json-schema": "^7.0.15",

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -10,7 +10,8 @@
  * serves the `docs` corpus. F1 adds `registry`; F2 wires the cross-repo corpora.
  *
  * Env: OPENROUTER_API_KEY (required), ASK_CORS_ORIGINS, ASK_RICH_UI, PORT,
- * UPSTASH_REDIS_REST_URL/_TOKEN (durable rate-limit; in-memory fallback otherwise).
+ * REDIS_URL/ASK_REDIS_URL or UPSTASH_REDIS_REST_URL/_TOKEN (durable rate-limit;
+ * in-memory fallback otherwise).
  */
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'

--- a/apps/docs-next/lib/ask/rate-limit.ts
+++ b/apps/docs-next/lib/ask/rate-limit.ts
@@ -1,13 +1,16 @@
 import { Ratelimit } from '@upstash/ratelimit'
 import { Redis } from '@upstash/redis'
+import { createClient } from 'redis'
 
 /**
- * Per-IP rate limit for the ask-docs route. Uses Upstash Redis when configured
- * (durable across serverless cold starts / regions); falls back to a per-instance
- * in-memory window otherwise so local dev and unconfigured deploys still work.
+ * Per-IP rate limit for the ask-docs route. Uses Redis protocol when REDIS_URL
+ * is configured (Railway/private-network friendly), then Upstash REST when
+ * configured; falls back to a per-instance in-memory window otherwise so local
+ * dev and unconfigured deploys still work.
  */
 const LIMIT = 8
 const WINDOW_SEC = 60
+const PREFIX = 'ask-docs'
 
 export interface RateLimitResult {
   ok: boolean
@@ -31,6 +34,76 @@ function memLimit(ip: string): RateLimitResult {
   return { ok: true, retryAfterSec: 0 }
 }
 
+// ── Redis protocol (durable) ────────────────────────────────────────────────
+interface RedisProtocolLimiter {
+  limit(ip: string): Promise<RateLimitResult>
+}
+
+let redisProtocolLimiter: RedisProtocolLimiter | null | undefined
+
+const REDIS_WINDOW_SCRIPT = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('TTL', KEYS[1])
+return { current, ttl }
+`
+
+function normalizeRedisUrl(raw: string): { url: string; family: 0 | 4 | 6 } {
+  const parsed = new URL(raw)
+  const familyParam = parsed.searchParams.get('family')
+  if (familyParam) parsed.searchParams.delete('family')
+  const requested = Number(process.env.REDIS_FAMILY ?? familyParam ?? 0)
+  const family: 0 | 4 | 6 = requested === 4 || requested === 6 ? requested : 0
+  return { url: parsed.toString(), family }
+}
+
+function parseRedisEvalResult(value: unknown): { count: number; ttl: number } {
+  if (!Array.isArray(value)) return { count: 0, ttl: WINDOW_SEC }
+  const [countRaw, ttlRaw] = value
+  const count = Number(countRaw)
+  const ttl = Number(ttlRaw)
+  return {
+    count: Number.isFinite(count) ? count : 0,
+    ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : WINDOW_SEC,
+  }
+}
+
+function getRedisProtocolLimiter(): RedisProtocolLimiter | null {
+  if (redisProtocolLimiter !== undefined) return redisProtocolLimiter
+  const raw = process.env.REDIS_URL ?? process.env.ASK_REDIS_URL
+  if (!raw) {
+    redisProtocolLimiter = null
+    return redisProtocolLimiter
+  }
+
+  const { url, family } = normalizeRedisUrl(raw)
+  const client = createClient({ url, socket: { family } })
+  client.on('error', (err: unknown) => {
+    console.warn('[ask-rate-limit] Redis protocol limiter error:', err instanceof Error ? err.message : String(err))
+  })
+  const ready = client.connect()
+
+  redisProtocolLimiter = {
+    async limit(ip: string): Promise<RateLimitResult> {
+      await ready
+      const key = `${PREFIX}:rl:${ip}`
+      const result = parseRedisEvalResult(
+        await client.eval(REDIS_WINDOW_SCRIPT, {
+          keys: [key],
+          arguments: [String(WINDOW_SEC)],
+        }),
+      )
+      return {
+        ok: result.count <= LIMIT,
+        retryAfterSec: result.count <= LIMIT ? 0 : Math.max(1, result.ttl),
+      }
+    },
+  }
+  return redisProtocolLimiter
+}
+
 // ── Upstash (durable) ───────────────────────────────────────────────────────
 let limiter: Ratelimit | null = null
 
@@ -42,13 +115,22 @@ function getLimiter(): Ratelimit | null {
   limiter = new Ratelimit({
     redis: new Redis({ url, token }),
     limiter: Ratelimit.slidingWindow(LIMIT, `${WINDOW_SEC} s`),
-    prefix: 'ask-docs',
+    prefix: PREFIX,
     analytics: false,
   })
   return limiter
 }
 
 export async function rateLimit(ip: string): Promise<RateLimitResult> {
+  const redisLimiter = getRedisProtocolLimiter()
+  if (redisLimiter) {
+    try {
+      return await redisLimiter.limit(ip)
+    } catch {
+      return memLimit(ip)
+    }
+  }
+
   const l = getLimiter()
   if (!l) return memLimit(ip)
   try {

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -51,6 +51,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
+    "redis": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",
     "tailwindcss": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       hono:
         specifier: ^4.6.14
         version: 4.12.26
+      redis:
+        specifier: ^6.0.0
+        version: 6.0.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@types/json-schema':
         specifier: ^7.0.15
@@ -196,6 +199,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      redis:
+        specifier: ^6.0.0
+        version: 6.0.0(@opentelemetry/api@1.9.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1


### PR DESCRIPTION
## Summary
- add Redis protocol-backed rate limiting via REDIS_URL / ASK_REDIS_URL
- keep Upstash REST and in-memory fallback behavior
- document Railway private networking usage with ?family=0

## Verification
- pnpm exec turbo run build --filter='@agentskit/adapters...' --filter='@agentskit/rag...' --filter='@agentskit/validation...'
- pnpm --filter @agentskit/memory build
- pnpm --filter @agentskit/ask-backend lint
- pre-push quality gates passed; full monorepo lint passed; full monorepo build was intentionally interrupted after unrelated packages to avoid waiting on the entire repo
