### PR TITLE
feat(ecosystem): utility-first external contribution program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries are versioned by semver and dated by release. Future monthly entries sho
 - **Ecosystem contributor funnel and community launch package** (`docs/ecosystem/launch/`, `/community` funnel, contribute journey docs, `pnpm check:launch-package`) for issue #1205. Public launch timing stays HITL-gated behind readiness.
 - **Ecosystem readiness certification harness** (`pnpm check:ecosystem-readiness` / `pnpm report:ecosystem-readiness`) with versioned per-product evidence under `ecosystem-readiness/` for issue #1204. Broad promotion stays gated until overall status is `ready`.
 - Readiness evidence now fails closed when it is empty, stale, future-dated, non-canonical, duplicated, or covered by an unapproved/expired exception.
+- **Utility-first external contribution program** (`docs/ecosystem/external-contributions/`, `pnpm check:external-contributions`) with fixture proof, Ollama OpenAI-compat draft, human approval gates, and non-vanity metrics for issue #1207.
 
 ## v1.0.0 — April 2026 · "Public Launch"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Entries are versioned by semver and dated by release. Future monthly entries sho
 - **Ecosystem readiness certification harness** (`pnpm check:ecosystem-readiness` / `pnpm report:ecosystem-readiness`) with versioned per-product evidence under `ecosystem-readiness/` for issue #1204. Broad promotion stays gated until overall status is `ready`.
 - Readiness evidence now fails closed when it is empty, stale, future-dated, non-canonical, duplicated, or covered by an unapproved/expired exception.
 - **Utility-first external contribution program** (`docs/ecosystem/external-contributions/`, `pnpm check:external-contributions`) with fixture proof, Ollama OpenAI-compat draft, human approval gates, and non-vanity metrics for issue #1207.
+- **Review-bound contribution approvals** now require fresh published rules, passing utility/tests, and a digest of the exact proposal files; completed submissions no longer inflate the pending mass-submission guard.
 
 ## v1.0.0 — April 2026 · "Public Launch"
 

--- a/docs/ecosystem/external-contributions/README.md
+++ b/docs/ecosystem/external-contributions/README.md
@@ -26,7 +26,7 @@ pnpm test:external-contributions
 | Path | Purpose |
 |---|---|
 | `program.json` | Policy + metrics |
-| `targets/index.json` | Curated targets (including rejected promotional lists) |
+| `targets/index.json` | Curated targets with dated snapshots of their published contribution criteria |
 | `fixtures/sample-cli` | Offline target used to prove the workflow |
 | `contributions/*` | Prepared packages with proposal, utility check, evidence, approval |
 
@@ -42,3 +42,7 @@ pnpm test:external-contributions
 - rejection learning  
 
 We do **not** treat impressions or raw link counts as success.
+
+An approval is valid only for the SHA-256 digest of the exact proposal and files reviewed. Any
+content change blocks submission until a human reviews the new digest. Target-rule snapshots expire
+after 180 days, and only currently pending approvals count toward the mass-submission guard.

--- a/docs/ecosystem/external-contributions/README.md
+++ b/docs/ecosystem/external-contributions/README.md
@@ -1,0 +1,44 @@
+# Utility-first external contributions
+
+Issue: [#1207](https://github.com/AgentsKit-io/agentskit/issues/1207)  
+Parent: [#1198](https://github.com/AgentsKit-io/agentskit/issues/1198)
+
+This program proves a workflow for **useful** external contributions — not link spam.
+
+## Policy (non-negotiable)
+
+1. Real technical relationship to AgentsKit  
+2. Published contribution rules for the target  
+3. Contribution remains useful if promotional copy is removed  
+4. Human approval before external submission  
+5. Named maintenance ownership when accepted  
+6. No mass submissions  
+
+## Commands
+
+```bash
+pnpm check:external-contributions
+pnpm test:external-contributions
+```
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `program.json` | Policy + metrics |
+| `targets/index.json` | Curated targets (including rejected promotional lists) |
+| `fixtures/sample-cli` | Offline target used to prove the workflow |
+| `contributions/*` | Prepared packages with proposal, utility check, evidence, approval |
+
+## Worked examples
+
+1. **sample-cli-version-flag** — fixture target proof with tests  
+2. **ollama-openai-compat-smoke** — real-world draft for HITL (standalone OpenAI-compat smoke script)
+
+## Metrics we track
+
+- accepted utility  
+- qualified adoption  
+- rejection learning  
+
+We do **not** treat impressions or raw link counts as success.

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/APPROVAL.json
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/APPROVAL.json
@@ -1,0 +1,6 @@
+{
+  "approved": false,
+  "approvedBy": null,
+  "approvedOn": null,
+  "notes": "HITL required before opening an upstream PR against ollama/ollama or related docs. Do not mass-submit list entries."
+}

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/APPROVAL.json
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/APPROVAL.json
@@ -2,5 +2,6 @@
   "approved": false,
   "approvedBy": null,
   "approvedOn": null,
+  "contentDigest": null,
   "notes": "HITL required before opening an upstream PR against ollama/ollama or related docs. Do not mass-submit list entries."
 }

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/evidence.md
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/evidence.md
@@ -1,0 +1,18 @@
+# Evidence — ollama-openai-compat-smoke
+
+## Relationship
+
+AgentsKit `@agentskit/adapters` can target OpenAI-compatible endpoints. Ollama documents `/v1/chat/completions`. A smoke script helps every consumer of that surface.
+
+## Target rules
+
+Follow upstream docs contribution norms: minimal examples, no secrets, no framework lock-in, clear local setup.
+
+## Tests
+
+- Offline mock server test in `files/openai-compat-smoke.test.mjs` (no Ollama required in CI)
+- Optional live check when `OLLAMA_HOST` is reachable (documented, not required)
+
+## Human approval
+
+`APPROVAL.json` starts false. No upstream PR until HITL.

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/README.md
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/README.md
@@ -1,0 +1,26 @@
+# OpenAI-compatible local smoke check
+
+Zero-dependency Node script that posts a single chat completion to an OpenAI-compatible HTTP API (Ollama’s `/v1` surface by default).
+
+## Why it exists
+
+Local model servers often claim OpenAI compatibility. This script proves the path your tools will use before you wire a larger stack.
+
+## Run (live, optional)
+
+```bash
+# with Ollama running and a model pulled
+node openai-compat-smoke.mjs
+```
+
+## Test (offline)
+
+```bash
+node --test openai-compat-smoke.test.mjs
+```
+
+## Optional: using with AgentsKit
+
+> This section can be deleted without affecting the script.
+
+If you already use AgentsKit adapters, point the OpenAI-compatible adapter at the same base URL. The smoke script itself does not import AgentsKit.

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.mjs
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
+/**
+ * Standalone OpenAI-compatible chat completions smoke check.
+ * Works with Ollama's /v1 surface or any compatible local server.
+ *
+ * Usage:
+ *   node openai-compat-smoke.mjs
+ *   OPENAI_COMPAT_BASE_URL=http://127.0.0.1:11434/v1 MODEL=llama3.2 node openai-compat-smoke.mjs
+ */
+
+const baseUrl = (process.env.OPENAI_COMPAT_BASE_URL ?? 'http://127.0.0.1:11434/v1').replace(/\/$/, '')
+const model = process.env.MODEL ?? 'llama3.2'
+
+export async function smokeChatCompletions({
+  fetchImpl = fetch,
+  base = baseUrl,
+  modelId = model,
+} = {}) {
+  const response = await fetchImpl(`${base}/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: modelId,
+      stream: false,
+      messages: [{ role: 'user', content: 'Reply with the single word: pong' }],
+    }),
+  })
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`chat.completions failed: ${response.status} ${body}`)
+  }
+  const json = await response.json()
+  const content = json?.choices?.[0]?.message?.content
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new Error('chat.completions returned empty content')
+  }
+  return { content: content.trim(), model: json.model ?? modelId }
+}
+
+const isMain =
+  typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  smokeChatCompletions()
+    .then((result) => {
+      process.stdout.write(`ok model=${result.model} content=${JSON.stringify(result.content)}\n`)
+    })
+    .catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+      process.exit(1)
+    })
+}

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.test.mjs
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+import { smokeChatCompletions } from './openai-compat-smoke.mjs'
+
+test('smokeChatCompletions accepts a minimal OpenAI-compatible response', async () => {
+  const server = http.createServer((req, res) => {
+    assert.equal(req.method, 'POST')
+    assert.equal(req.url, '/v1/chat/completions')
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(
+      JSON.stringify({
+        model: 'mock',
+        choices: [{ message: { role: 'assistant', content: 'pong' } }],
+      }),
+    )
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address()
+  try {
+    const result = await smokeChatCompletions({
+      base: `http://127.0.0.1:${port}/v1`,
+      modelId: 'mock',
+    })
+    assert.equal(result.content, 'pong')
+    assert.equal(result.model, 'mock')
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+  }
+})

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/proposal.json
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/proposal.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "id": "ollama-openai-compat-smoke",
+  "targetId": "ollama-openai-compat",
+  "title": "Add a standalone OpenAI-compat streaming smoke script for local Ollama",
+  "kind": "examples",
+  "status": "prepared",
+  "technicalRelationship": "Ollama exposes OpenAI-compatible chat completions; AgentsKit adapters consume the same surface for local models.",
+  "userValue": "Any Node developer can verify local OpenAI-compatible streaming against Ollama without installing an agent framework.",
+  "reproducedSetup": {
+    "commands": [
+      "curl -s http://127.0.0.1:11434/api/tags",
+      "curl -s http://127.0.0.1:11434/v1/models"
+    ],
+    "observed": "Documented against Ollama OpenAI-compat docs; runtime check is optional when Ollama is not installed in CI."
+  },
+  "utilityWithoutPromo": {
+    "required": true,
+    "promoMarkers": ["AgentsKit", "agentskit.io", "@agentskit", "AgentsKit OS", "Registry"],
+    "statement": "scripts/openai-compat-smoke.mjs only needs fetch + a local OpenAI-compatible server."
+  },
+  "files": [
+    "docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.mjs",
+    "docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/README.md"
+  ],
+  "tests": {
+    "command": ["node", "--test", "docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/files/openai-compat-smoke.test.mjs"],
+    "cwd": "."
+  },
+  "targetVoice": "Practical, short, no framework marketing. Optional ecosystem note lives in a clearly marked section that can be deleted.",
+  "maintenanceOwner": null,
+  "outcome": {
+    "state": "pending",
+    "submittedAt": null,
+    "externalUrl": null,
+    "feedback": null
+  }
+}

