### PR TITLE
feat(react-native): expose text style seams

### DIFF
--- a/.changeset/warm-chats-style.md
+++ b/.changeset/warm-chats-style.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/react-native': patch
+---
+
+Expose `contentStyle` on `Message` and `inputStyle` on `InputBar` so native hosts can theme text independently from wrapper layout.

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,1 +1,7 @@
 # @agentskit/react-native
+
+## Unreleased
+
+### Patch Changes
+
+- Add `Message.contentStyle` and `InputBar.inputStyle` pass-throughs for native text theming.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -33,7 +33,7 @@ Docs: [package guide](https://www.agentskit.io/docs/packages/react-native) · [a
 
 ### Headless on React Native
 
-React Native has no DOM, so there are no `data-ak-*` attributes. The web-parity story is carried by **`testID`** props (`ak-message`, `ak-input`, `ak-send`, …): the same stable hooks the web components expose via `data-ak-*`, surfaced through RN's native `testID` (Appium / e2e). Role and status are conveyed via `accessibilityLabel`. No `StyleSheet`/colors are baked in — pass your own through the optional `style` prop where a host primitive accepts it.
+React Native has no DOM, so there are no `data-ak-*` attributes. The web-parity story is carried by **`testID`** props (`ak-message`, `ak-input`, `ak-send`, …): the same stable hooks the web components expose via `data-ak-*`, surfaced through RN's native `testID` (Appium / e2e). Role and status are conveyed via `accessibilityLabel`. No `StyleSheet`/colors are baked in — use `style` for wrappers, `Message.contentStyle` for message text, and `InputBar.inputStyle` for composer text.
 
 ## Install
 

--- a/packages/react-native/src/components.tsx
+++ b/packages/react-native/src/components.tsx
@@ -61,10 +61,11 @@ export interface MessageProps {
   avatar?: ReactNode
   actions?: ReactNode
   style?: Style
+  contentStyle?: Style
   testID?: string
 }
 
-export function Message({ message, avatar, actions, style, testID = 'ak-message' }: MessageProps) {
+export function Message({ message, avatar, actions, style, contentStyle, testID = 'ak-message' }: MessageProps) {
   return (
     <View
       testID={testID}
@@ -72,7 +73,7 @@ export function Message({ message, avatar, actions, style, testID = 'ak-message'
       accessibilityLabel={`${message.role} message (${message.status})`}
     >
       {avatar ? <View testID="ak-avatar">{avatar}</View> : null}
-      <Text testID="ak-content">{message.content}</Text>
+      <Text testID="ak-content" style={contentStyle}>{message.content}</Text>
       {actions ? <View testID="ak-actions">{actions}</View> : null}
     </View>
   )
@@ -88,6 +89,7 @@ export interface InputBarProps {
   placeholder?: string
   disabled?: boolean
   style?: Style
+  inputStyle?: Style
   testID?: string
 }
 
@@ -96,6 +98,7 @@ export function InputBar({
   placeholder = 'Type a message...',
   disabled = false,
   style,
+  inputStyle,
   testID = 'ak-input-bar',
 }: InputBarProps) {
   const isStreaming = chat.status === 'streaming'
@@ -111,6 +114,7 @@ export function InputBar({
     <View testID={testID} style={style}>
       <TextInput
         testID="ak-input"
+        style={inputStyle}
         value={chat.input}
         onChangeText={chat.setInput}
         onSubmitEditing={handleSend}

--- a/packages/react-native/tests/components.test.tsx
+++ b/packages/react-native/tests/components.test.tsx
@@ -81,9 +81,20 @@ describe('Message', () => {
     expect(getByTestId('ak-avatar')).toBeTruthy()
     expect(getByTestId('ak-actions')).toBeTruthy()
   })
+
+  it('forwards content styles to the native text primitive', () => {
+    const { getByTestId } = render(<Message message={makeMessage()} contentStyle={{ color: '#ffffff', fontFamily: 'Brand Sans' }} />)
+    expect(getByTestId('ak-content').style.color).toBe('#ffffff')
+    expect(getByTestId('ak-content').style.fontFamily).toContain('Brand Sans')
+  })
 })
 
 describe('InputBar', () => {
+  it('forwards input styles to the native text input', () => {
+    const { getByTestId } = render(<InputBar chat={makeChat()} inputStyle={{ color: '#111827', fontFamily: 'Brand Sans' }} />)
+    expect(getByTestId('ak-input').style.fontFamily).toContain('Brand Sans')
+  })
+
   it('sends on submit and reflects input value', () => {
     const send = vi.fn()
     const chat = makeChat({ input: 'hi there', send })

--- a/packages/react-native/tests/react-native.mock.tsx
+++ b/packages/react-native/tests/react-native.mock.tsx
@@ -30,7 +30,7 @@ interface BaseProps {
 export const View = forwardRef<HTMLDivElement, BaseProps>(function View(props, ref) {
   const { testID, style, accessibilityLabel, children, accessibilityRole, accessibilityState, ...rest } = props
   return (
-    <div ref={ref} data-testid={testID} aria-label={accessibilityLabel} {...rest}>
+    <div ref={ref} data-testid={testID} aria-label={accessibilityLabel} style={style as React.CSSProperties | undefined} {...rest}>
       {children}
     </div>
   )
@@ -39,7 +39,7 @@ export const View = forwardRef<HTMLDivElement, BaseProps>(function View(props, r
 export const Text = forwardRef<HTMLSpanElement, BaseProps>(function Text(props, ref) {
   const { testID, style, accessibilityLabel, children, accessibilityRole, accessibilityState, ...rest } = props
   return (
-    <span ref={ref} data-testid={testID} aria-label={accessibilityLabel} {...rest}>
+    <span ref={ref} data-testid={testID} aria-label={accessibilityLabel} style={style as React.CSSProperties | undefined} {...rest}>
       {children}
     </span>
   )
@@ -72,6 +72,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function T
       ref={ref}
       data-testid={testID}
       aria-label={accessibilityLabel}
+      style={style as React.CSSProperties | undefined}
       value={value}
       placeholder={placeholder}
       disabled={editable === false}


### PR DESCRIPTION
Closes #1158

## Summary
- add `Message.contentStyle` for the internal native `Text`
- add `InputBar.inputStyle` for the internal `TextInput`
- preserve wrapper `style`, defaults, and existing API behavior
- document and test both public pass-throughs

## Validation
- React Native lint
- 27 tests passing
- React Native build and declarations passing
- all 17 quality gates and full pre-push lint/build passing

Unblocks AgentsKit-io/agentskit-chat#13 without downstream reimplementation.