### PR TITLE
fix(ask): preserve Doc Bridge CORS with env overrides

### DIFF
--- a/apps/ask-backend/src/cors-origins.test.ts
+++ b/apps/ask-backend/src/cors-origins.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCorsOrigins } from './cors-origins.js'
+
+describe('resolveCorsOrigins', () => {
+  it('includes the official Doc Bridge origin in the defaults', () => {
+    expect(resolveCorsOrigins()).toContain('https://agentskit-io.github.io')
+  })
+
+  it('preserves the official Doc Bridge origin when the environment overrides CORS', () => {
+    expect(resolveCorsOrigins('https://custom.example')).toEqual([
+      'https://custom.example',
+      'https://agentskit-io.github.io',
+    ])
+  })
+
+  it('normalizes and deduplicates configured origins', () => {
+    expect(
+      resolveCorsOrigins(' https://agentskit-io.github.io/, https://custom.example/,https://custom.example '),
+    ).toEqual(['https://agentskit-io.github.io', 'https://custom.example'])
+  })
+})

--- a/apps/ask-backend/src/cors-origins.ts
+++ b/apps/ask-backend/src/cors-origins.ts
@@ -1,0 +1,20 @@
+const DEFAULT_CORS_ORIGINS = [
+  'https://www.agentskit.io',
+  'https://agentskit.io',
+  'https://registry.agentskit.io',
+  'https://playbook.agentskit.io',
+  'https://akos.agentskit.io',
+  'http://localhost:3000',
+] as const
+
+const REQUIRED_CORS_ORIGINS = ['https://agentskit-io.github.io'] as const
+
+function normalizeOrigin(origin: string): string {
+  return origin.trim().replace(/\/+$/, '')
+}
+
+export function resolveCorsOrigins(configuredOrigins?: string): string[] {
+  const configured = configuredOrigins === undefined ? DEFAULT_CORS_ORIGINS : configuredOrigins.split(',')
+
+  return [...new Set([...configured, ...REQUIRED_CORS_ORIGINS].map(normalizeOrigin).filter(Boolean))]
+}

--- a/apps/ask-backend/src/server.ts
+++ b/apps/ask-backend/src/server.ts
@@ -16,6 +16,7 @@
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { resolveCorsOrigins } from './cors-origins.js'
 import { createMiddleware } from 'hono/factory'
 import type { JSONSchema7 } from 'json-schema'
 import type { RetrievedDocument, Retriever } from '@agentskit/core'
@@ -256,16 +257,9 @@ function warmCorpora(): void {
 
 const app = new Hono()
 
-// Parse the CORS allow-list defensively: trim each entry and strip a trailing slash
-// (an `Origin` header never has one, so `https://x/` would silently never match), and
-// drop empties. Log the effective list so a misconfigured ASK_CORS_ORIGINS is visible.
-const origins = (
-  process.env.ASK_CORS_ORIGINS ??
-  'https://www.agentskit.io,https://agentskit.io,https://registry.agentskit.io,https://playbook.agentskit.io,https://akos.agentskit.io,https://agentskit-io.github.io,http://localhost:3000'
-)
-  .split(',')
-  .map((o) => o.trim().replace(/\/+$/, ''))
-  .filter(Boolean)
+// Environment origins extend the official Doc Bridge origin rather than replacing
+// it, so the published chat keeps working when production has an explicit allow-list.
+const origins = resolveCorsOrigins(process.env.ASK_CORS_ORIGINS)
 console.log('[ask-backend] CORS allow-origins:', origins.join(', ') || '(none!)')
 app.use('/v1/*', cors({ origin: origins, allowMethods: ['POST', 'GET', 'OPTIONS'] }))
 


### PR DESCRIPTION
## Summary
- keep the official Doc Bridge GitHub Pages origin in the effective CORS allow-list
- treat `ASK_CORS_ORIGINS` as additional deployment configuration for that required origin
- normalize and deduplicate configured origins in a tested pure helper

## Production evidence
The Doc Bridge corpus is live and `/v1/search?corpus=doc-bridge` returns the published corpus, but Railway defines `ASK_CORS_ORIGINS`, which replaced the defaults and omitted `Access-Control-Allow-Origin` for `https://agentskit-io.github.io`.

## Verification
- `pnpm --filter @agentskit/ask-backend lint`
- `pnpm --filter @agentskit/ask-backend test` (29 tests)
- pre-push: all 21 quality gates, monorepo lint, and monorepo build
