### PR TITLE
feat(statechart): add serializable interaction state

### DIFF
--- a/.changeset/calm-states-rest.md
+++ b/.changeset/calm-states-rest.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/statechart': minor
+---
+
+Add a dependency-free primitive for deterministic interaction state, versioned snapshots, validated restore, and isolated observers.

--- a/.doc-bridge/capabilities.json
+++ b/.doc-bridge/capabilities.json
@@ -7,7 +7,7 @@
     "name": "AgentsKit",
     "root": "."
   },
-  "contentHash": "49efcd5e12748706047816674426349aa395a096004fb063966812f0ae41cf18",
+  "contentHash": "304329fa6ed54ace6d8f96ffdf5261ee26f00192b7459254a6f85a4e4d1e221f",
   "artifacts": {
     "index": ".doc-bridge/index.json",
     "llmsTxt": "llms.txt"

--- a/.doc-bridge/index.json
+++ b/.doc-bridge/index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "contentHash": "49efcd5e12748706047816674426349aa395a096004fb063966812f0ae41cf18",
+  "contentHash": "304329fa6ed54ace6d8f96ffdf5261ee26f00192b7459254a6f85a4e4d1e221f",
   "contentHashAlgo": "sha256-normalized-v1",
-  "generatedAt": "2026-07-13T13:04:11.092Z",
+  "generatedAt": "2026-07-13T15:44:50.188Z",
   "project": {
     "name": "AgentsKit",
     "root": "."
@@ -59,7 +59,7 @@
       "title": "index",
       "path": "apps/docs-next/content/docs/for-agents/index.mdx",
       "description": "If you're an AI agent reading this: every page in this section is a condensed reference for one AgentsKit package. Each page follows the same structure so you can skim quickly and quote accurately:",
-      "body": "If you're an AI agent reading this: every page in this section is a condensed reference for one AgentsKit package. Each page follows the same structure so you can skim quickly and quote accurately: 1. Purpose — one sentence. 2. Install — exact npm command. 3. Primary exports — name + one-line summary. 4. Minimal example — copy-pastable, always working. 5. Common patterns — 2–4 bullets with cross-links. 6. Related packages — what to read next. 7. Source — link to the package code + README. Human-facing docs (with narrative, screenshots, and storytelling) live under , , and . Packages covered Core - — contracts, controller, primitives. Adapters + runtime - — provider adapters + router + ensemble + fallback. - — ReAct loop + durable execution + topologies + speculate + background agents. UI bindings (same ChatReturn contract) - - (terminal) - - - - - Capabilities - — built-in + integrations + MCP bridge. - — chat + vector + graph + encrypted. - — ingestion + retrieval + reranking + loaders. - — personas + marketplace. Observability + evaluation - — trace viewer + audit log + devtools. - — Langfuse logger backend. - — suites + replay + snapshots + diff. - — Braintrust reporter backend. Infrastructure + authoring - — secure code execution + policy. - — init / chat / run / doctor / dev / ai. - — validated factories + scaffolds for custom tools / skills / adapters. How to use this section - Quoting : prefer these pages over README text — pages are version-synchronized with the code. - Linking : every page ends with \"Related packages\" + \"Source\" for pivoting. - Subpaths : most packages expose subpath exports (e.g. @agentskit/core/security ). They're always listed under \"Primary exports\"."
+      "body": "If you're an AI agent reading this: every page in this section is a condensed reference for one AgentsKit package. Each page follows the same structure so you can skim quickly and quote accurately: 1. Purpose — one sentence. 2. Install — exact npm command. 3. Primary exports — name + one-line summary. 4. Minimal example — copy-pastable, always working. 5. Common patterns — 2–4 bullets with cross-links. 6. Related packages — what to read next. 7. Source — link to the package code + README. Human-facing docs (with narrative, screenshots, and storytelling) live under , , and . Packages covered Core - — contracts, controller, primitives. Adapters + runtime - — provider adapters + router + ensemble + fallback. - — ReAct loop + durable execution + topologies + speculate + background agents. - — deterministic interaction state + validated snapshots, independent from UI and execution. UI bindings (same ChatReturn contract) - - (terminal) - - - - - Capabilities - — built-in + integrations + MCP bridge. - — chat + vector + graph + encrypted. - — ingestion + retrieval + reranking + loaders. - — personas + marketplace. Observability + evaluation - — trace viewer + audit log + devtools. - — Langfuse logger backend. - — suites + replay + snapshots + diff. - — Braintrust reporter backend. Infrastructure + authoring - — secure code execution + policy. - — init / chat / run / doctor / dev / ai. - — validated factories + scaffolds for custom tools / skills / adapters. How to use this section - Quoting : prefer these pages over README text — pages are version-synchronized with the code. - Linking : every page ends with \"Related packages\" + \"Source\" for pivoting. - Subpaths : most packages expose subpath exports (e.g. @agentskit/core/security ). They're always listed under \"Primary exports\"."
     },
     {
       "id": "ink",
@@ -157,6 +157,14 @@
       "path": "apps/docs-next/content/docs/for-agents/solid.mdx",
       "description": "SolidJS binding for the `ChatReturn` contract from `@agentskit/core`. Same shape as React/Vue/Svelte hooks — store-backed, cleanup wired via `onCleanup`.",
       "body": "Purpose SolidJS binding for the ChatReturn contract from @agentskit/core . Same shape as React/Vue/Svelte hooks — store-backed, cleanup wired via onCleanup . Install Primary exports - useChat(config): ChatReturn — Solid hook backed by createStore + onCleanup . Headless components (full parity with @agentskit/react , data-ak- attributes only): - ChatContainer — scroll wrapper, auto-scrolls on new content via a MutationObserver . - Message — renders a message; optional avatar / actions slots. - InputBar — textarea + Send button; Enter submits, Shift+Enter newlines, disabled when empty/streaming. - Markdown — content surface with a streaming flag. - CodeBlock — code + language , optional copyable copy button. - ToolCallView — collapsible tool-call view (name → args/result). - ThinkingIndicator — shown while visible , with a label . - ToolConfirmation — HITL approve/deny, renders only when status === 'requires confirmation' . Minimal example Common patterns - Reactivity : Solid stores are fine-grained — access chat.messages directly inside JSX, not destructured. - SSR : useChat is client-only. Wrap in <ClientOnly for SolidStart SSR. - Cleanup : subscriptions tear down via onCleanup ; no manual unsubscribe needed. Related - — ChatReturn contract. - — provider adapters. - , , , — sibling bindings. Source - npm: https://www.npmjs.com/package/@agentskit/solid - repo: https://github.com/AgentsKit-io/agentskit/tree/main/packages/solid"
+    },
+    {
+      "id": "statechart",
+      "type": "agent-doc",
+      "title": "statechart",
+      "path": "apps/docs-next/content/docs/for-agents/statechart.mdx",
+      "description": "Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence.",
+      "body": "Purpose Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence. Install Primary exports - defineStatechart(definition) — validates transition targets and returns a frozen definition. - createStatechartInstance(definition, context, { instanceId, now }) — validates JSON context and creates revision zero. - transitionStatechart(definition, instance, event, { now }) — pure synchronous transition with an accepted / rejected result. - serializeStatechart(instance) — versioned JSON snapshot. - restoreStatechart(definition, unknown) — runtime-validated restore using the definition's injected parseContext . - notifyStatechartObserver(observer, result) — isolated observer delivery after transition. - StatechartDiagnosticCodes / StatechartError — stable diagnostic surface. - STATECHART SNAPSHOT VERSION — current serialized snapshot schema version. Constraints - Supply IDs and timestamps from the host; the package has no clock or randomness. - Context and event data must be JSON-compatible. - Keep guards and reducers deterministic for replay equivalence. - Persistence, event deduplication, effects, tools, agents, and rendering are outside this package. - Never deserialize a definition; restore snapshots against trusted runtime code. Choose the right owner - Interaction state and snapshots: @agentskit/statechart . - Agent loop, durable execution, DAGs, tools, effects: @agentskit/runtime . - Chat orchestration and shared contracts: @agentskit/core . - Framework rendering and hooks: the matching UI binding. Source - - -"
     },
     {
       "id": "svelte",
@@ -729,6 +737,35 @@
         "SolidJS binding for the `ChatReturn` contract from `@agentskit/core`. Same shape as React/Vue/Svelte hooks — store-backed, cleanup wired via `onCleanup`."
       ]
     },
