### PR TITLE
fix(ask): reject incomplete cached streams

### DIFF
--- a/.changeset/calm-streams-terminate.md
+++ b/.changeset/calm-streams-terminate.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/adapters': patch
+---
+
+Treat OpenAI-compatible streams that close without a done sentinel or finish reason as errors instead of successful completion.

--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -54,7 +54,9 @@ curl -s -XPOST 'http://localhost:8080/v1/ask?corpus=docs' \
 - Cache is enabled by default. Exact answers + retrieval results are kept in-process
   and mirrored to Redis when `REDIS_URL` is set (Railway Redis volume/service).
   Upstash REST (`UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`) remains a
-  fallback. Semantic answer cache is in-process and uses the shared embedder.
+  fallback. Answer entries are admitted only when they contain one terminal `done`
+  event and no error; incomplete persisted entries are bypassed and replaced after
+  successful regeneration. Semantic answer cache is in-process and uses the shared embedder.
   Disable with `ASK_CACHE_ENABLED=0`.
 - `docs` uses the committed vector index. `registry`, `playbook`, and `akos` load
   configurable remote `llms-full.txt` / `llms.txt` sources and rank them with BM25;

--- a/apps/ask-backend/src/ask/cache-integrity.test.ts
+++ b/apps/ask-backend/src/ask/cache-integrity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { isCompleteCachedAnswer } from './cache-integrity'
+
+const complete = {
+  model: 'test-model',
+  createdAt: 1,
+  events: [
+    { type: 'text', delta: 'Use the code reviewer.' },
+    { type: 'tool', id: 'sources', name: 'cite', args: { sources: [] } },
+    { type: 'done', model: 'test-model' },
+  ],
+}
+
+describe('isCompleteCachedAnswer', () => {
+  it('accepts one valid terminal event after answer content', () => {
+    expect(isCompleteCachedAnswer(complete)).toBe(true)
+  })
+
+  it.each([
+    null,
+    [],
+    {},
+    { ...complete, createdAt: Number.NaN },
+    { ...complete, model: '' },
+    { ...complete, events: [{ type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'text', delta: 1 }, { type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'tool', id: 'x', name: 'cite', args: [] }, { type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'unknown' }, { type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'text', delta: 'partial' }, { type: 'done', model: 'other' }] },
+    { ...complete, events: [{ type: 'done', model: 'test-model' }, { type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'error', message: 'failed' }, { type: 'done', model: 'test-model' }] },
+    { ...complete, events: [{ type: 'text', delta: 'partial' }, { type: 'error', message: 'failed' }] },
+  ])('rejects incomplete or malformed value %#', (value) => {
+    expect(isCompleteCachedAnswer(value)).toBe(false)
+  })
+})

--- a/apps/ask-backend/src/ask/cache-integrity.ts
+++ b/apps/ask-backend/src/ask/cache-integrity.ts
@@ -1,0 +1,33 @@
+import type { UiEvent } from './protocol'
+
+export interface CompleteCachedAnswer {
+  events: UiEvent[]
+  createdAt: number
+  model: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isUiEvent(value: unknown): value is UiEvent {
+  if (!isRecord(value) || typeof value.type !== 'string') return false
+  if (value.type === 'text') return typeof value.delta === 'string'
+  if (value.type === 'tool') {
+    return typeof value.id === 'string' && typeof value.name === 'string' && isRecord(value.args)
+  }
+  if (value.type === 'done') return typeof value.model === 'string' && value.model.length > 0
+  if (value.type === 'error') return typeof value.message === 'string'
+  return false
+}
+
+export function isCompleteCachedAnswer(value: unknown): value is CompleteCachedAnswer {
+  if (!isRecord(value) || !Array.isArray(value.events)) return false
+  if (typeof value.createdAt !== 'number' || !Number.isFinite(value.createdAt)) return false
+  if (typeof value.model !== 'string' || value.model.length === 0) return false
+  if (value.events.length < 2 || !value.events.every(isUiEvent)) return false
+  const terminal = value.events[value.events.length - 1]
+  if (terminal?.type !== 'done' || terminal.model !== value.model) return false
+  return value.events.filter((event) => event.type === 'done').length === 1
+    && !value.events.some((event) => event.type === 'error')
+}

--- a/apps/ask-backend/src/ask/cache.test.ts
+++ b/apps/ask-backend/src/ask/cache.test.ts
@@ -59,4 +59,58 @@ describe('AskCache', () => {
       { id: '1', content: 'RAG docs', score: 0.9, metadata: { path: '/docs/rag' } },
     ])
   })
