### PR TITLE
feat(registry): add indexable category hubs

### DIFF
--- a/apps/registry/app/(home)/_components/categories.ts
+++ b/apps/registry/app/(home)/_components/categories.ts
@@ -1,47 +1,4 @@
-export const CATEGORY: Record<string, { label: string; blurb: string; icon: string }> = {
-  coding: { label: 'Coding', blurb: 'Reviews, tests, PRs, and release flow for engineering teams.', icon: 'code' },
-  research: { label: 'Research', blurb: 'Citation-first web research with every claim anchored to a source.', icon: 'search' },
-  marketing: { label: 'Marketing', blurb: 'Briefs, copy, competitive research, and social publishing.', icon: 'trending-up' },
-  agency: { label: 'Agency', blurb: 'Client briefs, decks, schedules, and creative review.', icon: 'megaphone' },
-  support: { label: 'Support', blurb: 'Ticket triage, KB search, and escalation drafting.', icon: 'life-buoy' },
-  legal: { label: 'Legal', blurb: 'Contract review, discovery, drafting, and privilege spotting.', icon: 'scale' },
-  fintech: { label: 'Fintech', blurb: 'KYC, sanctions, fraud, and transaction monitoring.', icon: 'landmark' },
-  clinical: { label: 'Clinical', blurb: 'Intake triage, SOAP notes, redaction, and referrals.', icon: 'heart-pulse' },
-  ops: { label: 'Ops', blurb: 'Internal workflows and knowledge promotion.', icon: 'git-branch' },
-  productivity: { label: 'Productivity', blurb: 'Docs chat, meeting actions, and weekly digests.', icon: 'calendar' },
-  sales: { label: 'Sales', blurb: 'Pipeline, outreach, proposals, and renewals.', icon: 'target' },
-  hr: { label: 'HR', blurb: 'Hiring, onboarding, policies, and performance.', icon: 'users' },
-  devops: { label: 'DevOps', blurb: 'Incidents, deploys, infra, and SRE workflows.', icon: 'server' },
-  data: { label: 'Data', blurb: 'SQL, lineage, quality, and analytics narratives.', icon: 'database' },
-  ecommerce: { label: 'E-commerce', blurb: 'Listings, returns, fraud, and fulfillment.', icon: 'shopping-cart' },
-  product: { label: 'Product', blurb: 'PRDs, prioritization, feedback, and roadmaps.', icon: 'layout' },
-  security: { label: 'Security', blurb: 'Threat triage, vulns, IR, and compliance gaps.', icon: 'shield' },
-  cybersecurity: { label: 'Security', blurb: 'Threat triage, vulns, IR, and compliance gaps.', icon: 'shield' },
-  insurance: { label: 'Insurance', blurb: 'Claims, underwriting, and policy workflows.', icon: 'umbrella' },
-  realestate: { label: 'Real Estate', blurb: 'Listings, leases, comps, and closings.', icon: 'home' },
-  education: { label: 'Education', blurb: 'Lesson plans, rubrics, and student feedback.', icon: 'graduation-cap' },
-  content: { label: 'Content', blurb: 'Blog, newsletter, podcast, and repurposing.', icon: 'file-text' },
-  compliance: { label: 'Compliance', blurb: 'LGPD, GDPR, retention, and breach notices.', icon: 'clipboard-check' },
-  ecosystem: { label: 'Ecosystem', blurb: 'Dogfood for doc-bridge, playbook, and registry.', icon: 'boxes' },
-}
-
-const ORDER = [
-  'coding', 'research', 'marketing', 'agency', 'support', 'legal', 'fintech', 'clinical', 'ops',
-  'productivity', 'sales', 'hr', 'devops', 'data', 'ecommerce', 'product', 'cybersecurity', 'security',
-  'insurance', 'realestate', 'education', 'content', 'compliance', 'ecosystem',
-]
-
-export function categoryMeta(id: string) {
-  return CATEGORY[id] ?? { label: id.charAt(0).toUpperCase() + id.slice(1), blurb: '', icon: 'box' }
-}
-
-export function sortedCategories(ids: string[]): string[] {
-  return [...new Set(ids)].sort((a, b) => {
-    const ai = ORDER.indexOf(a)
-    const bi = ORDER.indexOf(b)
-    return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
-  })
-}
+export { CATEGORY, categoryMeta, sortedCategories } from '@/lib/categories'
 
 export function agentPrompt(a: { id: string; title: string; description: string }): string {
   return [

--- a/apps/registry/app/agents/[id]/page.tsx
+++ b/apps/registry/app/agents/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock'
 import { factoryName, getAgent, getRegistryIndex, relatedAgents } from '@/lib/registry'
 import type { RegistryValidationEvidence } from '@/lib/registry'
+import { categoryMeta } from '@/lib/categories'
 import { AgentAnalytics } from './agent-analytics'
 import { AgentFeedback } from './agent-feedback'
 import { InstallCommand } from './install-command'
@@ -128,6 +129,7 @@ console.log(result.content)`
     license: agent.license ?? 'MIT',
     url: `https://registry.agentskit.io/agents/${agent.id}`,
   }
+  const category = categoryMeta(agent.category)
 
   return (
     <main className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-14">
@@ -135,7 +137,7 @@ console.log(result.content)`
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm text-ak-graphite">
         <Link href="/#agents" className="hover:text-ak-blue">Agents</Link><span>/</span>
-        <Link href={`/?category=${agent.category}#agents`} className="capitalize hover:text-ak-blue">{agent.category}</Link><span>/</span>
+        <Link href={`/categories/${agent.category}`} className="hover:text-ak-blue">{category.label}</Link><span>/</span>
         <span aria-current="page" className="truncate text-ak-foam">{agent.title}</span>
       </nav>
 
@@ -237,7 +239,7 @@ console.log(result.content)`
         <section className="mt-14 border-t border-ak-border pt-8">
           <div className="flex items-end justify-between gap-4">
             <div><p className="font-mono text-xs uppercase tracking-[0.14em] text-ak-blue">Keep exploring</p><h2 className="mt-2 text-2xl font-semibold text-ak-foam">Related agents</h2></div>
-            <Link href={`/?category=${agent.category}#agents`} className="text-sm text-ak-blue hover:underline">View category</Link>
+            <Link href={`/categories/${agent.category}`} className="text-sm text-ak-blue hover:underline">View category</Link>
           </div>
           <div className="mt-6 grid gap-x-6 sm:grid-cols-2 lg:grid-cols-4">
             {related.map((item) => (

--- a/apps/registry/app/categories/[category]/page.tsx
+++ b/apps/registry/app/categories/[category]/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import {
+  agentsInCategory,
+  categoryIds,
+  categoryJsonLd,
+  categoryMeta,
+  categoryMetadata,
+} from '@/lib/categories'
+import { getRegistryIndex } from '@/lib/registry'
+
+export const revalidate = 3600
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+  const agents = await getRegistryIndex()
+  return categoryIds(agents).map((category) => ({ category }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ category: string }> }): Promise<Metadata> {
+  const { category } = await params
+  const agents = await getRegistryIndex()
+  return categoryMetadata(category, agents) ?? {
+    title: 'Category not found',
+    description: 'This registry category does not exist.',
+    robots: { index: false, follow: false },
+  }
+}
+
+function agentStatus(reviewed: boolean, runnable: boolean): string {
+  if (reviewed && runnable) return 'Reviewed and runnable'
+  if (reviewed) return 'Independently reviewed'
+  if (runnable) return 'Runnable'
+  return 'Registry listed'
+}
+
+export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
+  const { category } = await params
+  const index = await getRegistryIndex()
+  const agents = agentsInCategory(index, category)
+  if (agents.length === 0) notFound()
+
+  const { label, blurb } = categoryMeta(category)
+  const reviewed = agents.filter((agent) => Boolean(agent.validation)).length
+  const runnable = agents.filter((agent) => Boolean(agent.runnable)).length
+  const jsonLd = categoryJsonLd(category, agents)
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+      />
+
+      <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm text-ak-graphite">
+        <Link href="/#agents" className="hover:text-ak-blue">Agents</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page" className="text-ak-foam">{label}</span>
+      </nav>
+
+      <header className="mt-8 border-b border-ak-border pb-9">
+        <p className="font-mono text-xs uppercase text-ak-blue">Registry category</p>
+        <h1 className="mt-3 font-display text-3xl font-semibold text-ak-foam sm:text-4xl">{label} AI agents</h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-ak-graphite sm:text-lg">{blurb}</p>
+
+        <dl className="mt-7 grid grid-cols-3 divide-x divide-ak-border border-y border-ak-border py-4">
+          <div className="pr-3">
+            <dt className="text-xs text-ak-graphite">Agents</dt>
+            <dd className="mt-1 font-mono text-lg font-semibold text-ak-foam">{agents.length}</dd>
+          </div>
+          <div className="px-3 sm:px-5">
+            <dt className="text-xs text-ak-graphite">Reviewed</dt>
+            <dd className="mt-1 font-mono text-lg font-semibold text-ak-foam">{reviewed}</dd>
+          </div>
+          <div className="pl-3 sm:pl-5">
+            <dt className="text-xs text-ak-graphite">Runnable</dt>
+            <dd className="mt-1 font-mono text-lg font-semibold text-ak-foam">{runnable}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <section aria-labelledby="category-agents" className="mt-9">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <h2 id="category-agents" className="text-xl font-semibold text-ak-foam">All {label} agents</h2>
+          <Link href={`/?category=${encodeURIComponent(category)}#agents`} className="text-sm text-ak-blue hover:underline">
+            Filter in catalog
+          </Link>
+        </div>
+
+        <div className="mt-5 grid gap-x-8 sm:grid-cols-2">
+          {agents.map((agent) => {
+            const status = agentStatus(Boolean(agent.validation), Boolean(agent.runnable))
+            return (
+              <Link
+                key={agent.id}
+                href={`/agents/${agent.id}`}
+                className="group min-w-0 border-t border-ak-border py-5 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ak-blue"
+              >
+                <div className="flex min-w-0 items-start justify-between gap-4">
+                  <h3 className="min-w-0 font-medium text-ak-foam group-hover:text-ak-blue">{agent.title}</h3>
+                  <span className="shrink-0 font-mono text-[11px] text-ak-graphite">{agent.version ? `v${agent.version}` : 'v1'}</span>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-ak-graphite">{agent.description}</p>
+                <p className="mt-3 flex items-center gap-2 text-xs text-ak-graphite">
+                  <span aria-hidden="true" className={agent.validation ? 'size-1.5 rounded-full bg-ak-green' : 'size-1.5 rounded-full bg-ak-border'} />
+                  {status}
+                </p>
+              </Link>
+            )
+          })}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/registry/app/categories/layout.tsx
+++ b/apps/registry/app/categories/layout.tsx
@@ -1,0 +1,7 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home'
+import type { ReactNode } from 'react'
+import { baseOptions } from '../layout.config'
+
+export default function CategoriesLayout({ children }: { children: ReactNode }) {
+  return <HomeLayout {...baseOptions}>{children}</HomeLayout>
+}

--- a/apps/registry/app/sitemap.ts
+++ b/apps/registry/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { source } from '@/lib/source'
 import { getRegistryIndex } from '@/lib/registry'
+import { categoryIds, categoryUrl } from '@/lib/categories'
 
 const SITE = 'https://registry.agentskit.io'
 
@@ -12,6 +13,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${SITE}${page.url}`,
       changeFrequency: 'monthly' as const,
       priority: page.slugs.length === 0 ? 0.9 : 0.7,
+    })),
+    ...categoryIds(agents).map((category) => ({
+      url: categoryUrl(category),
+      changeFrequency: 'weekly' as const,
+      priority: 0.85,
     })),
     ...agents.map((agent) => ({
       url: `${SITE}/agents/${agent.id}`,

--- a/apps/registry/content/docs/using.mdx
+++ b/apps/registry/content/docs/using.mdx
@@ -33,6 +33,10 @@ Swap the adapter for any provider (`anthropic`, `gemini`, `ollama`, …) — no 
 The [agent catalog](/#agents) can narrow the registry to independently reviewed or directly
 runnable agents. Results can be ordered by recommendation, independent review score, or name.
 
+Each category also has a stable, indexable URL, such as [Coding agents](/categories/coding) or
+[Legal agents](/categories/legal). Category pages list every matching agent and link to its
+canonical detail page.
+
 Select two or three agents and choose **Compare agents** to inspect review evidence, packages,
 required environment variables, capabilities, and install commands side by side. Filter and
 comparison state stays in the URL, so the resulting view can be shared with a teammate.

--- a/apps/registry/lib/categories.test.ts
+++ b/apps/registry/lib/categories.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { RegistryAgentSummary } from './registry'
+import {
+  agentsInCategory,
+  categoryIds,
+  categoryJsonLd,
+  categoryMetadata,
+  categoryUrl,
+} from './categories'
+
+const agents: RegistryAgentSummary[] = [
+  {
+    id: 'ops-zeta',
+    title: 'Zeta Agent',
+    description: 'Handles operations.',
+    category: 'ops',
+    packages: ['@agentskit/core'],
+  },
+  {
+    id: 'coding-alpha',
+    title: 'Alpha Agent',
+    description: 'Reviews code.',
+    category: 'coding',
+    packages: ['@agentskit/core'],
+    runnable: true,
+    validation: { status: 'approved', score: 98, confidence: 0.99 },
+  },
+  {
+    id: 'coding-beta',
+    title: 'Beta Agent',
+    description: 'Tests code.',
+    category: 'coding',
+    packages: ['@agentskit/core'],
+  },
+]
+
+describe('category helpers', () => {
+  it('returns each real category once in registry order', () => {
+    expect(categoryIds([...agents, agents[1]])).toEqual(['coding', 'ops'])
+  })
+
+  it('filters one category and sorts all matching agents by title', () => {
+    expect(agentsInCategory(agents, 'coding').map((agent) => agent.id))
+      .toEqual(['coding-alpha', 'coding-beta'])
+    expect(agentsInCategory(agents, 'missing')).toEqual([])
+  })
+
+  it('builds canonical metadata only for a real category', () => {
+    const metadata = categoryMetadata('coding', agents)
+    expect(metadata).toMatchObject({
+      title: 'Coding AI agents',
+      alternates: { canonical: 'https://registry.agentskit.io/categories/coding' },
+      openGraph: { url: 'https://registry.agentskit.io/categories/coding', type: 'website' },
+    })
+    expect(categoryMetadata('missing', agents)).toBeNull()
+  })
+
+  it('builds a CollectionPage ItemList with canonical agent URLs', () => {
+    const matching = agentsInCategory(agents, 'coding')
+    expect(categoryJsonLd('coding', matching)).toMatchObject({
+      '@type': 'CollectionPage',
+      url: categoryUrl('coding'),
+      mainEntity: {
+        '@type': 'ItemList',
+        numberOfItems: 2,
+        itemListElement: [
+          { position: 1, name: 'Alpha Agent', url: 'https://registry.agentskit.io/agents/coding-alpha' },
+          { position: 2, name: 'Beta Agent', url: 'https://registry.agentskit.io/agents/coding-beta' },
+        ],
+      },
+    })
+  })
+})

--- a/apps/registry/lib/categories.ts
+++ b/apps/registry/lib/categories.ts
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next'
+import type { RegistryAgentSummary } from './registry'
+
+const SITE = 'https://registry.agentskit.io'
+
+export const CATEGORY: Record<string, { label: string; blurb: string; icon: string }> = {
+  coding: { label: 'Coding', blurb: 'Reviews, tests, PRs, and release flow for engineering teams.', icon: 'code' },
+  research: { label: 'Research', blurb: 'Citation-first web research with every claim anchored to a source.', icon: 'search' },
+  marketing: { label: 'Marketing', blurb: 'Briefs, copy, competitive research, and social publishing.', icon: 'trending-up' },
+  agency: { label: 'Agency', blurb: 'Client briefs, decks, schedules, and creative review.', icon: 'megaphone' },
+  support: { label: 'Support', blurb: 'Ticket triage, KB search, and escalation drafting.', icon: 'life-buoy' },
+  legal: { label: 'Legal', blurb: 'Contract review, discovery, drafting, and privilege spotting.', icon: 'scale' },
+  fintech: { label: 'Fintech', blurb: 'KYC, sanctions, fraud, and transaction monitoring.', icon: 'landmark' },
+  clinical: { label: 'Clinical', blurb: 'Intake triage, SOAP notes, redaction, and referrals.', icon: 'heart-pulse' },
+  ops: { label: 'Ops', blurb: 'Internal workflows and knowledge promotion.', icon: 'git-branch' },
+  productivity: { label: 'Productivity', blurb: 'Docs chat, meeting actions, and weekly digests.', icon: 'calendar' },
+  sales: { label: 'Sales', blurb: 'Pipeline, outreach, proposals, and renewals.', icon: 'target' },
+  hr: { label: 'HR', blurb: 'Hiring, onboarding, policies, and performance.', icon: 'users' },
+  devops: { label: 'DevOps', blurb: 'Incidents, deploys, infra, and SRE workflows.', icon: 'server' },
+  data: { label: 'Data', blurb: 'SQL, lineage, quality, and analytics narratives.', icon: 'database' },
+  ecommerce: { label: 'E-commerce', blurb: 'Listings, returns, fraud, and fulfillment.', icon: 'shopping-cart' },
+  product: { label: 'Product', blurb: 'PRDs, prioritization, feedback, and roadmaps.', icon: 'layout' },
+  security: { label: 'Security', blurb: 'Threat triage, vulns, IR, and compliance gaps.', icon: 'shield' },
+  cybersecurity: { label: 'Security', blurb: 'Threat triage, vulns, IR, and compliance gaps.', icon: 'shield' },
+  insurance: { label: 'Insurance', blurb: 'Claims, underwriting, and policy workflows.', icon: 'umbrella' },
+  realestate: { label: 'Real Estate', blurb: 'Listings, leases, comps, and closings.', icon: 'home' },
+  education: { label: 'Education', blurb: 'Lesson plans, rubrics, and student feedback.', icon: 'graduation-cap' },
+  content: { label: 'Content', blurb: 'Blog, newsletter, podcast, and repurposing.', icon: 'file-text' },
+  compliance: { label: 'Compliance', blurb: 'LGPD, GDPR, retention, and breach notices.', icon: 'clipboard-check' },
+  ecosystem: { label: 'Ecosystem', blurb: 'Dogfood for doc-bridge, playbook, and registry.', icon: 'boxes' },
+}
+
+const ORDER = [
+  'coding', 'research', 'marketing', 'agency', 'support', 'legal', 'fintech', 'clinical', 'ops',
+  'productivity', 'sales', 'hr', 'devops', 'data', 'ecommerce', 'product', 'cybersecurity', 'security',
+  'insurance', 'realestate', 'education', 'content', 'compliance', 'ecosystem',
+]
+
+export function categoryMeta(id: string) {
+  return CATEGORY[id] ?? { label: id.charAt(0).toUpperCase() + id.slice(1), blurb: '', icon: 'box' }
+}
+
+export function sortedCategories(ids: string[]): string[] {
+  return [...new Set(ids)].sort((a, b) => {
+    const ai = ORDER.indexOf(a)
+    const bi = ORDER.indexOf(b)
+    return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi) || a.localeCompare(b)
+  })
+}
+
+export function categoryIds(agents: RegistryAgentSummary[]): string[] {
+  return sortedCategories(agents.map((agent) => agent.category).filter(Boolean))
+}
+
+export function agentsInCategory(agents: RegistryAgentSummary[], category: string): RegistryAgentSummary[] {
+  return agents
+    .filter((agent) => agent.category === category)
+    .sort((a, b) => a.title.localeCompare(b.title) || a.id.localeCompare(b.id))
+}
+
+export function categoryUrl(category: string): string {
+  return `${SITE}/categories/${encodeURIComponent(category)}`
+}
+
+export function categoryMetadata(category: string, agents: RegistryAgentSummary[]): Metadata | null {
+  const matching = agentsInCategory(agents, category)
+  if (matching.length === 0) return null
+
+  const { label, blurb } = categoryMeta(category)
+  const title = `${label} AI agents`
+  const description = `${blurb} Explore ${matching.length} ready-to-use ${label.toLowerCase()} AI agents for AgentsKit.`
+  const url = categoryUrl(category)
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: { title: `${title} - AgentsKit Registry`, description, url, type: 'website' },
+  }
+}
+
+export function categoryJsonLd(category: string, agents: RegistryAgentSummary[]) {
+  const { label, blurb } = categoryMeta(category)
+  const url = categoryUrl(category)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `${label} AI agents`,
+    description: blurb,
+    url,
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: agents.length,
+      itemListElement: agents.map((agent, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: agent.title,
+        url: `${SITE}/agents/${encodeURIComponent(agent.id)}`,
+      })),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add 23 statically generated, indexable category hubs backed by the production registry index
- add canonical metadata, Open Graph data, CollectionPage/ItemList JSON-LD, and sitemap entries
- connect agent breadcrumbs and related navigation to category hubs
- document stable category URLs and centralize category metadata

## Validation
- independent validator: **98/100 - APPROVED**
- `pnpm --filter @agentskit/registry-app test` (32 tests)
- `pnpm --filter @agentskit/registry-app lint`
- `pnpm --filter @agentskit/registry-app build` (389 pages: 346 agents + 23 categories)
- pre-push quality gates: 17/17
- pre-push monorepo tasks: 41/41
- browser QA at 1440px and 320px; no horizontal overflow or console errors

## Stack
- base: #1196
- follows #1195 and #1196