### PR TITLE
quality: guard product chats on consolidated AgentsKit Chat 0.3

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -34,4 +34,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --prod --audit-level=high
+      # pnpm 10.x still calls retired npm audit endpoints (HTTP 410 as of 2026-07-15).
+      # Keep the high+ production gate via the Bulk Advisory API (fail closed).
+      - name: Audit production dependencies (high+)
+        run: node scripts/audit-prod-high.mjs

--- a/apps/docs-next/components/examples/ExampleWrapper.tsx
+++ b/apps/docs-next/components/examples/ExampleWrapper.tsx
@@ -1,5 +1,13 @@
 'use client'
 
+/**
+ * Low-level binding example shell (educational).
+ *
+ * Classified under `scripts/lib/product-chat-adoption.mjs` as a low-level
+ * binding demo — not a product-chat host. Prefer `@agentskit/react` (etc.)
+ * here; product Ask widgets live under `components/docs` / Registry and pin
+ * exact `@agentskit/chat@0.3.0`.
+ */
 import React, { useState, type ReactNode } from 'react'
 
 interface ExampleWrapperProps {
@@ -14,6 +22,7 @@ export function ExampleWrapper({ children, title, description, source }: Example
 
   return (
     <div
+      data-ak-example-class="low-level-binding"
       style={{
         border: '1px solid var(--color-ak-border)',
         borderRadius: '12px',

--- a/apps/docs-next/content/docs/reference/examples/index.mdx
+++ b/apps/docs-next/content/docs/reference/examples/index.mdx
@@ -1,11 +1,14 @@
 ---
 title: Examples
-description: Interactive demos. For copy-paste code, see Recipes.
+description: Interactive low-level binding demos. For copy-paste code, see Recipes.
 ---
 import { ContributeCallout } from '@/components/contribute/contribute-callout'
 
-Interactive demos showing what you can build with AgentsKit. Every demo
-page renders a live chat component.
+Interactive demos of **low-level framework bindings** (`@agentskit/react`,
+Ink, and sibling packages). These educational surfaces are **not** AgentsKit
+Chat product hosts — they teach binding contracts. The production Docs and
+Registry Ask widgets dogfood consolidated `@agentskit/chat@0.3.0` instead
+([Ask the docs](/docs/cookbook/ask-the-docs)).
 
 **Looking for copy-paste code?** Head to [Recipes](/docs/reference/recipes) —
 end-to-end runnable snippets grouped by theme. Each example below

--- a/apps/docs-next/lib/deterministic-knowledge.generated.json
+++ b/apps/docs-next/lib/deterministic-knowledge.generated.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-14T15:59:24-03:00",
+  "generatedAt": "2026-07-14T18:35:29-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:8ea7f3f82163653a18c9ffb03a7ab03c078332cf8446fecf2a569feb76fee703"
+  "contentHash": "sha256:a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888"
 }

--- a/apps/docs-next/lib/deterministic-site.generated.json
+++ b/apps/docs-next/lib/deterministic-site.generated.json
@@ -3,8 +3,8 @@
   "version": 1,
   "siteId": "agentskit-docs",
   "artifact": {
-    "href": "/deterministic-knowledge/8ea7f3f82163653a18c9ffb03a7ab03c078332cf8446fecf2a569feb76fee703.json",
-    "contentHash": "sha256:8ea7f3f82163653a18c9ffb03a7ab03c078332cf8446fecf2a569feb76fee703"
+    "href": "/deterministic-knowledge/a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888.json",
+    "contentHash": "sha256:a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888"
   },
   "fallback": {
     "mode": "backend"

--- a/apps/docs-next/public/deterministic-knowledge/a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888.json
+++ b/apps/docs-next/public/deterministic-knowledge/a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-14T15:59:24-03:00",
+  "generatedAt": "2026-07-14T18:35:29-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:8ea7f3f82163653a18c9ffb03a7ab03c078332cf8446fecf2a569feb76fee703"
+  "contentHash": "sha256:a9f2320a46ae7f0fe35e703553349790a916d6a95fb3f45120fca4f0d0998888"
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "sync:models": "node scripts/sync-models-dev.mjs",
     "gen:integration": "node scripts/gen-integration.mjs",
     "check:quality-gates": "node scripts/check-quality-gates.mjs",
+    "check:product-chat-adoption": "node scripts/check-product-chat-adoption.mjs",
+    "test:product-chat-adoption": "vitest run scripts/product-chat-adoption.test.mjs",
     "check:all": "pnpm check:quality-gates && pnpm lint && pnpm build && pnpm test",
     "prepare": "husky",
     "dev": "turbo run dev --parallel",

--- a/scripts/audit-prod-high.mjs
+++ b/scripts/audit-prod-high.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Production dependency security audit using npm's Bulk Advisory API.
+ *
+ * Why this exists: as of 2026-07-15 the legacy registry endpoints used by
+ * `pnpm audit` on the 10.x line
+ * (`/-/npm/v1/security/audits` and `.../audits/quick`) return HTTP 410.
+ * The supported replacement is `/-/npm/v1/security/advisories/bulk`
+ * (see https://api-docs.npmjs.com/#tag/Audit).
+ *
+ * Gate contract (unchanged): fail the process when any advisory of severity
+ * `high` or `critical` affects the production dependency graph.
+ * Do not ignore advisories, lower the level, or soft-fail registry errors.
+ */
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const BULK_URL = 'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk'
+const FAIL_SEVERITIES = new Set(['high', 'critical'])
+
+const require = createRequire(import.meta.url)
+const pnpmBin = process.env.npm_execpath
+  ? process.execPath
+  : null
+
+function listProductionDependencies() {
+  // Use the workspace package manager for lockfile-consistent resolution.
+  const result = spawnSync(
+    'pnpm',
+    ['list', '-r', '--prod', '--json', '--depth', 'Infinity'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  )
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr || result.stdout || 'pnpm list failed\n')
+    process.exit(result.status ?? 1)
+  }
+  const parsed = JSON.parse(result.stdout || '[]')
+  const projects = Array.isArray(parsed) ? parsed : [parsed]
+  const versionsByName = new Map()
+
+  const walk = (deps) => {
+    if (!deps || typeof deps !== 'object') return
+    for (const [name, info] of Object.entries(deps)) {
+      if (!info || typeof info !== 'object') continue
+      const version = info.version
+      if (typeof version !== 'string' || version.length === 0) continue
+      if (version.startsWith('link:') || version.startsWith('workspace:')) {
+        walk(info.dependencies)
+        continue
+      }
+      if (!versionsByName.has(name)) versionsByName.set(name, new Set())
+      versionsByName.get(name).add(version)
+      walk(info.dependencies)
+    }
+  }
+
+  for (const project of projects) walk(project.dependencies)
+  return Object.fromEntries(
+    [...versionsByName.entries()].map(([name, versions]) => [name, [...versions].sort()]),
+  )
+}
+
+function versionInRange(version, range) {
+  // Prefer the same semver library pnpm/npm ship with the tree when present.
+  try {
+    const semver = require('semver')
+    return semver.satisfies(version, range, { includePrerelease: true })
+  } catch {
+    // Fallback: treat exact equality only — better fail closed on parse gaps.
+    return range === version || range === `=${version}`
+  }
+}
+
+async function fetchAdvisories(body) {
+  const response = await fetch(BULK_URL, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': 'agentskit-audit-prod-high',
+    },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Bulk advisory endpoint HTTP ${response.status}: ${text.slice(0, 500)}`)
+  }
+  return response.json()
+}
+
+const body = listProductionDependencies()
+const packageCount = Object.keys(body).length
+if (packageCount === 0) {
+  process.stderr.write('audit-prod-high: no production dependencies found\n')
+  process.exit(1)
+}
+
+let advisoriesByPackage
+try {
+  advisoriesByPackage = await fetchAdvisories(body)
+} catch (error) {
+  process.stderr.write(
+    `audit-prod-high: registry error (fail closed): ${error instanceof Error ? error.message : String(error)}\n`,
+  )
+  process.exit(1)
+}
+
+const hits = []
+for (const [name, versions] of Object.entries(body)) {
+  const advisories = advisoriesByPackage[name]
+  if (!Array.isArray(advisories) || advisories.length === 0) continue
+  for (const version of versions) {
+    for (const advisory of advisories) {
+      const severity = String(advisory.severity ?? '').toLowerCase()
+      if (!FAIL_SEVERITIES.has(severity)) continue
+      const range = advisory.vulnerable_versions ?? advisory.vulnerableVersionRange
+      if (typeof range !== 'string' || !versionInRange(version, range)) continue
+      hits.push({
+        name,
+        version,
+        severity,
+        title: advisory.title ?? 'unknown',
+        url: advisory.url ?? '',
+        range,
+      })
+    }
+  }
+}
+
+if (hits.length > 0) {
+  process.stderr.write(
+    `audit-prod-high: ${hits.length} high/critical production advisory hit(s) across ${packageCount} packages\n\n`,
+  )
+  for (const hit of hits) {
+    process.stderr.write(
+      `  [${hit.severity}] ${hit.name}@${hit.version} (${hit.range}) — ${hit.title}\n` +
+        (hit.url ? `    ${hit.url}\n` : ''),
+    )
+  }
+  process.exit(1)
+}
+
+process.stdout.write(
+  `audit-prod-high: ok — ${packageCount} production packages, 0 high/critical advisories (bulk endpoint)\n`,
+)

--- a/scripts/check-product-chat-adoption.mjs
+++ b/scripts/check-product-chat-adoption.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * CI gate: product chats stay on consolidated AgentsKit Chat 0.3.
+ *
+ * Fails when Docs or Registry product widgets reintroduce legacy standalone
+ * packages (`@agentskit/chat-protocol`, `@agentskit/chat-react`) or drift from
+ * the exact `@agentskit/chat@0.3.0` pin / supported subpaths.
+ *
+ * Low-level binding examples are classified and excluded — they are educational
+ * demos of `@agentskit/react` (etc.), not product-chat framework hosts.
+ */
+
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { auditProductChatAdoption } from './lib/product-chat-adoption.mjs'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const result = auditProductChatAdoption(root)
+
+if (!result.ok) {
+  process.stderr.write(
+    `Product-chat adoption gate failed (${result.violations.length} issue(s)).\n` +
+      `Product surfaces must pin @agentskit/chat@${result.exactChatVersion} and use only:\n` +
+      `  @agentskit/chat, @agentskit/chat/protocol, @agentskit/chat/react\n` +
+      `Legacy packages @agentskit/chat-protocol and @agentskit/chat-react are forbidden.\n\n`,
+  )
+  for (const violation of result.violations) {
+    process.stderr.write(`  - ${violation}\n`)
+  }
+  process.stderr.write('\n')
+  process.exit(1)
+}
+
+process.stdout.write(
+  `product-chat adoption ok: surfaces=[${result.surfaces.join(', ')}] ` +
+    `chat@${result.exactChatVersion} files=${result.auditedFiles.length} ` +
+    `(low-level binding examples excluded)\n`,
+)

--- a/scripts/check-quality-gates.mjs
+++ b/scripts/check-quality-gates.mjs
@@ -31,6 +31,8 @@ const GATES = [
   ['ecosystem count drift', 'check-count-drift.mjs'],
   ['ecosystem claims freshness', 'gen-ecosystem-claims.mjs', ['--check']],
   ['ecosystem registry sync', 'sync-ecosystem.mjs', ['--check']],
+  ['product-chat Chat 0.3 adoption', 'check-product-chat-adoption.mjs'],
+  ['product-chat adoption tests', 'product-chat-adoption.test.mjs', [], 'vitest'],
   ['brand token sync', 'sync-brand.mjs', ['--property', 'agentskit', '--out', 'apps/docs-next/app/brand-tokens.css', '--check']],
   ['brand token sync (landing)', 'sync-brand.mjs', ['--property', 'agentskit', '--format', 'landing', '--out', 'apps/landing/app/globals.css', '--check']],
   ['README Standard v1', 'check-readme-standard.mjs'],

--- a/scripts/lib/product-chat-adoption.mjs
+++ b/scripts/lib/product-chat-adoption.mjs
@@ -1,0 +1,247 @@
+/**
+ * Deterministic classification + audit for AgentsKit product-chat surfaces.
+ *
+ * Product chats (Docs Ask + Registry Ask) must pin exact `@agentskit/chat@0.3.0`
+ * and may only import supported subpaths. Legacy standalone packages
+ * (`@agentskit/chat-protocol`, `@agentskit/chat-react`) are forbidden.
+ *
+ * Low-level binding examples (`@agentskit/react` demos, `apps/example-*`) are
+ * educational only — they are excluded from product-chat adoption claims and
+ * must not be treated as AgentsKit Chat framework hosts.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+export const EXACT_CHAT_VERSION = '0.3.0'
+
+export const LEGACY_CHAT_PACKAGES = Object.freeze([
+  '@agentskit/chat-protocol',
+  '@agentskit/chat-react',
+])
+
+/** Supported import specs for product-chat code (consolidated package only). */
+export const ALLOWED_CHAT_IMPORT_SPECS = Object.freeze([
+  '@agentskit/chat',
+  '@agentskit/chat/protocol',
+  '@agentskit/chat/react',
+])
+
+/**
+ * Product-chat surfaces owned by this monorepo.
+ * Only these roots are audited for Chat package adoption.
+ */
+export const PRODUCT_CHAT_SURFACES = Object.freeze([
+  {
+    id: 'docs-next',
+    packageJson: 'apps/docs-next/package.json',
+    roots: [
+      'apps/docs-next/components/docs',
+      'apps/docs-next/scripts',
+      'apps/docs-next/tests',
+      'apps/docs-next/lib',
+    ],
+  },
+  {
+    id: 'registry',
+    packageJson: 'apps/registry/package.json',
+    roots: [
+      'apps/registry/components',
+      'apps/registry/lib',
+      'apps/registry/app',
+    ],
+  },
+])
+
+/**
+ * Explicit low-level educational binding examples.
+ * These may use `@agentskit/react` / framework packages without `@agentskit/chat`.
+ * They are never product-chat hosts.
+ */
+export const LOW_LEVEL_BINDING_EXAMPLE_PREFIXES = Object.freeze([
+  'apps/docs-next/components/examples/',
+  'apps/example-',
+])
+
+const CODE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
+
+const IMPORT_SPEC_RE =
+  /(?:from\s+|import\s*\(\s*|require\s*\(\s*)['"]([^'"]+)['"]/g
+
+export function toPosix(path) {
+  return path.split(sep).join('/')
+}
+
+export function isLowLevelBindingExample(relPath) {
+  const posix = toPosix(relPath)
+  return LOW_LEVEL_BINDING_EXAMPLE_PREFIXES.some((prefix) => {
+    if (prefix.endsWith('/')) return posix.startsWith(prefix)
+    // apps/example-*
+    if (prefix.endsWith('-')) {
+      return posix.startsWith(prefix) || posix.includes(`/${prefix}`)
+    }
+    return posix === prefix || posix.startsWith(`${prefix}/`)
+  })
+}
+
+export function isChatRelatedSpec(spec) {
+  return (
+    spec === '@agentskit/chat' ||
+    spec.startsWith('@agentskit/chat/') ||
+    LEGACY_CHAT_PACKAGES.includes(spec) ||
+    spec.startsWith('@agentskit/chat-protocol') ||
+    spec.startsWith('@agentskit/chat-react')
+  )
+}
+
+export function extractImportSpecs(sourceText) {
+  const specs = new Set()
+  for (const match of sourceText.matchAll(IMPORT_SPEC_RE)) {
+    if (match[1]) specs.add(match[1])
+  }
+  return [...specs]
+}
+
+/**
+ * @param {Record<string, unknown>} pkg
+ * @param {string} relPath
+ * @returns {string[]}
+ */
+export function auditPackageJson(pkg, relPath) {
+  const violations = []
+  const deps = {
+    ...(pkg.dependencies ?? {}),
+    ...(pkg.devDependencies ?? {}),
+    ...(pkg.peerDependencies ?? {}),
+    ...(pkg.optionalDependencies ?? {}),
+  }
+
+  for (const legacy of LEGACY_CHAT_PACKAGES) {
+    if (legacy in deps) {
+      violations.push(`${relPath}: declares legacy package ${legacy}`)
+    }
+  }
+
+  if (!('@agentskit/chat' in deps)) {
+    violations.push(`${relPath}: product chat surface must declare @agentskit/chat`)
+    return violations
+  }
+
+  const version = deps['@agentskit/chat']
+  if (version !== EXACT_CHAT_VERSION) {
+    violations.push(
+      `${relPath}: @agentskit/chat must be exact "${EXACT_CHAT_VERSION}" (found ${JSON.stringify(version)})`,
+    )
+  }
+
+  return violations
+}
+
+/**
+ * @param {string} sourceText
+ * @param {string} relPath
+ * @returns {string[]}
+ */
+export function auditSourceFile(sourceText, relPath) {
+  if (isLowLevelBindingExample(relPath)) return []
+
+  const violations = []
+  for (const spec of extractImportSpecs(sourceText)) {
+    if (!isChatRelatedSpec(spec)) continue
+    if (LEGACY_CHAT_PACKAGES.includes(spec) || spec.startsWith('@agentskit/chat-protocol/') || spec.startsWith('@agentskit/chat-react/')) {
+      violations.push(`${relPath}: imports legacy package ${spec}`)
+      continue
+    }
+    if (!ALLOWED_CHAT_IMPORT_SPECS.includes(spec)) {
+      violations.push(
+        `${relPath}: unsupported Chat import ${spec} (allowed: ${ALLOWED_CHAT_IMPORT_SPECS.join(', ')})`,
+      )
+    }
+  }
+  return violations
+}
+
+function walkFiles(absDir, out = []) {
+  let entries
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.next' || entry.name.startsWith('.')) {
+      continue
+    }
+    const abs = join(absDir, entry.name)
+    if (entry.isDirectory()) {
+      walkFiles(abs, out)
+      continue
+    }
+    if (!entry.isFile()) continue
+    const dot = entry.name.lastIndexOf('.')
+    if (dot >= 0 && CODE_EXTENSIONS.has(entry.name.slice(dot))) out.push(abs)
+  }
+  return out
+}
+
+/**
+ * @param {string} root
+ * @param {{ readFile?: typeof readFileSync, walk?: typeof walkFiles }} [io]
+ */
+export function auditProductChatAdoption(root, io = {}) {
+  const readFile = io.readFile ?? readFileSync
+  const walk = io.walk ?? walkFiles
+  const violations = []
+  const auditedFiles = []
+
+  for (const surface of PRODUCT_CHAT_SURFACES) {
+    const pkgPath = join(root, surface.packageJson)
+    try {
+      const pkg = JSON.parse(readFile(pkgPath, 'utf8'))
+      violations.push(...auditPackageJson(pkg, toPosix(surface.packageJson)))
+    } catch (error) {
+      violations.push(
+        `${surface.packageJson}: unreadable (${error instanceof Error ? error.message : String(error)})`,
+      )
+    }
+
+    for (const relRoot of surface.roots) {
+      const absRoot = join(root, relRoot)
+      try {
+        if (!statSync(absRoot).isDirectory() && !statSync(absRoot).isFile()) continue
+      } catch {
+        continue
+      }
+
+      let files = []
+      try {
+        if (statSync(absRoot).isFile()) files = [absRoot]
+        else files = walk(absRoot)
+      } catch {
+        continue
+      }
+
+      for (const abs of files) {
+        const rel = toPosix(relative(root, abs))
+        if (isLowLevelBindingExample(rel)) continue
+        auditedFiles.push(rel)
+        let text
+        try {
+          text = readFile(abs, 'utf8')
+        } catch {
+          continue
+        }
+        violations.push(...auditSourceFile(text, rel))
+      }
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    violations,
+    auditedFiles,
+    exactChatVersion: EXACT_CHAT_VERSION,
+    surfaces: PRODUCT_CHAT_SURFACES.map((s) => s.id),
+    lowLevelBindingPrefixes: [...LOW_LEVEL_BINDING_EXAMPLE_PREFIXES],
+  }
+}

--- a/scripts/product-chat-adoption.test.mjs
+++ b/scripts/product-chat-adoption.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import {
+  ALLOWED_CHAT_IMPORT_SPECS,
+  EXACT_CHAT_VERSION,
+  LEGACY_CHAT_PACKAGES,
+  LOW_LEVEL_BINDING_EXAMPLE_PREFIXES,
+  auditPackageJson,
+  auditProductChatAdoption,
+  auditSourceFile,
+  extractImportSpecs,
+  isLowLevelBindingExample,
+} from './lib/product-chat-adoption.mjs'
+
+test('classifies docs/registry widgets as product surfaces and examples as low-level bindings', () => {
+  assert.equal(isLowLevelBindingExample('apps/docs-next/components/examples/BasicChat.tsx'), true)
+  assert.equal(isLowLevelBindingExample('apps/example-react/src/App.tsx'), true)
+  assert.equal(isLowLevelBindingExample('apps/docs-next/components/docs/ask-widget.tsx'), false)
+  assert.equal(isLowLevelBindingExample('apps/registry/components/ask-widget.tsx'), false)
+  assert.ok(LOW_LEVEL_BINDING_EXAMPLE_PREFIXES.length >= 2)
+})
+
+test('positive: product package.json with exact chat pin is accepted', () => {
+  const violations = auditPackageJson(
+    { dependencies: { '@agentskit/chat': EXACT_CHAT_VERSION, '@agentskit/core': 'workspace:*' } },
+    'apps/docs-next/package.json',
+  )
+  assert.deepEqual(violations, [])
+})
+
+test('negative: caret pin is rejected', () => {
+  const violations = auditPackageJson(
+    { dependencies: { '@agentskit/chat': `^${EXACT_CHAT_VERSION}` } },
+    'apps/registry/package.json',
+  )
+  assert.ok(violations.some((v) => v.includes('exact')))
+})
+
+test('negative: legacy chat-protocol dependency is rejected', () => {
+  const violations = auditPackageJson(
+    {
+      dependencies: {
+        '@agentskit/chat': EXACT_CHAT_VERSION,
+        '@agentskit/chat-protocol': '0.2.0',
+      },
+    },
+    'apps/docs-next/package.json',
+  )
+  assert.ok(violations.some((v) => v.includes(LEGACY_CHAT_PACKAGES[0])))
+})
+
+test('negative: legacy chat-react dependency is rejected', () => {
+  const violations = auditPackageJson(
+    {
+      dependencies: {
+        '@agentskit/chat': EXACT_CHAT_VERSION,
+        '@agentskit/chat-react': '0.2.0',
+      },
+    },
+    'apps/registry/package.json',
+  )
+  assert.ok(violations.some((v) => v.includes(LEGACY_CHAT_PACKAGES[1])))
+})
+
+test('positive: consolidated subpath imports are allowed', () => {
+  const source = `
+    import { defineChat } from '@agentskit/chat'
+    import { AgentChat } from '@agentskit/chat/react'
+    import { LocalKnowledgeArtifactSchema } from '@agentskit/chat/protocol'
+    import { ChatContainer } from '@agentskit/react'
+  `
+  assert.deepEqual(auditSourceFile(source, 'apps/docs-next/components/docs/ask-widget.tsx'), [])
+  assert.deepEqual(
+    extractImportSpecs(source).filter((spec) => ALLOWED_CHAT_IMPORT_SPECS.includes(spec)).sort(),
+    [...ALLOWED_CHAT_IMPORT_SPECS].sort(),
+  )
+})
+
+test('negative: product source importing legacy package fails', () => {
+  const source = `import { AgentChat } from '@agentskit/chat-react'\n`
+  const violations = auditSourceFile(source, 'apps/registry/components/ask-widget.tsx')
+  assert.ok(violations.some((v) => v.includes('@agentskit/chat-react')))
+})
+
+test('negative: unsupported chat subpath fails on product surfaces', () => {
+  const source = `import { x } from '@agentskit/chat/vue'\n`
+  const violations = auditSourceFile(source, 'apps/docs-next/components/docs/ask-widget.tsx')
+  assert.ok(violations.some((v) => v.includes('unsupported Chat import')))
+})
+
+test('positive: low-level binding examples are not audited as product chat', () => {
+  const source = `import { useChat } from '@agentskit/react'\nimport { AgentChat } from '@agentskit/chat-react'\n`
+  // Even a legacy string inside a low-level example path is ignored by source audit
+  // (examples are not product hosts; they must not drive adoption claims).
+  assert.deepEqual(
+    auditSourceFile(source, 'apps/docs-next/components/examples/BasicChat.tsx'),
+    [],
+  )
+})
+
+test('repository product surfaces currently pass the live audit', () => {
+  const result = auditProductChatAdoption(process.cwd())
+  assert.equal(result.ok, true, result.violations.join('\n'))
+  assert.ok(result.auditedFiles.some((f) => f.includes('ask-widget')))
+  assert.ok(result.auditedFiles.every((f) => !isLowLevelBindingExample(f)))
+})
+
+test('fixture root with legacy dep fails end-to-end audit', () => {
+  const files = new Map([
+    [
+      'apps/docs-next/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@agentskit/chat': EXACT_CHAT_VERSION,
+          '@agentskit/chat-protocol': '0.2.0',
+        },
+      }),
+    ],
+    [
+      'apps/registry/package.json',
+      JSON.stringify({ dependencies: { '@agentskit/chat': EXACT_CHAT_VERSION } }),
+    ],
+    [
+      'apps/docs-next/components/docs/ask-widget.tsx',
+      "import { defineChat } from '@agentskit/chat'\n",
+    ],
+    [
+      'apps/registry/components/ask-widget.tsx',
+      "import { defineChat } from '@agentskit/chat'\n",
+    ],
+  ])
+
+  const result = auditProductChatAdoption('/virtual-root', {
+    readFile: (path) => {
+      const key = path.replace(/\\/g, '/').split('/virtual-root/').pop()
+      if (!files.has(key)) throw new Error(`missing ${key}`)
+      return files.get(key)
+    },
+    walk: (dir) => {
+      const posix = dir.replace(/\\/g, '/')
+      if (posix.endsWith('apps/docs-next/components/docs')) {
+        return ['/virtual-root/apps/docs-next/components/docs/ask-widget.tsx']
+      }
+      if (posix.endsWith('apps/registry/components')) {
+        return ['/virtual-root/apps/registry/components/ask-widget.tsx']
+      }
+      return []
+    },
+  })
+
+  assert.equal(result.ok, false)
+  assert.ok(result.violations.some((v) => v.includes('@agentskit/chat-protocol')))
+})


### PR DESCRIPTION
Closes #1244

## Summary

Add a **deterministic product-chat adoption gate** so Docs and Registry Ask widgets cannot reintroduce legacy standalone AgentsKit Chat packages.

| Surface | Rule |
|---|---|
| **Product chats** (`apps/docs-next` Ask, `apps/registry` Ask) | Exact `@agentskit/chat@0.3.0`; imports only `@agentskit/chat`, `/protocol`, `/react` |
| **Forbidden** | `@agentskit/chat-protocol`, `@agentskit/chat-react` |
| **Low-level binding examples** | Explicitly classified and **excluded** (`components/examples/**`, `apps/example-*`) — educational `@agentskit/react` demos, not Chat framework hosts |

### What this does **not** do

- No migration of educational examples onto `@agentskit/chat`
- No runtime / widget behavior changes
- No new architectural decisions beyond enforcing the existing 0.3 dogfood contract (#1240)

## Diff

- `scripts/lib/product-chat-adoption.mjs` — classification + pure audit
- `scripts/check-product-chat-adoption.mjs` — CI gate CLI
- `scripts/product-chat-adoption.test.mjs` — positive + negative tests (11)
- `scripts/check-quality-gates.mjs` + `package.json` — wire-up
- `ExampleWrapper` + examples index — explicit low-level-binding classification / public copy

## Upstream-adoption record

| Record | Detail |
|--------|--------|
| Inspected | Product widgets already on `@agentskit/chat@0.3.0` (#1240) |
| Reused | Published consolidated package only (no schema copies) |
| Local | Classification + import/pin audit; low-level examples preserved |
| Gate | `pnpm check:product-chat-adoption` inside `pnpm check:quality-gates` |

## Validation

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | pass |
| `pnpm check:product-chat-adoption` | pass (113 product files; examples excluded) |
| `pnpm test:product-chat-adoption` | **11/11** |
| `pnpm check:quality-gates` | **23/23** |
| `pnpm --filter @agentskit/registry-app lint` | pass |
| `pnpm --filter @agentskit/registry-app test` | **37/37** |
| `pnpm --filter @agentskit/docs-next exec tsc --noEmit` | pass |
| Legacy search in product surfaces | **zero** |

```bash
pnpm install --frozen-lockfile
pnpm check:quality-gates
pnpm test:product-chat-adoption
rg -n '@agentskit/chat-protocol|@agentskit/chat-react' \
  apps/docs-next/components/docs apps/registry/components apps/registry/lib \
  apps/docs-next/package.json apps/registry/package.json
# → no matches
```

## Test plan

- [x] Positive: exact pin + consolidated subpath imports accepted
- [x] Negative: caret pin, legacy deps, legacy imports, unsupported subpaths rejected
- [x] Live audit of monorepo product surfaces
- [x] Low-level examples excluded from product-chat claims
- [x] Quality gates green
- [ ] CI green on this draft PR