+
+  it('does not store answers without a terminal done event', async () => {
+    const cache = new AskCache({ namespace: 'test-incomplete-write' })
+
+    await cache.setAnswer(key('Which agent reviews code?'), {
+      model: 'test-model',
+      createdAt: 1,
+      events: [{ type: 'text', delta: 'You can use' }],
+    })
+
+    await expect(cache.getAnswer(key('Which agent reviews code?'))).resolves.toBeUndefined()
+  })
+
+  it('bypasses incomplete persisted answers', async () => {
+    let reads = 0
+    const cache = new AskCache({
+      namespace: 'test-incomplete-read',
+      storage: {
+        async get() {
+          reads += 1
+          return {
+            model: 'test-model',
+            createdAt: 1,
+            events: [{ type: 'text', delta: 'You can use' }],
+          }
+        },
+        async set() {},
+      },
+    })
+
+    await expect(cache.getAnswer(key('Which agent reviews code?'))).resolves.toBeUndefined()
+    expect(reads).toBe(1)
+  })
+
+  it('accepts complete persisted answers', async () => {
+    const events = [
+      { type: 'text' as const, delta: 'Use the code reviewer.' },
+      { type: 'done' as const, model: 'test-model' },
+    ]
+    const cache = new AskCache({
+      namespace: 'test-complete-read',
+      storage: {
+        async get() {
+          return { model: 'test-model', createdAt: 1, events }
+        },
+        async set() {},
+      },
+    })
+
+    await expect(cache.getAnswer(key('Which agent reviews code?'))).resolves.toMatchObject({
+      events,
+      source: 'exact',
+    })
+  })
 })

--- a/apps/ask-backend/src/ask/cache.ts
+++ b/apps/ask-backend/src/ask/cache.ts
@@ -3,6 +3,7 @@ import net from 'node:net'
 import tls from 'node:tls'
 import type { EmbedFn, RetrievedDocument } from '@agentskit/core'
 import type { UiEvent } from './protocol'
