### PR TITLE
docs(ecosystem): certify final AKOS production performance

### DIFF
--- a/artifacts/ecosystem-readiness/latest.json
+++ b/artifacts/ecosystem-readiness/latest.json
@@ -1301,10 +1301,11 @@
           "category": "performance",
           "status": "pass",
           "severity": "info",
-          "summary": "Post-migration production Lighthouse performance reaches the approved 90 floor (91 measured).",
+          "summary": "Three consecutive production Lighthouse runs meet the approved 90 floor (95, 91, and 93 measured; CLS 0 in every run).",
           "owner": "AgentsKit-io/agentskit-os",
           "evidence": [
-            "https://github.com/AgentsKit-io/agentskit-os/pull/5319"
+            "https://github.com/AgentsKit-io/agentskit-os/pull/5324",
+            "https://akos.agentskit.io/docs"
           ]
         },
         {

--- a/ecosystem-readiness/evidence/akos.json
+++ b/ecosystem-readiness/evidence/akos.json
@@ -62,10 +62,11 @@
       "category": "performance",
       "status": "pass",
       "severity": "info",
-      "summary": "Post-migration production Lighthouse performance reaches the approved 90 floor (91 measured).",
+      "summary": "Three consecutive production Lighthouse runs meet the approved 90 floor (95, 91, and 93 measured; CLS 0 in every run).",
       "owner": "AgentsKit-io/agentskit-os",
       "evidence": [
-        "https://github.com/AgentsKit-io/agentskit-os/pull/5319"
+        "https://github.com/AgentsKit-io/agentskit-os/pull/5324",
+        "https://akos.agentskit.io/docs"
       ]
     },
     {

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:65d7ea53032a389c62b83ae5087f89cfaacc2c22c2e1d892d7b80025d35c4131"
+        "sourceHash": "sha256:10f9872f4ec9cbbb647d639ac8777202c188a476be3f3dd055dd69d1852d67b6"
       },
       "exceptions": []
     },
@@ -366,7 +366,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6b860563694b46cbbd0204a4e1cf9f5613ef12fcc0a3d098dbe03db7b43f1a60"
+        "sourceHash": "sha256:f1bf426f04d78ab482a8d97b4552ee89a5b89e4cf62e52885e9b1d35f34fc369"
       },
       "exceptions": []
     },
@@ -445,7 +445,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:5b11d6817b51f384277e909dd51ff2653fdf60550c7c082bf457316882e80d99"
+        "sourceHash": "sha256:4e5e09e30fbd0b96dc906ba47afbc32bf1fc2225d1c20630b1ba51e09c0ca82a"
       },
       "exceptions": []
     },
@@ -524,7 +524,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:c00db2d1054a83a8f5f2e4caf8b063383e27fbd6b6bd53e7ff94d880e4393671"
+        "sourceHash": "sha256:3c9f9fee5a1a1d22a7bf56fc5e8fa6908885b95af4743ac126ddb9336f24f16f"
       },
       "exceptions": []
     },
@@ -603,7 +603,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:b186fbcc8f24e72bdce3a782ac2f2428fdef75198fcc642f49993828b140bbcb"
+        "sourceHash": "sha256:790ce19cd146ce0c038847c7ab2f9475efd3aaee580ba091128154854e792bc2"
       },
       "exceptions": []
     },
@@ -682,7 +682,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:0bc40258fec40900f8c6091fa48a1046f91856ff185ce35573764ba224032955"
+        "sourceHash": "sha256:99939cf6c452de210023c407dbaaafacf788446a86855bdff23a5d55a0fa0059"
       },
       "exceptions": []
     },
@@ -761,7 +761,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e68717705fdcbd804a02d68356355acadf95cc273aea313ef98d9f232687ae75"
+        "sourceHash": "sha256:bd6796dfe42a3f3f6949096fb76fa8f5ec616c62e1997d4495aba61e94dcfad3"
       },
       "exceptions": []
     },
@@ -840,7 +840,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6c2a26a23b36b87f62c6b3e11633a7f49c5d576f4331b34156d7a622ab1270b0"
+        "sourceHash": "sha256:87a4b6add91ed322520fc3e32331d760f612d4a715c51c39d944f66850035b96"
       },
       "exceptions": []
     },
@@ -919,7 +919,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:772560c63ccca97dd079b7e50ac6c361343fb42d1702d6714d0bc367dde93edd"
+        "sourceHash": "sha256:cc7230a734d80ccd8ead3bfe93ef364d6245c1b94177ea0ce4543969fbebedf9"
       },
       "exceptions": []
     },
@@ -998,7 +998,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e07e19f1a7aa46afff1ad600385dd0cb6754dd7eddb6ff322fa09b5e0be43fef"
+        "sourceHash": "sha256:e93dc7439a73c9e2668ef6579cad2445609f78da6aea41ec9a3d8bde2212ef26"
       },
       "exceptions": []
     },
@@ -1077,7 +1077,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:bd02f98ec97aadb2dd47128bc9ea578852a95ac55c8a4e190ba92dfb09ff93e7"
+        "sourceHash": "sha256:3abcd09753a5f8065bbb9544b4c86c5351f4866c69944c9276276ff721513dcf"
       },
       "exceptions": []
     },
