### PR TITLE
fix(registry): publish favicon and ecosystem machine links

### DIFF
--- a/apps/registry/app/deterministic/machine-docs.test.ts
+++ b/apps/registry/app/deterministic/machine-docs.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/lib/categories', () => ({
 }))
 
 import ForAgentsPage from '../for-agents/page'
+import { GET as getFavicon } from '../favicon.ico/route'
 import { GET as getLlmsFull } from '../llms-full.txt/route'
 import { GET as getLlmsIndex } from '../llms.txt/route'
 import sitemap from '../sitemap'
@@ -62,6 +63,26 @@ describe('Registry machine documentation contracts', () => {
     expect(body).toContain(`[For agents](${SITE}/docs/for-agents)`)
     expect(body).toContain(`[Full agent context](${SITE}/llms-full.txt)`)
     expect(body).toContain(`[Registry index](${SITE}/r/index.json)`)
+    expect(body.match(/^## AgentsKit ecosystem$/gm)).toHaveLength(1)
+
+    const expectedProducts = [
+      ['AgentsKit', 'https://www.agentskit.io/docs', 'https://www.agentskit.io/llms.txt'],
+      ['AgentsKit Registry', `${SITE}/docs`, `${SITE}/llms.txt`],
+      ['AgentsKit Chat', 'https://chat.agentskit.io/docs', 'https://chat.agentskit.io/llms.txt'],
+      ['Agents Playbook', 'https://playbook.agentskit.io/docs', 'https://playbook.agentskit.io/llms.txt'],
+      ['Doc Bridge', 'https://agentskit-io.github.io/doc-bridge/', 'https://agentskit-io.github.io/doc-bridge/llms.txt'],
+      ['AgentsKit Code Review', 'https://github.com/AgentsKit-io/code-review-cli#readme', 'https://raw.githubusercontent.com/AgentsKit-io/code-review-cli/main/llms.txt'],
+      ['AgentsKit OS', 'https://akos.agentskit.io/docs', 'https://akos.agentskit.io/llms.txt'],
+    ] as const
+
+    let previous = -1
+    for (const [name, docs, llms] of expectedProducts) {
+      const position = body.indexOf(`[${name}](${docs})`)
+      expect(position).toBeGreaterThan(previous)
+      expect(body).toContain(`Machine index: ${llms}`)
+      previous = position
+    }
+    expect(body).toContain(`[AgentsKit Registry](${SITE}/docs) **(current)**`)
   })
 
   it('publishes llms-full.txt as plain text with docs before the catalog', async () => {
@@ -100,5 +121,12 @@ describe('Registry machine documentation contracts', () => {
     expect(icon).toContain('<svg')
     expect(icon).toContain('viewBox="0 0 64 64"')
     expect(icon).toContain('#58A6FF')
+  })
+
+  it('serves the conventional favicon path from the canonical Registry icon', () => {
+    const response = getFavicon(new Request(`${SITE}/favicon.ico`))
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get('location')).toBe(`${SITE}/icon.svg`)
   })
 })

--- a/apps/registry/app/favicon.ico/route.ts
+++ b/apps/registry/app/favicon.ico/route.ts
@@ -1,0 +1,3 @@
+export function GET(request: Request) {
+  return Response.redirect(new URL('/icon.svg', request.url), 308)
+}

--- a/apps/registry/app/llms.txt/route.ts
+++ b/apps/registry/app/llms.txt/route.ts
@@ -1,8 +1,31 @@
 import { source } from '@/lib/source'
 import { getRegistryIndex } from '@/lib/registry'
+import ecosystemManifest from '../../../../ecosystem.json'
 
 export const revalidate = 3600
 const SITE = 'https://registry.agentskit.io'
+
+interface EcosystemProduct {
+  readonly id: string
+  readonly name: string
+  readonly promise: string
+  readonly surfaces: {
+    readonly docs: string
+    readonly llms?: string
+  }
+  readonly navigation: {
+    readonly order: number
+  }
+}
+
+const ecosystemProducts = (ecosystemManifest.products as readonly EcosystemProduct[])
+  .toSorted((left, right) => left.navigation.order - right.navigation.order)
+
+function ecosystemLine(product: EcosystemProduct): string {
+  const current = product.id === 'registry' ? ' **(current)**' : ''
+  const machineIndex = product.surfaces.llms ? ` Machine index: ${product.surfaces.llms}` : ''
+  return `- [${product.name}](${product.surfaces.docs})${current} — ${product.promise}${machineIndex}`
+}
 
 export async function GET() {
   const agents = await getRegistryIndex()
@@ -10,6 +33,10 @@ export async function GET() {
     '# AgentsKit Registry',
     '',
     '> Ready-to-use, provider-agnostic AI agents. Copy the source into your project and own the code.',
+    '',
+    '## AgentsKit ecosystem',
+    '',
+    ...ecosystemProducts.map(ecosystemLine),
     '',
     '## Documentation',
     '',


### PR DESCRIPTION
Closes #1250

Part of #1198

## What changed

- publishes a working Registry favicon alias at /favicon.ico backed by the canonical Registry SVG icon
- derives the Registry llms.txt ecosystem section from the root ecosystem manifest
- lists all seven products in canonical navigation order with documentation and machine-readable links
- marks Registry as the current product
- adds deterministic coverage for the favicon and ecosystem contract

## Verification

- Registry focused tests: 6/6
- Registry full test suite: 44/44
- Registry lint: passed
- Registry production build: passed (395 pages)
- Doc Bridge gate: 7/7 required and 2/2 recommended
- repository pre-push quality gates: 25/25
- local smoke: favicon redirect 308, SVG 200 image/svg+xml, llms.txt 200 with exactly seven products

No maturity data was changed.