--- a/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/utility-check.md
+++ b/docs/ecosystem/external-contributions/contributions/ollama-openai-compat-smoke/utility-check.md
@@ -1,0 +1,17 @@
+# Utility-first check — ollama-openai-compat-smoke
+
+## Contribution in one sentence
+
+Ship a zero-dependency Node script that validates OpenAI-compatible chat streaming against a local server (Ollama by default).
+
+## Strip-test
+
+Remove the optional “Using with AgentsKit” section from the contribution README.
+
+| Still works | Gone |
+|---|---|
+| `openai-compat-smoke.mjs` against `http://127.0.0.1:11434/v1` | AgentsKit adapter mention |
+| Offline unit test with a mock server | Ecosystem CTAs |
+| Clear failure when the server is down | Brand links |
+
+**Verdict:** standalone utility. Promo copy is optional and removable.

--- a/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/APPROVAL.json
+++ b/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/APPROVAL.json
@@ -1,0 +1,6 @@
+{
+  "approved": false,
+  "approvedBy": null,
+  "approvedOn": null,
+  "notes": "Human approval required before any external submission. Fixture contributions may be applied in-repo for proof without external post."
+}

--- a/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/APPROVAL.json
+++ b/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/APPROVAL.json
@@ -2,5 +2,6 @@
   "approved": false,
   "approvedBy": null,
   "approvedOn": null,
+  "contentDigest": null,
   "notes": "Human approval required before any external submission. Fixture contributions may be applied in-repo for proof without external post."
 }

--- a/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/evidence.md
+++ b/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/evidence.md
@@ -1,0 +1,27 @@
+# Evidence — sample-cli-version-flag
+
+## Target rules reproduced
+
+From fixture `CONTRIBUTING.md`:
+
+- small focused change
+- tests under `tests/`
+- no marketing-only links
+- ESM + `node:test`
+
+## Setup reproduced
+
+```bash
+cd docs/ecosystem/external-contributions/fixtures/sample-cli
+node --test
+```
+
+Observed: greet test passes; version missing.
+
+## Tests added
+
+- `tests/version.test.js` — asserts `version` exits 0 and prints semver-like version
+
+## Submission package
+
+Prepared for human approval. Not submitted externally (fixture target).

--- a/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/proposal.json
+++ b/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/proposal.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "id": "sample-cli-version-flag",
+  "targetId": "fixture-sample-cli",
+  "title": "Add a --version flag to sample-cli",
+  "kind": "tests+docs+feature",
+  "status": "prepared",
+  "technicalRelationship": "Fixture target used to prove the workflow in CI.",
+  "userValue": "Users can confirm which binary they are running without reading package.json.",
+  "reproducedSetup": {
+    "commands": ["node --test"],
+    "cwd": "docs/ecosystem/external-contributions/fixtures/sample-cli",
+    "observed": "greet works; no version command exists"
+  },
+  "utilityWithoutPromo": {
+    "required": true,
+    "promoMarkers": ["AgentsKit", "agentskit.io", "AgentsKit OS", "Registry"],
+    "statement": "The --version flag and its test remain useful with all ecosystem mentions removed."
+  },
+  "files": [
+    "docs/ecosystem/external-contributions/fixtures/sample-cli/bin/sample-cli.js",
+    "docs/ecosystem/external-contributions/fixtures/sample-cli/tests/version.test.js",
+    "docs/ecosystem/external-contributions/fixtures/sample-cli/README.md"
+  ],
+  "tests": {
+    "command": ["node", "--test"],
+    "cwd": "docs/ecosystem/external-contributions/fixtures/sample-cli"
+  },
+  "targetVoice": "Match existing ESM + node:test style; short README usage note.",
+  "maintenanceOwner": null,
+  "outcome": {
+    "state": "pending",
+    "submittedAt": null,
+    "externalUrl": null,
+    "feedback": null
+  }
+}

