### PR TITLE
fix(rag): preserve optional S3 peer import

### DIFF
--- a/.changeset/warm-pears-fix.md
+++ b/.changeset/warm-pears-fix.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/rag': patch
+---
+
+Keep the optional S3 SDK runtime-dynamic so browser bundlers can import the core RAG API without installing the S3 peer.

--- a/apps/example-rag-chat/package.json
+++ b/apps/example-rag-chat/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit",
+    "build": "tsc --noEmit && vite build",
     "lint": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/rag/src/loaders.ts
+++ b/packages/rag/src/loaders.ts
@@ -199,12 +199,12 @@ interface S3SdkLike {
 }
 
 let cachedS3Sdk: Promise<S3SdkLike> | null = null
+const importOptionalPeer = (moduleId: string): Promise<unknown> => import(/* @vite-ignore */ moduleId)
 async function loadS3Sdk(): Promise<S3SdkLike> {
   if (!cachedS3Sdk) {
     cachedS3Sdk = (async () => {
       try {
-        const moduleId = '@aws-sdk/client-s3'
-        return (await import(/* @vite-ignore */ moduleId)) as unknown as S3SdkLike
+        return (await importOptionalPeer('@aws-sdk/client-s3')) as S3SdkLike
       } catch {
         throw new RagError({ code: RagErrorCodes.AK_RAG_PEER_MISSING, message: 'Install @aws-sdk/client-s3 to use loadS3: npm install @aws-sdk/client-s3', hint: 'loadS3 uses the optional peer "@aws-sdk/client-s3".' })
       }


### PR DESCRIPTION
Closes #1180

Keeps the optional S3 SDK specifier behind a runtime-dynamic import boundary so Vite consumers can import `createRAG` without installing the S3 peer. Existing command injection and typed missing-peer behavior remain unchanged. The RAG browser example now runs a production Vite bundle in its normal build gate, providing regression coverage for the published boundary.

## Validation
- `pnpm --filter @agentskit/core build`
- `pnpm --filter @agentskit/rag test` (61 passed)
- `pnpm --filter @agentskit/rag lint`
- `pnpm --filter @agentskit/rag build`
- `pnpm --filter @agentskit/example-rag-chat build` (real Vite production bundle without S3 SDK)
- `pnpm docs:bridge:gate`
- pre-push: 17 quality gates + 41 lint/build tasks