### PR TITLE
fix: remove dead symbols from quickstarts

### DIFF
--- a/.changeset/clean-codeql-quickstarts.md
+++ b/.changeset/clean-codeql-quickstarts.md
@@ -1,0 +1,10 @@
+---
+'@agentskit/adapters': patch
+'@agentskit/integrations': patch
+'@agentskit/memory': patch
+'@agentskit/observability': patch
+'@agentskit/rag': patch
+'@agentskit/react': patch
+---
+
+Remove dead symbols from the synchronized README quickstarts and keep each example copy-ready.

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -50,7 +50,7 @@ npm install @agentskit/adapters
 
 <!-- readme-example:quickstart -->
 ```ts
-import { anthropic, openai, ollama } from '@agentskit/adapters'
+import { anthropic } from '@agentskit/adapters'
 import { createRuntime } from '@agentskit/runtime'
 
 // Switch provider by swapping one import

--- a/packages/adapters/fixtures/readme-quickstart.ts
+++ b/packages/adapters/fixtures/readme-quickstart.ts
@@ -1,4 +1,4 @@
-import { anthropic, openai, ollama } from '@agentskit/adapters'
+import { anthropic } from '@agentskit/adapters'
 import { createRuntime } from '@agentskit/runtime'
 
 // Switch provider by swapping one import

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -42,13 +42,13 @@ npm install @agentskit/integrations
 
 <!-- readme-example:quickstart -->
 ```ts
-import { defineIntegration, defineAction } from '@agentskit/integrations'
-
 // Most consumers don't author integrations directly — they pull ready-made
 // service descriptors from the registry and project them into tools:
-import { registry, toTools } from '@agentskit/integrations'
+import { integrationTools } from '@agentskit/integrations'
 
-const tools = toTools(registry.get('resend'))
+export const tools = integrationTools('slack', {
+  credential: process.env.SLACK_BOT_TOKEN,
+})
 ```
 
 Service descriptors live under `src/services/`. The descriptor declares the

--- a/packages/integrations/fixtures/readme-quickstart.ts
+++ b/packages/integrations/fixtures/readme-quickstart.ts
@@ -1,7 +1,7 @@
-import { defineIntegration, defineAction } from '@agentskit/integrations'
-
 // Most consumers don't author integrations directly — they pull ready-made
 // service descriptors from the registry and project them into tools:
-import { registry, toTools } from '@agentskit/integrations'
+import { integrationTools } from '@agentskit/integrations'
 
-const tools = toTools(registry.get('resend'))
+export const tools = integrationTools('slack', {
+  credential: process.env.SLACK_BOT_TOKEN,
+})

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -54,7 +54,7 @@ npm install @agentskit/memory better-sqlite3
 ```ts
 import { createRuntime } from '@agentskit/runtime'
 import { anthropic } from '@agentskit/adapters'
