### PR TITLE
fix(react-native): abort active chat stream on unmount

### DIFF
--- a/.changeset/react-native-unmount-abort.md
+++ b/.changeset/react-native-unmount-abort.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/react-native': patch
+---
+
+Abort the active chat stream when the owning React Native component unmounts.

--- a/packages/react-native/src/useChat.ts
+++ b/packages/react-native/src/useChat.ts
@@ -17,6 +17,8 @@ export function useChat(config: ChatConfig): ChatReturn {
     controllerRef.current?.updateConfig(config)
   }, [config])
 
+  useEffect(() => () => controllerRef.current?.stop(), [])
+
   const state = useSyncExternalStore(
     controllerRef.current.subscribe,
     controllerRef.current.getState,

--- a/packages/react-native/tests/useChat.test.ts
+++ b/packages/react-native/tests/useChat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core'
 import { useChat } from '../src'
@@ -62,6 +62,26 @@ describe('@agentskit/react-native useChat', () => {
     for (const fn of ['stop', 'retry', 'edit', 'regenerate', 'clear', 'approve', 'deny'] as const) {
       expect(typeof result.current[fn]).toBe('function')
     }
+  })
+
+  it('aborts the current stream when unmounted', async () => {
+    const abort = vi.fn()
+    const adapter: AdapterFactory = {
+      createSource: () => ({
+        async *stream() {
+          yield { type: 'text', content: 'working' } as const
+          await new Promise(() => {})
+        },
+        abort,
+      }),
+    }
+    const { result, unmount } = renderHook(() => useChat({ adapter }))
+
+    void act(() => { void result.current.send('Go') })
+    await waitFor(() => expect(result.current.status).toBe('streaming'))
+    unmount()
+
+    expect(abort).toHaveBeenCalledOnce()
   })
 
   it('updateConfig fires when config reference changes', () => {


### PR DESCRIPTION
## Summary

- stop the React Native chat controller when its owning component unmounts
- add a regression test for a pending stream
- publish the fix as a patch changeset

Closes #1126.
Blocks AgentsKit-io/agentskit-chat#3 until released.

## Validation

- `pnpm --filter @agentskit/react-native lint`
- `pnpm --filter @agentskit/react-native test` — 25 tests
- required pre-push gates — 17 quality gates, global lint (57/57), global build (41/41)