### PR TITLE
fix(ask): retry embedding model download

### DIFF
--- a/apps/ask-backend/Dockerfile
+++ b/apps/ask-backend/Dockerfile
@@ -38,8 +38,21 @@ RUN pnpm install --frozen-lockfile \
 # network dependency, and no chance a transient first-load failure poisons the server.
 # `embed.ts` reads the same TRANSFORMERS_CACHE, so build + runtime agree on the path.
 # Run from the app dir so pnpm resolves `@huggingface/transformers` (hoisted there).
+# Retry transient Hub/CDN failures; a partial download remains in the cache and can
+# resume on the next attempt, while a persistent failure still stops the image build.
 ENV TRANSFORMERS_CACHE=/app/.transformers-cache
-RUN cd apps/ask-backend && node --input-type=module -e "import('@huggingface/transformers').then(async (t) => { t.env.cacheDir = process.env.TRANSFORMERS_CACHE; await t.pipeline('feature-extraction', 'Xenova/bge-small-en-v1.5'); console.log('embedding model baked into image'); })"
+RUN cd apps/ask-backend \
+ && attempt=1 \
+ && until node --input-type=module -e "import('@huggingface/transformers').then(async (t) => { t.env.cacheDir = process.env.TRANSFORMERS_CACHE; await t.pipeline('feature-extraction', 'Xenova/bge-small-en-v1.5'); console.log('embedding model baked into image'); })"; do \
+      if [ "$attempt" -ge 3 ]; then \
+        echo "embedding model download failed after $attempt attempts" >&2; \
+        exit 1; \
+      fi; \
+      delay=$((attempt * 5)); \
+      echo "embedding model download failed; retrying in ${delay}s" >&2; \
+      sleep "$delay"; \
+      attempt=$((attempt + 1)); \
+    done
 
 ENV NODE_ENV=production
 ENV PORT=8080


### PR DESCRIPTION
## Summary
- retry the build-time Hugging Face embedding model download up to three times
- retain partial cache state between attempts
- use bounded 5s/10s backoff and still fail closed after a persistent error

## Production evidence
Railway deployment `4475b05e-3a3e-4f7a-8358-92142c2b9e52` completed all 11 package builds, then failed because Hugging Face transiently returned `403 Forbidden` for the 133 MB ONNX model. The artifact became available again immediately afterward, so this makes the existing build-time bake resilient without moving the network dependency to runtime.

## Verification
- POSIX shell syntax validation for the `RUN` body
- `git diff --check`
- pre-push: all 21 quality gates, monorepo lint, and monorepo build

Docker daemon was unavailable locally; the Railway builder remains the end-to-end Docker validation.
