### PR TITLE
fix(core): canonicalize validated memory records

### DIFF
--- a/.changeset/calm-records-project.md
+++ b/.changeset/calm-records-project.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/core': patch
+---
+
+Return a canonical projection from memory-record validation and reject impossible calendar timestamps.

--- a/packages/core/src/memory-validation.ts
+++ b/packages/core/src/memory-validation.ts
@@ -1,5 +1,9 @@
 import { ConfigError, ErrorCodes } from './errors'
-import type { MemoryRecord } from './types'
+import type { ContentPart } from './types/content'
+import type { MemoryRecord } from './types/message'
+import type { ToolCall } from './types/tool'
+
+type SerializedMessage = MemoryRecord['messages'][number]
 
 const MAX_JSON_DEPTH = 32
 const MAX_JSON_NODES = 10_000
@@ -55,7 +59,7 @@ function optionalString(record: Record<string, unknown>, key: string): void {
   if (record[key] !== undefined && typeof record[key] !== 'string') invalidRecord()
 }
 
-function validatePart(value: unknown): void {
+function validatePart(value: unknown): asserts value is ContentPart {
   if (!isRecord(value) || typeof value.type !== 'string' || !partTypes.has(value.type)) invalidRecord()
   if (value.type === 'text') {
     if (typeof value.text !== 'string') invalidRecord()
@@ -70,7 +74,7 @@ function validatePart(value: unknown): void {
   if (value.type === 'file') optionalString(value, 'filename')
 }
 
-function validateToolCall(value: unknown): void {
+function validateToolCall(value: unknown): asserts value is ToolCall {
   if (!isRecord(value)) invalidRecord()
   if (typeof value.id !== 'string' || typeof value.name !== 'string' || !isRecord(value.args)) invalidRecord()
   if (typeof value.status !== 'string' || !toolStatuses.has(value.status)) invalidRecord()
@@ -78,13 +82,14 @@ function validateToolCall(value: unknown): void {
   optionalString(value, 'error')
 }
 
-function validateMessage(value: unknown): void {
+function validateMessage(value: unknown): asserts value is SerializedMessage {
   if (!isRecord(value)) invalidRecord()
   if (typeof value.id !== 'string' || typeof value.content !== 'string') invalidRecord()
   if (typeof value.role !== 'string' || !roles.has(value.role)) invalidRecord()
   if (typeof value.status !== 'string' || !messageStatuses.has(value.status)) invalidRecord()
   if (typeof value.createdAt !== 'string' || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value.createdAt)) invalidRecord()
-  if (Number.isNaN(Date.parse(value.createdAt))) invalidRecord()
+  const timestamp = Date.parse(value.createdAt)
+  if (Number.isNaN(timestamp) || new Date(timestamp).toISOString() !== value.createdAt) invalidRecord()
   optionalString(value, 'toolCallId')
   if (value.parts !== undefined) {
     if (!Array.isArray(value.parts)) invalidRecord()
@@ -97,9 +102,63 @@ function validateMessage(value: unknown): void {
   if (value.metadata !== undefined && !isRecord(value.metadata)) invalidRecord()
 }
 
+function projectPart(part: ContentPart): ContentPart {
+  switch (part.type) {
+    case 'text': return { type: 'text', text: part.text }
+    case 'image': return {
+      type: 'image', source: part.source,
+      ...(part.mimeType === undefined ? {} : { mimeType: part.mimeType }),
+      ...(part.detail === undefined ? {} : { detail: part.detail }),
+    }
+    case 'audio': return {
+      type: 'audio', source: part.source,
+      ...(part.mimeType === undefined ? {} : { mimeType: part.mimeType }),
+      ...(part.durationSec === undefined ? {} : { durationSec: part.durationSec }),
+    }
+    case 'video': return {
+      type: 'video', source: part.source,
+      ...(part.mimeType === undefined ? {} : { mimeType: part.mimeType }),
+      ...(part.durationSec === undefined ? {} : { durationSec: part.durationSec }),
+    }
+    case 'file': return {
+      type: 'file', source: part.source,
+      ...(part.mimeType === undefined ? {} : { mimeType: part.mimeType }),
+      ...(part.filename === undefined ? {} : { filename: part.filename }),
+    }
+  }
+}
+
+function projectToolCall(call: ToolCall): ToolCall {
+  return {
+    id: call.id,
+    name: call.name,
+    args: call.args,
+    status: call.status,
+    ...(call.result === undefined ? {} : { result: call.result }),
+    ...(call.error === undefined ? {} : { error: call.error }),
+  }
+}
+
+function projectMessage(message: SerializedMessage): SerializedMessage {
+  return {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    status: message.status,
+    createdAt: message.createdAt,
+    ...(message.parts === undefined ? {} : { parts: message.parts.map(projectPart) }),
+    ...(message.toolCalls === undefined ? {} : { toolCalls: message.toolCalls.map(projectToolCall) }),
+    ...(message.toolCallId === undefined ? {} : { toolCallId: message.toolCallId }),
+    ...(message.metadata === undefined ? {} : { metadata: message.metadata }),
+  }
+}
+
 export function validateMemoryRecord(input: unknown): MemoryRecord {
   assertJsonValue(input)
   if (!isRecord(input) || input.version !== 1 || !Array.isArray(input.messages)) invalidRecord()
-  input.messages.forEach(validateMessage)
-  return input as unknown as MemoryRecord
+  const messages = input.messages.map(message => {
+    validateMessage(message)
+    return projectMessage(message)
+  })
+  return { version: 1, messages }
 }

--- a/packages/core/tests/memory.test.ts
+++ b/packages/core/tests/memory.test.ts
@@ -57,13 +57,14 @@ describe('validateMemoryRecord', () => {
       metadata: { nested: { safe: true } },
     }])
 
-    expect(validateMemoryRecord(record)).toBe(record)
+    expect(validateMemoryRecord(record)).toEqual(record)
   })
 
   it.each([
     null,
     { version: 2, messages: [] },
     { version: 1, messages: [{ ...sampleMessage, createdAt: 'not-a-date' }] },
+    { version: 1, messages: [{ ...sampleMessage, createdAt: '2026-02-30T00:00:00.000Z' }] },
     { version: 1, messages: [{ id: 'x', role: 'unknown', content: '', status: 'complete', createdAt: '2026-01-01T00:00:00.000Z' }] },
   ])('rejects an invalid record without echoing input', input => {
     expect(() => validateMemoryRecord(input)).toThrow(ConfigError)
@@ -96,6 +97,23 @@ describe('validateMemoryRecord', () => {
   it('allows a shared non-cyclic JSON reference', () => {
     const shared = { safe: true }
     const record = serializeMessages([{ ...sampleMessage, metadata: { first: shared, second: shared } }])
-    expect(validateMemoryRecord(record)).toBe(record)
+    expect(validateMemoryRecord(record)).toEqual(record)
+  })
+
+  it('projects only canonical structural fields', () => {
+    const record = serializeMessages([{
+      ...sampleMessage,
+      parts: [{ type: 'text', text: 'hello', future: 'drop' }],
+      toolCalls: [{ id: 'call-1', name: 'lookup', args: { keep: true }, status: 'complete', future: 'drop' }],
+      metadata: { keep: true },
+      future: 'drop',
+    } as unknown as Message])
+
+    const validated = validateMemoryRecord(record)
+    expect(validated.messages[0]).not.toHaveProperty('future')
+    expect(validated.messages[0]?.parts?.[0]).not.toHaveProperty('future')
+    expect(validated.messages[0]?.toolCalls?.[0]).not.toHaveProperty('future')
+    expect(validated.messages[0]?.toolCalls?.[0]?.args).toEqual({ keep: true })
+    expect(validated.messages[0]?.metadata).toEqual({ keep: true })
   })
 })


### PR DESCRIPTION
Closes #1138

## Summary
- strip unknown structural fields while preserving metadata and tool args
- reject impossible/non-canonical calendar timestamps
- add focused projection and timestamp regressions

## Validation
- core lint: pass
- core tests: 350 pass
- core build: pass
- all 17 quality gates: pass
- size limits: pass (main entry unchanged at 8.33 KB ESM / 9.97 KB CJS gzip)
- full pre-push lint/build: 41/41 pass