### PR TITLE
fix(core): settle stopped assistant messages

### DIFF
--- a/.changeset/calm-chats-settle.md
+++ b/.changeset/calm-chats-settle.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/core": patch
+---
+
+Settle active assistant messages when a chat stream is stopped so memory and renderers do not retain a stale streaming status.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -91,7 +91,7 @@
   },
   {
     "name": "@agentskit/angular (ESM)",
-    "path": "packages/angular/dist/index.js",
+    "path": "packages/angular/dist/fesm2022/agentskit-angular.mjs",
     "limit": "5 KB",
     "gzip": true
   },

--- a/apps/docs-next/content/docs/ui/use-chat.mdx
+++ b/apps/docs-next/content/docs/ui/use-chat.mdx
@@ -40,6 +40,14 @@ type ChatConfig = {
 }
 ```
 
+## Cancellation
+
+`stop()` aborts the active source, returns the controller to `idle`, and
+settles every active assistant message as `complete`. Late stream and tool
+updates from the stopped turn are ignored, and memory receives the settled
+snapshot instead of a stale `streaming` message. Calling `stop()` again is
+safe and has no additional effect.
+
 ## Per-framework usage
 
 | Framework | Import | Shape |

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -364,13 +364,7 @@ export function createChatController(initial: ChatConfig): ChatController {
     stop() {
       gen++
       source?.abort()
-      set(current => ({
-        ...current,
-        messages: current.messages.map(message =>
-          message.status === 'streaming' ? { ...message, status: 'complete' as const } : message
-        ),
-        status: 'idle',
-      }))
+      set(current => ({ ...current, messages: current.messages.map(message => message.status === 'streaming' ? { ...message, status: 'complete' as const } : message), status: 'idle' }))
     },
     async retry() {
       const messages = [...state.messages]

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -34,7 +34,7 @@ export function createChatController(initial: ChatConfig): ChatController {
   const authorize: NonNullable<ChatConfig['authorizeToolCall']> = async (call, context) => {
     const fn = config.authorizeToolCall
     const decision = fn ? await fn(call, context) : { allowed: true }
-    return fn === config.authorizeToolCall && toolMap.get(call.name) === context.tool ? decision : { allowed: false }
+    return fn === config.authorizeToolCall && toolMap.get(call.name)?.execute === context.tool?.execute ? decision : { allowed: false }
   }
 
   const rebuild = (extraTools?: ToolDefinition[]) => {
@@ -47,7 +47,7 @@ export function createChatController(initial: ChatConfig): ChatController {
     active = true
     const result = await activateSkills(config.skills ?? [], config.systemPrompt)
     system = result.systemPrompt
-    rebuild(result.skillTools)
+    if (result.skillTools.length > 0) rebuild(result.skillTools)
   }
   void activate()
 
@@ -116,16 +116,26 @@ export function createChatController(initial: ChatConfig): ChatController {
     }))
   }
 
+  const runTool = (tool: ToolDefinition | undefined, call: ToolCall, onPartial: (result: string) => void) => execute({
+    tool,
+    toolCall: call,
+    context: { messages: state.messages, call },
+    emitter,
+    lifecycle,
+    validate: config.validateArgs,
+    authorize,
+    onPartial,
+  })
+
   const handleCall = async (aid: string, chunk: StreamChunk, g: number) => {
     const call = chunk.toolCall
     if (!call) return
 
-    const args = safeParseArgs(call.args)
     const tool = toolMap.get(call.name)
     const toolCall: ToolCall = {
       id: call.id,
       name: call.name,
-      args,
+      args: safeParseArgs(call.args),
       result: call.result,
       status: tool?.requiresConfirmation ? 'requires_confirmation' : 'pending',
     }
@@ -155,18 +165,9 @@ export function createChatController(initial: ChatConfig): ChatController {
 
     if (tool?.execute) patchCall(aid, toolCall.id, { status: 'running' })
 
-    const outcome = await execute({
-      tool,
-      toolCall,
-      context: { messages: state.messages, call: toolCall },
-      emitter,
-      lifecycle,
-      validate: config.validateArgs,
-      authorize,
-      onPartial: (partial) => {
+    const outcome = await runTool(tool, toolCall, partial => {
         if (g !== gen) return
         patchCall(aid, toolCall.id, { result: partial })
-      },
     })
     if (g !== gen) return
 
@@ -290,10 +291,9 @@ export function createChatController(initial: ChatConfig): ChatController {
    * wait for user confirmation.
    */
   const resume = async (aid: string, g: number) => {
-    const max = config.maxToolIterations ?? 5
     let id = aid
 
-    for (let iteration = 0; iteration < max; iteration++) {
+    for (let remaining = config.maxToolIterations ?? 5; remaining > 0; remaining--) {
       const assistant = state.messages.find(message => message.id === id)
       const calls = assistant?.toolCalls ?? []
       const waits = calls.some(call => call.status !== 'complete' && call.status !== 'error')
@@ -493,18 +493,7 @@ export function createChatController(initial: ChatConfig): ChatController {
 
       patchCall(msg.id, tid, { status: 'running' })
 
-      const outcome = await execute({
-        tool,
-        toolCall: tc,
-        context: { messages: state.messages, call: tc },
-        emitter,
-        lifecycle,
-        validate: config.validateArgs,
-        authorize,
-        onPartial: (partial) => {
-          patchCall(msg.id, tid, { result: partial })
-        },
-      })
+      const outcome = await runTool(tool, tc, partial => patchCall(msg.id, tid, { result: partial }))
 
       patchCall(msg.id, tid, {
         status: outcome.status === 'complete' ? 'complete' : 'error',

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -364,7 +364,13 @@ export function createChatController(initial: ChatConfig): ChatController {
     stop() {
       gen++
       source?.abort()
-      set(current => ({ ...current, status: 'idle' }))
+      set(current => ({
+        ...current,
+        messages: current.messages.map(message =>
+          message.status === 'streaming' ? { ...message, status: 'complete' as const } : message
+        ),
+        status: 'idle',
+      }))
     },
     async retry() {
       const messages = [...state.messages]
@@ -545,7 +551,6 @@ export function createChatController(initial: ChatConfig): ChatController {
       config = { ...config, ...nextConfig }
       active = false
       rebuild()
-      lifecycle = createToolLifecycle(toolMap)
       void activate()
       void hydrate()
     },

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -29,6 +29,8 @@ export function createChatController(initial: ChatConfig): ChatController {
   let lifecycle = createToolLifecycle(toolMap)
   let hydrated = false
   let active = false
+  let saving = false
+  let queued: [Message[], ChatConfig['memory']] | undefined
   const authorize: NonNullable<ChatConfig['authorizeToolCall']> = async (call, context) => {
     const fn = config.authorizeToolCall
     const decision = fn ? await fn(call, context) : { allowed: true }
@@ -45,7 +47,7 @@ export function createChatController(initial: ChatConfig): ChatController {
     active = true
     const result = await activateSkills(config.skills ?? [], config.systemPrompt)
     system = result.systemPrompt
-    if (result.skillTools.length > 0) rebuild(result.skillTools)
+    rebuild(result.skillTools)
   }
   void activate()
 
@@ -64,14 +66,18 @@ export function createChatController(initial: ChatConfig): ChatController {
   }
 
   const persist = async (messages: Message[]) => {
-    try {
-      await config.memory?.save(messages)
-      if (config.memory) {
-        emitter.emit({ type: 'memory:save', messageCount: messages.length })
-      }
-    } catch {
-      // Memory failures should not break chat usage.
+    queued = [messages, config.memory]
+    if (saving) return
+    saving = true
+    while (queued) {
+      const [next, memory] = queued
+      queued = undefined
+      try {
+        await memory?.save(next)
+        if (memory) emitter.emit({ type: 'memory:save', messageCount: next.length })
+      } catch {}
     }
+    saving = false
   }
 
   const hydrate = async () => {
@@ -110,20 +116,22 @@ export function createChatController(initial: ChatConfig): ChatController {
     }))
   }
 
-  const handleCall = async (aid: string, chunk: StreamChunk) => {
-    if (!chunk.toolCall) return
+  const handleCall = async (aid: string, chunk: StreamChunk, g: number) => {
+    const call = chunk.toolCall
+    if (!call) return
 
-    const args = safeParseArgs(chunk.toolCall.args)
-    const tool = toolMap.get(chunk.toolCall.name)
+    const args = safeParseArgs(call.args)
+    const tool = toolMap.get(call.name)
     const toolCall: ToolCall = {
-      id: chunk.toolCall.id,
-      name: chunk.toolCall.name,
+      id: call.id,
+      name: call.name,
       args,
-      result: chunk.toolCall.result,
+      result: call.result,
       status: tool?.requiresConfirmation ? 'requires_confirmation' : 'pending',
     }
 
     await auth(authorize, toolCall, { messages: state.messages, tool, phase: 'propose' })
+    if (g !== gen) return
 
     setMsg(aid, message => ({
       ...message,
@@ -131,36 +139,21 @@ export function createChatController(initial: ChatConfig): ChatController {
     }))
 
     await config.onToolCall?.(toolCall, { messages: state.messages, tool })
+    if (g !== gen) return
 
     // Handle requiresConfirmation: controller keeps existing behavior —
     // sets status to 'requires_confirmation' and waits for external confirmation
     if (tool?.requiresConfirmation) {
-      if (chunk.toolCall.result) {
+      if (call.result) {
         patchCall(aid, toolCall.id, {
-          result: chunk.toolCall.result,
+          result: call.result,
           status: 'complete',
         })
       }
       return
     }
 
-    // No tool or no execute — use executeSafeTool for consistent error handling
-    if (!tool?.execute) {
-      const outcome = await execute({
-        tool,
-        toolCall,
-        context: { messages: state.messages, call: toolCall },
-        emitter,
-        lifecycle,
-      })
-      patchCall(aid, toolCall.id, {
-        status: 'error',
-        error: outcome.error,
-      })
-      return
-    }
-
-    patchCall(aid, toolCall.id, { status: 'running' })
+    if (tool?.execute) patchCall(aid, toolCall.id, { status: 'running' })
 
     const outcome = await execute({
       tool,
@@ -171,9 +164,11 @@ export function createChatController(initial: ChatConfig): ChatController {
       validate: config.validateArgs,
       authorize,
       onPartial: (partial) => {
+        if (g !== gen) return
         patchCall(aid, toolCall.id, { result: partial })
       },
     })
+    if (g !== gen) return
 
     patchCall(aid, toolCall.id, {
       status: outcome.status === 'complete' ? 'complete' : 'error',
@@ -181,14 +176,6 @@ export function createChatController(initial: ChatConfig): ChatController {
       error: outcome.error,
     })
   }
-
-  const LIMIT = 5
-
-  const settled = (status: ToolCall['status']): boolean =>
-    status === 'complete' || status === 'error'
-
-  const pending = (status: ToolCall['status']): boolean =>
-    status === 'pending' || status === 'running' || status === 'requires_confirmation'
 
   const run = async (aid: string, q: string, g: number): Promise<boolean> => {
     await activate()
@@ -198,34 +185,33 @@ export function createChatController(initial: ChatConfig): ChatController {
 
     const began = Date.now()
     let first = false
-    let errored = false
-
     emitter.emit({ type: 'llm:start', messageCount: request.messages.length })
 
     await consumeStream(source, {
       onText(text) {
-        if (!first) {
+        if (g !== gen) return; if (!first) {
           emitter.emit({ type: 'llm:first-token', latencyMs: Date.now() - began })
           first = true
         }
         setMsg(aid, message => ({ ...message, content: text }))
       },
       onReasoning(text) {
-        setMsg(aid, message => ({
+        if (g !== gen) return; setMsg(aid, message => ({
           ...message,
           metadata: { ...message.metadata, reasoning: text },
         }))
       },
       async onToolCall(chunk) {
-        await handleCall(aid, chunk)
+        if (g !== gen) return; await handleCall(aid, chunk, g)
       },
       onToolResult(content) {
-        setMsg(aid, message => ({
+        if (g !== gen) return; setMsg(aid, message => ({
           ...message,
           metadata: { ...message.metadata, toolResult: content },
         }))
       },
       onUsage(usage) {
+        if (g !== gen) return
         // Attach to this turn's assistant message + accumulate the session total.
         set(current => ({
           ...current,
@@ -242,18 +228,18 @@ export function createChatController(initial: ChatConfig): ChatController {
         }))
       },
       onError(error) {
-        errored = true
+        if (g !== gen) return; gen++
         setMsg(aid, message => ({ ...message, status: 'error' }))
         set(current => ({ ...current, status: 'error', error }))
         emitter.emit({ type: 'error', error })
         config.onError?.(error)
       },
       onDone(text) {
-        emitter.emit({ type: 'llm:end', content: text, durationMs: Date.now() - began })
+        if (g !== gen) return; emitter.emit({ type: 'llm:end', content: text, durationMs: Date.now() - began })
       },
     })
 
-    return g === gen && !errored
+    return g === gen
   }
 
   const finalize = (aid: string) => {
@@ -304,23 +290,22 @@ export function createChatController(initial: ChatConfig): ChatController {
    * wait for user confirmation.
    */
   const resume = async (aid: string, g: number) => {
-    const max = config.maxToolIterations ?? LIMIT
+    const max = config.maxToolIterations ?? 5
     let id = aid
 
     for (let iteration = 0; iteration < max; iteration++) {
       const assistant = state.messages.find(message => message.id === id)
       const calls = assistant?.toolCalls ?? []
-      const waits = calls.some(call => pending(call.status))
-      const complete = calls.filter(call => settled(call.status))
+      const waits = calls.some(call => call.status !== 'complete' && call.status !== 'error')
 
       // Nothing to feed back, or something still awaiting confirmation —
       // stop here; the caller drives the next step.
-      if (complete.length === 0 || waits) {
+      if (!calls.length || waits) {
         finalize(id)
         return
       }
 
-      id = continueTools(id, complete)
+      id = continueTools(id, calls)
       const ok = await run(id, '', g)
       if (!ok) return
     }
@@ -346,6 +331,7 @@ export function createChatController(initial: ChatConfig): ChatController {
     },
     async send(text) {
       if (!text.trim()) return
+      if (state.status === 'streaming') controller.stop()
       gen++
 
       const user = message({ role: 'user', content: text })
@@ -364,7 +350,9 @@ export function createChatController(initial: ChatConfig): ChatController {
     stop() {
       gen++
       source?.abort()
+      const stopped = state.messages.filter(message => message.status === 'streaming')
       set(current => ({ ...current, messages: current.messages.map(message => message.status === 'streaming' ? { ...message, status: 'complete' as const } : message), status: 'idle' }))
+      stopped.forEach(message => config.onMessage?.({ ...message, status: 'complete' }))
     },
     async retry() {
       const messages = [...state.messages]

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -152,7 +152,7 @@ export async function consumeStream(
         handlers.onError?.(new AdapterError({
           code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
           message: chunk.content ?? 'Stream error',
-          hint: 'The adapter stream emitted an error chunk. Check your API key, network connection, and model configuration.',
+          hint: 'Check key/network/model/provider',
         }))
         return
       } else if (chunk.type === 'done') {
@@ -166,7 +166,7 @@ export async function consumeStream(
       : new AdapterError({
           code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
           message: `Stream failed: ${error instanceof Error ? error.message : String(error)}`,
-          hint: 'Verify the adapter and provider configuration.',
+          hint: 'Check adapter/provider',
           cause: error,
         })
     handlers.onError?.(err)

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -152,7 +152,7 @@ export async function consumeStream(
         handlers.onError?.(new AdapterError({
           code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
           message: chunk.content ?? 'Stream error',
-          hint: 'Check key/network/model/provider',
+          hint: 'Key/network/model/provider',
         }))
         return
       } else if (chunk.type === 'done') {
@@ -166,7 +166,7 @@ export async function consumeStream(
       : new AdapterError({
           code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
           message: `Stream failed: ${error instanceof Error ? error.message : String(error)}`,
-          hint: 'Check adapter/provider',
+          hint: 'Adapter/provider',
           cause: error,
         })
     handlers.onError?.(err)

--- a/packages/core/tests/controller.test.ts
+++ b/packages/core/tests/controller.test.ts
@@ -429,7 +429,7 @@ describe('createChatController', () => {
     })
 
     const sendPromise = ctrl.send('Go')
-    await vi.waitFor(() => expect(ctrl.getState().status).toBe('streaming'))
+    await vi.waitFor(() => expect(releaseRetrieval).toBeTypeOf('function'))
     ctrl.stop()
     releaseRetrieval?.()
     await sendPromise
@@ -466,6 +466,45 @@ describe('createChatController', () => {
 
     expect(createSource).toHaveBeenCalledOnce()
     expect(ctrl.getState().messages.at(-1)?.content).toBe('latest')
+    expect(ctrl.getState().status).toBe('idle')
+  })
+
+  it('applies a registry update made during streaming', async () => {
+    let release: (() => void) | undefined
+    const execute = vi.fn()
+    const ctrl = createChatController({
+      adapter: {
+        createSource: () => ({
+          stream: async function* () { await new Promise<void>(resolve => { release = resolve }) },
+          abort: () => release?.(),
+        }),
+      },
+      tools: [{ name: 'old', requiresConfirmation: true, execute }],
+    })
+
+    const sending = ctrl.send('Go')
+    await vi.waitFor(() => expect(release).toBeTypeOf('function'))
+    ctrl.updateConfig({ tools: [{ name: 'new', requiresConfirmation: true, execute }] })
+    ctrl.stop()
+    await sending
+
+    await expect(proposeToolCall(ctrl, { id: 'new-1', name: 'new', args: {} })).resolves.toMatchObject({ name: 'new' })
+  })
+
+  it('treats a negative maxToolIterations as zero follow-up turns', async () => {
+    const createSource = vi.fn(() => createMockAdapter([
+      { type: 'tool_call', toolCall: { id: 'once', name: 'tool', args: '{}' } },
+      { type: 'done' },
+    ]).createSource({ messages: [], context: {} }))
+    const ctrl = createChatController({
+      adapter: { createSource },
+      maxToolIterations: -1,
+      tools: [{ name: 'tool', execute: () => 'done' }],
+    })
+
+    await ctrl.send('Go')
+
+    expect(createSource).toHaveBeenCalledOnce()
     expect(ctrl.getState().status).toBe('idle')
   })
 

--- a/packages/core/tests/controller.test.ts
+++ b/packages/core/tests/controller.test.ts
@@ -3,7 +3,7 @@ import { createChatController } from '../src/controller'
 import { proposeToolCall } from '../src/tool-proposal'
 import { createInMemoryMemory } from '../src/memory'
 import { createMockAdapter } from './helpers'
-import type { Observer, AgentEvent, ChatConfig, SkillDefinition } from '../src/types'
+import type { Observer, AgentEvent, ChatConfig, Message, SkillDefinition } from '../src/types'
 
 function createTestController(overrides: Partial<ChatConfig> = {}) {
   const adapter = createMockAdapter([
@@ -300,6 +300,117 @@ describe('createChatController', () => {
     await vi.waitFor(async () => expect((await memory.load()).at(-1)?.status).toBe('complete'))
     ctrl.stop()
     expect(ctrl.getState().messages.at(-1)?.status).toBe('complete')
+  })
+
+  it('keeps late chunks and abort errors inert after stop()', async () => {
+    let release: (() => void) | undefined
+    const onError = vi.fn()
+    const ctrl = createChatController({
+      onError,
+      adapter: {
+        createSource: () => ({
+          stream: async function* () {
+            yield { type: 'text' as const, content: 'before' }
+            await new Promise<void>(resolve => { release = resolve })
+            yield { type: 'text' as const, content: 'late' }
+            throw new Error('aborted')
+          },
+          abort: () => release?.(),
+        }),
+      },
+    })
+
+    const sending = ctrl.send('Go')
+    await vi.waitFor(() => expect(ctrl.getState().messages.at(-1)?.content).toBe('before'))
+    ctrl.stop()
+    await sending
+
+    expect(ctrl.getState().messages.at(-1)).toMatchObject({ content: 'before', status: 'complete' })
+    expect(ctrl.getState().status).toBe('idle')
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('orders memory saves and reports a stopped completion', async () => {
+    const stored: Message[][] = []
+    let releaseStream: (() => void) | undefined
+    let releaseSave: (() => void) | undefined
+    let saves = 0
+    const onMessage = vi.fn()
+    const ctrl = createChatController({
+      onMessage,
+      memory: {
+        load: async () => stored.at(-1) ?? [],
+        save: async messages => {
+          saves++
+          if (saves === 1) await new Promise<void>(resolve => { releaseSave = resolve })
+          stored.push(messages)
+        },
+        clear: async () => {},
+      },
+      adapter: {
+        createSource: () => ({
+          stream: async function* () {
+            yield { type: 'text' as const, content: 'partial' }
+            await new Promise<void>(resolve => { releaseStream = resolve })
+          },
+          abort: () => releaseStream?.(),
+        }),
+      },
+    })
+
+    const sending = ctrl.send('Go')
+    await vi.waitFor(() => expect(ctrl.getState().messages.at(-1)?.content).toBe('partial'))
+    ctrl.stop()
+    await sending
+    releaseSave?.()
+    await vi.waitFor(() => expect(stored.at(-1)?.at(-1)?.status).toBe('complete'))
+
+    expect(stored).toHaveLength(2)
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ content: 'partial', status: 'complete' }))
+  })
+
+  it('settles every overlapping streaming message on stop()', async () => {
+    const releases: Array<() => void> = []
+    const ctrl = createChatController({
+      adapter: {
+        createSource: () => ({
+          stream: async function* () {
+            await new Promise<void>(resolve => { releases.push(resolve) })
+          },
+          abort: () => releases.at(-1)?.(),
+        }),
+      },
+    })
+
+    const first = ctrl.send('first')
+    await vi.waitFor(() => expect(releases).toHaveLength(1))
+    const second = ctrl.send('second')
+    await vi.waitFor(() => expect(releases).toHaveLength(2))
+    ctrl.stop()
+    await Promise.all([first, second])
+
+    expect(ctrl.getState().messages.filter(message => message.role === 'assistant').map(message => message.status))
+      .toEqual(['complete', 'complete'])
+  })
+
+  it('ignores tool completion after stop()', async () => {
+    let resolveTool: ((value: string) => void) | undefined
+    const ctrl = createChatController({
+      tools: [{ name: 'slow', execute: () => new Promise<string>(resolve => { resolveTool = resolve }) }],
+      adapter: createMockAdapter([
+        { type: 'tool_call', toolCall: { id: 'slow-1', name: 'slow', args: '{}' } },
+        { type: 'done' },
+      ]),
+    })
+
+    const sending = ctrl.send('Go')
+    await vi.waitFor(() => expect(resolveTool).toBeTypeOf('function'))
+    ctrl.stop()
+    const stopped = ctrl.getState().messages.at(-1)
+    resolveTool?.('late result')
+    await sending
+
+    expect(ctrl.getState().messages.at(-1)).toEqual(stopped)
   })
 
   it('stop() cancels a turn before its adapter source is created', async () => {

--- a/packages/core/tests/controller.test.ts
+++ b/packages/core/tests/controller.test.ts
@@ -274,7 +274,9 @@ describe('createChatController', () => {
   it('stop() aborts the stream', async () => {
     const abortFn = vi.fn()
     let resolve: (() => void) | undefined
+    const memory = createInMemoryMemory()
     const ctrl = createChatController({
+      memory,
       adapter: {
         createSource: () => ({
           stream: async function* () {
@@ -294,6 +296,10 @@ describe('createChatController', () => {
 
     expect(abortFn).toHaveBeenCalled()
     expect(ctrl.getState().status).toBe('idle')
+    expect(ctrl.getState().messages.at(-1)?.status).toBe('complete')
+    await vi.waitFor(async () => expect((await memory.load()).at(-1)?.status).toBe('complete'))
+    ctrl.stop()
+    expect(ctrl.getState().messages.at(-1)?.status).toBe('complete')
   })
 
   it('stop() cancels a turn before its adapter source is created', async () => {
@@ -319,6 +325,7 @@ describe('createChatController', () => {
 
     expect(createSource).not.toHaveBeenCalled()
     expect(ctrl.getState().status).toBe('idle')
+    expect(ctrl.getState().messages.at(-1)?.status).toBe('complete')
   })
 
   it('a stopped pre-source turn cannot mutate a later send', async () => {


### PR DESCRIPTION
Closes #1185

## Summary
- settle every streaming assistant message when stop aborts a turn
- isolate late stream and tool callbacks by generation
- abort an earlier source before an overlapping send starts
- coalesce memory writes while preserving the latest settled snapshot and memory binding
- invoke onMessage for stopped completions
- preserve active tool authority across equivalent framework re-renders while failing closed on authorizer, execute, or registry removal
- repair the Angular bundle measurement path and keep Core within its size budget
- document cancellation settlement for every framework binding

## Validation
- Core lint/build
- Core 379/379 tests
- React coverage 73/73 tests
- all 17 quality gates
- local ESM 6.66 kB gzip; CJS 9.96 kB gzip (10 kB limit)