### PR TITLE
fix(solid): stop streams on owner cleanup

### DIFF
--- a/.changeset/quiet-solid-streams.md
+++ b/.changeset/quiet-solid-streams.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/solid': patch
+---
+
+Stop active chat streams when their Solid owner is disposed.

--- a/packages/solid/src/useChat.ts
+++ b/packages/solid/src/useChat.ts
@@ -10,7 +10,10 @@ export function useChat(config: ChatConfig): ChatReturn {
   const controller = createChatController(config)
   const [state, setState] = createStore<ChatState>(controller.getState())
   const unsubscribe = controller.subscribe(() => setState(controller.getState()))
-  onCleanup(() => unsubscribe())
+  onCleanup(() => {
+    unsubscribe()
+    controller.stop()
+  })
 
   return new Proxy(
     {

--- a/packages/solid/tests/useChat.test.ts
+++ b/packages/solid/tests/useChat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createRoot } from 'solid-js'
 import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core'
 import { useChat } from '../src'
@@ -64,5 +64,28 @@ describe('@agentskit/solid', () => {
       expect(chat.input).toBe('draft')
       dispose()
     })
+  })
+
+  it('stops an active stream when its owner is disposed', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => { release = resolve })
+    let sourceReady: (() => void) | undefined
+    const ready = new Promise<void>(resolve => { sourceReady = resolve })
+    const abort = vi.fn(() => release?.())
+    let dispose = () => {}
+    const chat = createRoot(ownerDispose => {
+      dispose = ownerDispose
+      return useChat({ adapter: { createSource: () => { sourceReady?.(); return { async *stream() {
+        yield { type: 'text' as const, content: 'started' }
+        await gate
+        yield { type: 'done' as const }
+      }, abort } } } })
+    })
+
+    const sending = chat.send('hello')
+    await ready
+    dispose()
+    expect(abort).toHaveBeenCalledOnce()
+    await sending
   })
 })


### PR DESCRIPTION
Closes #1168

## Summary
- stop the chat controller when a Solid owner is disposed
- preserve subscription cleanup
- add an active-stream abort regression test
- add a patch changeset

## Verification
- `pnpm --filter @agentskit/solid lint`
- `pnpm --filter @agentskit/solid test` (28/28)
- `pnpm --filter @agentskit/solid build`