### PR TITLE
fix(rag): make optional loaders Metro-safe

### DIFF
--- a/.changeset/calm-ravens-bundle.md
+++ b/.changeset/calm-ravens-bundle.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/rag': patch
+---
+
+Add browser and React Native package entries that keep the optional S3 SDK out of Metro bundles while preserving lazy SDK resolution for Node consumers.

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -86,6 +86,21 @@ You can also call `rag.retrieve({ query, messages })` to satisfy the core `Retri
 - **Rerankers:** `createRerankedRetriever` (Cohere Rerank, BGE, BM25 default), `createHybridRetriever` (vector + BM25 blend), standalone `bm25Score`. [Recipe](https://www.agentskit.io/docs/recipes/rag-reranking).
 - **Document loaders:** `loadUrl`, `loadGitHubFile`, `loadGitHubTree`, `loadNotionPage`, `loadConfluencePage`, `loadGoogleDriveFile`, `loadPdf` (BYO parser). [Recipe](https://www.agentskit.io/docs/recipes/doc-loaders).
 
+### S3 in Expo and React Native runtimes
+
+Node consumers may install `@aws-sdk/client-s3` and let `loadS3` resolve it lazily. Browser, Expo/Metro, and React Native bundles keep that peer out of the universal entry; pass the command constructors explicitly when invoking the loader:
+
+```ts
+import { GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { loadS3 } from '@agentskit/rag'
+
+await loadS3({
+  client: new S3Client({}),
+  bucket: 'knowledge',
+  commands: { GetObjectCommand, ListObjectsV2Command },
+})
+```
+
 ## Ecosystem
 
 | Package | Role |

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -27,10 +27,14 @@
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
+  "browser": "./dist/index.browser.js",
+  "react-native": "./dist/index.browser.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-native": "./dist/index.browser.js",
+      "browser": "./dist/index.browser.js",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
@@ -45,8 +49,10 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test": "pnpm test:prepare && vitest run",
+    "test:prepare": "pnpm --filter @agentskit/core build && pnpm build",
+    "test:metro": "pnpm test:prepare && vitest run tests/metro-bundle.test.ts",
+    "test:coverage": "pnpm test:prepare && vitest run --coverage",
     "lint": "tsc --noEmit",
     "dev": "tsup --watch"
   },
@@ -55,6 +61,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.5",
+    "metro": "0.84.4",
+    "metro-runtime": "0.84.4",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/rag/src/index-node.ts
+++ b/packages/rag/src/index-node.ts
@@ -1,0 +1,2 @@
+export * from './index'
+export { loadS3 } from './loaders-node'

--- a/packages/rag/src/loaders-node.ts
+++ b/packages/rag/src/loaders-node.ts
@@ -1,0 +1,33 @@
+import { RagError, RagErrorCodes } from './errors'
+import { loadS3 as loadS3Universal } from './loaders'
+import type { InputDocument } from './types'
+import type { S3LoaderOptions } from './loaders'
+
+export * from './loaders'
+
+type S3Commands = NonNullable<S3LoaderOptions['commands']>
+
+let cachedS3Sdk: Promise<S3Commands> | null = null
+const importOptionalPeer = (moduleId: string): Promise<unknown> => import(/* @vite-ignore */ moduleId)
+
+async function loadS3Sdk(): Promise<S3Commands> {
+  if (!cachedS3Sdk) {
+    cachedS3Sdk = (async () => {
+      try {
+        return (await importOptionalPeer('@aws-sdk/client-s3')) as S3Commands
+      } catch {
+        throw new RagError({
+          code: RagErrorCodes.AK_RAG_PEER_MISSING,
+          message: 'Install @aws-sdk/client-s3 to use loadS3: npm install @aws-sdk/client-s3',
+          hint: 'loadS3 uses the optional peer "@aws-sdk/client-s3".',
+        })
+      }
+    })()
+  }
+  return cachedS3Sdk
+}
+
+export async function loadS3(options: S3LoaderOptions): Promise<InputDocument[]> {
+  const commands = options.commands ?? await loadS3Sdk()
+  return loadS3Universal({ ...options, commands })
+}

--- a/packages/rag/src/loaders.ts
+++ b/packages/rag/src/loaders.ts
@@ -179,7 +179,8 @@ export interface S3LoaderOptions extends LoaderOptions {
   /**
    * AWS SDK v3 commands. Pass them in to skip the dynamic import:
    * \`{ ListObjectsV2Command, GetObjectCommand }\` from \`@aws-sdk/client-s3\`.
-   * Optional — when omitted the loader resolves them lazily.
+   * Optional in Node, where the loader resolves them lazily.
+   * Required in browser, Expo/Metro, and React Native universal bundles.
    */
   commands?: {
     ListObjectsV2Command: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
@@ -193,28 +194,15 @@ export interface S3LoaderOptions extends LoaderOptions {
   maxFiles?: number
 }
 
-interface S3SdkLike {
-  ListObjectsV2Command: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
-  GetObjectCommand: new (input: Record<string, unknown>) => { input: Record<string, unknown> }
-}
-
-let cachedS3Sdk: Promise<S3SdkLike> | null = null
-const importOptionalPeer = (moduleId: string): Promise<unknown> => import(/* @vite-ignore */ moduleId)
-async function loadS3Sdk(): Promise<S3SdkLike> {
-  if (!cachedS3Sdk) {
-    cachedS3Sdk = (async () => {
-      try {
-        return (await importOptionalPeer('@aws-sdk/client-s3')) as S3SdkLike
-      } catch {
-        throw new RagError({ code: RagErrorCodes.AK_RAG_PEER_MISSING, message: 'Install @aws-sdk/client-s3 to use loadS3: npm install @aws-sdk/client-s3', hint: 'loadS3 uses the optional peer "@aws-sdk/client-s3".' })
-      }
-    })()
-  }
-  return cachedS3Sdk
-}
-
 export async function loadS3(options: S3LoaderOptions): Promise<InputDocument[]> {
-  const { ListObjectsV2Command, GetObjectCommand } = options.commands ?? await loadS3Sdk()
+  if (!options.commands) {
+    throw new RagError({
+      code: RagErrorCodes.AK_RAG_PEER_MISSING,
+      message: 'Pass S3 command constructors through loadS3({ commands }) in browser, Expo/Metro, and React Native runtimes.',
+      hint: 'Universal bundles do not resolve the optional "@aws-sdk/client-s3" peer automatically.',
+    })
+  }
+  const { ListObjectsV2Command, GetObjectCommand } = options.commands
   const docs: InputDocument[] = []
   let continuationToken: string | undefined
   const maxFiles = options.maxFiles ?? 100

--- a/packages/rag/tests/index-node.test.ts
+++ b/packages/rag/tests/index-node.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import * as nodeEntry from '../src/index-node'
+import { loadS3 as loadS3Node } from '../src/loaders-node'
+import { loadS3 as loadS3Universal } from '../src/loaders'
+
+describe('Node package entry', () => {
+  it('overrides only the S3 loader with the lazy Node resolver', () => {
+    expect(nodeEntry.createRAG).toBeTypeOf('function')
+    expect(nodeEntry.loadS3).toBe(loadS3Node)
+    expect(nodeEntry.loadS3).not.toBe(loadS3Universal)
+  })
+})

--- a/packages/rag/tests/loaders-node.test.ts
+++ b/packages/rag/tests/loaders-node.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadS3 } from '../src/loaders-node'
+
+describe('Node S3 loader', () => {
+  it('uses explicitly injected commands without resolving the optional peer', async () => {
+    class ListCommand { constructor(readonly input: Record<string, unknown>) {} }
+    class GetCommand { constructor(readonly input: Record<string, unknown>) {} }
+    const send = vi.fn(async (command: { input: Record<string, unknown> }) => (
+      'Key' in command.input
+        ? { Body: { transformToString: async () => 'body' } }
+        : { Contents: [{ Key: 'doc.txt' }], IsTruncated: false }
+    ))
+
+    const docs = await loadS3({
+      bucket: 'fixture',
+      client: { send },
+      commands: { ListObjectsV2Command: ListCommand, GetObjectCommand: GetCommand },
+    })
+
+    expect(docs).toEqual([{
+      content: 'body',
+      source: 's3://fixture/doc.txt',
+      metadata: { bucket: 'fixture', key: 'doc.txt' },
+    }])
+  })
+})

--- a/packages/rag/tests/loaders.test.ts
+++ b/packages/rag/tests/loaders.test.ts
@@ -132,6 +132,14 @@ describe('loadPdf', () => {
 })
 
 describe('loadS3', () => {
+  it('fails at invocation time when universal runtimes omit command injection', async () => {
+    const send = vi.fn()
+    await expect(loadS3({ client: { send }, bucket: 'bk' })).rejects.toMatchObject({
+      code: 'AK_RAG_PEER_MISSING',
+    })
+    expect(send).not.toHaveBeenCalled()
+  })
+
   it('paginates and stops at maxFiles', async () => {
     let listCall = 0
     const client = {

--- a/packages/rag/tests/metro-bundle.mjs
+++ b/packages/rag/tests/metro-bundle.mjs
@@ -1,0 +1,124 @@
+import { cp, mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { loadConfig, runBuild } from 'metro'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const repositoryRoot = resolve(packageRoot, '../..')
+const metroRuntimeRoot = await realpath(resolve(packageRoot, 'node_modules/metro-runtime'))
+
+async function linkPackage(projectRoot, name, target) {
+  const destination = join(projectRoot, 'node_modules', ...name.split('/'))
+  await mkdir(dirname(destination), { recursive: true })
+  await symlink(target, destination, 'dir')
+}
+
+async function verifyLazyNodePeer() {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agentskit-rag-node-'))
+  try {
+    const installedRag = join(projectRoot, 'node_modules/@agentskit/rag')
+    await mkdir(installedRag, { recursive: true })
+    await cp(resolve(packageRoot, 'dist'), join(installedRag, 'dist'), { recursive: true })
+    await cp(resolve(packageRoot, 'package.json'), join(installedRag, 'package.json'))
+    await linkPackage(projectRoot, '@agentskit/core', resolve(repositoryRoot, 'packages/core'))
+
+    const sdkRoot = join(projectRoot, 'node_modules/@aws-sdk/client-s3')
+    await mkdir(sdkRoot, { recursive: true })
+    await writeFile(join(sdkRoot, 'package.json'), JSON.stringify({ type: 'module', exports: './index.js' }))
+    await writeFile(join(sdkRoot, 'index.js'), [
+      'export class ListObjectsV2Command { constructor(input) { this.input = input } }',
+      'export class GetObjectCommand { constructor(input) { this.input = input } }',
+    ].join('\n'))
+
+    const client = {
+      send: async command => 'Key' in command.input
+        ? { Body: { transformToString: async () => 'body' } }
+        : { Contents: [{ Key: 'doc.txt' }], IsTruncated: false },
+    }
+    const nodeEntry = await import(pathToFileURL(join(installedRag, 'dist/index.js')).href)
+    const docs = await nodeEntry.loadS3({
+      bucket: 'fixture',
+      client,
+    })
+    if (docs[0]?.source !== 's3://fixture/doc.txt') {
+      throw new Error('The Node ESM entry did not lazily resolve the installed S3 peer')
+    }
+
+    const requireFromFixture = createRequire(join(projectRoot, 'fixture.cjs'))
+    const cjsEntry = requireFromFixture(join(installedRag, 'dist/index.cjs'))
+    const cjsDocs = await cjsEntry.loadS3({ bucket: 'fixture', client })
+    if (cjsDocs[0]?.source !== 's3://fixture/doc.txt') {
+      throw new Error('The Node CJS entry did not lazily resolve the installed S3 peer')
+    }
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true })
+  }
+}
+
+export async function runMetroBundleChecks() {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agentskit-rag-metro-'))
+  try {
+  const universalSource = await readFile(resolve(packageRoot, 'dist/index.browser.js'), 'utf8')
+  if (/\bimport\s*\(/u.test(universalSource)) {
+    throw new Error('The universal RAG entry contains a dynamic import')
+  }
+
+  const nodeEntry = await import(pathToFileURL(resolve(packageRoot, 'dist/index.js')).href)
+  try {
+    await nodeEntry.loadS3({ client: { send: async () => ({}) }, bucket: 'fixture' })
+    throw new Error('The Node RAG entry unexpectedly resolved a missing S3 peer')
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes('Install @aws-sdk/client-s3')) {
+      throw error
+    }
+  }
+
+  await verifyLazyNodePeer()
+  await linkPackage(projectRoot, '@agentskit/rag', packageRoot)
+  await linkPackage(projectRoot, '@agentskit/core', resolve(repositoryRoot, 'packages/core'))
+  await linkPackage(projectRoot, 'metro-runtime', metroRuntimeRoot)
+  await writeFile(
+    join(projectRoot, 'index.js'),
+    "import { createRAG } from '@agentskit/rag'; globalThis.__agentskitRag = createRAG;\n",
+  )
+
+  const baseConfig = await loadConfig({ cwd: projectRoot, projectRoot })
+  const config = {
+    ...baseConfig,
+    projectRoot,
+    watchFolders: [projectRoot, repositoryRoot, metroRuntimeRoot],
+    resolver: {
+      ...baseConfig.resolver,
+      useWatchman: false,
+      nodeModulesPaths: [join(projectRoot, 'node_modules'), join(repositoryRoot, 'node_modules')],
+      unstable_enablePackageExports: true,
+      unstable_conditionsByPlatform: {
+        ...baseConfig.resolver.unstable_conditionsByPlatform,
+        ios: ['react-native'],
+        android: ['react-native'],
+        web: ['browser'],
+      },
+    },
+  }
+
+  for (const platform of ['web', 'ios']) {
+    const output = join(projectRoot, `bundle.${platform}.js`)
+    await runBuild(config, {
+      entry: 'index.js',
+      dev: false,
+      minify: false,
+      out: output,
+      platform,
+      sourceMap: false,
+    })
+    const bundle = await readFile(output, 'utf8')
+    if (!bundle.includes('__agentskitRag')) {
+      throw new Error(`Metro ${platform} bundle did not include the public RAG entry point`)
+    }
+  }
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true })
+  }
+}

--- a/packages/rag/tests/metro-bundle.test.ts
+++ b/packages/rag/tests/metro-bundle.test.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'vitest'
+import { runMetroBundleChecks } from './metro-bundle.mjs'
+
+describe('public Metro bundle', () => {
+  it('bundles the universal entry for web and React Native while preserving the lazy Node peer', async () => {
+    await runMetroBundleChecks()
+  }, 30_000)
+})

--- a/packages/rag/tsup.config.ts
+++ b/packages/rag/tsup.config.ts
@@ -1,14 +1,27 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    chunker: 'src/chunker.ts',
+export default defineConfig([
+  {
+    entry: {
+      index: 'src/index-node.ts',
+      chunker: 'src/chunker.ts',
+    },
+    format: ['esm', 'cjs'],
+    dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+    sourcemap: true,
+    clean: true,
+    external: ['@agentskit/core'],
+    treeshake: true,
   },
-  format: ['esm', 'cjs'],
-  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
-  sourcemap: true,
-  clean: true,
-  external: ['@agentskit/core'],
-  treeshake: true,
-})
+  {
+    entry: {
+      'index.browser': 'src/index.ts',
+    },
+    format: ['esm', 'cjs'],
+    dts: false,
+    sourcemap: true,
+    clean: false,
+    external: ['@agentskit/core'],
+    treeshake: true,
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1159,6 +1159,12 @@ importers:
       '@types/node':
         specifier: ^25.9.5
         version: 25.9.5
+      metro:
+        specifier: 0.84.4
+        version: 0.84.4
+      metro-runtime:
+        specifier: 0.84.4
+        version: 0.84.4
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)


### PR DESCRIPTION
## What

Splits the RAG package entry into a Node variant with lazy optional S3 peer resolution and a browser/React Native variant that requires explicit command injection. Adds real Metro web/iOS bundle coverage, Node ESM/CJS peer fixtures, public runtime guidance, and a patch changeset.

## Why

Closes #1213

Metro rejects non-literal dynamic imports before an Expo application mounts. The universal entry must remain free of that construct while Node keeps the existing lazy optional-peer behavior.

## Checklist

- [x] 65 unit/integration tests passing
- [x] 96.8% line coverage
- [x] Metro web and iOS bundles passing
- [x] Vite production example passing without the optional peer
- [x] Node ESM and CJS lazy-peer paths passing
- [x] 17 quality gates passing
- [x] doc-bridge gate passing
- [x] Multi-perspective code review approved