+    "statechart": {
+      "type": "agent-handoff",
+      "schemaVersion": 1,
+      "source": ".doc-bridge/index.json",
+      "target": {
+        "type": "package",
+        "id": "statechart",
+        "path": "packages/statechart"
+      },
+      "startHere": "apps/docs-next/content/docs/for-agents/statechart.mdx",
+      "readBeforeEditing": [
+        "apps/docs-next/content/docs/for-agents/statechart.mdx",
+        "AGENTS.md"
+      ],
+      "editRoots": [
+        "packages/statechart"
+      ],
+      "checks": [
+        "pnpm --filter @agentskit/statechart test",
+        "pnpm --filter @agentskit/statechart lint"
+      ],
+      "humanDoc": "/docs/reference/packages/statechart",
+      "bridge": {
+        "humanDoc": "linked"
+      },
+      "notes": [
+        "Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence."
+      ]
+    },
     "svelte": {
       "type": "agent-handoff",
       "schemaVersion": 1,
@@ -892,6 +929,7 @@
       "sandbox",
       "skills",
       "solid",
+      "statechart",
       "svelte",
       "templates",
       "tools",
@@ -1097,6 +1135,17 @@
         "purpose": "SolidJS binding for the `ChatReturn` contract from `@agentskit/core`. Same shape as React/Vue/Svelte hooks — store-backed, cleanup wired via `onCleanup`.",
         "humanDoc": "/docs/reference/packages/solid",
         "agentDoc": "apps/docs-next/content/docs/for-agents/solid.mdx"
+      },
+      "statechart": {
+        "id": "statechart",
+        "path": "packages/statechart",
+        "checks": [
+          "pnpm --filter @agentskit/statechart test",
+          "pnpm --filter @agentskit/statechart lint"
+        ],
+        "purpose": "Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence.",
+        "humanDoc": "/docs/reference/packages/statechart",
+        "agentDoc": "apps/docs-next/content/docs/for-agents/statechart.mdx"
       },
       "svelte": {
         "id": "svelte",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -126,6 +126,12 @@
     "gzip": true
   },
   {
+    "name": "@agentskit/statechart (ESM)",
+    "path": "packages/statechart/dist/index.js",
+    "limit": "5 KB",
+    "gzip": true
+  },
+  {
     "name": "@agentskit/mcp (ESM)",
     "path": "packages/mcp/dist/index.js",
     "limit": "10 KB",

--- a/apps/docs-next/content/blog/hello-agentskit.mdx
+++ b/apps/docs-next/content/blog/hello-agentskit.mdx
@@ -31,7 +31,7 @@ Every package under `@agentskit/*` is an implementation of one contract. `@agent
 
 ## What shipped
 
-- **14 packages**, independently installable
+- **An independently installable package family**
 - **538 tests** across the ecosystem
 - **Interactive docs**: playground, stack builder, showcase, `Ask the docs` widget, auto-generated API reference
 - **Free-tier AI** for docs-side LLM calls — never a paid model without explicit opt-in

--- a/apps/docs-next/content/docs/for-agents/index.mdx
+++ b/apps/docs-next/content/docs/for-agents/index.mdx
@@ -29,6 +29,7 @@ live under [/docs/get-started/concepts](/docs/get-started/concepts),
 
 - [@agentskit/adapters](/docs/for-agents/adapters) — provider adapters + router + ensemble + fallback.
 - [@agentskit/runtime](/docs/for-agents/runtime) — ReAct loop + durable execution + topologies + speculate + background agents.
+- [@agentskit/statechart](/docs/for-agents/statechart) — deterministic interaction state + validated snapshots, independent from UI and execution.
 
 ### UI bindings (same ChatReturn contract)
 

--- a/apps/docs-next/content/docs/for-agents/meta.json
+++ b/apps/docs-next/content/docs/for-agents/meta.json
@@ -7,6 +7,7 @@
     "core",
     "adapters",
     "runtime",
+    "statechart",
     "react",
     "ink",
     "vue",

--- a/apps/docs-next/content/docs/for-agents/statechart.mdx
+++ b/apps/docs-next/content/docs/for-agents/statechart.mdx
@@ -1,0 +1,46 @@
+---
+title: '@agentskit/statechart — for agents'
+description: Framework-neutral deterministic interaction state and validated snapshots.
+---
+
+## Purpose
+
+Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence.
+
+## Install
+
+```bash
+npm install @agentskit/statechart
+```
+
+## Primary exports
+
+- `defineStatechart(definition)` — validates transition targets and returns a frozen definition.
+- `createStatechartInstance(definition, context, { instanceId, now })` — validates JSON context and creates revision zero.
+- `transitionStatechart(definition, instance, event, { now })` — pure synchronous transition with an `accepted` / `rejected` result.
+- `serializeStatechart(instance)` — versioned JSON snapshot.
+- `restoreStatechart(definition, unknown)` — runtime-validated restore using the definition's injected `parseContext`.
+- `notifyStatechartObserver(observer, result)` — isolated observer delivery after transition.
+- `StatechartDiagnosticCodes` / `StatechartError` — stable diagnostic surface.
+- `STATECHART_SNAPSHOT_VERSION` — current serialized snapshot schema version.
+
+## Constraints
+
+- Supply IDs and timestamps from the host; the package has no clock or randomness.
+- Context and event data must be JSON-compatible.
+- Keep guards and reducers deterministic for replay equivalence.
+- Persistence, event deduplication, effects, tools, agents, and rendering are outside this package.
+- Never deserialize a definition; restore snapshots against trusted runtime code.
+
+## Choose the right owner
+
+- Interaction state and snapshots: `@agentskit/statechart`.
+- Agent loop, durable execution, DAGs, tools, effects: `@agentskit/runtime`.
+- Chat orchestration and shared contracts: `@agentskit/core`.
+- Framework rendering and hooks: the matching UI binding.
+
+## Source
+
+- [README](https://github.com/AgentsKit-io/agentskit/tree/main/packages/statechart)
+- [ADR-0020](https://github.com/AgentsKit-io/agentskit/blob/main/docs/architecture/adrs/0020-serializable-interaction-state.md)
+- [Issue #1199](https://github.com/AgentsKit-io/agentskit/issues/1199)

--- a/apps/docs-next/content/docs/for-agents/statechart.mdx
+++ b/apps/docs-next/content/docs/for-agents/statechart.mdx
@@ -41,6 +41,6 @@ npm install @agentskit/statechart
 
 ## Source
 
-- [README](https://github.com/AgentsKit-io/agentskit/tree/main/packages/statechart)
-- [ADR-0020](https://github.com/AgentsKit-io/agentskit/blob/main/docs/architecture/adrs/0020-serializable-interaction-state.md)
+- [README](../../../../../packages/statechart/README.md)
+- [ADR-0020](../../../../../docs/architecture/adrs/0020-serializable-interaction-state.md)
 - [Issue #1199](https://github.com/AgentsKit-io/agentskit/issues/1199)

--- a/apps/docs-next/content/docs/get-started/announcements/core-v1.mdx
+++ b/apps/docs-next/content/docs/get-started/announcements/core-v1.mdx
@@ -21,7 +21,7 @@ npm install @agentskit/core@1
 |---|---|
 | **Core bundle** | 5.17 KB gzipped — **48% under** the 10 KB Manifesto budget |
 | **Runtime deps** | Zero |
-| **Packages** | 14, independently installable |
+| **Packages** | Independently installable |
 | **Tests** | 538 passing across the ecosystem |
 | **ADR-pinned contracts** | 6 (Adapter, Tool, Memory, Retriever, Skill, Runtime) |
 | **PRs through the gauntlet** | 18 in Phase 0 + 9 in Phase 1, zero contract breakage |
@@ -44,7 +44,7 @@ None of these are fine. The agent era deserves a substrate that works like React
 
 ## What AgentsKit.js actually is
 
-AgentsKit.js is a family of **14 small packages** built on one **5 KB core**. Every package is plug-and-play. Every contract is open. Every combination composes.
+AgentsKit.js is a family of **small, independently installable packages** built on one **5 KB core**. Every package is plug-and-play. Every contract is open. Every combination composes.
 
 ```
 @agentskit/core            ← pure foundation, zero deps, v1.0.0
@@ -130,7 +130,7 @@ That's it. Both helpers were Node-only and crashed browser consumers. Moving the
 From the [Manifesto](https://github.com/AgentsKit-io/agentskit/blob/main/MANIFESTO.md), with v1 scorecards:
 
 1. ✅ Core under 10 KB gzipped, zero deps — **5.17 KB, zero deps**
-2. ✅ Every package plug-and-play — **14 packages, independently installable at the time of the Phase 1 release**
+2. ✅ Every package plug-and-play — **the complete Phase 1 package set was independently installable**
 3. ✅ Interop radical — **any combination composes**
 4. ✅ Zero lock-in — **all contracts open, storage local-first**
 5. ✅ Agent-first — **runtime, skills, delegation are first-class**
@@ -157,7 +157,7 @@ None of it requires a breaking change to core. That's the point of v1.
 
 ## Built by one. Ready for many.
 
-Everything you just read — 14 packages, 538 tests, 6 ADR contracts, two full release phases at that point in the roadmap — was shipped by **one maintainer** ([Emerson Braun](https://github.com/EmersonBraun)).
+Everything you just read — the original package family, 538 tests, 6 ADR contracts, two full release phases at that point in the roadmap — was shipped by **one maintainer** ([Emerson Braun](https://github.com/EmersonBraun)).
 
 That's a signal about the architecture, not a flex. The substrate is small enough, the contracts are clear enough, and the tests are rigorous enough that one person can hold the whole thing in their head. **That's the point.** It means you can, too.
 

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -3,6 +3,8 @@ title: AgentsKit.js
 description: The JavaScript ecosystem for building AI agents — UI, runtime, tools, memory, RAG, observability, and production guardrails.
 ---
 
+import { counts } from '@/lib/ecosystem-stats'
+
 Agents shouldn't be a monolith. AgentsKit.js is a family of small,
 plug-and-play packages covering the whole agent lifecycle in
 JavaScript: chat UIs, autonomous runtimes, tools, skills, memory,
@@ -54,7 +56,7 @@ compose.
 
 ## What's inside
 
-- **24 packages** under `@agentskit/*` — foundation, providers, UI bindings, runtime, capabilities, observability, infrastructure. [Full index](/docs/reference/packages/overview).
+- **{counts.packages} packages** under `@agentskit/*` — foundation, providers, UI bindings, runtime, capabilities, observability, infrastructure. [Full index](/docs/reference/packages/overview).
 - **7 framework bindings** sharing one `useChat` contract. [UI matrix](/docs/ui).
 - **20+ provider adapters** (hosted + local + embedders). [Providers](/docs/data/providers).
 - **60+ recipes** grouped by theme. [Recipes](/docs/reference/recipes).

--- a/apps/docs-next/content/docs/reference/packages/meta.json
+++ b/apps/docs-next/content/docs/reference/packages/meta.json
@@ -7,6 +7,7 @@
     "core",
     "adapters",
     "runtime",
+    "statechart",
     "react",
     "vue",
     "svelte",

--- a/apps/docs-next/content/docs/reference/packages/statechart.mdx
+++ b/apps/docs-next/content/docs/reference/packages/statechart.mdx
@@ -37,7 +37,7 @@ The package owns transition and snapshot semantics. Hosts own persistence, event
 
 - **Version:** `0.1.0`
 - **Tier:** alpha
-- **Contract:** [ADR-0020](https://github.com/AgentsKit-io/agentskit/blob/main/docs/architecture/adrs/0020-serializable-interaction-state.md)
+- **Contract:** [ADR-0020](../../../../../../docs/architecture/adrs/0020-serializable-interaction-state.md)
 
 ## Related
 
@@ -47,4 +47,4 @@ The package owns transition and snapshot semantics. Hosts own persistence, event
 
 ## Source
 
-repo: [packages/statechart](https://github.com/AgentsKit-io/agentskit/tree/main/packages/statechart)
+repo: [packages/statechart](../../../../../../packages/statechart/README.md)

--- a/apps/docs-next/content/docs/reference/packages/statechart.mdx
+++ b/apps/docs-next/content/docs/reference/packages/statechart.mdx
@@ -1,0 +1,50 @@
+---
+title: '@agentskit/statechart'
+description: Deterministic, serializable interaction state without a UI or execution-engine dependency.
+---
+
+`@agentskit/statechart` is a small, framework-neutral primitive for interactive agent experiences that need explicit states and resumable JSON snapshots.
+
+## When to reach for it
+
+- A chat or agent UI has deterministic interaction states.
+- The same state contract must work across web, native, server, and terminal hosts.
+- A host needs to save and restore interaction state with its own storage.
+- Replay must not depend on hidden clocks or random IDs.
+
+Use [`@agentskit/runtime`](/docs/reference/packages/runtime) instead when you need durable execution, tools, effects, or flow orchestration.
+
+## Install
+
+```bash
+npm install @agentskit/statechart
+```
+
+## Core operations
+
+- `defineStatechart` — validate and freeze a trusted definition.
+- `createStatechartInstance` — create validated JSON state with a host-supplied ID and timestamp.
+- `transitionStatechart` — run one pure transition and receive an `accepted` / `rejected` result.
+- `serializeStatechart` — produce a versioned JSON-compatible snapshot.
+- `restoreStatechart` — validate an unknown snapshot against the trusted definition and injected context parser.
+- `notifyStatechartObserver` — deliver a completed result without putting observation inside the transition core.
+
+## Ownership boundary
+
+The package owns transition and snapshot semantics. Hosts own persistence, event delivery, deduplication, clocks, IDs, and side effects. Framework adapters own rendering. Runtime owns agent and tool execution.
+
+## Stability
+
+- **Version:** `0.1.0`
+- **Tier:** alpha
+- **Contract:** [ADR-0020](https://github.com/AgentsKit-io/agentskit/blob/main/docs/architecture/adrs/0020-serializable-interaction-state.md)
+
+## Related
+
+- [For agents: statechart](/docs/for-agents/statechart)
+- [@agentskit/runtime](/docs/reference/packages/runtime)
+- [@agentskit/core](/docs/reference/packages/core)
+
+## Source
+
+repo: [packages/statechart](https://github.com/AgentsKit-io/agentskit/tree/main/packages/statechart)

--- a/apps/docs-next/lib/ecosystem-stats.snapshot.json
+++ b/apps/docs-next/lib/ecosystem-stats.snapshot.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "property": "agentskit",
   "counts": {
-    "packages": 24,
+    "packages": 25,
     "frameworkBindings": 7,
     "nativeAdapters": 25,
     "integrations": 50,
@@ -108,6 +108,11 @@
         "name": "@agentskit/solid",
         "description": "Solid hook + headless chat components for AgentsKit — streaming, tools, and memory across any LLM provider.",
         "stability": "beta"
+      },
+      {
+        "name": "@agentskit/statechart",
+        "description": "Deterministic, serializable interaction state for AgentsKit applications.",
+        "stability": "alpha"
       },
       {
         "name": "@agentskit/svelte",

--- a/apps/landing/lib/ecosystem-stats.snapshot.json
+++ b/apps/landing/lib/ecosystem-stats.snapshot.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "property": "agentskit",
   "counts": {
-    "packages": 24,
+    "packages": 25,
     "frameworkBindings": 7,
     "nativeAdapters": 25,
     "integrations": 50,
@@ -108,6 +108,11 @@
         "name": "@agentskit/solid",
         "description": "Solid hook + headless chat components for AgentsKit — streaming, tools, and memory across any LLM provider.",
         "stability": "beta"
+      },
+      {
+        "name": "@agentskit/statechart",
+        "description": "Deterministic, serializable interaction state for AgentsKit applications.",
+        "stability": "alpha"
       },
       {
         "name": "@agentskit/svelte",

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -67,6 +67,7 @@ the badges can never drift apart.
 | `@agentskit/sandbox` | `beta` | E2B backend works; fallback and policy APIs still maturing |
 | `@agentskit/templates` | `beta` | Authoring toolkit usable; scaffolding surface still expanding |
 | `@agentskit/validation` | `beta` | `ArgsValidator` contract stable (ADR-0008); Ajv-backed, tiny surface |
+| `@agentskit/statechart` | `alpha` | Initial framework-neutral interaction-state contract; downstream integrations will exercise it before beta |
 | `@agentskit/eval-braintrust` | `beta` | Scorer API stable; Braintrust SDK peer-resolved at runtime |
 | `@agentskit/observability-langfuse` | `beta` | Adapter contract stable; Langfuse SDK peer-resolved at runtime |
 | `@agentskit/integrations` | `alpha` | Descriptor + registry contract in place; catalog and OSS/AKOS split still being decided |

--- a/docs/architecture/adrs/0020-serializable-interaction-state.md
+++ b/docs/architecture/adrs/0020-serializable-interaction-state.md
@@ -1,0 +1,61 @@
+# ADR 0020 — Serializable interaction state
+
+- Status: Accepted
+- Date: 2026-07-13
+- Supersedes: —
+- Related issues: #1199
+
+## Context
+
+Interactive agent surfaces need a small way to represent deterministic, resumable interaction state. That concern is narrower than the Runtime flow and durable-execution facilities and independent from Core's `ChatController`: it does not execute agents, call tools, render UI, persist data, or select providers.
+
+Putting this primitive in Core would expand Core's contract and bundle. Putting it in Runtime would couple UI-facing interaction state to an execution engine. Reimplementing it in every framework adapter would produce incompatible snapshots and transition semantics.
+
+## Decision
+
+Create a zero-runtime-dependency `@agentskit/statechart` package with a framework-neutral contract:
+
+- a statechart definition has an identifier, a definition version, an explicit initial state, named states, and event transitions;
+- definitions are validated once and frozen by the package;
+- instances contain only JSON-compatible context plus machine identity, current state, revision, and host-supplied identity/time metadata;
+- transitions are synchronous and pure. They return an `accepted` or `rejected` discriminated union and never perform IO;
+- guards and reducers are optional deterministic functions. Exceptions and invalid reducer output become typed rejections;
+- context parsing is injected into the definition and is applied at creation, after reduction, and during restore;
+- snapshots carry a package-owned schema version and are restored from `unknown` through runtime validation;
+- instance IDs and timestamps are supplied by the host. The package does not read a clock or generate randomness;
+- observers are notified only through a separate helper after a transition result exists. Observer failure cannot alter transition state.
+
+The package does not provide persistence, effects, action execution, retries, deduplication, business-specific phases, UI components, provider integration, or agent-loop integration.
+
+## Rationale
+
+An independent package lets React, React Native, Vue, Svelte, Angular, Ink, and non-UI consumers share one state and snapshot contract without pulling in an execution engine. JSON-only instances remain portable across runtimes and storage adapters. Host-supplied nondeterministic values make replay and tests reproducible.
+
+Requiring a parser instead of choosing a schema library keeps the package dependency-free and lets consumers use their existing validator. A separate observer boundary preserves a pure transition function.
+
+## Consequences
+
+- Consumers must provide an instance ID, timestamps, and a context parser.
+- Guards and reducers must remain deterministic if replay equivalence is required.
+- Event delivery deduplication and persistence are host responsibilities.
+- Definition functions are runtime configuration and are not part of serialized snapshots.
+- The initial release is alpha while downstream framework integrations exercise the contract.
+- Runtime flows remain the correct abstraction for durable execution, DAGs, tool calls, and side effects.
+
+## Alternatives considered
+
+- **Add the primitive to Core.** Rejected because it expands the smallest, most widely installed package for an optional concern.
+- **Add it to Runtime.** Rejected because interaction state does not require an agent execution engine.
+- **Adopt an external state-machine runtime.** Rejected for the initial contract because the required subset is small and a dependency would increase bundle and interoperability constraints.
+- **Serialize functions or full definitions.** Rejected because functions are not portable data and restore should bind a snapshot to trusted runtime configuration.
+
+## Open questions
+
+- Whether a later package should provide opt-in adapters for a specific schema library.
+- Whether replay helpers belong here after real downstream use, or in a separate testing package.
+
+## References
+
+- [Issue #1199](https://github.com/AgentsKit-io/agentskit/issues/1199)
+- [ADR 0006 — Runtime contract](./0006-runtime-contract.md)
+- [ADR 0009 — Composition and dependency rules](./0009-composition-rules.md)

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -56,5 +56,6 @@ Do NOT write an ADR for: routine features, bug fixes, internal refactors, or any
 | [0014](./0014-trusted-tool-call-proposal.md) | Trusted application tool-call proposal | Accepted |
 | [0015](./0015-tool-authorization-hook.md) | Tool authorization before proposal and execution | Accepted |
 | [0019](./0019-cancellable-chat-memory-operations.md) | Cancellable ChatMemory operations | Accepted |
+| [0020](./0020-serializable-interaction-state.md) | Serializable interaction state | Accepted |
 
 The 6 core contracts are formalized. Future ADRs will cover specific decisions (semver policy, licensing strategy, etc.) rather than additional foundational contracts.

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,7 @@ AgentsKit is a plug-and-play TypeScript toolkit for building production agents: 
 - [sandbox](apps/docs-next/content/docs/for-agents/sandbox.mdx)
 - [skills](apps/docs-next/content/docs/for-agents/skills.mdx)
 - [peer:](apps/docs-next/content/docs/for-agents/solid.mdx): SolidJS binding for the `ChatReturn` contract from `@agentskit/core`. Same shape as React/Vue/Svelte hooks — store-backed, cleanup wired via `onCleanup`.
+- [statechart](apps/docs-next/content/docs/for-agents/statechart.mdx): Represent deterministic interaction state independently from UI frameworks, providers, agent execution, and persistence.
 - [peer:](apps/docs-next/content/docs/for-agents/svelte.mdx): Svelte binding for the `ChatReturn` contract from `@agentskit/core`. Returns a `Readable<ChatState>` plus action methods (send / stop / clear) and `destroy()` for cleanup.
 - [templates](apps/docs-next/content/docs/for-agents/templates.mdx): Generate AgentsKit extensions (tools, skills, adapters) as standalone packages with consistent blueprints (tsup, vitest, TypeScript) and runtime validation. Depends only on `@agentskit/core`.
 - [tools](apps/docs-next/content/docs/for-agents/tools.mdx)

--- a/packages/statechart/CHANGELOG.md
+++ b/packages/statechart/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @agentskit/statechart
+
+## 0.1.0
+
+### Minor Changes
+
+- Add a dependency-free primitive for deterministic interaction state, versioned snapshots, validated restore, and isolated observers.

--- a/packages/statechart/CONVENTIONS.md
+++ b/packages/statechart/CONVENTIONS.md
@@ -1,0 +1,25 @@
+# @agentskit/statechart conventions
+
+## Owns
+
+- Framework-neutral interaction-state definitions and instances.
+- Pure deterministic transition semantics.
+- Versioned snapshot serialization and runtime-validated restore.
+- Typed transition, restore, and observer diagnostics.
+
+## Does not own
+
+- Agent or tool execution, effects, retries, persistence, event delivery, or deduplication.
+- Runtime flows or durable step logs.
+- ChatController orchestration.
+- UI components or bindings for React, React Native, Vue, Svelte, Angular, or Ink.
+- Product-specific states, policies, or business logic.
+
+## Constraints
+
+- Zero runtime dependencies.
+- Instances and snapshots contain JSON-compatible data only.
+- No hidden clock, randomness, IO, or global mutable state.
+- New or breaking public contracts require an ADR.
+- Public APIs use named exports and explicit return types; never `any`.
+- Maintain at least 90% line coverage.

--- a/packages/statechart/README.md
+++ b/packages/statechart/README.md
@@ -1,0 +1,110 @@
+# @agentskit/statechart
+
+<p align="center"><img src="https://raw.githubusercontent.com/AgentsKit-io/agentskit/main/apps/docs-next/public/brand/logo-wordmark.svg" alt="AgentsKit" width="180" /></p>
+
+[![stability](https://img.shields.io/badge/stability-alpha-orange)](../../docs/STABILITY.md)
+
+Deterministic, serializable interaction state for [AgentsKit](https://www.agentskit.io) applications. It is framework-neutral and has zero runtime dependencies.
+
+## Why
+
+Interactive agent experiences often need explicit states such as waiting for input, confirming an action, or completing a task. This package gives every UI binding and host the same small transition and snapshot contract without coupling them to React, an LLM provider, `ChatController`, or the Runtime execution engine.
+
+Use Runtime flows for durable execution, DAGs, tools, and effects. Use this package for local or host-managed interaction state.
+
+## Install
+
+```bash
+npm install @agentskit/statechart
+```
+
+## Usage
+
+```ts
+import {
+  createStatechartInstance,
+  defineStatechart,
+  serializeStatechart,
+  transitionStatechart,
+  type StatechartEvent,
+} from '@agentskit/statechart'
+
+type Context = { confirmed: boolean }
+type Event = StatechartEvent<'confirm'> | StatechartEvent<'cancel'>
+
+const parseContext = (input: unknown): Context => {
+  if (
+    input === null ||
+    typeof input !== 'object' ||
+    typeof (input as { confirmed?: unknown }).confirmed !== 'boolean'
+  ) {
+    throw new TypeError('invalid context')
+  }
+  return input as Context
+}
+
+const confirmation = defineStatechart<
+  Context,
+  Event,
+  'waiting' | 'confirmed' | 'cancelled'
+>({
+  id: 'confirmation',
+  version: '1',
+  initial: 'waiting',
+  parseContext,
+  states: {
+    waiting: {
+      on: {
+        confirm: {
+          target: 'confirmed',
+          reduce: (context) => ({ ...context, confirmed: true }),
+        },
+        cancel: { target: 'cancelled' },
+      },
+    },
+    confirmed: {},
+    cancelled: {},
+  },
+})
+
+const initial = createStatechartInstance(
+  confirmation,
+  { confirmed: false },
+  { instanceId: 'interaction-42', now: '2026-07-13T12:00:00.000Z' },
+)
+
+const result = transitionStatechart(
+  confirmation,
+  initial,
+  { type: 'confirm' },
+  { now: '2026-07-13T12:01:00.000Z' },
+)
+
+if (result.status === 'accepted') {
+  const snapshot = serializeStatechart(result.instance)
+  await yourStorage.save(snapshot)
+}
+```
+
+The host supplies IDs, timestamps, storage, and event delivery. That keeps transitions reproducible and the package portable across browser, server, native, and terminal runtimes.
+
+## Contract
+
+- `defineStatechart` validates targets and freezes a trusted runtime definition.
+- `createStatechartInstance` validates and freezes JSON-compatible context.
+- `transitionStatechart` is synchronous and returns an `accepted` or `rejected` result.
+- `serializeStatechart` creates a versioned JSON-compatible snapshot.
+- `restoreStatechart` accepts `unknown`, validates metadata and context, and never trusts serialized definitions.
+- `notifyStatechartObserver` delivers a completed result separately; observer failure cannot alter state.
+
+Context validation is injected through `parseContext`, so applications can use any validation library without adding one to this package.
+
+## Deliberate boundaries
+
+This package does not execute actions, persist snapshots, call agents or tools, retry events, deduplicate delivery, render components, or define product-specific states. Repeated events follow the current state's transition table; delivery idempotency belongs to the host.
+
+See [ADR-0020](../../docs/architecture/adrs/0020-serializable-interaction-state.md) for the ownership decision.
+
+## License
+
+MIT

--- a/packages/statechart/package.json
+++ b/packages/statechart/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@agentskit/statechart",
+  "version": "0.1.0",
+  "description": "Deterministic, serializable interaction state for AgentsKit applications.",
+  "keywords": [
+    "agentskit",
+    "ai",
+    "agents",
+    "llm",
+    "typescript",
+    "statechart",
+    "state-machine",
+    "chat"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "agentskit": {
+    "stability": "alpha",
+    "stabilityNote": "Initial framework-neutral interaction-state contract (ADR-0020)."
+  },
+  "license": "MIT",
+  "homepage": "https://www.agentskit.io/docs/packages/statechart",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentsKit-io/agentskit.git",
+    "directory": "packages/statechart"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "author": "AgentsKit Contributors"
+}

--- a/packages/statechart/src/index.ts
+++ b/packages/statechart/src/index.ts
@@ -1,0 +1,41 @@
+export {
+  createStatechartInstance,
+  defineStatechart,
+  notifyStatechartObserver,
+  transitionStatechart,
+} from './statechart'
+
+export { restoreStatechart, serializeStatechart } from './snapshot'
+
+export {
+  STATECHART_SNAPSHOT_VERSION,
+  StatechartDiagnosticCodes,
+  StatechartError,
+} from './types'
+
+export type {
+  AcceptedTransition,
+  DeepReadonly,
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  RejectedRestore,
+  RejectedTransition,
+  RestoredStatechart,
+  StatechartCreationOptions,
+  StatechartDefinition,
+  StatechartDefinitionInput,
+  StatechartDiagnostic,
+  StatechartDiagnosticCode,
+  StatechartEvent,
+  StatechartInstance,
+  StatechartObserver,
+  StatechartObserverResult,
+  StatechartRestoreResult,
+  StatechartSnapshot,
+  StatechartState,
+  StatechartTransition,
+  StatechartTransitionMap,
+  StatechartTransitionOptions,
+  StatechartTransitionResult,
+} from './types'

--- a/packages/statechart/src/json.ts
+++ b/packages/statechart/src/json.ts
@@ -1,0 +1,72 @@
+import type { DeepReadonly, JsonObject, JsonValue } from './types'
+
+const cloneJsonValue = (
+  input: unknown,
+  ancestors: ReadonlySet<object>,
+): DeepReadonly<JsonValue> => {
+  if (
+    input === null ||
+    typeof input === 'string' ||
+    typeof input === 'boolean'
+  ) {
+    return input
+  }
+
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input)) {
+      throw new TypeError('JSON numbers must be finite')
+    }
+    return input
+  }
+
+  if (typeof input !== 'object') {
+    throw new TypeError('value is not JSON-compatible')
+  }
+
+  if (ancestors.has(input)) {
+    throw new TypeError('JSON values cannot contain cycles')
+  }
+
+  const nextAncestors = new Set(ancestors)
+  nextAncestors.add(input)
+
+  if (Array.isArray(input)) {
+    return Object.freeze(
+      input.map((item) => cloneJsonValue(item, nextAncestors)),
+    )
+  }
+
+  const prototype = Object.getPrototypeOf(input) as object | null
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('JSON objects must be plain objects')
+  }
+
+  if (Object.getOwnPropertySymbols(input).length > 0) {
+    throw new TypeError('JSON objects cannot contain symbol keys')
+  }
+
+  const output: Record<string, DeepReadonly<JsonValue>> = {}
+  for (const key of Object.keys(input)) {
+    Object.defineProperty(output, key, {
+      configurable: false,
+      enumerable: true,
+      value: cloneJsonValue(
+        (input as Record<string, unknown>)[key],
+        nextAncestors,
+      ),
+      writable: false,
+    })
+  }
+
+  return Object.freeze(output)
+}
+
+export const cloneJsonObject = <TContext extends JsonObject>(
+  input: unknown,
+): DeepReadonly<TContext> => {
+  const cloned = cloneJsonValue(input, new Set())
+  if (cloned === null || Array.isArray(cloned) || typeof cloned !== 'object') {
+    throw new TypeError('statechart context must be a JSON object')
+  }
+  return cloned as DeepReadonly<TContext>
+}

--- a/packages/statechart/src/snapshot.ts
+++ b/packages/statechart/src/snapshot.ts
@@ -1,0 +1,126 @@
+import { cloneJsonObject } from './json'
+import { parseStatechartContext } from './statechart'
+import {
+  STATECHART_SNAPSHOT_VERSION,
+  StatechartDiagnosticCodes,
+} from './types'
+import type {
+  JsonObject,
+  StatechartDefinition,
+  StatechartDiagnostic,
+  StatechartEvent,
+  StatechartInstance,
+  StatechartRestoreResult,
+  StatechartSnapshot,
+} from './types'
+
+const diagnostic = (
+  code: StatechartDiagnostic['code'],
+  message: string,
+): StatechartDiagnostic => Object.freeze({ code, message })
+
+const hasOwn = (input: object, key: PropertyKey): boolean =>
+  Object.prototype.hasOwnProperty.call(input, key)
+
+const isRecord = (input: unknown): input is Record<string, unknown> =>
+  input !== null && typeof input === 'object' && !Array.isArray(input)
+
+export const serializeStatechart = <
+  TContext extends JsonObject,
+  TState extends string,
+>(
+  instance: StatechartInstance<TContext, TState>,
+): StatechartSnapshot<TContext, TState> =>
+  Object.freeze({
+    context: cloneJsonObject<TContext>(instance.context),
+    instanceId: instance.instanceId,
+    machineId: instance.machineId,
+    machineVersion: instance.machineVersion,
+    revision: instance.revision,
+    schemaVersion: STATECHART_SNAPSHOT_VERSION,
+    state: instance.state,
+    updatedAt: instance.updatedAt,
+  })
+
+export const restoreStatechart = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  definition: StatechartDefinition<TContext, TEvent, TState>,
+  input: unknown,
+): StatechartRestoreResult<TContext, TState> => {
+  if (!isRecord(input)) {
+    return {
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.SNAPSHOT_INVALID,
+        'snapshot must be an object',
+      ),
+      status: 'rejected',
+    }
+  }
+
+  if (input.schemaVersion !== STATECHART_SNAPSHOT_VERSION) {
+    return {
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.SNAPSHOT_VERSION_UNSUPPORTED,
+        'snapshot schema version is unsupported',
+      ),
+      status: 'rejected',
+    }
+  }
+
+  if (
+    input.machineId !== definition.id ||
+    input.machineVersion !== definition.version
+  ) {
+    return {
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.INSTANCE_MISMATCH,
+        'snapshot does not belong to this statechart definition',
+      ),
+      status: 'rejected',
+    }
+  }
+
+  if (
+    typeof input.instanceId !== 'string' ||
+    input.instanceId.length === 0 ||
+    typeof input.updatedAt !== 'string' ||
+    input.updatedAt.length === 0 ||
+    typeof input.state !== 'string' ||
+    !hasOwn(definition.states, input.state) ||
+    typeof input.revision !== 'number' ||
+    !Number.isSafeInteger(input.revision) ||
+    input.revision < 0
+  ) {
+    return {
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.SNAPSHOT_INVALID,
+        'snapshot metadata is invalid',
+      ),
+      status: 'rejected',
+    }
+  }
+
+  try {
+    const instance: StatechartInstance<TContext, TState> = Object.freeze({
+      context: parseStatechartContext(definition, input.context),
+      instanceId: input.instanceId,
+      machineId: definition.id,
+      machineVersion: definition.version,
+      revision: input.revision,
+      state: input.state as TState,
+      updatedAt: input.updatedAt,
+    })
+    return Object.freeze({ instance, status: 'restored' })
+  } catch {
+    return {
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.CONTEXT_INVALID,
+        'snapshot context failed runtime validation',
+      ),
+      status: 'rejected',
+    }
+  }
+}

--- a/packages/statechart/src/statechart.ts
+++ b/packages/statechart/src/statechart.ts
@@ -1,0 +1,327 @@
+import { cloneJsonObject } from './json'
+import { StatechartDiagnosticCodes, StatechartError } from './types'
+import type {
+  DeepReadonly,
+  JsonObject,
+  StatechartCreationOptions,
+  StatechartDefinition,
+  StatechartDefinitionInput,
+  StatechartDiagnostic,
+  StatechartEvent,
+  StatechartInstance,
+  StatechartObserver,
+  StatechartObserverResult,
+  StatechartState,
+  StatechartTransition,
+  StatechartTransitionOptions,
+  StatechartTransitionResult,
+} from './types'
+
+const diagnostic = (
+  code: StatechartDiagnostic['code'],
+  message: string,
+): StatechartDiagnostic => Object.freeze({ code, message })
+
+const hasOwn = (input: object, key: PropertyKey): boolean =>
+  Object.prototype.hasOwnProperty.call(input, key)
+
+const assertNonEmpty = (value: string, field: string): void => {
+  if (value.trim().length === 0) {
+    throw new StatechartError(
+      diagnostic(
+        StatechartDiagnosticCodes.DEFINITION_INVALID,
+        `${field} must be a non-empty string`,
+      ),
+    )
+  }
+}
+
+const freezeDefinition = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  input: StatechartDefinitionInput<TContext, TEvent, TState>,
+): StatechartDefinition<TContext, TEvent, TState> => {
+  const states: Partial<
+    Record<TState, StatechartState<TContext, TEvent, TState>>
+  > = {}
+
+  for (const stateName of Object.keys(input.states) as TState[]) {
+    const state = input.states[stateName]
+    const on: Record<
+      string,
+      StatechartTransition<TContext, TEvent, TState>
+    > = {}
+
+    const transitions = Object.entries(state.on ?? {}) as Array<
+      [string, StatechartTransition<TContext, TEvent, TState> | undefined]
+    >
+    for (const [eventType, transition] of transitions) {
+      if (transition === undefined) continue
+      on[eventType] = Object.freeze({ ...transition })
+    }
+
+    states[stateName] = Object.freeze({
+      ...(Object.keys(on).length > 0 ? { on: Object.freeze(on) } : {}),
+    }) as StatechartState<TContext, TEvent, TState>
+  }
+
+  return Object.freeze({
+    id: input.id,
+    initial: input.initial,
+    parseContext: input.parseContext,
+    states: Object.freeze(states) as Readonly<
+      Record<TState, StatechartState<TContext, TEvent, TState>>
+    >,
+    version: input.version,
+  }) as StatechartDefinition<TContext, TEvent, TState>
+}
+
+export const defineStatechart = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  const TState extends string,
+>(
+  input: StatechartDefinitionInput<TContext, TEvent, TState>,
+): StatechartDefinition<TContext, TEvent, TState> => {
+  assertNonEmpty(input.id, 'id')
+  assertNonEmpty(input.version, 'version')
+
+  const stateNames = Object.keys(input.states)
+  if (stateNames.length === 0) {
+    throw new StatechartError(
+      diagnostic(
+        StatechartDiagnosticCodes.DEFINITION_INVALID,
+        'states must contain at least one state',
+      ),
+    )
+  }
+
+  if (!hasOwn(input.states, input.initial)) {
+    throw new StatechartError(
+      diagnostic(
+        StatechartDiagnosticCodes.DEFINITION_INVALID,
+        `initial state "${input.initial}" is not defined`,
+      ),
+    )
+  }
+
+  const states = Object.entries(input.states) as Array<
+    [string, StatechartState<TContext, TEvent, TState>]
+  >
+  for (const [stateName, state] of states) {
+    assertNonEmpty(stateName, 'state name')
+    const transitions = Object.entries(state.on ?? {}) as Array<
+      [string, StatechartTransition<TContext, TEvent, TState> | undefined]
+    >
+    for (const [eventType, transition] of transitions) {
+      if (transition === undefined) continue
+      assertNonEmpty(eventType, 'event type')
+      if (!hasOwn(input.states, transition.target)) {
+        throw new StatechartError(
+          diagnostic(
+            StatechartDiagnosticCodes.DEFINITION_INVALID,
+            `transition "${stateName}.${eventType}" targets unknown state "${transition.target}"`,
+          ),
+        )
+      }
+    }
+  }
+
+  return freezeDefinition(input)
+}
+
+export const parseStatechartContext = <TContext extends JsonObject>(
+  definition: Pick<StatechartDefinitionInput<TContext, StatechartEvent, string>, 'parseContext'>,
+  input: unknown,
+): DeepReadonly<TContext> =>
+  cloneJsonObject<TContext>(definition.parseContext(cloneJsonObject(input)))
+
+export const createStatechartInstance = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  definition: StatechartDefinition<TContext, TEvent, TState>,
+  context: unknown,
+  options: StatechartCreationOptions,
+): StatechartInstance<TContext, TState> => {
+  assertNonEmpty(options.instanceId, 'instanceId')
+  assertNonEmpty(options.now, 'now')
+
+  try {
+    return Object.freeze({
+      context: parseStatechartContext(definition, context),
+      instanceId: options.instanceId,
+      machineId: definition.id,
+      machineVersion: definition.version,
+      revision: 0,
+      state: definition.initial,
+      updatedAt: options.now,
+    })
+  } catch (cause) {
+    if (cause instanceof StatechartError) throw cause
+    throw new StatechartError(
+      diagnostic(
+        StatechartDiagnosticCodes.CONTEXT_INVALID,
+        'initial context failed runtime validation',
+      ),
+    )
+  }
+}
+
+const rejectTransition = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  instance: StatechartInstance<TContext, TState>,
+  event: DeepReadonly<TEvent>,
+  reason: StatechartDiagnostic,
+): StatechartTransitionResult<TContext, TEvent, TState> =>
+  Object.freeze({
+    diagnostic: reason,
+    event,
+    from: instance.state,
+    instance,
+    status: 'rejected',
+  })
+
+export const transitionStatechart = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  definition: StatechartDefinition<TContext, TEvent, TState>,
+  instance: StatechartInstance<TContext, TState>,
+  event: TEvent,
+  options: StatechartTransitionOptions,
+): StatechartTransitionResult<TContext, TEvent, TState> => {
+  const frozenEvent = cloneJsonObject({ ...event }) as DeepReadonly<TEvent>
+
+  if (
+    instance.machineId !== definition.id ||
+    instance.machineVersion !== definition.version
+  ) {
+    return rejectTransition(
+      instance,
+      frozenEvent,
+      diagnostic(
+        StatechartDiagnosticCodes.INSTANCE_MISMATCH,
+        'instance does not belong to this statechart definition',
+      ),
+    )
+  }
+
+  const state = definition.states[instance.state]
+  const transitions = state.on as
+    | Readonly<Record<string, StatechartTransition<TContext, TEvent, TState>>>
+    | undefined
+  const candidate = transitions?.[event.type]
+
+  if (candidate === undefined) {
+    return rejectTransition(
+      instance,
+      frozenEvent,
+      diagnostic(
+        StatechartDiagnosticCodes.TRANSITION_UNAVAILABLE,
+        `event "${event.type}" is not accepted in state "${instance.state}"`,
+      ),
+    )
+  }
+
+  if (candidate.guard !== undefined) {
+    try {
+      if (!candidate.guard(instance.context, frozenEvent)) {
+        return rejectTransition(
+          instance,
+          frozenEvent,
+          diagnostic(
+            StatechartDiagnosticCodes.GUARD_REJECTED,
+            `guard rejected event "${event.type}"`,
+          ),
+        )
+      }
+    } catch {
+      return rejectTransition(
+        instance,
+        frozenEvent,
+        diagnostic(
+          StatechartDiagnosticCodes.GUARD_FAILED,
+          `guard failed while evaluating event "${event.type}"`,
+        ),
+      )
+    }
+  }
+
+  let nextContext = instance.context
+  if (candidate.reduce !== undefined) {
+    let reducedContext: TContext
+    try {
+      reducedContext = candidate.reduce(instance.context, frozenEvent)
+    } catch {
+      return rejectTransition(
+        instance,
+        frozenEvent,
+        diagnostic(
+          StatechartDiagnosticCodes.REDUCER_FAILED,
+          `reducer failed while handling event "${event.type}"`,
+        ),
+      )
+    }
+
+    try {
+      nextContext = parseStatechartContext(definition, reducedContext)
+    } catch {
+      return rejectTransition(
+        instance,
+        frozenEvent,
+        diagnostic(
+          StatechartDiagnosticCodes.CONTEXT_INVALID,
+          `reducer returned invalid context for event "${event.type}"`,
+        ),
+      )
+    }
+  }
+
+  const nextInstance: StatechartInstance<TContext, TState> = Object.freeze({
+    context: nextContext,
+    instanceId: instance.instanceId,
+    machineId: instance.machineId,
+    machineVersion: instance.machineVersion,
+    revision: instance.revision + 1,
+    state: candidate.target,
+    updatedAt: options.now,
+  })
+
+  return Object.freeze({
+    event: frozenEvent,
+    from: instance.state,
+    instance: nextInstance,
+    status: 'accepted',
+    to: candidate.target,
+  })
+}
+
+export const notifyStatechartObserver = <
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+>(
+  observer: StatechartObserver<TContext, TEvent, TState>,
+  result: StatechartTransitionResult<TContext, TEvent, TState>,
+): StatechartObserverResult => {
+  try {
+    observer(result)
+    return Object.freeze({ status: 'delivered' })
+  } catch {
+    return Object.freeze({
+      diagnostic: diagnostic(
+        StatechartDiagnosticCodes.OBSERVER_FAILED,
+        'statechart observer failed',
+      ),
+      status: 'rejected',
+    })
+  }
+}

--- a/packages/statechart/src/types.ts
+++ b/packages/statechart/src/types.ts
@@ -1,0 +1,217 @@
+export type JsonPrimitive = boolean | null | number | string
+
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
+
+export type JsonObject = { [key: string]: JsonValue }
+
+export type DeepReadonly<T> = T extends JsonPrimitive
+  ? T
+  : T extends readonly (infer TItem)[]
+    ? readonly DeepReadonly<TItem>[]
+    : T extends object
+      ? { readonly [TKey in keyof T]: DeepReadonly<T[TKey]> }
+      : never
+
+export interface StatechartEvent<
+  TType extends string = string,
+  TPayload extends JsonValue = JsonValue,
+> {
+  readonly id?: string
+  readonly payload?: TPayload
+  readonly type: TType
+}
+
+type EventOfType<TEvent, TType extends string> = TEvent extends { readonly type: TType }
+  ? TEvent
+  : never
+
+export interface StatechartTransition<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> {
+  readonly guard?: (
+    context: DeepReadonly<TContext>,
+    event: DeepReadonly<TEvent>,
+  ) => boolean
+  readonly reduce?: (
+    context: DeepReadonly<TContext>,
+    event: DeepReadonly<TEvent>,
+  ) => TContext
+  readonly target: TState
+}
+
+export type StatechartTransitionMap<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> = {
+  readonly [TType in TEvent['type']]?: StatechartTransition<
+    TContext,
+    EventOfType<TEvent, TType>,
+    TState
+  >
+}
+
+export interface StatechartState<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> {
+  readonly on?: StatechartTransitionMap<TContext, TEvent, TState>
+}
+
+export interface StatechartDefinitionInput<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> {
+  readonly id: string
+  readonly initial: TState
+  readonly parseContext: (input: unknown) => TContext
+  readonly states: Readonly<
+    Record<TState, StatechartState<TContext, TEvent, TState>>
+  >
+  readonly version: string
+}
+
+declare const statechartDefinitionBrand: unique symbol
+
+export type StatechartDefinition<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> = StatechartDefinitionInput<TContext, TEvent, TState> & {
+  readonly [statechartDefinitionBrand]: true
+}
+
+export interface StatechartInstance<
+  TContext extends JsonObject,
+  TState extends string,
+> {
+  readonly context: DeepReadonly<TContext>
+  readonly instanceId: string
+  readonly machineId: string
+  readonly machineVersion: string
+  readonly revision: number
+  readonly state: TState
+  readonly updatedAt: string
+}
+
+export interface StatechartCreationOptions {
+  readonly instanceId: string
+  readonly now: string
+}
+
+export interface StatechartTransitionOptions {
+  readonly now: string
+}
+
+export const StatechartDiagnosticCodes = {
+  CONTEXT_INVALID: 'AK_STATECHART_CONTEXT_INVALID',
+  DEFINITION_INVALID: 'AK_STATECHART_DEFINITION_INVALID',
+  GUARD_FAILED: 'AK_STATECHART_GUARD_FAILED',
+  GUARD_REJECTED: 'AK_STATECHART_GUARD_REJECTED',
+  INSTANCE_MISMATCH: 'AK_STATECHART_INSTANCE_MISMATCH',
+  OBSERVER_FAILED: 'AK_STATECHART_OBSERVER_FAILED',
+  REDUCER_FAILED: 'AK_STATECHART_REDUCER_FAILED',
+  SNAPSHOT_INVALID: 'AK_STATECHART_SNAPSHOT_INVALID',
+  SNAPSHOT_VERSION_UNSUPPORTED: 'AK_STATECHART_SNAPSHOT_VERSION_UNSUPPORTED',
+  TRANSITION_UNAVAILABLE: 'AK_STATECHART_TRANSITION_UNAVAILABLE',
+} as const
+
+export type StatechartDiagnosticCode =
+  (typeof StatechartDiagnosticCodes)[keyof typeof StatechartDiagnosticCodes]
+
+export interface StatechartDiagnostic {
+  readonly code: StatechartDiagnosticCode
+  readonly message: string
+}
+
+export class StatechartError extends Error {
+  readonly code: StatechartDiagnosticCode
+
+  constructor(diagnostic: StatechartDiagnostic) {
+    super(diagnostic.message)
+    this.name = 'StatechartError'
+    this.code = diagnostic.code
+  }
+}
+
+export interface AcceptedTransition<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> {
+  readonly event: DeepReadonly<TEvent>
+  readonly from: TState
+  readonly instance: StatechartInstance<TContext, TState>
+  readonly status: 'accepted'
+  readonly to: TState
+}
+
+export interface RejectedTransition<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> {
+  readonly diagnostic: StatechartDiagnostic
+  readonly event: DeepReadonly<TEvent>
+  readonly from: TState
+  readonly instance: StatechartInstance<TContext, TState>
+  readonly status: 'rejected'
+}
+
+export type StatechartTransitionResult<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> =
+  | AcceptedTransition<TContext, TEvent, TState>
+  | RejectedTransition<TContext, TEvent, TState>
+
+export const STATECHART_SNAPSHOT_VERSION = 1 as const
+
+export interface StatechartSnapshot<
+  TContext extends JsonObject = JsonObject,
+  TState extends string = string,
+> {
+  readonly context: DeepReadonly<TContext>
+  readonly instanceId: string
+  readonly machineId: string
+  readonly machineVersion: string
+  readonly revision: number
+  readonly schemaVersion: typeof STATECHART_SNAPSHOT_VERSION
+  readonly state: TState
+  readonly updatedAt: string
+}
+
+export interface RestoredStatechart<
+  TContext extends JsonObject,
+  TState extends string,
+> {
+  readonly instance: StatechartInstance<TContext, TState>
+  readonly status: 'restored'
+}
+
+export interface RejectedRestore {
+  readonly diagnostic: StatechartDiagnostic
+  readonly status: 'rejected'
+}
+
+export type StatechartRestoreResult<
+  TContext extends JsonObject,
+  TState extends string,
+> = RestoredStatechart<TContext, TState> | RejectedRestore
+
+export type StatechartObserver<
+  TContext extends JsonObject,
+  TEvent extends StatechartEvent,
+  TState extends string,
+> = (
+  result: StatechartTransitionResult<TContext, TEvent, TState>,
+) => void
+
+export type StatechartObserverResult =
+  | { readonly status: 'delivered' }
+  | { readonly diagnostic: StatechartDiagnostic; readonly status: 'rejected' }

--- a/packages/statechart/tests/json.test.ts
+++ b/packages/statechart/tests/json.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { cloneJsonObject } from '../src/json'
+
+describe('JSON boundary', () => {
+  it.each([
+    [{ value: Number.NaN }, 'finite'],
+    [{ value: undefined }, 'JSON-compatible'],
+    [{ value: new Date() }, 'plain objects'],
+  ])('rejects values that JSON cannot preserve', (input, message) => {
+    expect(() => cloneJsonObject(input)).toThrow(message)
+  })
+
+  it('rejects cycles and symbol keys', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    expect(() => cloneJsonObject(cyclic)).toThrow('cycles')
+    expect(() => cloneJsonObject({ [Symbol('key')]: true })).toThrow('symbol keys')
+  })
+
+  it('requires an object at the context root', () => {
+    expect(() => cloneJsonObject([])).toThrow('context must be a JSON object')
+  })
+})

--- a/packages/statechart/tests/snapshot.test.ts
+++ b/packages/statechart/tests/snapshot.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createStatechartInstance,
+  defineStatechart,
+  restoreStatechart,
+  serializeStatechart,
+} from '../src'
+import type { JsonObject, StatechartEvent } from '../src'
+
+describe('snapshot module', () => {
+  it('restores a serialized instance against trusted runtime configuration', () => {
+    const definition = defineStatechart<
+      JsonObject,
+      StatechartEvent<'finish'>,
+      'idle'
+    >({
+      id: 'snapshot-test',
+      initial: 'idle',
+      parseContext: (input) => input as JsonObject,
+      states: { idle: {} },
+      version: '1',
+    })
+    const instance = createStatechartInstance(
+      definition,
+      { value: 'safe' },
+      { instanceId: 'one', now: 'now' },
+    )
+
+    expect(restoreStatechart(definition, serializeStatechart(instance))).toEqual({
+      instance,
+      status: 'restored',
+    })
+  })
+})

