### PR TITLE
fix(release): remove ignored app changeset

### DIFF
--- a/.changeset/bright-agents-discover.md
+++ b/.changeset/bright-agents-discover.md
@@ -1,5 +1,0 @@
----
-"@agentskit/registry-app": patch
----
-
-Answer exact Registry questions locally with the AgentsKit Chat deterministic protocol, defer semantic questions to the backend, and publish the verified discovery artifacts through the Registry site.


### PR DESCRIPTION
## Summary

- remove the orphaned changeset for the ignored private Registry app
- restore the release workflow's no-op path when no public package needs a version bump

## Root cause

`@agentskit/registry-app` is private and listed in `.changeset/config.json#ignore`. The stale changeset made `changesets/action` enter version-PR mode, while `pnpm changeset version` correctly produced no diff. The action then attempted to open an empty PR and failed with `No commits between main and changeset-release/main`.

## Validation

- `pnpm exec changeset status --since=origin/main` reports no package bumps
- `pnpm changeset version` exits successfully with `No unreleased changesets found`
- full pre-push quality gates passed

Failed run fixed: https://github.com/AgentsKit-io/agentskit/actions/runs/29370086414
