### PR TITLE
fix(angular): stop streams on service cleanup

### DIFF
--- a/.changeset/calm-angular-streams.md
+++ b/.changeset/calm-angular-streams.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/angular': patch
+---
+
+Stop active chat streams when the Angular service is destroyed or reinitialized.

--- a/packages/angular/src/chat.service.ts
+++ b/packages/angular/src/chat.service.ts
@@ -84,6 +84,7 @@ export class AgentskitChat implements OnDestroy {
 
   destroy(): void {
     this.unsubscribe?.()
+    this.controller?.stop()
     this.unsubscribe = undefined
     this.controller = undefined
     this.state.set(null)

--- a/packages/angular/tests/service.test.ts
+++ b/packages/angular/tests/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import 'zone.js'
 import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core'
 import { AgentskitChat } from '../src'
@@ -89,5 +89,24 @@ describe('AgentskitChat', () => {
     svc.init({ adapter: mockAdapter([]) })
     svc.ngOnDestroy()
     expect(svc.state()).toBeNull()
+  })
+
+  it('destroy() stops an active adapter source', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => { release = resolve })
+    let sourceReady: (() => void) | undefined
+    const ready = new Promise<void>(resolve => { sourceReady = resolve })
+    const abort = vi.fn(() => release?.())
+    const svc = new AgentskitChat()
+    svc.init({ adapter: { createSource: () => { sourceReady?.(); return { async *stream() {
+      yield { type: 'text' as const, content: 'started' }
+      await gate
+      yield { type: 'done' as const }
+    }, abort } } } })
+
+    svc.send('hello')
+    await ready
+    svc.destroy()
+    expect(abort).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
Closes #1171

## Summary
- stop the current controller when the Angular service is destroyed
- cover active-source abort on teardown
- preserve signal, observable, and unsubscribe cleanup
- add a patch changeset

## Verification
- `pnpm --filter @agentskit/angular lint`
- `pnpm --filter @agentskit/angular test` (19/19)
- `pnpm --filter @agentskit/angular build`