### PR TITLE
feat(core): support cancellable chat memory operations

### DIFF
--- a/.changeset/calm-memories-cancel.md
+++ b/.changeset/calm-memories-cancel.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/core': patch
+---
+
+Add optional AbortSignal propagation to ChatMemory load, save, and clear operations.

--- a/docs/architecture/adrs/0019-cancellable-chat-memory-operations.md
+++ b/docs/architecture/adrs/0019-cancellable-chat-memory-operations.md
@@ -1,0 +1,17 @@
+# ADR 0019: Cancellable ChatMemory operations
+
+**Status:** Accepted
+
+## Context
+
+Server and edge request lifecycles have deadlines and disconnect signals, but `ChatMemory` operations could not receive an `AbortSignal`. Remote or host-provided memory backends therefore had no standard way to stop work after their caller was gone.
+
+## Decision
+
+Add an optional `MemoryOperationOptions` argument with `signal?: AbortSignal` to `ChatMemory.load`, `save`, and `clear`. The change is additive: existing implementations and callers remain compatible. Implementations must fail promptly when the signal is already aborted and should forward it when their underlying client supports cancellation.
+
+## Consequences
+
+- Request-scoped hosts can propagate one cancellation boundary through message IO.
+- Backends whose SDK cannot cancel an in-flight command still check before starting; callers may additionally race their deadline.
+- No runtime dependency or default timeout is added to Core.

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -55,5 +55,6 @@ Do NOT write an ADR for: routine features, bug fixes, internal refactors, or any
 | [0013](./0013-memory-record-runtime-validation.md) | Runtime validation for serialized message records | Accepted |
 | [0014](./0014-trusted-tool-call-proposal.md) | Trusted application tool-call proposal | Accepted |
 | [0015](./0015-tool-authorization-hook.md) | Tool authorization before proposal and execution | Accepted |
+| [0019](./0019-cancellable-chat-memory-operations.md) | Cancellable ChatMemory operations | Accepted |
 
 The 6 core contracts are formalized. Future ADRs will cover specific decisions (semver policy, licensing strategy, etc.) rather than additional foundational contracts.

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -5,9 +5,13 @@ import type { RetrievedDocument } from './retrieval'
 export interface ChatMemory {
   /** Data-residency region for this memory backend, when known. */
   region?: DataRegion
-  load: () => MaybePromise<Message[]>
-  save: (messages: Message[]) => MaybePromise<void>
-  clear?: () => MaybePromise<void>
+  load: (options?: MemoryOperationOptions) => MaybePromise<Message[]>
+  save: (messages: Message[], options?: MemoryOperationOptions) => MaybePromise<void>
+  clear?: (options?: MemoryOperationOptions) => MaybePromise<void>
+}
+
+export interface MemoryOperationOptions {
+  signal?: AbortSignal
 }
 
 export interface VectorDocument {

--- a/packages/core/tests/memory.test.ts
+++ b/packages/core/tests/memory.test.ts
@@ -14,6 +14,18 @@ const sampleMessage: Message = {
 }
 
 describe('createInMemoryMemory', () => {
+  it('allows memory implementations to observe cancellation', async () => {
+    const controller = new AbortController()
+    controller.abort(new Error('cancelled'))
+    const mem: import('../src/types').ChatMemory = {
+      load: async options => { options?.signal?.throwIfAborted(); return [] },
+      save: async (_messages, options) => { options?.signal?.throwIfAborted() },
+      clear: async options => { options?.signal?.throwIfAborted() },
+    }
+    await expect(mem.load({ signal: controller.signal })).rejects.toThrow('cancelled')
+    await expect(mem.save([], { signal: controller.signal })).rejects.toThrow('cancelled')
+    await expect(mem.clear?.({ signal: controller.signal })).rejects.toThrow('cancelled')
+  })
   it('starts empty by default', async () => {
     const mem = createInMemoryMemory()
     expect(await mem.load()).toEqual([])


### PR DESCRIPTION
Closes #1155

Adds an optional `MemoryOperationOptions` argument carrying `AbortSignal` to ChatMemory load/save/clear. The contract is additive and zero-runtime-cost; existing implementations remain compatible while remote/host implementations can propagate caller cancellation.

Validation: core lint, 373 tests, build, 17 quality gates, full monorepo lint/build push gates, and size limits (Core CJS 9.99 kB).