### PR TITLE
feat(ask): serve the Doc Bridge corpus

### DIFF
--- a/apps/ask-backend/README.md
+++ b/apps/ask-backend/README.md
@@ -6,7 +6,7 @@ serverless cold-start, no native-binary tracing hacks — serving grounded, cite
 for every AgentsKit property over HTTP.
 
 One embedder + one $0 LLM pool + the shared guards serve **N corpora**, routed by a
-`corpus` query param. Current corpora: `docs`, `registry`, `playbook`, `akos`.
+`corpus` query param. Current corpora: `docs`, `registry`, `playbook`, `doc-bridge`, `akos`.
 
 ## API
 
@@ -126,6 +126,7 @@ Remote corpus sources:
 
 - `ASK_REGISTRY_LLMS_FULL_URL`, `ASK_REGISTRY_LLMS_URL`, `ASK_REGISTRY_INDEX_URL`
 - `ASK_PLAYBOOK_LLMS_FULL_URL`, `ASK_PLAYBOOK_LLMS_URL`
+- `ASK_DOC_BRIDGE_LLMS_FULL_URL`, `ASK_DOC_BRIDGE_LLMS_URL`
 - `ASK_AKOS_LLMS_FULL_URL`, `ASK_AKOS_LLMS_URL` (`AKOS_*` aliases are also accepted)
 
 AKOS funnel:

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -116,6 +116,31 @@ const corpora: Record<string, Corpus> = {
     persona: 'playbook-coach',
     title: 'Agents Playbook',
   },
+  'doc-bridge': {
+    retriever: createRemoteCorpusRetriever({
+      id: 'doc-bridge',
+      title: 'AgentsKit Doc Bridge',
+      sources: [
+        {
+          title: 'Doc Bridge full docs',
+          url:
+            process.env.ASK_DOC_BRIDGE_LLMS_FULL_URL ??
+            'https://agentskit-io.github.io/doc-bridge/llms-full.txt',
+        },
+        {
+          title: 'Doc Bridge llms',
+          url:
+            process.env.ASK_DOC_BRIDGE_LLMS_URL ??
+            'https://agentskit-io.github.io/doc-bridge/llms.txt',
+        },
+      ],
+    }),
+    systemPrompt: docsAssistant.systemPrompt,
+    temperature: docsAssistant.temperature,
+    formatContext: (docs) => formatCitedContext(docs).context,
+    persona: 'docs-helper',
+    title: 'AgentsKit Doc Bridge',
+  },
   akos: {
     retriever: createRemoteCorpusRetriever({
       id: 'akos',
@@ -236,7 +261,7 @@ const app = new Hono()
 // drop empties. Log the effective list so a misconfigured ASK_CORS_ORIGINS is visible.
 const origins = (
   process.env.ASK_CORS_ORIGINS ??
-  'https://www.agentskit.io,https://agentskit.io,https://registry.agentskit.io,https://playbook.agentskit.io,https://akos.agentskit.io,http://localhost:3000'
+  'https://www.agentskit.io,https://agentskit.io,https://registry.agentskit.io,https://playbook.agentskit.io,https://akos.agentskit.io,https://agentskit-io.github.io,http://localhost:3000'
 )
   .split(',')
   .map((o) => o.trim().replace(/\/+$/, ''))


### PR DESCRIPTION
## Summary

- register Doc Bridge as a first-class remote Ask corpus backed by its published llms surfaces
- allow the GitHub Pages origin used by the Doc Bridge portal
- document the new corpus and environment overrides

## Evidence

- ask-backend lint passes
- ask-backend: 26 tests pass
- all 21 repository quality gates pass
- full monorepo lint and build pass in the pre-push hook
- local /v1/corpora response includes doc-bridge and returns Access-Control-Allow-Origin for https://agentskit-io.github.io

Companion to AgentsKit-io/doc-bridge#36.