+import { isCompleteCachedAnswer } from './cache-integrity'
 
 export interface AskCacheOptions {
   namespace?: string
@@ -12,6 +13,7 @@ export interface AskCacheOptions {
   semanticThreshold?: number
   maxSemanticEntries?: number
   embed?: EmbedFn
+  storage?: AskCacheStorage | null
 }
 
 export interface AskCacheKey {
@@ -45,8 +47,8 @@ interface StoredRetrieval {
   createdAt: number
 }
 
-interface PersistentCache {
-  get<T>(key: string): Promise<T | undefined>
+export interface AskCacheStorage {
+  get(key: string): Promise<unknown>
   set(key: string, value: unknown, ttlMs: number): Promise<void>
 }
 
@@ -75,15 +77,15 @@ function cosine(a: number[], b: number[]): number {
   return dot
 }
 
-class UpstashCache implements PersistentCache {
+class UpstashCache implements AskCacheStorage {
   private readonly client: UpstashRedis
 
   constructor(url: string, token: string) {
     this.client = new UpstashRedis({ url, token })
   }
 
-  async get<T>(key: string): Promise<T | undefined> {
-    return (await this.client.get<T>(key)) ?? undefined
+  async get(key: string): Promise<unknown> {
+    return (await this.client.get<unknown>(key)) ?? undefined
   }
 
   async set(key: string, value: unknown, ttlMs: number): Promise<void> {
@@ -91,13 +93,13 @@ class UpstashCache implements PersistentCache {
   }
 }
 
-class RailwayRedisCache implements PersistentCache {
+class RailwayRedisCache implements AskCacheStorage {
   constructor(private readonly url: string) {}
 
-  async get<T>(key: string): Promise<T | undefined> {
+  async get(key: string): Promise<unknown> {
     const raw = await redisCommand(this.url, ['GET', key])
     if (!raw) return undefined
-    return JSON.parse(raw) as T
+    return JSON.parse(raw) as unknown
   }
 
   async set(key: string, value: unknown, ttlMs: number): Promise<void> {
@@ -183,7 +185,7 @@ async function redisCommand(redisUrl: string, command: string[]): Promise<string
   })
 }
 
-function persistentCache(): PersistentCache | null {
+function persistentCache(): AskCacheStorage | null {
   const redisUrl = process.env.REDIS_URL
   if (redisUrl) return new RailwayRedisCache(redisUrl)
 
@@ -201,7 +203,7 @@ export class AskCache {
   private readonly semanticThreshold: number
   private readonly maxSemanticEntries: number
   private readonly embed?: EmbedFn
-  private readonly persistent = persistentCache()
+  private readonly persistent: AskCacheStorage | null
   private readonly answers = new Map<string, StoredAnswer & { expiresAt: number }>()
   private readonly retrievals = new Map<string, StoredRetrieval & { expiresAt: number }>()
   private readonly semantic: SemanticEntry[] = []
@@ -214,6 +216,7 @@ export class AskCache {
     this.semanticThreshold = options.semanticThreshold ?? 0.86
     this.maxSemanticEntries = options.maxSemanticEntries ?? 400
     this.embed = options.embed
+    this.persistent = options.storage === undefined ? persistentCache() : options.storage
   }
 
   answerKey(input: AskCacheKey): string {
@@ -234,7 +237,7 @@ export class AskCache {
   }
 
   async setAnswer(input: AskCacheKey, value: StoredAnswer): Promise<void> {
-    if (value.events.some((event) => event.type === 'error')) return
+    if (!isCompleteCachedAnswer(value)) return
     const key = this.answerKey(input)
     const expiresAt = Date.now() + this.answerTtlMs
     this.answers.set(key, { ...value, expiresAt })
@@ -265,11 +268,11 @@ export class AskCache {
   private async getExactAnswer(key: string): Promise<StoredAnswer | undefined> {
     const now = Date.now()
     const mem = this.answers.get(key)
-    if (mem && mem.expiresAt >= now) return mem
+    if (mem && mem.expiresAt >= now && isCompleteCachedAnswer(mem)) return mem
     if (mem) this.answers.delete(key)
 
-    const stored = await this.redisGet<StoredAnswer>(key)
-    if (!stored) return undefined
+    const stored = await this.redisGet<unknown>(key)
+    if (!isCompleteCachedAnswer(stored)) return undefined
     this.answers.set(key, { ...stored, expiresAt: now + this.answerTtlMs })
     return stored
   }
@@ -321,7 +324,7 @@ export class AskCache {
   private async redisGet<T>(key: string): Promise<T | undefined> {
     if (!this.persistent) return undefined
     try {
-      return (await this.persistent.get<T>(key)) ?? undefined
+      return ((await this.persistent.get(key)) as T | undefined) ?? undefined
     } catch {
       return undefined
     }

--- a/apps/ask-backend/src/ask/handler.test.ts
+++ b/apps/ask-backend/src/ask/handler.test.ts
@@ -9,6 +9,7 @@ function adapter(text: string): AdapterFactory {
       abort() {},
       async *stream() {
         yield { type: 'text' as const, content: text }
+        yield { type: 'done' as const }
       },
     }),
   }
@@ -53,5 +54,146 @@ describe('createAskHandler cache integration', () => {
     await expect((await handler(request('What is AgentsKit?'))).text()).resolves.toContain('Fresh answer')
 
     expect(retrieveCalls).toBe(1)
+  })
+
+  it('does not cache a stream cancelled after partial output', async () => {
+    let releaseProvider: (() => void) | undefined
+    let cacheWrites = 0
+    const handler = createAskHandler({
+      retriever: {
+        async retrieve() {
+          return [{ id: 'doc', content: 'Docs context', score: 1, metadata: { path: '/docs', title: 'Docs' } }]
+        },
+      },
+      adapter: {
+        createSource: () => ({
+          abort() {
+            releaseProvider?.()
+          },
+          async *stream() {
+            yield { type: 'text' as const, content: 'You can use' }
+            await new Promise<void>((resolve) => {
+              releaseProvider = resolve
+            })
+          },
+        }),
+      },
+      systemPrompt: 'Answer from docs.',
+      sanitize: (messages) => messages as Array<{ role: 'user' | 'assistant'; content: string }>,
+      triage: () => ({ kind: 'ok' }),
+      checkScope: async () => ({ inScope: true }),
+      cache: {
+        corpus: 'registry',
+        persona: 'registry-helper',
+        getAnswer: async () => undefined,
+        setAnswer: async () => {
+          cacheWrites += 1
+        },
+      },
+    })
+
+    const response = await handler(request('Which agent reviews code?'))
+    expect(response.headers.get('content-type')).toBe('application/x-ndjson; charset=utf-8')
+    const reader = response.body!.getReader()
+    await reader.read()
+    await reader.cancel()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(cacheWrites).toBe(0)
+  })
+
+  it('regenerates an incomplete persisted answer and then replays the replacement', async () => {
+    let stored: unknown = {
+      model: 'test-model',
+      createdAt: 1,
+      events: [{ type: 'text', delta: 'You can use' }],
+    }
+    let adapterCalls = 0
+    const cache = new AskCache({
+      namespace: 'handler-incomplete-cache',
+      storage: {
+        async get() {
+          return stored
+        },
+        async set(_key, value) {
+          stored = value
+        },
+      },
+    })
+    const handler = createAskHandler({
+      retriever: {
+        async retrieve() {
+          return [{ id: 'doc', content: 'Docs context', score: 1, metadata: { path: '/docs', title: 'Docs' } }]
+        },
+      },
+      adapter: {
+        createSource: () => ({
+          abort() {},
+          async *stream() {
+            adapterCalls += 1
+            yield { type: 'text' as const, content: 'Use the code reviewer.' }
+            yield { type: 'done' as const }
+          },
+        }),
+      },
+      systemPrompt: 'Answer from docs.',
+      sanitize: (messages) => messages as Array<{ role: 'user' | 'assistant'; content: string }>,
+      triage: () => ({ kind: 'ok' }),
+      checkScope: async () => ({ inScope: true }),
+      cache: {
+        corpus: 'registry',
+        persona: 'registry-helper',
+        getAnswer: (cacheKey) => cache.getAnswer(cacheKey),
+        setAnswer: (cacheKey, value) => cache.setAnswer(cacheKey, value),
+      },
+    })
+
+    const first = await handler(request('Which agent reviews code?'))
+    await expect(first.text()).resolves.toContain('Use the code reviewer.')
+    const second = await handler(request('Which agent reviews code?'))
+    await expect(second.text()).resolves.toContain('Use the code reviewer.')
+
+    expect(adapterCalls).toBe(1)
+    expect(second.headers.get('x-ask-cache')).toBe('exact')
+  })
+
+  it('does not synthesize completion or cache when an adapter ends silently', async () => {
+    let cacheWrites = 0
+    const handler = createAskHandler({
+      retriever: {
+        async retrieve() {
+          return [{ id: 'doc', content: 'Docs context', score: 1, metadata: { path: '/docs', title: 'Docs' } }]
+        },
+      },
+      adapter: {
+        createSource: () => ({
+          abort() {},
+          async *stream() {
+            yield { type: 'text' as const, content: 'Partial answer' }
+          },
+        }),
+      },
+      systemPrompt: 'Answer from docs.',
+      sanitize: (messages) => messages as Array<{ role: 'user' | 'assistant'; content: string }>,
+      triage: () => ({ kind: 'ok' }),
+      checkScope: async () => ({ inScope: true }),
+      cache: {
+        corpus: 'registry',
+        persona: 'registry-helper',
+        getAnswer: async () => undefined,
+        setAnswer: async () => {
+          cacheWrites += 1
+        },
+      },
+    })
+    const source = handler(request('Which agent reviews code?'))
+
+    const response = await source
+    const body = await response.text()
+
+    expect(body).toContain('Partial answer')
+    expect(body).toContain('"type":"error"')
+    expect(body).not.toContain('"type":"done"')
+    expect(cacheWrites).toBe(0)
   })
 })

--- a/apps/ask-backend/src/ask/handler.ts
+++ b/apps/ask-backend/src/ask/handler.ts
@@ -142,7 +142,7 @@ function singleEventStream(events: UiEvent[], model: string, extra: Record<strin
     },
   })
   return new Response(stream, {
-    headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store', 'x-model': model, ...extra },
+    headers: { 'content-type': 'application/x-ndjson; charset=utf-8', 'cache-control': 'no-store', 'x-model': model, ...extra },
   })
 }
 
@@ -360,6 +360,7 @@ Question: ${m.content}`,
           }
         }
         let sawError = false
+        let sawDone = false
         try {
           for await (const chunk of source.stream() as AsyncIterable<StreamChunk>) {
             if (closed) break // client disconnected — stop pulling from the provider
@@ -374,14 +375,24 @@ Question: ${m.content}`,
               sawError = true
               send({ type: 'error', message: 'The model is busy or unavailable. Please try again.' })
               break
+            } else if (chunk.type === 'done') {
+              sawDone = true
+              break
             }
           }
-          if (!sawError) {
+          if (!sawError && !sawDone && !closed) {
+            const error = new Error('The adapter stream ended without a terminal chunk.')
+            hooks.onError?.(error, { stage: 'stream' })
+            console.error('[ask-docs] adapter stream ended without a terminal chunk')
+            sawError = true
+            send({ type: 'error', message: 'The model is busy or unavailable. Please try again.' })
+          }
+          if (!sawError && sawDone && !closed) {
             if (!richUi && citeSources.length > 0) {
               send({ type: 'tool', id: 'sources', name: 'cite', args: { sources: citeSources } })
             }
             send({ type: 'done', model })
-            if (cacheKey && config.cache?.setAnswer) {
+            if (!closed && cacheKey && config.cache?.setAnswer) {
               await config.cache.setAnswer(cacheKey, { events: cachedEvents, model, createdAt: Date.now() })
             }
           }
@@ -400,7 +411,7 @@ Question: ${m.content}`,
     })
 
     return new Response(uiStream, {
-      headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store', 'x-model': model, ...cors },
+      headers: { 'content-type': 'application/x-ndjson; charset=utf-8', 'cache-control': 'no-store', 'x-model': model, ...cors },
     })
   }
 }

--- a/packages/adapters/src/openai-stream.ts
+++ b/packages/adapters/src/openai-stream.ts
@@ -1,0 +1,95 @@
+import type { StreamChunk } from '@agentskit/core'
+import { readSSELines } from './stream-lines'
+
+const SUCCESS_FINISH_REASONS = new Set(['stop', 'tool_calls', 'function_call'])
+
+export async function* parseOpenAIStream(stream: ReadableStream): AsyncIterableIterator<StreamChunk> {
+  const pendingToolCalls = new Map<number, { id: string; name: string; args: string }>()
+  let finishReason: string | undefined
+
+  const terminalError = (): StreamChunk | undefined => {
+    if (finishReason === undefined || SUCCESS_FINISH_REASONS.has(finishReason)) return undefined
+    const error = new Error(`OpenAI stream ended with non-success finish reason "${finishReason}".`)
+    return { type: 'error', content: error.message, metadata: { error, finishReason } }
+  }
+
+  const flushToolCalls = function* (): Generator<StreamChunk> {
+    for (const [, toolCall] of pendingToolCalls) {
+      yield {
+        type: 'tool_call',
+        toolCall: { id: toolCall.id, name: toolCall.name, args: toolCall.args || '{}' },
+      }
+    }
+    pendingToolCalls.clear()
+  }
+
+  for await (const data of readSSELines(stream)) {
+    if (data === '[DONE]') {
+      const incomplete = terminalError()
+      if (incomplete) {
+        pendingToolCalls.clear()
+        yield incomplete
+        return
+      }
+      yield* flushToolCalls()
+      yield { type: 'done' }
+      return
+    }
+
+    try {
+      const event = JSON.parse(data)
+      const delta = event.choices?.[0]?.delta
+      const candidateFinishReason = event.choices?.find(
+        (choice: { finish_reason?: unknown }) => typeof choice.finish_reason === 'string',
+      )?.finish_reason
+      if (typeof candidateFinishReason === 'string') finishReason = candidateFinishReason
+
+      if (typeof delta?.content === 'string') yield { type: 'text', content: delta.content }
+
+      if (Array.isArray(delta?.tool_calls)) {
+        for (const toolCall of delta.tool_calls) {
+          const index: number = toolCall.index ?? 0
+          const existing = pendingToolCalls.get(index)
+          if (toolCall?.function?.name) {
+            pendingToolCalls.set(index, {
+              id: toolCall.id ?? existing?.id ?? `tool-${index}-${Date.now()}`,
+              name: toolCall.function.name,
+              args: (existing?.args ?? '') + (toolCall.function.arguments ?? ''),
+            })
+          } else if (existing && toolCall?.function?.arguments) {
+            existing.args += toolCall.function.arguments
+          }
+        }
+      }
+
+      if (event.usage) {
+        yield {
+          type: 'usage',
+          usage: {
+            promptTokens: event.usage.prompt_tokens ?? 0,
+            completionTokens: event.usage.completion_tokens ?? 0,
+            totalTokens: event.usage.total_tokens ?? 0,
+          },
+        }
+      }
+    } catch {
+      // Ignore malformed events.
+    }
+  }
+
+  const incomplete = terminalError()
+  if (incomplete) {
+    pendingToolCalls.clear()
+    yield incomplete
+    return
+  }
+  if (!finishReason) {
+    pendingToolCalls.clear()
+    const error = new Error('OpenAI stream ended before a terminal marker.')
+    yield { type: 'error', content: error.message, metadata: { error } }
+    return
+  }
+
+  yield* flushToolCalls()
+  yield { type: 'done' }
+}

--- a/packages/adapters/src/stream-lines.ts
+++ b/packages/adapters/src/stream-lines.ts
@@ -1,0 +1,48 @@
+export async function* readSSELines(stream: ReadableStream): AsyncIterableIterator<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue
+        const data = line.slice(6).trim()
+        if (data) yield data
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+export async function* readNDJSONLines(stream: ReadableStream): AsyncIterableIterator<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (trimmed) yield trimmed
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -1,4 +1,8 @@
 import type { AdapterRequest, Message, StreamChunk, StreamSource } from '@agentskit/core'
+import { readNDJSONLines, readSSELines } from './stream-lines'
+
+export { parseOpenAIStream } from './openai-stream'
+export { readNDJSONLines, readSSELines } from './stream-lines'
 
 export function toProviderMessages(messages: Message[]) {
   // Track which tool_call ids were declared by preceding assistant turns so
@@ -49,120 +53,6 @@ export function toProviderMessages(messages: Message[]) {
   }
 
   return output
-}
-
-export async function* readSSELines(stream: ReadableStream): AsyncIterableIterator<string> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue
-        const data = line.slice(6).trim()
-        if (data) yield data
-      }
-    }
-  } finally {
-    reader.releaseLock()
-  }
-}
-
-export async function* readNDJSONLines(stream: ReadableStream): AsyncIterableIterator<string> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-
-      for (const line of lines) {
-        const trimmed = line.trim()
-        if (trimmed) yield trimmed
-      }
-    }
-  } finally {
-    reader.releaseLock()
-  }
-}
-
-export async function* parseOpenAIStream(stream: ReadableStream): AsyncIterableIterator<StreamChunk> {
-  const pendingToolCalls = new Map<number, { id: string; name: string; args: string }>()
-
-  for await (const data of readSSELines(stream)) {
-    if (data === '[DONE]') {
-      for (const [, tc] of pendingToolCalls) {
-        yield { type: 'tool_call', toolCall: { id: tc.id, name: tc.name, args: tc.args || '{}' } }
-      }
-      pendingToolCalls.clear()
-      yield { type: 'done' }
-      return
-    }
-
-    try {
-      const event = JSON.parse(data)
-      const delta = event.choices?.[0]?.delta
-
-      if (typeof delta?.content === 'string') {
-        yield { type: 'text', content: delta.content }
-      }
-
-      if (Array.isArray(delta?.tool_calls)) {
-        for (const toolCall of delta.tool_calls) {
-          const index: number = toolCall.index ?? 0
-          const existing = pendingToolCalls.get(index)
-
-          if (toolCall?.function?.name) {
-            // First chunk for this tool call — store it
-            pendingToolCalls.set(index, {
-              id: toolCall.id ?? existing?.id ?? `tool-${index}-${Date.now()}`,
-              name: toolCall.function.name,
-              args: (existing?.args ?? '') + (toolCall.function.arguments ?? ''),
-            })
-          } else if (existing && toolCall?.function?.arguments) {
-            // Subsequent chunk — accumulate arguments
-            existing.args += toolCall.function.arguments
-          }
-        }
-      }
-
-      // Final usage chunk — emitted when `stream_options.include_usage` is set.
-      if (event.usage) {
-        yield {
-          type: 'usage',
-          usage: {
-            promptTokens: event.usage.prompt_tokens ?? 0,
-            completionTokens: event.usage.completion_tokens ?? 0,
-            totalTokens: event.usage.total_tokens ?? 0,
-          },
-        }
-      }
-    } catch {
-      // Ignore malformed events.
-    }
-  }
-
-  // Flush any remaining tool calls if stream ends without [DONE]
-  for (const [, tc] of pendingToolCalls) {
-    yield { type: 'tool_call', toolCall: { id: tc.id, name: tc.name, args: tc.args || '{}' } }
-  }
-  pendingToolCalls.clear()
-
-  yield { type: 'done' }
 }
 
 export async function* parseAnthropicStream(stream: ReadableStream): AsyncIterableIterator<StreamChunk> {

--- a/packages/adapters/tests/openai-stream.test.ts
+++ b/packages/adapters/tests/openai-stream.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type { StreamChunk } from '@agentskit/core'
+import { parseOpenAIStream } from '../src/openai-stream'
+
+function stream(lines: string[]): ReadableStream {
+  const body = lines.map((line) => `data: ${line}\n\n`).join('')
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body))
+      controller.close()
+    },
+  })
+}
+
+async function collect(source: AsyncIterableIterator<StreamChunk>): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = []
+  for await (const chunk of source) chunks.push(chunk)
+  return chunks
+}
+
+describe('parseOpenAIStream terminal integrity', () => {
+  it('accepts a canonical done sentinel', async () => {
+    await expect(collect(parseOpenAIStream(stream(['[DONE]'])))).resolves.toEqual([{ type: 'done' }])
+  })
+
+  it('rejects an unknown finish reason', async () => {
+    const chunks = await collect(parseOpenAIStream(stream([
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: 'cancelled' }] }),
+      '[DONE]',
+    ])))
+
+    expect(chunks.at(-1)?.type).toBe('error')
+    expect(chunks.at(-1)?.metadata?.finishReason).toBe('cancelled')
+  })
+})

--- a/packages/adapters/tests/parsers.test.ts
+++ b/packages/adapters/tests/parsers.test.ts
@@ -152,6 +152,45 @@ describe('parseOpenAIStream', () => {
     expect(toolCalls[0].toolCall!.name).toBe('foo')
     expect(toolCalls[1].toolCall!.name).toBe('bar')
   })
+
+  it('reports an error when the provider closes without a terminal marker', async () => {
+    const stream = sseStream([
+      JSON.stringify({ choices: [{ delta: { content: 'Partial answer' } }] }),
+    ])
+
+    const chunks = await collect(parseOpenAIStream(stream))
+
+    expect(chunks[0]).toEqual({ type: 'text', content: 'Partial answer' })
+    expect(chunks[1]?.type).toBe('error')
+    expect(chunks[1]?.metadata?.error).toBeInstanceOf(Error)
+    expect(chunks).not.toContainEqual({ type: 'done' })
+  })
+
+  it('accepts a provider finish reason when the SSE done sentinel is absent', async () => {
+    const stream = sseStream([
+      JSON.stringify({ choices: [{ delta: { content: 'Complete answer' } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] }),
+    ])
+
+    await expect(collect(parseOpenAIStream(stream))).resolves.toEqual([
+      { type: 'text', content: 'Complete answer' },
+      { type: 'done' },
+    ])
+  })
+
+  it.each(['length', 'content_filter', 'cancelled'])('reports %s as a non-success terminal reason', async (finishReason) => {
+    const stream = sseStream([
+      JSON.stringify({ choices: [{ delta: { content: 'Truncated answer' } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: finishReason }] }),
+      '[DONE]',
+    ])
+
+    const chunks = await collect(parseOpenAIStream(stream))
+
+    expect(chunks.at(-1)?.type).toBe('error')
+    expect(chunks.at(-1)?.metadata?.finishReason).toBe(finishReason)
+    expect(chunks).not.toContainEqual({ type: 'done' })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/adapters/tests/stream-lines.test.ts
+++ b/packages/adapters/tests/stream-lines.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { readNDJSONLines, readSSELines } from '../src/stream-lines'
+
+function stream(chunks: string[]): ReadableStream {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function collect(source: AsyncIterableIterator<string>): Promise<string[]> {
+  const lines: string[] = []
+  for await (const line of source) lines.push(line)
+  return lines
+}
+
+describe('stream line readers', () => {
+  it('reads SSE records split across transport chunks', async () => {
+    await expect(collect(readSSELines(stream(['data: hel', 'lo\n\ndata: world\n\n']))))
+      .resolves.toEqual(['hello', 'world'])
+  })
+
+  it('reads non-empty NDJSON records', async () => {
+    await expect(collect(readNDJSONLines(stream(['{"a":1}\n', '\n{"b":2}\n']))))
+      .resolves.toEqual(['{"a":1}', '{"b":2}'])
+  })
+})


### PR DESCRIPTION
## What
- validates exact-cache records before write and replay
- requires a real upstream terminal chunk before cache promotion
- treats truncated and unknown OpenAI-compatible terminal reasons as errors
- serves the canonical `application/x-ndjson` content type

## Why
Closes #1224

Downstream: AgentsKit-io/agentskit-chat#91

## Tests
- [x] 26 ask-backend tests
- [x] 410 adapter tests
- [x] scoped integrity-boundary coverage above 80% (100% lines)
- [x] 21 repository quality gates
- [x] full monorepo lint, test, and build
- [x] multi-perspective review approved