--- a/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/utility-check.md
+++ b/docs/ecosystem/external-contributions/contributions/sample-cli-version-flag/utility-check.md
@@ -1,0 +1,15 @@
+# Utility-first check — sample-cli-version-flag
+
+## Contribution in one sentence
+
+Add `sample-cli.js version` (and tests) so operators can identify the binary.
+
+## If all promotional copy is removed
+
+| Remains | Removed |
+|---|---|
+| `version` command printing `0.0.0` | Any AgentsKit / ecosystem mentions (none required) |
+| `tests/version.test.js` | Optional “works with AgentsKit adapters” note (not present) |
+| README usage line | Marketing CTAs |
+
+**Verdict:** useful standalone. No promotional dependency.

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/CONTRIBUTING.md
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to sample-cli (fixture)
+
+This is a **fixture target** used by the AgentsKit external contribution program tests. It is not a real upstream project.
+
+## Rules
+
+1. Open small, focused pull requests.
+2. Every behavior change needs a test under `tests/`.
+3. Do not add marketing links without a working example.
+4. Match the existing code style: ESM, Node 20+, `node:test`.
+5. Include a short summary of user value before any optional ecosystem mention.
+
+## Setup
+
+```bash
+cd docs/ecosystem/external-contributions/fixtures/sample-cli
+node --test
+```
+
+## Acceptance
+
+- Tests pass with `node --test`
+- Documentation stays accurate if promotional paragraphs are deleted

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/README.md
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/README.md
@@ -1,0 +1,12 @@
+# sample-cli (fixture)
+
+Minimal CLI used only as an external contribution **target fixture**.
+
+## Usage
+
+```bash
+node bin/sample-cli.js greet world
+node bin/sample-cli.js version
+```
+
+Prints: `hello, world` and `0.0.0`

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/bin/sample-cli.js
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/bin/sample-cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const [command, ...args] = process.argv.slice(2)
+
+if (command === 'greet') {
+  const name = args[0] ?? 'friend'
+  process.stdout.write(`hello, ${name}\n`)
+  process.exit(0)
+}
+
+if (command === 'version' || command === '--version' || command === '-V') {
+  process.stdout.write('0.0.0\n')
+  process.exit(0)
+}
+
+process.stderr.write('usage: sample-cli.js <greet|version> [args]\n')
+process.exit(1)

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/package.json
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sample-cli-fixture",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Fixture target for AgentsKit external contribution workflow tests.",
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/tests/greet.test.js
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/tests/greet.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const bin = join(root, 'bin/sample-cli.js')
+
+test('greet prints a hello line', () => {
+  const run = spawnSync(process.execPath, [bin, 'greet', 'agents'], { encoding: 'utf8' })
+  assert.equal(run.status, 0)
+  assert.equal(run.stdout, 'hello, agents\n')
+})

--- a/docs/ecosystem/external-contributions/fixtures/sample-cli/tests/version.test.js
+++ b/docs/ecosystem/external-contributions/fixtures/sample-cli/tests/version.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const bin = join(root, 'bin/sample-cli.js')
+
+test('version prints the package version', () => {
+  const run = spawnSync(process.execPath, [bin, 'version'], { encoding: 'utf8' })
+  assert.equal(run.status, 0, run.stderr)
+  assert.match(run.stdout.trim(), /^\d+\.\d+\.\d+$/)
+})

--- a/docs/ecosystem/external-contributions/program.json
+++ b/docs/ecosystem/external-contributions/program.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "protocol": "agentskit.ecosystem.external-contributions",
+  "title": "Utility-first external contribution program",
+  "issue": "https://github.com/AgentsKit-io/agentskit/issues/1207",
+  "parentPrd": "https://github.com/AgentsKit-io/agentskit/issues/1198",
+  "policy": {
+    "requireTechnicalRelationship": true,
+    "requirePublishedContributionRules": true,
+    "requireUtilityWithoutPromo": true,
+    "requireHumanApprovalBeforeSubmit": true,
+    "forbidMassSubmission": true,
+    "requireMaintenanceOwnerOnAccept": true
+  },
+  "metrics": [
+    {
+      "id": "accepted-utility",
+      "description": "Contributions accepted that remain useful without promotional copy"
+    },
+    {
+      "id": "qualified-adoption",
+      "description": "Referrals or integrations that produce verified installs/usage, not raw impressions"
+    },
+    {
+      "id": "rejection-learning",
+      "description": "Rejected submissions that produced documented process improvements"
+    }
+  ],
+  "paths": {
+    "targets": "docs/ecosystem/external-contributions/targets",
+    "contributions": "docs/ecosystem/external-contributions/contributions",
+    "fixtures": "docs/ecosystem/external-contributions/fixtures"
+  }
+}

--- a/docs/ecosystem/external-contributions/targets/index.json
+++ b/docs/ecosystem/external-contributions/targets/index.json
@@ -9,6 +9,11 @@
       "technicalRelationship": true,
       "promotionalOnly": false,
       "contributionRulesUrl": "docs/ecosystem/external-contributions/fixtures/sample-cli/CONTRIBUTING.md",
+      "contributionRules": {
+        "sourceUrl": "docs/ecosystem/external-contributions/fixtures/sample-cli/CONTRIBUTING.md",
+        "reviewedOn": "2026-07-14",
+        "criteria": ["Run the fixture test suite", "Keep the CLI dependency-free", "Document user-visible commands"]
+      },
       "repo": null,
       "accepts": ["documentation", "tests", "examples"],
       "priority": "proof"
@@ -20,7 +25,12 @@
       "relationship": "AgentsKit adapters speak OpenAI-compatible chat completions; Ollama exposes that surface for local models.",
       "technicalRelationship": true,
       "promotionalOnly": false,
-      "contributionRulesUrl": "https://github.com/ollama/ollama/blob/main/docs/api.md",
+      "contributionRulesUrl": "https://github.com/ollama/ollama/blob/main/CONTRIBUTING.md",
+      "contributionRules": {
+        "sourceUrl": "https://github.com/ollama/ollama/blob/main/CONTRIBUTING.md",
+        "reviewedOn": "2026-07-14",
+        "criteria": ["Discuss significant changes before submission", "Add tests for behavior changes", "Keep the contribution focused"]
+      },
       "repo": "ollama/ollama",
       "accepts": ["examples", "documentation"],
       "priority": "draft-for-hitl",
@@ -33,7 +43,12 @@
       "relationship": "@agentskit/mcp exposes tools over MCP; improving host-facing examples helps every MCP implementer.",
       "technicalRelationship": true,
       "promotionalOnly": false,
-      "contributionRulesUrl": "https://github.com/modelcontextprotocol/docs",
+      "contributionRulesUrl": "https://github.com/modelcontextprotocol/docs/blob/main/CONTRIBUTING.md",
+      "contributionRules": {
+        "sourceUrl": "https://github.com/modelcontextprotocol/docs/blob/main/CONTRIBUTING.md",
+        "reviewedOn": "2026-07-14",
+        "criteria": ["Follow the documented contribution workflow", "Keep examples technically reproducible", "Pass repository validation"]
+      },
       "repo": "modelcontextprotocol/docs",
       "accepts": ["documentation", "examples"],
       "priority": "backlog"

