### PR TITLE
fix(ink): stop streaming responses on Escape

### DIFF
--- a/.changeset/ink-escape-cancel.md
+++ b/.changeset/ink-escape-cancel.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/ink': patch
+---
+
+Make the streaming cancellation hint actionable by stopping the active response on Escape.

--- a/packages/ink/src/components/InputBar.tsx
+++ b/packages/ink/src/components/InputBar.tsx
@@ -53,7 +53,10 @@ export function InputBar({
   }, [])
 
   useInput((input, key) => {
-    if (isBusy) return
+    if (isBusy) {
+      if (chat.status === 'streaming' && key.escape) chat.stop()
+      return
+    }
 
     if (key.upArrow) {
       if (effectiveHistory.length === 0) return
@@ -114,7 +117,7 @@ export function InputBar({
 
   const hint = isBusy
     ? chat.status === 'streaming'
-      ? 'streaming response... press Ctrl+C to abort'
+      ? 'streaming response... press Esc to stop'
       : 'input disabled'
     : effectiveHistory.length > 0
       ? `${placeholder}  ·  ↑/↓ to recall previous messages`

--- a/packages/ink/tests/InputBar.test.tsx
+++ b/packages/ink/tests/InputBar.test.tsx
@@ -139,6 +139,15 @@ describe('InputBar', () => {
     expect(setInput).not.toHaveBeenCalled()
   })
 
+  it('stops the streaming response on escape', () => {
+    const stop = vi.fn()
+    const chat = mockChat({ status: 'streaming', stop })
+    render(<InputBar chat={chat} />)
+
+    capturedHandler!('', key({ escape: true }))
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
   it('disabled prop blocks all input', () => {
     const setInput = vi.fn()
     const send = vi.fn()
@@ -350,6 +359,7 @@ describe('InputBar', () => {
     const chat = mockChat({ status: 'streaming' })
     const { lastFrame } = render(<InputBar chat={chat} />)
     expect(lastFrame()).toContain('streaming response')
+    expect(lastFrame()).toContain('Esc to stop')
   })
 
   it('shows disabled hint when disabled=true and not streaming', () => {


### PR DESCRIPTION
## Summary

- make the streaming cancellation hint actionable
- stop the active response when Escape is pressed while streaming
- keep ordinary input disabled during streaming
- leave Ctrl+C available for host SIGINT behavior

Closes #1132.
Blocks AgentsKit-io/agentskit-chat#4 until released.

## Validation

- Ink lint
- Ink tests: 116 passing
- 17 quality gates
- global lint: 57/57
- global build: 41/41