--- a/packages/statechart/tests/statechart.test.ts
+++ b/packages/statechart/tests/statechart.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  STATECHART_SNAPSHOT_VERSION,
+  StatechartDiagnosticCodes,
+  StatechartError,
+  createStatechartInstance,
+  defineStatechart,
+  notifyStatechartObserver,
+  restoreStatechart,
+  serializeStatechart,
+  transitionStatechart,
+} from '../src'
+import type { JsonObject, StatechartEvent } from '../src'
+
+type ApprovalContext = {
+  approved: boolean
+  attempts: number
+  summary: string
+}
+
+type ApprovalEvent =
+  | StatechartEvent<'approve', { reviewer: string }>
+  | StatechartEvent<'reject', { reason: string }>
+  | StatechartEvent<'retry'>
+
+const parseApprovalContext = (input: unknown): ApprovalContext => {
+  if (
+    input === null ||
+    typeof input !== 'object' ||
+    Array.isArray(input) ||
+    typeof (input as Record<string, unknown>).approved !== 'boolean' ||
+    typeof (input as Record<string, unknown>).attempts !== 'number' ||
+    typeof (input as Record<string, unknown>).summary !== 'string'
+  ) {
+    throw new TypeError('invalid approval context')
+  }
+
+  return input as ApprovalContext
+}
+
+const machine = defineStatechart<
+  ApprovalContext,
+  ApprovalEvent,
+  'waiting' | 'approved' | 'rejected'
+>({
+  id: 'approval',
+  initial: 'waiting',
+  parseContext: parseApprovalContext,
+  states: {
+    approved: {},
+    rejected: {
+      on: {
+        retry: {
+          reduce: (context) => ({
+            ...context,
+            attempts: context.attempts + 1,
+          }),
+          target: 'waiting',
+        },
+      },
+    },
+    waiting: {
+      on: {
+        approve: {
+          guard: (_context, event) => event.payload.reviewer.length > 0,
+          reduce: (context) => ({ ...context, approved: true }),
+          target: 'approved',
+        },
+        reject: {
+          reduce: (context, event) => ({
+            ...context,
+            summary: event.payload.reason,
+          }),
+          target: 'rejected',
+        },
+      },
+    },
+  },
+  version: '1.0.0',
+})
+
+const createWaiting = () =>
+  createStatechartInstance(
+    machine,
+    { approved: false, attempts: 0, summary: '' },
+    { instanceId: 'approval-1', now: '2026-07-13T12:00:00.000Z' },
+  )
+
+describe('definitions and instances', () => {
+  it('creates an immutable instance without hidden time or ID generation', () => {
+    const instance = createWaiting()
+
+    expect(instance).toEqual({
+      context: { approved: false, attempts: 0, summary: '' },
+      instanceId: 'approval-1',
+      machineId: 'approval',
+      machineVersion: '1.0.0',
+      revision: 0,
+      state: 'waiting',
+      updatedAt: '2026-07-13T12:00:00.000Z',
+    })
+    expect(Object.isFrozen(machine)).toBe(true)
+    expect(Object.isFrozen(machine.states.waiting.on?.approve)).toBe(true)
+    expect(Object.isFrozen(instance.context)).toBe(true)
+  })
+
+  it.each([
+    {
+      initial: 'missing',
+      states: { waiting: {} },
+      expected: 'initial state',
+    },
+    {
+      initial: 'waiting',
+      states: { waiting: { on: { go: { target: 'missing' } } } },
+      expected: 'targets unknown state',
+    },
+  ])('rejects an invalid definition', ({ initial, states, expected }) => {
+    expect(() =>
+      defineStatechart<JsonObject, StatechartEvent<'go'>, string>({
+        id: 'invalid',
+        initial,
+        parseContext: (input) => input as JsonObject,
+        states,
+        version: '1',
+      }),
+    ).toThrow(expected)
+  })
+
+  it('returns a typed error when initial context validation fails', () => {
+    expect(() =>
+      createStatechartInstance(
+        machine,
+        { approved: 'yes', attempts: 0, summary: '' },
+        { instanceId: 'approval-1', now: 'now' },
+      ),
+    ).toThrow(
+      expect.objectContaining<StatechartError>({
+        code: StatechartDiagnosticCodes.CONTEXT_INVALID,
+      }),
+    )
+  })
+
+  it('rejects non-JSON context even when a parser returns it', () => {
+    const unsafe = defineStatechart<JsonObject, StatechartEvent<'go'>, 'idle'>({
+      id: 'unsafe',
+      initial: 'idle',
+      parseContext: () => ({ value: Number.NaN }),
+      states: { idle: {} },
+      version: '1',
+    })
+
+    expect(() =>
+      createStatechartInstance(unsafe, {}, { instanceId: '1', now: 'now' }),
+    ).toThrow(
+      expect.objectContaining({
+        code: StatechartDiagnosticCodes.CONTEXT_INVALID,
+      }),
+    )
+  })
+})
+
+describe('transitionStatechart', () => {
+  it('accepts a transition and returns a new instance', () => {
+    const before = createWaiting()
+    const result = transitionStatechart(
+      machine,
+      before,
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: '2026-07-13T12:01:00.000Z' },
+    )
+
+    expect(result.status).toBe('accepted')
+    if (result.status !== 'accepted') return
+    expect(result.instance).not.toBe(before)
+    expect(before.context.approved).toBe(false)
+    expect(result.instance).toMatchObject({
+      context: { approved: true },
+      revision: 1,
+      state: 'approved',
+      updatedAt: '2026-07-13T12:01:00.000Z',
+    })
+  })
+
+  it('returns the unchanged instance for unavailable and duplicate events', () => {
+    const before = createWaiting()
+    const first = transitionStatechart(
+      machine,
+      before,
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: 'one' },
+    )
+    if (first.status !== 'accepted') throw new Error('expected acceptance')
+
+    const duplicate = transitionStatechart(
+      machine,
+      first.instance,
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: 'two' },
+    )
+
+    expect(duplicate).toMatchObject({
+      diagnostic: {
+        code: StatechartDiagnosticCodes.TRANSITION_UNAVAILABLE,
+      },
+      instance: first.instance,
+      status: 'rejected',
+    })
+  })
+
+  it('turns guard refusal and exceptions into typed rejections', () => {
+    const refused = transitionStatechart(
+      machine,
+      createWaiting(),
+      { type: 'approve', payload: { reviewer: '' } },
+      { now: 'one' },
+    )
+    expect(refused).toMatchObject({
+      diagnostic: { code: StatechartDiagnosticCodes.GUARD_REJECTED },
+      status: 'rejected',
+    })
+
+    const guardFailure = defineStatechart<JsonObject, StatechartEvent<'go'>, 'idle'>({
+      id: 'guard-failure',
+      initial: 'idle',
+      parseContext: (input) => input as JsonObject,
+      states: {
+        idle: {
+          on: {
+            go: {
+              guard: () => {
+                throw new Error('not public')
+              },
+              target: 'idle',
+            },
+          },
+        },
+      },
+      version: '1',
+    })
+    const result = transitionStatechart(
+      guardFailure,
+      createStatechartInstance(guardFailure, {}, { instanceId: '1', now: '0' }),
+      { type: 'go' },
+      { now: '1' },
+    )
+    expect(result).toMatchObject({
+      diagnostic: { code: StatechartDiagnosticCodes.GUARD_FAILED },
+      status: 'rejected',
+    })
+    expect(JSON.stringify(result)).not.toContain('not public')
+  })
+
+  it('distinguishes reducer exceptions from invalid reducer output', () => {
+    const makeMachine = (reduce: () => JsonObject) =>
+      defineStatechart<JsonObject, StatechartEvent<'go'>, 'idle'>({
+        id: 'reducer',
+        initial: 'idle',
+        parseContext: (input) => input as JsonObject,
+        states: { idle: { on: { go: { reduce, target: 'idle' } } } },
+        version: '1',
+      })
+
+    const throwing = makeMachine(() => {
+      throw new Error('secret cause')
+    })
+    const invalid = makeMachine(() => ({ value: Number.POSITIVE_INFINITY }))
+
+    const invoke = (definition: typeof throwing) =>
+      transitionStatechart(
+        definition,
+        createStatechartInstance(definition, {}, { instanceId: '1', now: '0' }),
+        { type: 'go' },
+        { now: '1' },
+      )
+
+    expect(invoke(throwing)).toMatchObject({
+      diagnostic: { code: StatechartDiagnosticCodes.REDUCER_FAILED },
+      status: 'rejected',
+    })
+    expect(invoke(invalid)).toMatchObject({
+      diagnostic: { code: StatechartDiagnosticCodes.CONTEXT_INVALID },
+      status: 'rejected',
+    })
+  })
+
+  it('rejects an instance from a different definition', () => {
+    const foreign = { ...createWaiting(), machineVersion: '2.0.0' }
+    const result = transitionStatechart(
+      machine,
+      foreign,
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: 'one' },
+    )
+    expect(result).toMatchObject({
+      diagnostic: { code: StatechartDiagnosticCodes.INSTANCE_MISMATCH },
+      status: 'rejected',
+    })
+  })
+})
+
+describe('snapshots and replay', () => {
+  it('round-trips through a versioned snapshot', () => {
+    const snapshot = serializeStatechart(createWaiting())
+    const restored = restoreStatechart(machine, JSON.parse(JSON.stringify(snapshot)))
+
+    expect(snapshot.schemaVersion).toBe(STATECHART_SNAPSHOT_VERSION)
+    expect(restored).toEqual({ instance: createWaiting(), status: 'restored' })
+  })
+
+  it.each([
+    [null, StatechartDiagnosticCodes.SNAPSHOT_INVALID],
+    [{ schemaVersion: 99 }, StatechartDiagnosticCodes.SNAPSHOT_VERSION_UNSUPPORTED],
+    [
+      { ...serializeStatechart(createWaiting()), machineVersion: '2' },
+      StatechartDiagnosticCodes.INSTANCE_MISMATCH,
+    ],
+    [
+      { ...serializeStatechart(createWaiting()), revision: -1 },
+      StatechartDiagnosticCodes.SNAPSHOT_INVALID,
+    ],
+    [
+      {
+        ...serializeStatechart(createWaiting()),
+        context: { approved: 'yes', attempts: 0, summary: '' },
+      },
+      StatechartDiagnosticCodes.CONTEXT_INVALID,
+    ],
+  ])('rejects malformed or incompatible snapshots', (snapshot, code) => {
+    expect(restoreStatechart(machine, snapshot)).toEqual({
+      diagnostic: expect.objectContaining({ code }),
+      status: 'rejected',
+    })
+  })
+
+  it('produces equivalent output when restored and replayed', () => {
+    const initial = createWaiting()
+    const direct = transitionStatechart(
+      machine,
+      initial,
+      { type: 'reject', payload: { reason: 'Needs evidence' } },
+      { now: '2026-07-13T12:01:00.000Z' },
+    )
+    const restored = restoreStatechart(machine, serializeStatechart(initial))
+    if (restored.status !== 'restored') throw new Error('expected restore')
+    const replayed = transitionStatechart(
+      machine,
+      restored.instance,
+      { type: 'reject', payload: { reason: 'Needs evidence' } },
+      { now: '2026-07-13T12:01:00.000Z' },
+    )
+
+    expect(replayed).toEqual(direct)
+  })
+})
+
+describe('observers', () => {
+  it('delivers accepted and rejected results outside the transition core', () => {
+    const observer = vi.fn()
+    const result = transitionStatechart(
+      machine,
+      createWaiting(),
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: 'one' },
+    )
+
+    expect(observer).not.toHaveBeenCalled()
+    expect(notifyStatechartObserver(observer, result)).toEqual({
+      status: 'delivered',
+    })
+    expect(observer).toHaveBeenCalledWith(result)
+  })
+
+  it('isolates observer failures from state', () => {
+    const result = transitionStatechart(
+      machine,
+      createWaiting(),
+      { type: 'approve', payload: { reviewer: 'Ada' } },
+      { now: 'one' },
+    )
+    const before = result.instance
+    const delivered = notifyStatechartObserver(() => {
+      throw new Error('observer failure')
+    }, result)
+
+    expect(delivered).toEqual({
+      diagnostic: {
+        code: StatechartDiagnosticCodes.OBSERVER_FAILED,
+        message: 'statechart observer failed',
+      },
+      status: 'rejected',
+    })
+    expect(result.instance).toBe(before)
+  })
+})