-import { sqliteChatMemory, fileVectorMemory } from '@agentskit/memory'
+import { sqliteChatMemory } from '@agentskit/memory'
 
 const runtime = createRuntime({
   adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),

--- a/packages/memory/fixtures/readme-quickstart.ts
+++ b/packages/memory/fixtures/readme-quickstart.ts
@@ -1,6 +1,6 @@
 import { createRuntime } from '@agentskit/runtime'
 import { anthropic } from '@agentskit/adapters'
-import { sqliteChatMemory, fileVectorMemory } from '@agentskit/memory'
+import { sqliteChatMemory } from '@agentskit/memory'
 
 const runtime = createRuntime({
   adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -63,6 +63,7 @@ const runtime = createRuntime({
 })
 
 const result = await runtime.run('Analyze sales data in ./data/sales.csv')
+console.log(result.content)
 // Every step is now logged and traced automatically
 ```
 

--- a/packages/observability/fixtures/readme-quickstart.ts
+++ b/packages/observability/fixtures/readme-quickstart.ts
@@ -11,4 +11,5 @@ const runtime = createRuntime({
 })
 
 const result = await runtime.run('Analyze sales data in ./data/sales.csv')
+console.log(result.content)
 // Every step is now logged and traced automatically

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -64,6 +64,7 @@ await rag.ingest([
 ])
 
 const docs = await rag.search('How does AgentsKit work?', { topK: 5 })
+console.log(docs)
 ```
 
 ## With runtime (retriever)

--- a/packages/rag/fixtures/readme-quickstart.ts
+++ b/packages/rag/fixtures/readme-quickstart.ts
@@ -12,3 +12,4 @@ await rag.ingest([
 ])
 
 const docs = await rag.search('How does AgentsKit work?', { topK: 5 })
+console.log(docs)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -54,7 +54,7 @@ import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
 import { anthropic } from '@agentskit/adapters'
 import '@agentskit/react/theme'
 
-function Chat() {
+export function Chat() {
   const chat = useChat({
     adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
   })

--- a/packages/react/fixtures/readme-quickstart.tsx
+++ b/packages/react/fixtures/readme-quickstart.tsx
@@ -2,7 +2,7 @@ import { useChat, ChatContainer, Message, InputBar } from '@agentskit/react'
 import { anthropic } from '@agentskit/adapters'
 import '@agentskit/react/theme'
 
-function Chat() {
+export function Chat() {
   const chat = useChat({
     adapter: anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
   })

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:10f9872f4ec9cbbb647d639ac8777202c188a476be3f3dd055dd69d1852d67b6"
+        "sourceHash": "sha256:c9217e2f71f18ace4c3e346b653bba1c9472eba61da0c15118268f20f3a04963"
       },
       "exceptions": []
     },
@@ -840,7 +840,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:87a4b6add91ed322520fc3e32331d760f612d4a715c51c39d944f66850035b96"
+        "sourceHash": "sha256:23337f78a508a14fead33367d9bca75931ffde62ceec4d952e5ba3c65ee660ff"
       },
       "exceptions": []
     },
@@ -998,7 +998,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:e93dc7439a73c9e2668ef6579cad2445609f78da6aea41ec9a3d8bde2212ef26"
+        "sourceHash": "sha256:a2f96165e2fa3df19e53cd104be4150f3728f6b79172c9e736e51ac8caeba36b"
       },
       "exceptions": []
     },
@@ -1077,7 +1077,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:3abcd09753a5f8065bbb9544b4c86c5351f4866c69944c9276276ff721513dcf"
+        "sourceHash": "sha256:9b9649d43fcc51db8c517463eb1c759cb67b9e24fcd8b03eabb84e6e005bc46f"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:d0676ea69c8e2fe92862563c96cb0f22929c6c8f7ff6818696c9c46a187f6e6f"
+        "sourceHash": "sha256:473ab76a3f81a4bcf6e74d5319945eac4a2777440f81fe91df82b3fcef2182a0"
       },
       "exceptions": []
     },
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:83c9d56a6fb29ff5a1dec80eb9ccdc515c2c0ec61e13e23e31b1f45e539931b3"
+        "sourceHash": "sha256:6cea6748e390e32a8b01578dc2e2e09bf828fcfbc6641c36d04e63f902ef46e5"
       },
       "exceptions": []
     },

--- a/scripts/audit-prod-high.mjs
+++ b/scripts/audit-prod-high.mjs
@@ -19,9 +19,6 @@ const BULK_URL = 'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk'
 const FAIL_SEVERITIES = new Set(['high', 'critical'])
 
 const require = createRequire(import.meta.url)
-const pnpmBin = process.env.npm_execpath
-  ? process.execPath
-  : null
 
 function listProductionDependencies() {
   // Use the workspace package manager for lockfile-consistent resolution.


### PR DESCRIPTION
## Summary

- resolve CodeQL unused-symbol alerts #122, #123, #124, #125, #126, #127, #132, and #134
- replace the invalid integrations quickstart with the public `integrationTools('slack', ...)` API
- keep README fixtures and freshness hashes synchronized
- add patch changesets for the affected public packages

## Validation

- 25/25 repository quality gates passed
- full lint passed: 56/56 tasks
- full build passed: 42/42 tasks
- README fixtures passed: 30/30
- affected package tests passed: 1,021 tests
- production audit passed: 978 packages, zero high/critical advisories
- multi-agent review completed with no remaining high-confidence findings
