### PR TITLE
docs: guard private consumer confidentiality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ AgentsKit is the most complete agent toolkit for the JavaScript ecosystem — 14
 3. **Interop is mandatory.** Any combination of packages must compose.
 4. **Contracts are pinned to ADRs.** The six core contracts (Adapter, Tool, Memory, Retriever, Skill, Runtime) live in [`docs/architecture/adrs/`](./docs/architecture/adrs/). Changing a contract requires a new ADR + coordinated major bump of affected packages.
 5. **v1 stability promise.** Breaking changes to core require a major bump and a deprecation cycle of ≥ 1 minor release.
+6. **Private consumers are black-box evidence only.** Public issues, ADRs, RFCs, docs, tests, fixtures, and source must not expose private repository identifiers, implementation details, product flows, policies, data, topology, or business logic. Convert confidential observations into independently specified public requirements and synthetic fixtures. Follow [`docs/PRIVATE-CONSUMER-POLICY.md`](./docs/PRIVATE-CONSUMER-POLICY.md).
 
 ## Code conventions
 

--- a/docs/PRIVATE-CONSUMER-POLICY.md
+++ b/docs/PRIVATE-CONSUMER-POLICY.md
@@ -1,0 +1,43 @@
+# Private consumer confidentiality policy
+
+AgentsKit can learn from private consumers without publishing how those products work.
+
+## Allowed public evidence
+
+- independently written, product-neutral requirements;
+- published AgentsKit API analysis;
+- public provider documentation;
+- synthetic examples and fixtures;
+- compatibility, security, performance, and recovery criteria;
+- anonymized adoption outcomes with explicit publication approval.
+
+## Prohibited public evidence
+
+- private repository paths, symbols, schemas, prompts, source, or dependency names;
+- private issues, commits, screenshots, logs, telemetry, or fixtures;
+- descriptions of private flows, states, permissions, integrations, topology, or business rules;
+- copied or mechanically translated private code;
+- claims whose only support is confidential implementation knowledge.
+
+## Required workflow
+
+1. Review the private consumer in a confidential context.
+2. Restate the need as a product-neutral requirement without private identifiers.
+3. Verify whether a published AgentsKit contract already owns it.
+4. Write the public issue using only public sources and synthetic examples.
+5. Implement and test the public contract independently.
+6. Scan the diff and reachable Git history for private identifiers and derived details.
+7. Adopt the supported public release in the private consumer through a separately reviewed change.
+
+## Incident response
+
+If private detail reaches a public artifact:
+
+1. stop publication and remove active references;
+2. rewrite affected feature-branch refs where safe;
+3. inspect pull-request refs and direct object reachability;
+4. contact GitHub Support when server-side object or cache purge is required;
+5. audit related issues, comments, docs, fixtures, and generated artifacts;
+6. record only the remediation and generic guardrail publicly, never repeat the private content.
+
+History removal and provider-side purge are separate completion gates. A clean current diff alone does not close a disclosure incident.


### PR DESCRIPTION
## What changed

- add a mandatory black-box rule for private-consumer evidence to `AGENTS.md`
- document allowed and prohibited public evidence
- define an independent public-requirement and synthetic-fixture workflow
- define incident response for active refs, reachable history, and provider-side purge

## Why

Private dogfood should improve AgentsKit without publishing private implementation, product behavior, data, policy, topology, or business logic. The repository previously lacked an explicit publication guardrail for that boundary.

## Impact

Public capabilities must stand independently on public APIs, public provider documentation, and synthetic examples. Private consumer adoption remains a separate confidential change.

## Validation

- `git diff --check`
- Doc Bridge index and gate passed using the existing workspace runtime
- final diff scanned for private product identifiers

This PR intentionally does not delete historical documents because a public deletion diff would repeat their content. Historical remediation is tracked confidentially and requires coordinated history rewrite/provider purge.