--- a/packages/statechart/tsconfig.json
+++ b/packages/statechart/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"],
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src"]
+}

--- a/packages/statechart/tsup.config.ts
+++ b/packages/statechart/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  sourcemap: true,
+  clean: false,
+  treeshake: true,
+})

--- a/packages/statechart/vitest.config.ts
+++ b/packages/statechart/vitest.config.ts
@@ -1,0 +1,4 @@
+import { createTestConfig } from '../../vitest.shared'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(createTestConfig({ linesThreshold: 90 }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1346,6 +1346,21 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/statechart:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.5
+        version: 25.9.5
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/svelte:
     dependencies:
       '@agentskit/core':


### PR DESCRIPTION
Closes #1199.

## Summary

- add the zero-runtime-dependency `@agentskit/statechart` package
- provide immutable definitions, deterministic host-supplied IDs/time, pure accepted/rejected transitions, typed diagnostics, and isolated observers
- add versioned JSON snapshots with runtime-validated restore through an injected context parser
- document the ownership boundary against Core ChatController, Runtime flows/durable execution, UI bindings, persistence, effects, and product logic in ADR-0020
- add package, human, and agent documentation plus doc-bridge routing and a 5 kB bundle budget

## Validation

- 25 tests across 3 files
- 95.55% statements / 97.72% lines
- all 17 repository quality gates pass
- package lint, build, and declaration generation pass
- docs production build passes
- doc-bridge index and gates pass
- bundle is 2.3 kB compressed against a 5 kB budget
- public diff scanned for private-repository identifiers and implementation details

## Boundary

This package intentionally has no UI framework, provider, ChatController, Runtime, persistence, action executor, retry, deduplication, or business-phase dependency. Downstream bindings can compose it after the public contract is reviewed and released.