@@ -1156,7 +1156,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:c1416306eb8ec07044393856c40ddf3cd8e9b5891a66c47eb39234e2f01893a0"
+        "sourceHash": "sha256:ef20bc785d9d4ccdc90e1b8bc87d737558b4a4b4af31941c471efeab1a8bea3a"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:75f1dfbaa382433da19e95f50256e0cf95e4b5c894ab504db0840bfd39c2c9a1"
+        "sourceHash": "sha256:d0676ea69c8e2fe92862563c96cb0f22929c6c8f7ff6818696c9c46a187f6e6f"
       },
       "exceptions": []
     },
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8152c96ce444afc03b952e75f164a8ffa012aaea45faeb30a737d617ac2b7489"
+        "sourceHash": "sha256:83c9d56a6fb29ff5a1dec80eb9ccdc515c2c0ec61e13e23e31b1f45e539931b3"
       },
       "exceptions": []
     },
@@ -1393,7 +1393,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8f5bd04f93338771aebd013cbd0111a45c3ebe1bd4ae35da4efc6d2872ef0fba"
+        "sourceHash": "sha256:98ce32ae55555e80a2668f7f5eb47455f78ad6c4a0d95b5bd257a3335f88d6f0"
       },
       "exceptions": []
     },
@@ -1472,7 +1472,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:3085540075c7ed434f753b8d7e79bfda804cf27c33be42d493b8f6c8da2c730a"
+        "sourceHash": "sha256:0f1572e6c890fdc8a810ab38f0809959d8dc7262c8cefe89d4a8cc14d8ee92a6"
       },
       "exceptions": []
     },
@@ -1551,7 +1551,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d5fb037a31db52522b8e99ebd540fb0dc1d616d84cfc5cdf36013f6531592c53"
+        "sourceHash": "sha256:b5d939ddf9b78e2c9d12ea9b6d46fef0899ec54555a49a9f6066f27e22048370"
       },
       "exceptions": []
     },
@@ -1630,7 +1630,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a8f72f7c6e5083fe655d81d5e59a4685a8ccb1093e934b5328691b2790869474"
+        "sourceHash": "sha256:ab129b68f46a72a709c7580cdda343526afd3923f1b91befcabafcb517b2aa82"
       },
       "exceptions": []
     },
@@ -1709,7 +1709,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d6b55fa389ee5a12e052dbc3401d83d015869ef5b702639cfc804fb07257d29b"
+        "sourceHash": "sha256:cab6e98cdb54f9d802ae045410c98eae0c58cef70d69c446ed843ad6bbc139ed"
       },
       "exceptions": []
     },
@@ -1788,7 +1788,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:27cd8ea957f582190e34f22599964e11398bbbc786f649cdb7ffa99c8d55ed5c"
+        "sourceHash": "sha256:f280975975d3e786fa1fa31915a7a6d77d6dc13070ca9519391bde684e5c52cb"
       },
       "exceptions": []
     },
@@ -1867,7 +1867,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e3fac9e2e98b819e5b778f993bc3fd97172d67c4c665e6207ea8729de30592af"
+        "sourceHash": "sha256:2419be1f43667a8993472e22ab84ee389a22d7b737f6c4651a4bca9b23811995"
       },
       "exceptions": []
     },
@@ -1946,7 +1946,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:2d42df6219a8130312c44a923045e264582bc26daf38902b7b6e3be18e7370e0"
+        "sourceHash": "sha256:54ec97649e0daf43939a8d7280005097ff77a1f1f7a53117d5501cc74e058c00"
       },
       "exceptions": []
     },
@@ -2025,7 +2025,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:92d29b0da1b0d8e45161ee4b5f0d9ba5fe2bc639f97fdd1cb8a937cc0043d43c"
+        "sourceHash": "sha256:be386838520ee2f6df8ab24641c6ee4d772272b2c5110113217a620f4e0a96f7"
       },
       "exceptions": []
     },
@@ -2104,7 +2104,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:8535aa224fd37edc92142e69b922b6d53cec30fa46701f11cdc61d9fa8093315"
+        "sourceHash": "sha256:07b06821adcf0a8ea567b1935f7b09258f2ff1dad5e9ab699fd26b0df64561a6"
       },
       "exceptions": []
     },
@@ -2183,7 +2183,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:eebab1e454ad4975d26b0e55a94bd182c014c800b556db777152d6070e1399f1"
+        "sourceHash": "sha256:a4df5fcece105d4a32505c31be072db03be8e082b1b9ad6502f5dd6f3a74f5ef"
       },
       "exceptions": []
     },


### PR DESCRIPTION
## Summary

- records three consecutive production Lighthouse runs for AKOS `/docs`
- links the performance gate to AgentsKit OS #5324 and the deployed canonical page
- regenerates the canonical latest readiness artifact
- refreshes README Standard hashes invalidated by the automated version PR #1238

## Production evidence

| Run | Performance | Accessibility | Best practices | SEO | CLS |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 95 | 100 | 100 | 100 | 0 |
| 2 | 91 | 100 | 100 | 100 | 0 |
| 3 | 93 | 100 | 100 | 100 | 0 |

## Validation

- `pnpm check:quality-gates` — 21/21 passed
- README Standard — 506 assertions, 0 failures
- `pnpm test:ecosystem` — 21 passed
- `pnpm check:ecosystem-readiness` — 7/7 ready, 0 findings
- `pnpm report:ecosystem-readiness` — regenerated artifacts
- `git diff --check`