### PR TITLE
docs(chat): dogfood consolidated v0.3 package

### DIFF
--- a/apps/docs-next/components/docs/ask-widget.tsx
+++ b/apps/docs-next/components/docs/ask-widget.tsx
@@ -31,11 +31,11 @@ import {
   StandardComponent as FrameworkStandardComponent,
   type AgentChatSlots,
   type StandardComponentProps,
-} from '@agentskit/chat-react'
+} from '@agentskit/chat/react'
 import {
   decodeDeterministicSiteConfig,
   verifyLocalKnowledgeArtifactSync,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 import { z } from 'zod'
 import { AnimatedLogo } from '@/components/brand/animated-logo'
 import deterministicKnowledge from '@/lib/deterministic-knowledge.generated.json'

--- a/apps/docs-next/content/docs/cookbook/ask-the-docs.mdx
+++ b/apps/docs-next/content/docs/cookbook/ask-the-docs.mdx
@@ -8,7 +8,7 @@ This is the recipe for the chat you're using right now: a **grounded RAG assista
 The production widget dogfoods the public AgentsKit Chat framework. `AgentChat` owns the canonical message timeline, streaming lifecycle, cancellation, retry/edit/regenerate behavior, persistence through AgentsKit memory, component validation, and accessible rendering diagnostics. The docs host keeps only its corpus branding, Markdown slot, generated local knowledge, and a small adapter that converts the existing Ask NDJSON boundary into ordered assistant content. Citations use the standard `source-list` contract rather than a site-private citation component. Known exact questions now use the [deterministic local answer plane](./deterministic-docs-answers) before this RAG path, so they require no backend request.
 
 ```ts
-import { createAssistantContentEncoder } from '@agentskit/chat-protocol'
+import { createAssistantContentEncoder } from '@agentskit/chat/protocol'
 
 const content = createAssistantContentEncoder()
 yield { type: 'text', content: content.encode({ kind: 'text', text: answerChunk }) }

--- a/apps/docs-next/content/docs/cookbook/deterministic-docs-answers.mdx
+++ b/apps/docs-next/content/docs/cookbook/deterministic-docs-answers.mdx
@@ -35,7 +35,7 @@ import {
 import {
   decodeDeterministicSiteConfig,
   verifyLocalKnowledgeArtifact,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 
 const site = decodeDeterministicSiteConfig(siteJson)
 if (!site.ok) throw new Error(site.diagnostic.message)
@@ -67,7 +67,7 @@ pnpm --filter @agentskit/docs-next gen:deterministic-knowledge
 The generator:
 
 1. Sorts every source and entry for byte-stable output.
-2. Validates all v1 bounds and safe links with `@agentskit/chat-protocol`.
+2. Validates all v1 bounds and safe links with `@agentskit/chat/protocol`.
 3. Computes and verifies the canonical SHA-256 content hash.
 4. Enforces a **96 KiB product budget**, below the protocol's 512 KiB ceiling.
 5. Publishes a content-addressed JSON URL with a one-year immutable cache header.

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -26,9 +26,7 @@
   },
   "dependencies": {
     "@agentskit/adapters": "workspace:*",
-    "@agentskit/chat": "0.2.0",
-    "@agentskit/chat-protocol": "0.2.0",
-    "@agentskit/chat-react": "0.2.0",
+    "@agentskit/chat": "0.3.0",
     "@agentskit/core": "workspace:*",
     "@agentskit/eval": "workspace:*",
     "@agentskit/memory": "workspace:*",

--- a/apps/docs-next/scripts/gen-deterministic-knowledge.mjs
+++ b/apps/docs-next/scripts/gen-deterministic-knowledge.mjs
@@ -12,7 +12,7 @@ import {
   computeLocalKnowledgeArtifactContentHash,
   normalizeKnowledgeKey,
   verifyLocalKnowledgeArtifact,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 
 const appRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 const repoRoot = join(appRoot, '../..')

--- a/apps/docs-next/tests/deterministic-docs-answers.test.mjs
+++ b/apps/docs-next/tests/deterministic-docs-answers.test.mjs
@@ -9,7 +9,7 @@ import {
   decodeAssistantContent,
   decodeDeterministicSiteConfig,
   verifyLocalKnowledgeArtifactSync,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 import { test } from 'vitest'
 import { REPO_ROOT } from '../../../scripts/compute-stats.mjs'
 
@@ -150,9 +150,8 @@ test('the real widget composes published AgentsChat local-first contracts', () =
   assert.match(widget, /choiceSubmission: adapter\.resolveChoiceSubmission/)
   assert.match(widget, /fallbackMode: deterministicSite\.fallback\.mode/)
   assert.match(widget, /data-ak-answer-path/)
-  assert.match(docsPackage, /"@agentskit\/chat": "0\.2\.0"/)
-  assert.match(docsPackage, /"@agentskit\/chat-protocol": "0\.2\.0"/)
-  assert.match(docsPackage, /"@agentskit\/chat-react": "0\.2\.0"/)
+  assert.match(docsPackage, /"@agentskit\/chat": "0\.3\.0"/)
+  assert.doesNotMatch(docsPackage, /"@agentskit\/chat-(?:protocol|react)":/)
   assert.doesNotMatch(rootPackage, /"@agentskit\/chat(?:-protocol)?":/)
   assert.doesNotMatch(widget, /function normalizeDeterministic|new Map<string, DeterministicKnowledgeEntry/)
 })

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -94,9 +94,9 @@ pnpm --filter @agentskit/registry-app build
 
 ## AgentsKit Chat dogfood
 
-The floating **Ask Registry** surface consumes the stable npm packages
-`@agentskit/chat`, `@agentskit/chat-protocol`, and `@agentskit/chat-react` at
-exact version `0.2.0`. This app owns only the `registry` corpus,
+The floating **Ask Registry** surface consumes the stable npm package
+`@agentskit/chat` at exact version `0.3.0`, using its `/protocol` and `/react`
+subpaths. This app owns only the `registry` corpus,
 `NEXT_PUBLIC_ASK_ENDPOINT`, Registry branding, CTA, and React slots. AgentsKit
 Chat owns the Ask wire contract, streaming adapter, ordered content, standard
 `source-list`, memory migration, and application shell. AgentsKit owns
@@ -107,7 +107,7 @@ Implementation:
 - `components/ask-widget.tsx` — native Registry shell, renderer slots, corpus,
   endpoint, and canonical storage identity;
 - `@agentskit/chat` — shared Ask adapter and session-memory integration;
-- `@agentskit/chat-protocol` — runtime-validated Ask NDJSON boundary and
+- `@agentskit/chat/protocol` — runtime-validated Ask NDJSON boundary and
   ordered event projection.
 
 The browser preloads the Registry-owned, content-hashed deterministic artifact

--- a/apps/registry/components/ask-widget.tsx
+++ b/apps/registry/components/ask-widget.tsx
@@ -4,7 +4,7 @@ import { Children, createContext, useCallback, useContext, useEffect, useMemo, u
 import type { ChatReturn, Message as AgentsKitMessage } from '@agentskit/core'
 import { ChatContainer } from '@agentskit/react'
 import { SourceListPropsSchema, StandardComponentCatalog, createAskAdapter, createAskSessionMemory, defineChat, defineComponentManifest } from '@agentskit/chat'
-import { AgentChat, StandardComponent as FrameworkStandardComponent, type AgentChatSlots, type StandardComponentProps } from '@agentskit/chat-react'
+import { AgentChat, StandardComponent as FrameworkStandardComponent, type AgentChatSlots, type StandardComponentProps } from '@agentskit/chat/react'
 import { createRegistryDiscoveryAdapter, loadRegistryDiscovery, type RegistryDiscoveryInputs } from '@/lib/discovery'
 
 const CORPUS = 'registry'

--- a/apps/registry/lib/discovery.test.ts
+++ b/apps/registry/lib/discovery.test.ts
@@ -7,7 +7,7 @@ import {
   DETERMINISTIC_SITE_PROTOCOL_VERSION,
   computeLocalKnowledgeArtifactContentHash,
   type LocalKnowledgeArtifactHashInput,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 import { createRegistryDiscoveryAdapter, loadRegistryDiscovery } from './discovery'
 
 const request = (content: string): AdapterRequest => ({

--- a/apps/registry/lib/discovery.ts
+++ b/apps/registry/lib/discovery.ts
@@ -7,7 +7,7 @@ import {
   decodeDeterministicSiteConfig,
   verifyLocalKnowledgeArtifactSync,
   type AnswerResponse,
-} from '@agentskit/chat-protocol'
+} from '@agentskit/chat/protocol'
 
 const DEFAULT_BASE =
   'https://raw.githubusercontent.com/AgentsKit-io/agentskit-registry/main/public/deterministic'

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -12,9 +12,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@agentskit/chat": "0.2.0",
-    "@agentskit/chat-protocol": "0.2.0",
-    "@agentskit/chat-react": "0.2.0",
+    "@agentskit/chat": "0.3.0",
     "@agentskit/core": "workspace:*",
     "@agentskit/react": "workspace:*",
     "fumadocs-core": "^16.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: link:packages/core
       '@agentskit/doc-bridge':
         specifier: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz
-        version: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/adapters@0.13.13(@aws-sdk/client-bedrock-runtime@3.1068.0))(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)
+        version: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)
       '@agentskit/eval':
         specifier: workspace:*
         version: link:packages/eval
@@ -127,14 +127,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/adapters
       '@agentskit/chat':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/chat-protocol':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/chat-react':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(react@19.2.7)
+        specifier: 0.3.0
+        version: 0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       '@agentskit/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -182,19 +176,19 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       fumadocs-core:
         specifier: ^16.11.1
-        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.1.0
-        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^16.11.1
-        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
+        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -203,7 +197,7 @@ importers:
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: '>=16.2.6 <17'
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       postcss:
         specifier: '>=8.5.15 <9'
         version: 8.5.15
@@ -610,7 +604,7 @@ importers:
     dependencies:
       next:
         specifier: '>=16.2.6 <17'
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       posthog-js:
         specifier: ^1.399.1
         version: 1.399.1
@@ -643,14 +637,8 @@ importers:
   apps/registry:
     dependencies:
       '@agentskit/chat':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/chat-protocol':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/chat-react':
-        specifier: 0.2.0
-        version: 0.2.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(react@19.2.7)
+        specifier: 0.3.0
+        version: 0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       '@agentskit/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -659,16 +647,16 @@ importers:
         version: link:../../packages/react
       fumadocs-core:
         specifier: ^16.11.1
-        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.1.0
-        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^16.11.1
-        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
+        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       next:
         specifier: '>=16.2.6 <17'
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       posthog-js:
         specifier: ^1.399.1
         version: 1.399.1
@@ -1519,29 +1507,59 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@agentskit/adapters@0.13.13':
-    resolution: {integrity: sha512-goVGDN3eMwRVtOsKOGkpGI0kXvgfFJhbuJD/GuIB9Fq1zoAOIUWeAyfrA8ngTgfv0dmlLsVzmN36J5fI/FuuQA==}
+  '@agentskit/chat@0.3.0':
+    resolution: {integrity: sha512-N424oOZ5DClrCMTp5V5djOg+N2rwj2LJ+ZtqQvpwBEO/sZ1BORFnenqFAJEyWptAw3/REHi9etDhhTWJcWGBnQ==}
     peerDependencies:
-      '@aws-sdk/client-bedrock-runtime': ^3.0.0
-    peerDependenciesMeta:
-      '@aws-sdk/client-bedrock-runtime':
-        optional: true
-
-  '@agentskit/chat-protocol@0.2.0':
-    resolution: {integrity: sha512-zzQrj4YRDi3wpdQ5GkSSyO1iafrMY0VwSat7XaxG2kf6A6xYyEuYVEFEee/2aWU+VVPLwR2qC2Mq8+oCIk9ItQ==}
-    peerDependencies:
-      '@agentskit/core': ^1.12.1
-
-  '@agentskit/chat-react@0.2.0':
-    resolution: {integrity: sha512-md1LjRoDbPM0BQPtzcTSUMrfUlO4WxfMBd7YTblaIW5uD5bvtY/SVSBPI1YldI1A/lhGi7PBFSDB5+VLzxiUzg==}
-    peerDependencies:
-      '@agentskit/react': ^0.7.1
-      react: '>=18'
-
-  '@agentskit/chat@0.2.0':
-    resolution: {integrity: sha512-7bxvOwFPkxZYywQkghL5f/1H8uW0Mx4H+T8BsZ7Xmh6fomdS3T2vk14mrX6V+YN3dcRUJ1uO1CHYOhvhJ3et8w==}
-    peerDependencies:
+      '@agentskit/angular': ^0.4.6
       '@agentskit/core': ^1.12.3
+      '@agentskit/ink': ^0.10.1
+      '@agentskit/react': ^0.7.1
+      '@agentskit/react-native': ^0.4.4
+      '@agentskit/solid': ^0.4.4
+      '@agentskit/svelte': ^0.4.4
+      '@agentskit/vue': ^0.4.4
+      '@angular/common': '>=18.1 <22'
+      '@angular/core': '>=18.1 <22'
+      ink: '>=7.1.0'
+      react: '>=18'
+      react-native: '*'
+      rxjs: ^7.0.0
+      solid-js: ^1.9.0
+      svelte: ^5.0.0
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      '@agentskit/angular':
+        optional: true
+      '@agentskit/ink':
+        optional: true
+      '@agentskit/react':
+        optional: true
+      '@agentskit/react-native':
+        optional: true
+      '@agentskit/solid':
+        optional: true
+      '@agentskit/svelte':
+        optional: true
+      '@agentskit/vue':
+        optional: true
+      '@angular/common':
+        optional: true
+      '@angular/core':
+        optional: true
+      ink:
+        optional: true
+      react:
+        optional: true
+      react-native:
+        optional: true
+      rxjs:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   '@agentskit/core@1.12.3':
     resolution: {integrity: sha512-fNHrzpEoCaWHDK2fwk/BIhcPseN6zCdy3N0WjzdelnmRuh7zy9/Ki0zcukesK5ZAAmXdz2+Dj8FI7AM32JyOKw==}
@@ -1571,6 +1589,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  '@agentskit/eval@0.4.19':
+    resolution: {integrity: sha512-DYjEa6bgzP/rVqTZBuguXjn+JuoPG9NfVUa/ogubm5hPlVKL0SVD1ThTDfuhTqrMqOgqHIBwIHv5yFbjnqheDg==}
 
   '@agentskit/ink@0.10.4':
     resolution: {integrity: sha512-M3/yBrEM2Pen1LVa+0xZQds0bDaSaY5jK90jpwg6fGg+dDcU+ZyxgqcW2TufddQJxVrOFzJr9xlRVBELmdJB3g==}
@@ -8665,48 +8686,42 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@agentskit/adapters@0.13.13(@aws-sdk/client-bedrock-runtime@3.1068.0)':
-    dependencies:
-      '@agentskit/core': 1.12.3
-    optionalDependencies:
-      '@aws-sdk/client-bedrock-runtime': 3.1068.0
-    optional: true
-
-  '@agentskit/chat-protocol@0.2.0(@agentskit/core@packages+core)':
+  '@agentskit/chat@0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@agentskit/core': link:packages/core
-      '@noble/hashes': 2.2.0
-      zod: 4.4.3
-
-  '@agentskit/chat-react@0.2.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(react@19.2.7)':
-    dependencies:
-      '@agentskit/chat': 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/chat-protocol': 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/react': link:packages/react
-      react: 19.2.7
-    transitivePeerDependencies:
-      - '@agentskit/core'
-
-  '@agentskit/chat@0.2.0(@agentskit/core@packages+core)':
-    dependencies:
-      '@agentskit/chat-protocol': 0.2.0(@agentskit/core@packages+core)
-      '@agentskit/core': link:packages/core
+      '@agentskit/eval': 0.4.19
       '@agentskit/memory': 0.11.0
       '@agentskit/statechart': 0.2.0
+      tslib: 2.8.1
       zod: 4.4.3
+    optionalDependencies:
+      '@agentskit/ink': 0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
+      '@agentskit/react': link:packages/react
+      '@angular/common': 21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
+      '@angular/core': 21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2)
+      ink: 7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
+      react: 19.2.7
+      react-native: 0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
+      rxjs: 7.8.2
+      solid-js: 1.9.14
+      svelte: 5.56.4
+      vue: 3.5.39(typescript@6.0.3)
 
   '@agentskit/core@1.12.3': {}
 
-  '@agentskit/doc-bridge@https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/adapters@0.13.13(@aws-sdk/client-bedrock-runtime@3.1068.0))(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)':
+  '@agentskit/doc-bridge@https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
-      '@agentskit/adapters': 0.13.13(@aws-sdk/client-bedrock-runtime@3.1068.0)
       '@agentskit/core': link:packages/core
       '@agentskit/ink': 0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
       '@agentskit/memory': 0.11.0
       '@agentskit/rag': 0.4.14
       react: 19.2.7
+
+  '@agentskit/eval@0.4.19':
+    dependencies:
+      '@agentskit/core': 1.12.3
 
   '@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)':
     dependencies:
@@ -10208,7 +10223,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
 
-  '@noble/hashes@2.2.0': {}
+  '@noble/hashes@2.2.0':
+    optional: true
 
   '@nodable/entities@2.2.0': {}
 
@@ -11559,9 +11575,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       react: 19.2.7
       svelte: 5.56.4
       vue: 3.5.39(typescript@6.0.3)
@@ -11570,9 +11586,9 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.52
 
-  '@vercel/speed-insights@2.0.0(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       react: 19.2.7
       svelte: 5.56.4
       vue: 3.5.39(typescript@6.0.3)
@@ -13000,7 +13016,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -13026,21 +13042,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 1.24.0(react@19.2.7)
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       github-slugger: 2.0.0
       js-yaml: 5.2.1
       mdast-util-mdx: 3.0.0
@@ -13057,14 +13073,14 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       react: 19.2.7
       rolldown: 1.1.5
       vite: 8.1.4(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
+  fumadocs-ui@16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.1.0(tailwindcss@4.3.2)
@@ -13080,7 +13096,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.24.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.24.0(react@19.2.7)
       motion: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -13094,7 +13110,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
@@ -14638,7 +14654,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0):
+  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -14647,7 +14663,7 @@ snapshots:
       postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -15819,10 +15835,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   stylis@4.4.0: {}
 

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:65d7ea53032a389c62b83ae5087f89cfaacc2c22c2e1d892d7b80025d35c4131"
+        "sourceHash": "sha256:10f9872f4ec9cbbb647d639ac8777202c188a476be3f3dd055dd69d1852d67b6"
       },
       "exceptions": []
     },
@@ -366,7 +366,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6b860563694b46cbbd0204a4e1cf9f5613ef12fcc0a3d098dbe03db7b43f1a60"
+        "sourceHash": "sha256:f1bf426f04d78ab482a8d97b4552ee89a5b89e4cf62e52885e9b1d35f34fc369"
       },
       "exceptions": []
     },
@@ -445,7 +445,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:5b11d6817b51f384277e909dd51ff2653fdf60550c7c082bf457316882e80d99"
+        "sourceHash": "sha256:4e5e09e30fbd0b96dc906ba47afbc32bf1fc2225d1c20630b1ba51e09c0ca82a"
       },
       "exceptions": []
     },
@@ -524,7 +524,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:c00db2d1054a83a8f5f2e4caf8b063383e27fbd6b6bd53e7ff94d880e4393671"
+        "sourceHash": "sha256:3c9f9fee5a1a1d22a7bf56fc5e8fa6908885b95af4743ac126ddb9336f24f16f"
       },
       "exceptions": []
     },
@@ -603,7 +603,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:b186fbcc8f24e72bdce3a782ac2f2428fdef75198fcc642f49993828b140bbcb"
+        "sourceHash": "sha256:790ce19cd146ce0c038847c7ab2f9475efd3aaee580ba091128154854e792bc2"
       },
       "exceptions": []
     },
@@ -682,7 +682,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:0bc40258fec40900f8c6091fa48a1046f91856ff185ce35573764ba224032955"
+        "sourceHash": "sha256:99939cf6c452de210023c407dbaaafacf788446a86855bdff23a5d55a0fa0059"
       },
       "exceptions": []
     },
@@ -761,7 +761,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e68717705fdcbd804a02d68356355acadf95cc273aea313ef98d9f232687ae75"
+        "sourceHash": "sha256:bd6796dfe42a3f3f6949096fb76fa8f5ec616c62e1997d4495aba61e94dcfad3"
       },
       "exceptions": []
     },
@@ -840,7 +840,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6c2a26a23b36b87f62c6b3e11633a7f49c5d576f4331b34156d7a622ab1270b0"
+        "sourceHash": "sha256:87a4b6add91ed322520fc3e32331d760f612d4a715c51c39d944f66850035b96"
       },
       "exceptions": []
     },
@@ -919,7 +919,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:772560c63ccca97dd079b7e50ac6c361343fb42d1702d6714d0bc367dde93edd"
+        "sourceHash": "sha256:cc7230a734d80ccd8ead3bfe93ef364d6245c1b94177ea0ce4543969fbebedf9"
       },
       "exceptions": []
     },
@@ -998,7 +998,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e07e19f1a7aa46afff1ad600385dd0cb6754dd7eddb6ff322fa09b5e0be43fef"
+        "sourceHash": "sha256:e93dc7439a73c9e2668ef6579cad2445609f78da6aea41ec9a3d8bde2212ef26"
       },
       "exceptions": []
     },
@@ -1077,7 +1077,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:bd02f98ec97aadb2dd47128bc9ea578852a95ac55c8a4e190ba92dfb09ff93e7"
+        "sourceHash": "sha256:3abcd09753a5f8065bbb9544b4c86c5351f4866c69944c9276276ff721513dcf"
       },
       "exceptions": []
     },
@@ -1156,7 +1156,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:c1416306eb8ec07044393856c40ddf3cd8e9b5891a66c47eb39234e2f01893a0"
+        "sourceHash": "sha256:ef20bc785d9d4ccdc90e1b8bc87d737558b4a4b4af31941c471efeab1a8bea3a"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:75f1dfbaa382433da19e95f50256e0cf95e4b5c894ab504db0840bfd39c2c9a1"
+        "sourceHash": "sha256:d0676ea69c8e2fe92862563c96cb0f22929c6c8f7ff6818696c9c46a187f6e6f"
       },
       "exceptions": []
     },
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8152c96ce444afc03b952e75f164a8ffa012aaea45faeb30a737d617ac2b7489"
+        "sourceHash": "sha256:83c9d56a6fb29ff5a1dec80eb9ccdc515c2c0ec61e13e23e31b1f45e539931b3"
       },
       "exceptions": []
     },
@@ -1393,7 +1393,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8f5bd04f93338771aebd013cbd0111a45c3ebe1bd4ae35da4efc6d2872ef0fba"
+        "sourceHash": "sha256:98ce32ae55555e80a2668f7f5eb47455f78ad6c4a0d95b5bd257a3335f88d6f0"
       },
       "exceptions": []
     },
@@ -1472,7 +1472,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:3085540075c7ed434f753b8d7e79bfda804cf27c33be42d493b8f6c8da2c730a"
+        "sourceHash": "sha256:0f1572e6c890fdc8a810ab38f0809959d8dc7262c8cefe89d4a8cc14d8ee92a6"
       },
       "exceptions": []
     },
@@ -1551,7 +1551,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d5fb037a31db52522b8e99ebd540fb0dc1d616d84cfc5cdf36013f6531592c53"
+        "sourceHash": "sha256:b5d939ddf9b78e2c9d12ea9b6d46fef0899ec54555a49a9f6066f27e22048370"
       },
       "exceptions": []
     },
@@ -1630,7 +1630,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a8f72f7c6e5083fe655d81d5e59a4685a8ccb1093e934b5328691b2790869474"
+        "sourceHash": "sha256:ab129b68f46a72a709c7580cdda343526afd3923f1b91befcabafcb517b2aa82"
       },
       "exceptions": []
     },
@@ -1709,7 +1709,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d6b55fa389ee5a12e052dbc3401d83d015869ef5b702639cfc804fb07257d29b"
+        "sourceHash": "sha256:cab6e98cdb54f9d802ae045410c98eae0c58cef70d69c446ed843ad6bbc139ed"
       },
       "exceptions": []
     },
@@ -1788,7 +1788,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:27cd8ea957f582190e34f22599964e11398bbbc786f649cdb7ffa99c8d55ed5c"
+        "sourceHash": "sha256:f280975975d3e786fa1fa31915a7a6d77d6dc13070ca9519391bde684e5c52cb"
       },
       "exceptions": []
     },
@@ -1867,7 +1867,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e3fac9e2e98b819e5b778f993bc3fd97172d67c4c665e6207ea8729de30592af"
+        "sourceHash": "sha256:2419be1f43667a8993472e22ab84ee389a22d7b737f6c4651a4bca9b23811995"
       },
       "exceptions": []
     },
@@ -1946,7 +1946,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:2d42df6219a8130312c44a923045e264582bc26daf38902b7b6e3be18e7370e0"
+        "sourceHash": "sha256:54ec97649e0daf43939a8d7280005097ff77a1f1f7a53117d5501cc74e058c00"
       },
       "exceptions": []
     },
@@ -2025,7 +2025,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:92d29b0da1b0d8e45161ee4b5f0d9ba5fe2bc639f97fdd1cb8a937cc0043d43c"
+        "sourceHash": "sha256:be386838520ee2f6df8ab24641c6ee4d772272b2c5110113217a620f4e0a96f7"
       },
       "exceptions": []
     },
@@ -2104,7 +2104,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8535aa224fd37edc92142e69b922b6d53cec30fa46701f11cdc61d9fa8093315"
+        "sourceHash": "sha256:07b06821adcf0a8ea567b1935f7b09258f2ff1dad5e9ab699fd26b0df64561a6"
       },
       "exceptions": []
     },
@@ -2183,7 +2183,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:eebab1e454ad4975d26b0e55a94bd182c014c800b556db777152d6070e1399f1"
+        "sourceHash": "sha256:a4df5fcece105d4a32505c31be072db03be8e082b1b9ad6502f5dd6f3a74f5ef"
       },
       "exceptions": []
     },
@@ -2253,7 +2253,7 @@
           "ecosystem-claims.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:bdd0e7489786518132d7f68d67bc7a9e0039890a56352c709acb742b52914739"
+        "sourceHash": "sha256:ff37f962e973d4248e787605e5bfc1cf963e95c1db960d8dcdc7ced75bbb4e15"
       },
       "exceptions": [
         {
@@ -2423,7 +2423,7 @@
           "ecosystem-claims.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:ac5358617cc4061f3bdbe79a1ee929a0156fc56c3ef12d2ca2aa9ed08c4e6f88"
+        "sourceHash": "sha256:765453f0c40fa06810bcadbc0fdc02d19d15f23f62146d6d76437f3a029624bd"
       },
       "exceptions": [
         {


### PR DESCRIPTION
## Summary

- migrate Docs and Registry to the public `@agentskit/chat@0.3.0` package
- consume the consolidated `/protocol` and `/react` subpaths and remove legacy chat package dependencies
- refresh deterministic-answer assertions, the public lockfile, and README Standard evidence

## Why

This is public dogfood for the consolidated two-package AgentsKit Chat v0 surface. Docs and Registry exercise the released framework without copying runtime implementation or private product logic.

## Validation

- Docs: lint, 7 tests, production build (1,183 pages)
- Registry: lint, 37 tests, production build (390 pages)
- doc-bridge index and gate
- full pre-push suite: 21 quality gates
- monorepo lint/build: 42/42 tasks
- README Standard: 506 passed, 0 failed

Release: https://github.com/AgentsKit-io/agentskit-chat/releases/tag/v0.3.0
Tracks: https://github.com/AgentsKit-io/agentskit-chat/issues/30