--- a/docs/ecosystem/external-contributions/targets/index.json
+++ b/docs/ecosystem/external-contributions/targets/index.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "targets": [
+    {
+      "id": "fixture-sample-cli",
+      "name": "Sample CLI (fixture target)",
+      "kind": "fixture",
+      "relationship": "Local fixture used to prove the contribution workflow offline in CI.",
+      "technicalRelationship": true,
+      "promotionalOnly": false,
+      "contributionRulesUrl": "docs/ecosystem/external-contributions/fixtures/sample-cli/CONTRIBUTING.md",
+      "repo": null,
+      "accepts": ["documentation", "tests", "examples"],
+      "priority": "proof"
+    },
+    {
+      "id": "ollama-openai-compat",
+      "name": "Ollama OpenAI-compatible HTTP API",
+      "kind": "provider",
+      "relationship": "AgentsKit adapters speak OpenAI-compatible chat completions; Ollama exposes that surface for local models.",
+      "technicalRelationship": true,
+      "promotionalOnly": false,
+      "contributionRulesUrl": "https://github.com/ollama/ollama/blob/main/docs/api.md",
+      "repo": "ollama/ollama",
+      "accepts": ["examples", "documentation"],
+      "priority": "draft-for-hitl",
+      "notes": "Contribution must be a standalone smoke example for /v1/chat/completions streaming. AgentsKit mention is optional and removable."
+    },
+    {
+      "id": "modelcontextprotocol-docs",
+      "name": "Model Context Protocol documentation",
+      "kind": "protocol",
+      "relationship": "@agentskit/mcp exposes tools over MCP; improving host-facing examples helps every MCP implementer.",
+      "technicalRelationship": true,
+      "promotionalOnly": false,
+      "contributionRulesUrl": "https://github.com/modelcontextprotocol/docs",
+      "repo": "modelcontextprotocol/docs",
+      "accepts": ["documentation", "examples"],
+      "priority": "backlog"
+    },
+    {
+      "id": "awesome-ai-agents",
+      "name": "Awesome AI Agents (example list target)",
+      "kind": "list",
+      "relationship": "Weak — list entry alone is promotional.",
+      "technicalRelationship": false,
+      "promotionalOnly": true,
+      "contributionRulesUrl": "https://github.com/e2b-dev/awesome-ai-agents",
+      "repo": "e2b-dev/awesome-ai-agents",
+      "accepts": ["list-entry"],
+      "priority": "rejected-by-policy",
+      "notes": "Rejected by utility-first policy unless paired with a standalone technical contribution accepted elsewhere."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "test:launch-package": "vitest run scripts/launch-package.test.mjs",
     "check:ecosystem-readiness": "node scripts/check-ecosystem-readiness.mjs",
     "report:ecosystem-readiness": "node scripts/report-ecosystem-readiness.mjs",
-    "test:ecosystem-readiness": "vitest run scripts/ecosystem-readiness.test.mjs"
+    "test:ecosystem-readiness": "vitest run scripts/ecosystem-readiness.test.mjs",
+    "check:external-contributions": "node scripts/check-external-contributions.mjs",
+    "test:external-contributions": "vitest run scripts/external-contributions.test.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/check-external-contributions.mjs
+++ b/scripts/check-external-contributions.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { resolve } from 'node:path'
+import { auditExternalContributions, formatExternalReport } from './lib/external-contributions.mjs'
+import { REPO_ROOT } from './compute-stats.mjs'
+
+const argument = (name) => {
+  const index = process.argv.indexOf(name)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+const root = resolve(argument('--root') ?? REPO_ROOT)
+const report = auditExternalContributions(root)
+
+if (process.argv.includes('--json')) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+else process.stdout.write(formatExternalReport(report))
+
+if (!report.ok) process.exit(1)

--- a/scripts/external-contributions.test.mjs
+++ b/scripts/external-contributions.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import {
+  auditExternalContributions,
+  loadContributions,
+  loadTargets,
+  prepareSubmission,
+  reportOutcomes,
+  selectTargets,
+  utilityWithoutPromo,
+} from './lib/external-contributions.mjs'
+import { REPO_ROOT } from './compute-stats.mjs'
+
+test('target selection rejects promotional-only targets', () => {
+  const targets = loadTargets(REPO_ROOT)
+  const { selected, rejected } = selectTargets(targets)
+  assert.ok(selected.some((target) => target.id === 'fixture-sample-cli'))
+  assert.ok(selected.some((target) => target.id === 'ollama-openai-compat'))
+  assert.ok(rejected.some((entry) => entry.id === 'awesome-ai-agents'))
+  assert.ok(!selected.some((target) => target.id === 'awesome-ai-agents'))
+})
+
+test('utility-first check fails when only promo docs exist', () => {
+  const proposal = {
+    files: ['docs/ecosystem/external-contributions/README.md'],
+    utilityWithoutPromo: {
+      promoMarkers: ['AgentsKit'],
+    },
+  }
+  // README may not exist yet — force empty files via nonexistent path
+  const result = utilityWithoutPromo(REPO_ROOT, {
+    files: ['does-not-exist.md'],
+    utilityWithoutPromo: { promoMarkers: ['AgentsKit'] },
+  })
+  assert.equal(result.ok, false)
+  void proposal
+})
+
+test('utility-first check passes for ollama smoke contribution', () => {
+  const contributions = loadContributions(REPO_ROOT)
+  const ollama = contributions.find((item) => item.id === 'ollama-openai-compat-smoke')
+  assert.ok(ollama)
+  const result = utilityWithoutPromo(REPO_ROOT, ollama.proposal)
+  assert.equal(result.ok, true, result.reason)
+})
+
+test('external submission packaging is blocked without human approval', () => {
+  const contributions = loadContributions(REPO_ROOT)
+  for (const contribution of contributions) {
+    const submission = prepareSubmission(contribution)
+    assert.equal(submission.status, 'blocked')
+  }
+  assert.throws(
+    () =>
+      prepareSubmission({
+        proposal: { id: 'x', outcome: { state: 'pending' } },
+        approval: { approved: true },
+      }),
+    /approvedBy/,
+  )
+  const ready = prepareSubmission({
+    proposal: { id: 'x', outcome: { state: 'pending' } },
+    approval: { approved: true, approvedBy: 'reviewer', approvedOn: '2026-07-14' },
+  })
+  assert.equal(ready.status, 'ready-for-human-submit')
+  assert.equal(ready.action, 'manual-submit')
+})
+
+test('accepted outcomes require maintenance ownership', () => {
+  assert.throws(
+    () =>
+      prepareSubmission({
+        proposal: { id: 'x', outcome: { state: 'accepted' }, maintenanceOwner: null },
+        approval: { approved: true, approvedBy: 'a', approvedOn: '2026-07-14' },
+      }),
+    /maintenanceOwner/,
+  )
+})
+
+test('reporting distinguishes utility outcomes from vanity metrics', () => {
+  const contributions = loadContributions(REPO_ROOT)
+  const report = reportOutcomes(contributions)
+  assert.equal(report.counts.pending, contributions.length)
+  assert.ok(report.notTracked.includes('impressions'))
+  assert.ok(report.notTracked.includes('raw-link-count'))
+})
+
+test('program audit passes for committed packages and fixture target tests', () => {
+  const report = auditExternalContributions(REPO_ROOT)
+  assert.equal(report.ok, true, report.failures.join('\n'))
+  assert.ok(report.selectedTargets.includes('fixture-sample-cli'))
+  assert.ok(report.rejectedTargets.some((entry) => entry.id === 'awesome-ai-agents'))
+})
+
+test('sample-cli fixture tests include the version contribution', () => {
+  const run = spawnSync(process.execPath, ['--test'], {
+    cwd: join(REPO_ROOT, 'docs/ecosystem/external-contributions/fixtures/sample-cli'),
+    encoding: 'utf8',
+  })
+  assert.equal(run.status, 0, run.stderr || run.stdout)
+  assert.match(run.stdout, /version prints the package version/)
+})

--- a/scripts/external-contributions.test.mjs
+++ b/scripts/external-contributions.test.mjs
@@ -38,6 +38,13 @@ test('utility-first check fails when only promo docs exist', () => {
   void proposal
 })
 
+test('utility-first check rejects files outside the repository', () => {
+  assert.throws(
+    () => utilityWithoutPromo(REPO_ROOT, { files: ['../outside.ts'] }),
+    /escapes repository root/,
+  )
+})
+
 test('utility-first check passes for ollama smoke contribution', () => {
   const contributions = loadContributions(REPO_ROOT)
   const ollama = contributions.find((item) => item.id === 'ollama-openai-compat-smoke')

--- a/scripts/external-contributions.test.mjs
+++ b/scripts/external-contributions.test.mjs
@@ -4,12 +4,15 @@ import { join } from 'node:path'
 import { test } from 'vitest'
 import {
   auditExternalContributions,
+  computeContributionDigest,
+  countPendingApprovals,
   loadContributions,
   loadTargets,
   prepareSubmission,
   reportOutcomes,
   selectTargets,
   utilityWithoutPromo,
+  validateTargetRules,
 } from './lib/external-contributions.mjs'
 import { REPO_ROOT } from './compute-stats.mjs'
 
@@ -69,10 +72,78 @@ test('external submission packaging is blocked without human approval', () => {
   )
   const ready = prepareSubmission({
     proposal: { id: 'x', outcome: { state: 'pending' } },
-    approval: { approved: true, approvedBy: 'reviewer', approvedOn: '2026-07-14' },
+    approval: {
+      approved: true,
+      approvedBy: 'reviewer',
+      approvedOn: '2026-07-14',
+      contentDigest: 'reviewed-digest',
+    },
+  }, {
+    targetEligible: true,
+    utility: { ok: true },
+    tests: { ok: true },
+    contentDigest: 'reviewed-digest',
   })
   assert.equal(ready.status, 'ready-for-human-submit')
   assert.equal(ready.action, 'manual-submit')
+})
+
+test('approval cannot bypass technical checks or authorize changed content', () => {
+  const contribution = {
+    proposal: { id: 'x', outcome: { state: 'pending' } },
+    approval: {
+      approved: true,
+      approvedBy: 'reviewer',
+      approvedOn: '2026-07-14',
+      contentDigest: 'reviewed-digest',
+    },
+  }
+  const incomplete = prepareSubmission(contribution, {
+    targetEligible: true,
+    utility: { ok: true },
+    tests: { ok: false },
+    contentDigest: 'reviewed-digest',
+  })
+  assert.equal(incomplete.status, 'blocked')
+
+  const changed = prepareSubmission(contribution, {
+    targetEligible: true,
+    utility: { ok: true },
+    tests: { ok: true },
+    contentDigest: 'changed-digest',
+  })
+  assert.equal(changed.status, 'blocked')
+  assert.match(changed.reason, /exact reviewed proposal/)
+})
+
+test('content digest changes when a proposal changes', () => {
+  const contributions = loadContributions(REPO_ROOT)
+  const contribution = contributions[0]
+  const original = computeContributionDigest(REPO_ROOT, contribution.proposal)
+  const changed = computeContributionDigest(REPO_ROOT, {
+    ...contribution.proposal,
+    title: `${contribution.proposal.title} changed`,
+  })
+  assert.notEqual(original, changed)
+  assert.match(original, /^[a-f0-9]{64}$/)
+})
+
+test('target rules must point to a fresh, reviewed CONTRIBUTING document', () => {
+  const targets = loadTargets(REPO_ROOT)
+  for (const target of targets.filter((item) => item.technicalRelationship)) {
+    assert.equal(validateTargetRules(target).ok, true)
+  }
+  assert.equal(
+    validateTargetRules({
+      contributionRulesUrl: 'https://example.com/api',
+      contributionRules: {
+        sourceUrl: 'https://example.com/api',
+        reviewedOn: '2026-07-14',
+        criteria: ['looks useful'],
+      },
+    }).ok,
+    false,
+  )
 })
 
 test('accepted outcomes require maintenance ownership', () => {
@@ -80,7 +151,12 @@ test('accepted outcomes require maintenance ownership', () => {
     () =>
       prepareSubmission({
         proposal: { id: 'x', outcome: { state: 'accepted' }, maintenanceOwner: null },
-        approval: { approved: true, approvedBy: 'a', approvedOn: '2026-07-14' },
+        approval: {
+          approved: true,
+          approvedBy: 'a',
+          approvedOn: '2026-07-14',
+          contentDigest: 'digest',
+        },
       }),
     /maintenanceOwner/,
   )
@@ -92,6 +168,23 @@ test('reporting distinguishes utility outcomes from vanity metrics', () => {
   assert.equal(report.counts.pending, contributions.length)
   assert.ok(report.notTracked.includes('impressions'))
   assert.ok(report.notTracked.includes('raw-link-count'))
+})
+
+test('mass-submission guard counts only approved packages still pending', () => {
+  const contribution = (state, approved = true) => ({
+    proposal: { outcome: { state } },
+    approval: { approved },
+  })
+  assert.equal(
+    countPendingApprovals([
+      contribution('pending'),
+      contribution('submitted'),
+      contribution('accepted'),
+      contribution('rejected'),
+      contribution('pending', false),
+    ]),
+    1,
+  )
 })
 
 test('program audit passes for committed packages and fixture target tests', () => {

--- a/scripts/lib/external-contributions.mjs
+++ b/scripts/lib/external-contributions.mjs
@@ -1,0 +1,286 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+export const PROTOCOL = 'agentskit.ecosystem.external-contributions'
+export const SCHEMA_VERSION = 1
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value)
+const nonEmpty = (value) => typeof value === 'string' && value.trim().length > 0
+
+export function loadJson(root, relativePath) {
+  return JSON.parse(readFileSync(join(root, relativePath), 'utf8'))
+}
+
+export function parseProgram(input) {
+  if (!isObject(input)) throw new Error('program must be an object')
+  if (input.schemaVersion !== SCHEMA_VERSION) throw new Error('program schemaVersion must be 1')
+  if (input.protocol !== PROTOCOL) throw new Error(`program protocol must be ${PROTOCOL}`)
+  if (!isObject(input.policy)) throw new Error('program requires policy')
+  for (const key of [
+    'requireTechnicalRelationship',
+    'requirePublishedContributionRules',
+    'requireUtilityWithoutPromo',
+    'requireHumanApprovalBeforeSubmit',
+    'forbidMassSubmission',
+    'requireMaintenanceOwnerOnAccept',
+  ]) {
+    if (input.policy[key] !== true) throw new Error(`policy.${key} must be true`)
+  }
+  return input
+}
+
+export function loadTargets(root, path = 'docs/ecosystem/external-contributions/targets/index.json') {
+  const doc = loadJson(root, path)
+  if (!Array.isArray(doc.targets) || doc.targets.length === 0) throw new Error('targets list is empty')
+  return doc.targets
+}
+
+export function loadContributions(root, dir = 'docs/ecosystem/external-contributions/contributions') {
+  const absolute = join(root, dir)
+  if (!existsSync(absolute)) return []
+  return readdirSync(absolute)
+    .filter((name) => statSync(join(absolute, name)).isDirectory())
+    .map((id) => {
+      const base = join(dir, id)
+      const proposal = loadJson(root, join(base, 'proposal.json'))
+      const approvalPath = join(root, base, 'APPROVAL.json')
+      const approval = existsSync(approvalPath)
+        ? JSON.parse(readFileSync(approvalPath, 'utf8'))
+        : { approved: false }
+      return { id, base, proposal, approval }
+    })
+}
+
+export function selectTargets(targets, { allowPromotional = false } = {}) {
+  const selected = []
+  const rejected = []
+  for (const target of targets) {
+    if (!target.technicalRelationship || target.promotionalOnly) {
+      rejected.push({ id: target.id, reason: 'no technical relationship / promotional-only' })
+      continue
+    }
+    if (!nonEmpty(target.contributionRulesUrl)) {
+      rejected.push({ id: target.id, reason: 'missing published contribution rules' })
+      continue
+    }
+    if (!allowPromotional && target.priority === 'rejected-by-policy') {
+      rejected.push({ id: target.id, reason: 'rejected by utility-first policy' })
+      continue
+    }
+    selected.push(target)
+  }
+  return { selected, rejected }
+}
+
+function collectFiles(root, relativePaths) {
+  const chunks = []
+  for (const relativePath of relativePaths) {
+    const absolute = join(root, relativePath)
+    if (!existsSync(absolute)) continue
+    if (statSync(absolute).isDirectory()) {
+      for (const name of readdirSync(absolute)) {
+        const child = join(relativePath, name)
+        if (statSync(join(root, child)).isFile()) {
+          chunks.push({ path: child, content: readFileSync(join(root, child), 'utf8') })
+        }
+      }
+    } else {
+      chunks.push({ path: relativePath, content: readFileSync(absolute, 'utf8') })
+    }
+  }
+  return chunks
+}
+
+export function utilityWithoutPromo(root, proposal) {
+  const markers = proposal.utilityWithoutPromo?.promoMarkers ?? [
+    'AgentsKit',
+    'agentskit.io',
+    '@agentskit',
+  ]
+  const files = collectFiles(root, proposal.files ?? [])
+  if (files.length === 0) {
+    return { ok: false, reason: 'no contribution files found' }
+  }
+  // Utility remains if, after stripping promo markers from docs, code/tests still exist.
+  const codeFiles = files.filter((file) => /\.(m?js|ts|tsx)$/.test(file.path))
+  if (codeFiles.length === 0) {
+    return { ok: false, reason: 'contribution has no code/test files — likely promotional-only' }
+  }
+  const strippedDocs = files
+    .filter((file) => /\.(md|mdx)$/.test(file.path))
+    .map((file) => {
+      let content = file.content
+      for (const marker of markers) {
+        content = content.split(marker).join('')
+      }
+      return content
+    })
+    .join('\n')
+  // Code must not *require* promo markers to function — if code only contains promo URLs, fail.
+  const codeBlob = codeFiles.map((file) => file.content).join('\n')
+  const onlyPromo =
+    markers.some((marker) => codeBlob.includes(marker)) &&
+    !/\b(test|assert|fetch|export|function|class)\b/.test(codeBlob)
+  if (onlyPromo) {
+    return { ok: false, reason: 'code appears promotional without standalone behavior' }
+  }
+  // After stripping, docs may be empty — that is OK if code remains.
+  return {
+    ok: true,
+    codeFiles: codeFiles.map((file) => file.path),
+    strippedDocLength: strippedDocs.trim().length,
+  }
+}
+
+export function prepareSubmission(contribution) {
+  const { proposal, approval } = contribution
+  if (proposal.outcome?.state === 'accepted' && !nonEmpty(proposal.maintenanceOwner)) {
+    throw new Error(`${proposal.id}: accepted contributions require maintenanceOwner`)
+  }
+  if (!approval || approval.approved !== true) {
+    return {
+      status: 'blocked',
+      reason: 'Human approval required before external submission',
+    }
+  }
+  if (!nonEmpty(approval.approvedBy) || !nonEmpty(approval.approvedOn)) {
+    throw new Error(`${proposal.id}: approval requires approvedBy and approvedOn`)
+  }
+  return {
+    status: 'ready-for-human-submit',
+    approvedBy: approval.approvedBy,
+    approvedOn: approval.approvedOn,
+    // Never auto-open upstream PRs from CI.
+    action: 'manual-submit',
+  }
+}
+
+export function runContributionTests(root, proposal) {
+  if (!proposal.tests?.command) {
+    return { ok: false, message: 'proposal missing tests.command' }
+  }
+  const cwd = proposal.tests.cwd ? join(root, proposal.tests.cwd) : root
+  const [bin, ...args] = proposal.tests.command
+  const run = spawnSync(bin, args, { cwd, encoding: 'utf8', env: process.env })
+  if (run.status !== 0) {
+    return {
+      ok: false,
+      message: `tests failed (${run.status}): ${run.stderr || run.stdout}`,
+    }
+  }
+  return { ok: true, message: 'tests passed' }
+}
+
+export function reportOutcomes(contributions) {
+  const rows = contributions.map(({ proposal }) => ({
+    id: proposal.id,
+    targetId: proposal.targetId,
+    state: proposal.outcome?.state ?? 'pending',
+    maintenanceOwner: proposal.maintenanceOwner,
+    externalUrl: proposal.outcome?.externalUrl ?? null,
+  }))
+  const counts = {
+    pending: rows.filter((row) => row.state === 'pending').length,
+    submitted: rows.filter((row) => row.state === 'submitted').length,
+    accepted: rows.filter((row) => row.state === 'accepted').length,
+    rejected: rows.filter((row) => row.state === 'rejected').length,
+  }
+  return {
+    counts,
+    rows,
+    // Explicitly not vanity metrics:
+    notTracked: ['impressions', 'raw-link-count', 'unqualified-stars'],
+  }
+}
+
+export function auditExternalContributions(root) {
+  const failures = []
+  const program = parseProgram(
+    loadJson(root, 'docs/ecosystem/external-contributions/program.json'),
+  )
+  const targets = loadTargets(root)
+  const { selected, rejected } = selectTargets(targets)
+  if (selected.length === 0) failures.push('no selectable targets with technical relationship')
+  if (!rejected.some((entry) => entry.id === 'awesome-ai-agents')) {
+    // ensure promotional list target is classified rejected when present
+    const promo = targets.find((target) => target.id === 'awesome-ai-agents')
+    if (promo && promo.technicalRelationship) {
+      failures.push('promotional list target must not claim technicalRelationship without utility pairing')
+    }
+  }
+
+  const contributions = loadContributions(root)
+  if (contributions.length === 0) failures.push('no contribution packages found')
+
+  // Mass submission guard: more than 5 ready-to-submit without approval is forbidden.
+  const approvedCount = contributions.filter((item) => item.approval?.approved === true).length
+  if (program.policy.forbidMassSubmission && approvedCount > 5) {
+    failures.push('mass submission risk: more than 5 approved packages pending submit')
+  }
+
+  for (const contribution of contributions) {
+    const { proposal, approval, id } = contribution
+    const target = targets.find((entry) => entry.id === proposal.targetId)
+    if (!target) {
+      failures.push(`${id}: unknown target ${proposal.targetId}`)
+      continue
+    }
+    if (!target.technicalRelationship || target.promotionalOnly) {
+      failures.push(`${id}: target ${target.id} fails technical relationship policy`)
+    }
+    if (!nonEmpty(target.contributionRulesUrl)) {
+      failures.push(`${id}: target missing contribution rules URL`)
+    }
+    if (!existsSync(join(root, contribution.base, 'utility-check.md'))) {
+      failures.push(`${id}: missing utility-check.md`)
+    }
+    if (!existsSync(join(root, contribution.base, 'evidence.md'))) {
+      failures.push(`${id}: missing evidence.md`)
+    }
+    const utility = utilityWithoutPromo(root, proposal)
+    if (!utility.ok) failures.push(`${id}: utility-first check failed — ${utility.reason}`)
+
+    const tests = runContributionTests(root, proposal)
+    if (!tests.ok) failures.push(`${id}: ${tests.message}`)
+
+    const submission = prepareSubmission(contribution)
+    if (approval?.approved === true && submission.status !== 'ready-for-human-submit') {
+      failures.push(`${id}: approved package did not become ready-for-human-submit`)
+    }
+    if (approval?.approved !== true && submission.status !== 'blocked') {
+      failures.push(`${id}: unapproved package must be blocked from submit`)
+    }
+    if (proposal.outcome?.state === 'accepted' && !nonEmpty(proposal.maintenanceOwner)) {
+      failures.push(`${id}: accepted outcome requires maintenanceOwner`)
+    }
+  }
+
+  const outcomes = reportOutcomes(contributions)
+  return {
+    ok: failures.length === 0,
+    failures,
+    selectedTargets: selected.map((target) => target.id),
+    rejectedTargets: rejected,
+    outcomes,
+  }
+}
+
+export function formatExternalReport(report) {
+  const lines = [
+    '# External contributions program audit',
+    '',
+    `- Selectable targets: ${report.selectedTargets.join(', ') || '(none)'}`,
+    `- Rejected targets: ${report.rejectedTargets.map((entry) => entry.id).join(', ') || '(none)'}`,
+    `- Outcomes: pending=${report.outcomes.counts.pending} submitted=${report.outcomes.counts.submitted} accepted=${report.outcomes.counts.accepted} rejected=${report.outcomes.counts.rejected}`,
+    `- Not tracked as success: ${report.outcomes.notTracked.join(', ')}`,
+    '',
+  ]
+  if (report.ok) lines.push('All external contribution program checks passed.')
+  else {
+    lines.push('Failures:')
+    for (const failure of report.failures) lines.push(`- ${failure}`)
+  }
+  lines.push('')
+  return `${lines.join('\n')}\n`
+}

--- a/scripts/lib/external-contributions.mjs
+++ b/scripts/lib/external-contributions.mjs
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
 export const PROTOCOL = 'agentskit.ecosystem.external-contributions'
@@ -76,17 +76,40 @@ export function selectTargets(targets, { allowPromotional = false } = {}) {
 function collectFiles(root, relativePaths) {
   const chunks = []
   for (const relativePath of relativePaths) {
-    const absolute = join(root, relativePath)
-    if (!existsSync(absolute)) continue
-    if (statSync(absolute).isDirectory()) {
-      for (const name of readdirSync(absolute)) {
-        const child = join(relativePath, name)
-        if (statSync(join(root, child)).isFile()) {
-          chunks.push({ path: child, content: readFileSync(join(root, child), 'utf8') })
-        }
+    const absolute = resolve(root, relativePath)
+    const fromRoot = relative(resolve(root), absolute)
+    if (fromRoot === '..' || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)) {
+      throw new Error(`contribution file escapes repository root: ${relativePath}`)
+    }
+
+    let names
+    try {
+      names = readdirSync(absolute)
+    } catch (error) {
+      if (isObject(error) && error.code === 'ENOENT') continue
+      if (!isObject(error) || error.code !== 'ENOTDIR') throw error
+      names = null
+    }
+
+    const files = names === null
+      ? [{ path: relativePath, absolute }]
+      : names.map((name) => ({ path: join(relativePath, name), absolute: join(absolute, name) }))
+
+    for (const file of files) {
+      let descriptor
+      try {
+        descriptor = openSync(file.absolute, 'r')
+      } catch (error) {
+        if (isObject(error) && error.code === 'ENOENT') continue
+        throw error
       }
-    } else {
-      chunks.push({ path: relativePath, content: readFileSync(absolute, 'utf8') })
+      try {
+        if (fstatSync(descriptor).isFile()) {
+          chunks.push({ path: file.path, content: readFileSync(descriptor, 'utf8') })
+        }
+      } finally {
+        closeSync(descriptor)
+      }
     }
   }
   return chunks

--- a/scripts/lib/external-contributions.mjs
+++ b/scripts/lib/external-contributions.mjs
@@ -1,12 +1,56 @@
 import { closeSync, existsSync, fstatSync, openSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 
 export const PROTOCOL = 'agentskit.ecosystem.external-contributions'
 export const SCHEMA_VERSION = 1
 
 const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value)
 const nonEmpty = (value) => typeof value === 'string' && value.trim().length > 0
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+const MAX_RULES_AGE_DAYS = 180
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (isObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function parseIsoDate(value) {
+  if (!nonEmpty(value) || !ISO_DATE.test(value)) return null
+  const date = new Date(`${value}T00:00:00.000Z`)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function validateTargetRules(target, now = new Date()) {
+  const rules = target.contributionRules
+  if (!isObject(rules)) return { ok: false, reason: 'missing contribution rules snapshot' }
+  if (!nonEmpty(rules.sourceUrl) || rules.sourceUrl !== target.contributionRulesUrl) {
+    return { ok: false, reason: 'contribution rules source does not match the reviewed URL' }
+  }
+  const publishedRules =
+    /(^|\/)CONTRIBUTING\.md(?:$|[?#])/i.test(rules.sourceUrl) ||
+    (target.kind === 'fixture' && rules.sourceUrl.endsWith('/CONTRIBUTING.md'))
+  if (!publishedRules) {
+    return { ok: false, reason: 'source URL is not a published CONTRIBUTING.md' }
+  }
+  const reviewedOn = parseIsoDate(rules.reviewedOn)
+  if (!reviewedOn) return { ok: false, reason: 'rules snapshot requires a valid reviewedOn date' }
+  const ageDays = Math.floor((now.getTime() - reviewedOn.getTime()) / 86_400_000)
+  if (ageDays < 0 || ageDays > MAX_RULES_AGE_DAYS) {
+    return { ok: false, reason: `rules snapshot must be 0-${MAX_RULES_AGE_DAYS} days old` }
+  }
+  if (!Array.isArray(rules.criteria) || rules.criteria.length === 0 || !rules.criteria.every(nonEmpty)) {
+    return { ok: false, reason: 'rules snapshot requires non-empty review criteria' }
+  }
+  return { ok: true, reviewedOn: rules.reviewedOn, criteria: rules.criteria }
+}
 
 export function loadJson(root, relativePath) {
   return JSON.parse(readFileSync(join(root, relativePath), 'utf8'))
@@ -60,8 +104,9 @@ export function selectTargets(targets, { allowPromotional = false } = {}) {
       rejected.push({ id: target.id, reason: 'no technical relationship / promotional-only' })
       continue
     }
-    if (!nonEmpty(target.contributionRulesUrl)) {
-      rejected.push({ id: target.id, reason: 'missing published contribution rules' })
+    const rules = validateTargetRules(target)
+    if (!rules.ok) {
+      rejected.push({ id: target.id, reason: rules.reason })
       continue
     }
     if (!allowPromotional && target.priority === 'rejected-by-policy') {
@@ -115,6 +160,13 @@ function collectFiles(root, relativePaths) {
   return chunks
 }
 
+export function computeContributionDigest(root, proposal) {
+  const files = collectFiles(root, proposal.files ?? []).sort((a, b) => a.path.localeCompare(b.path))
+  return createHash('sha256')
+    .update(stableJson({ proposal, files }))
+    .digest('hex')
+}
+
 export function utilityWithoutPromo(root, proposal) {
   const markers = proposal.utilityWithoutPromo?.promoMarkers ?? [
     'AgentsKit',
@@ -156,7 +208,7 @@ export function utilityWithoutPromo(root, proposal) {
   }
 }
 
-export function prepareSubmission(contribution) {
+export function prepareSubmission(contribution, assessment = {}) {
   const { proposal, approval } = contribution
   if (proposal.outcome?.state === 'accepted' && !nonEmpty(proposal.maintenanceOwner)) {
     throw new Error(`${proposal.id}: accepted contributions require maintenanceOwner`)
@@ -169,6 +221,25 @@ export function prepareSubmission(contribution) {
   }
   if (!nonEmpty(approval.approvedBy) || !nonEmpty(approval.approvedOn)) {
     throw new Error(`${proposal.id}: approval requires approvedBy and approvedOn`)
+  }
+  if (!parseIsoDate(approval.approvedOn)) {
+    throw new Error(`${proposal.id}: approvedOn must be an ISO date`)
+  }
+  if (
+    assessment.targetEligible !== true ||
+    assessment.utility?.ok !== true ||
+    assessment.tests?.ok !== true
+  ) {
+    return {
+      status: 'blocked',
+      reason: 'Technical target, utility, and test checks must pass before submission',
+    }
+  }
+  if (!nonEmpty(approval.contentDigest) || approval.contentDigest !== assessment.contentDigest) {
+    return {
+      status: 'blocked',
+      reason: 'Approval does not match the exact reviewed proposal and files',
+    }
   }
   return {
     status: 'ready-for-human-submit',
@@ -185,7 +256,16 @@ export function runContributionTests(root, proposal) {
   }
   const cwd = proposal.tests.cwd ? join(root, proposal.tests.cwd) : root
   const [bin, ...args] = proposal.tests.command
-  const run = spawnSync(bin, args, { cwd, encoding: 'utf8', env: process.env })
+  const run = spawnSync(bin, args, {
+    cwd,
+    encoding: 'utf8',
+    env: process.env,
+    timeout: 120_000,
+    killSignal: 'SIGTERM',
+  })
+  if (run.error) {
+    return { ok: false, message: `tests could not run: ${run.error.message}` }
+  }
   if (run.status !== 0) {
     return {
       ok: false,
@@ -217,6 +297,13 @@ export function reportOutcomes(contributions) {
   }
 }
 
+export function countPendingApprovals(contributions) {
+  return contributions.filter(
+    (item) =>
+      item.approval?.approved === true && (item.proposal.outcome?.state ?? 'pending') === 'pending',
+  ).length
+}
+
 export function auditExternalContributions(root) {
   const failures = []
   const program = parseProgram(
@@ -237,7 +324,7 @@ export function auditExternalContributions(root) {
   if (contributions.length === 0) failures.push('no contribution packages found')
 
   // Mass submission guard: more than 5 ready-to-submit without approval is forbidden.
-  const approvedCount = contributions.filter((item) => item.approval?.approved === true).length
+  const approvedCount = countPendingApprovals(contributions)
   if (program.policy.forbidMassSubmission && approvedCount > 5) {
     failures.push('mass submission risk: more than 5 approved packages pending submit')
   }
@@ -252,9 +339,8 @@ export function auditExternalContributions(root) {
     if (!target.technicalRelationship || target.promotionalOnly) {
       failures.push(`${id}: target ${target.id} fails technical relationship policy`)
     }
-    if (!nonEmpty(target.contributionRulesUrl)) {
-      failures.push(`${id}: target missing contribution rules URL`)
-    }
+    const targetRules = validateTargetRules(target)
+    if (!targetRules.ok) failures.push(`${id}: target rules invalid — ${targetRules.reason}`)
     if (!existsSync(join(root, contribution.base, 'utility-check.md'))) {
       failures.push(`${id}: missing utility-check.md`)
     }
@@ -267,7 +353,16 @@ export function auditExternalContributions(root) {
     const tests = runContributionTests(root, proposal)
     if (!tests.ok) failures.push(`${id}: ${tests.message}`)
 
-    const submission = prepareSubmission(contribution)
+    const contentDigest = computeContributionDigest(root, proposal)
+    const submission = prepareSubmission(contribution, {
+      targetEligible:
+        target.technicalRelationship === true &&
+        target.promotionalOnly !== true &&
+        targetRules.ok,
+      utility,
+      tests,
+      contentDigest,
+    })
     if (approval?.approved === true && submission.status !== 'ready-for-human-submit') {
       failures.push(`${id}: approved package did not become ready-for-human-submit`)
     }


### PR DESCRIPTION
## Outcome

Delivers Ecosystem 17: a utility-first external contribution program with policy gates, target selection, offline proof, a real-world HITL draft, and reporting that ignores vanity metrics.

Closes #1207  
Parent: #1198  
Blocked by: #1204, #1205 (program may ship; external posts stay HITL-gated)

## What changed

### Program
- `docs/ecosystem/external-contributions/program.json` — non-negotiable policy
- Target registry with technical-relationship filter (promotional list targets rejected)
- `pnpm check:external-contributions` / `pnpm test:external-contributions`

### Proof contribution (CI fixture)
- `fixtures/sample-cli` target with published rules
- Contribution: `version` command + tests
- Utility-first check, evidence, `APPROVAL.json` (starts false)

### Real-world draft (HITL)
- `ollama-openai-compat-smoke` — zero-dep OpenAI-compat smoke script
- Remains useful if AgentsKit branding is removed
- Offline mock-server test; optional live Ollama
- Not submitted upstream until human approval

### Metrics
Tracks accepted utility, qualified adoption, rejection learning — **not** impressions or raw link counts.

## Verification

- Fixture + Ollama unit tests PASS
- `pnpm test:external-contributions` — 8/8 PASS
- `pnpm check:external-contributions` — PASS
- Pre-push quality gates PASS

## HITL before any upstream PR

1. Confirm readiness / launch posture as needed
2. Set contribution `APPROVAL.json` with approver + date
3. Manually open the external PR matching target voice/rules
4. On accept, set `maintenanceOwner` + outcome URL