### PR TITLE
chore(docs): converge product chats on 0.4.0

### DIFF
--- a/apps/docs-next/components/examples/ExampleWrapper.tsx
+++ b/apps/docs-next/components/examples/ExampleWrapper.tsx
@@ -6,7 +6,7 @@
  * Classified under `scripts/lib/product-chat-adoption.mjs` as a low-level
  * binding demo — not a product-chat host. Prefer `@agentskit/react` (etc.)
  * here; product Ask widgets live under `components/docs` / Registry and pin
- * exact `@agentskit/chat@0.3.0`.
+ * exact `@agentskit/chat@0.4.0`.
  */
 import React, { useState, type ReactNode } from 'react'
 

--- a/apps/docs-next/content/docs/reference/examples/index.mdx
+++ b/apps/docs-next/content/docs/reference/examples/index.mdx
@@ -7,7 +7,7 @@ import { ContributeCallout } from '@/components/contribute/contribute-callout'
 Interactive demos of **low-level framework bindings** (`@agentskit/react`,
 Ink, and sibling packages). These educational surfaces are **not** AgentsKit
 Chat product hosts — they teach binding contracts. The production Docs and
-Registry Ask widgets dogfood consolidated `@agentskit/chat@0.3.0` instead
+Registry Ask widgets dogfood consolidated `@agentskit/chat@0.4.0` instead
 ([Ask the docs](/docs/cookbook/ask-the-docs)).
 
 **Looking for copy-paste code?** Head to [Recipes](/docs/reference/recipes) —

--- a/apps/docs-next/lib/deterministic-knowledge.generated.json
+++ b/apps/docs-next/lib/deterministic-knowledge.generated.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-14T18:35:29-03:00",
+  "generatedAt": "2026-07-15T22:24:19-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:916743bbd15146ac167db4fe9cd69c0ef6d80475d53b71d021c3bbe9517c4d74"
+  "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
 }

--- a/apps/docs-next/lib/deterministic-site.generated.json
+++ b/apps/docs-next/lib/deterministic-site.generated.json
@@ -3,8 +3,8 @@
   "version": 1,
   "siteId": "agentskit-docs",
   "artifact": {
-    "href": "/deterministic-knowledge/916743bbd15146ac167db4fe9cd69c0ef6d80475d53b71d021c3bbe9517c4d74.json",
-    "contentHash": "sha256:916743bbd15146ac167db4fe9cd69c0ef6d80475d53b71d021c3bbe9517c4d74"
+    "href": "/deterministic-knowledge/1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865.json",
+    "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
   },
   "fallback": {
     "mode": "backend"

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@agentskit/adapters": "workspace:*",
-    "@agentskit/chat": "0.3.0",
+    "@agentskit/chat": "0.4.0",
     "@agentskit/core": "workspace:*",
     "@agentskit/eval": "workspace:*",
     "@agentskit/memory": "workspace:*",

--- a/apps/docs-next/public/deterministic-knowledge/1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865.json
+++ b/apps/docs-next/public/deterministic-knowledge/1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-14T18:35:29-03:00",
+  "generatedAt": "2026-07-15T22:24:19-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:916743bbd15146ac167db4fe9cd69c0ef6d80475d53b71d021c3bbe9517c4d74"
+  "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
 }

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -95,7 +95,7 @@ pnpm --filter @agentskit/registry-app build
 ## AgentsKit Chat dogfood
 
 The floating **Ask Registry** surface consumes the stable npm package
-`@agentskit/chat` at exact version `0.3.0`, using its `/protocol` and `/react`
+`@agentskit/chat` at exact version `0.4.0`, using its `/protocol` and `/react`
 subpaths. This app owns only the `registry` corpus,
 `NEXT_PUBLIC_ASK_ENDPOINT`, Registry branding, CTA, and React slots. AgentsKit
 Chat owns the Ask wire contract, streaming adapter, ordered content, standard

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -12,7 +12,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@agentskit/chat": "0.3.0",
+    "@agentskit/chat": "0.4.0",
     "@agentskit/core": "workspace:*",
     "@agentskit/react": "workspace:*",
     "fumadocs-core": "^16.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: link:packages/core
       '@agentskit/doc-bridge':
         specifier: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz
-        version: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)
+        version: https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(react@19.2.7)
       '@agentskit/eval':
         specifier: workspace:*
         version: link:packages/eval
@@ -127,8 +127,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/adapters
       '@agentskit/chat':
-        specifier: 0.3.0
-        version: 0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
+        specifier: 0.4.0
+        version: 0.4.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       '@agentskit/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -637,8 +637,8 @@ importers:
   apps/registry:
     dependencies:
       '@agentskit/chat':
-        specifier: 0.3.0
-        version: 0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
+        specifier: 0.4.0
+        version: 0.4.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))
       '@agentskit/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1507,8 +1507,8 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@agentskit/chat@0.3.0':
-    resolution: {integrity: sha512-N424oOZ5DClrCMTp5V5djOg+N2rwj2LJ+ZtqQvpwBEO/sZ1BORFnenqFAJEyWptAw3/REHi9etDhhTWJcWGBnQ==}
+  '@agentskit/chat@0.4.0':
+    resolution: {integrity: sha512-RJ4akVS3LtoXrFpy7/3Lqd92cCpdbg10DcGxnm/w0DgdO1wM33s5OTD6JeWJ6QBojUFbG0IdH+AGm1ZPsh1KtQ==}
     peerDependencies:
       '@agentskit/angular': ^0.4.6
       '@agentskit/core': ^1.12.3
@@ -1593,16 +1593,8 @@ packages:
   '@agentskit/eval@0.4.19':
     resolution: {integrity: sha512-DYjEa6bgzP/rVqTZBuguXjn+JuoPG9NfVUa/ogubm5hPlVKL0SVD1ThTDfuhTqrMqOgqHIBwIHv5yFbjnqheDg==}
 
-  '@agentskit/ink@0.10.4':
-    resolution: {integrity: sha512-M3/yBrEM2Pen1LVa+0xZQds0bDaSaY5jK90jpwg6fGg+dDcU+ZyxgqcW2TufddQJxVrOFzJr9xlRVBELmdJB3g==}
-    peerDependencies:
-      react: '>=18.0.0'
-
   '@agentskit/memory@0.11.0':
     resolution: {integrity: sha512-sTAVVmaHIKLUYH3nFfbjmWwm3zfQ1Ljy1ct4mVhOlrvqfequ+sekrA+dzStX4PrQEtGob3MEy3qZlwwA+oxsqw==}
-
-  '@agentskit/rag@0.4.14':
-    resolution: {integrity: sha512-MYIKHWuoBHf+5Nvmtp7RsPogQCdy/WLKvepl7L2+iU74x/vpTNuCjeQZz7Hqu9BWwAgGShejHoLNHlRLQSYtNw==}
 
   '@agentskit/statechart@0.2.0':
     resolution: {integrity: sha512-P1wn2s5tcKe/WvtJWySm7/Pu1tKAKbet6vqocJuQUTlzRgdQeGq9l8DEj1mqR6duYSaQJW2Kb0w2zPLFUNLosQ==}
@@ -8686,7 +8678,7 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@agentskit/chat@0.3.0(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
+  '@agentskit/chat@0.4.0(@agentskit/core@packages+core)(@agentskit/react@packages+react)(@angular/common@21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(ink@7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)(solid-js@1.9.14)(svelte@5.56.4)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@agentskit/core': link:packages/core
       '@agentskit/eval': 0.4.19
@@ -8695,7 +8687,6 @@ snapshots:
       tslib: 2.8.1
       zod: 4.4.3
     optionalDependencies:
-      '@agentskit/ink': 0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
       '@agentskit/react': link:packages/react
       '@angular/common': 21.2.18(@angular/core@21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 21.2.18(@angular/compiler@21.2.18)(rxjs@7.8.2)(zone.js@0.16.2)
@@ -8709,42 +8700,20 @@ snapshots:
 
   '@agentskit/core@1.12.3': {}
 
-  '@agentskit/doc-bridge@https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7))(@agentskit/memory@0.11.0)(@agentskit/rag@0.4.14)(react@19.2.7)':
+  '@agentskit/doc-bridge@https://github.com/AgentsKit-io/doc-bridge/releases/download/v1.1.0/agentskit-doc-bridge-1.1.0.tgz(@agentskit/core@packages+core)(react@19.2.7)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
       '@agentskit/core': link:packages/core
-      '@agentskit/ink': 0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
-      '@agentskit/memory': 0.11.0
-      '@agentskit/rag': 0.4.14
       react: 19.2.7
 
   '@agentskit/eval@0.4.19':
     dependencies:
       '@agentskit/core': 1.12.3
 
-  '@agentskit/ink@0.10.4(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)':
-    dependencies:
-      '@agentskit/core': 1.12.3
-      ink: 7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
-      marked: 15.0.12
-      marked-terminal: 7.3.0(marked@15.0.12)
-      react: 19.2.7
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - react-devtools-core
-      - utf-8-validate
-    optional: true
-
   '@agentskit/memory@0.11.0':
     dependencies:
       '@agentskit/core': 1.12.3
-
-  '@agentskit/rag@0.4.14':
-    dependencies:
-      '@agentskit/core': 1.12.3
-    optional: true
 
   '@agentskit/statechart@0.2.0': {}
 

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -198,8 +198,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-10-13",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-10-14",
         "sources": [
           "README.md",
           "apps/docs-next/fixtures/first-agent/agent.ts",
@@ -278,8 +278,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/adapters/README.md",
           "packages/adapters/package.json",
@@ -357,8 +357,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/angular/README.md",
           "packages/angular/package.json",
@@ -436,8 +436,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/cli/README.md",
           "packages/cli/package.json",
@@ -515,8 +515,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/core/README.md",
           "packages/core/package.json",
@@ -594,8 +594,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/eval/README.md",
           "packages/eval/package.json",
@@ -673,8 +673,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/eval-braintrust/README.md",
           "packages/eval-braintrust/package.json",
@@ -752,8 +752,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/ink/README.md",
           "packages/ink/package.json",
@@ -831,8 +831,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/integrations/README.md",
           "packages/integrations/package.json",
@@ -910,8 +910,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/mcp/README.md",
           "packages/mcp/package.json",
@@ -989,8 +989,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/memory/README.md",
           "packages/memory/package.json",
@@ -1068,8 +1068,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/observability/README.md",
           "packages/observability/package.json",
@@ -1147,8 +1147,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/observability-langfuse/README.md",
           "packages/observability-langfuse/package.json",
@@ -1226,8 +1226,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/rag/README.md",
           "packages/rag/package.json",
@@ -1305,8 +1305,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/react/README.md",
           "packages/react/package.json",
@@ -1384,8 +1384,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/react-native/README.md",
           "packages/react-native/package.json",
@@ -1463,8 +1463,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/runtime/README.md",
           "packages/runtime/package.json",
@@ -1542,8 +1542,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/sandbox/README.md",
           "packages/sandbox/package.json",
@@ -1621,8 +1621,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/skills/README.md",
           "packages/skills/package.json",
@@ -1700,8 +1700,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/solid/README.md",
           "packages/solid/package.json",
@@ -1779,8 +1779,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/statechart/README.md",
           "packages/statechart/package.json",
@@ -1858,8 +1858,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/svelte/README.md",
           "packages/svelte/package.json",
@@ -1937,8 +1937,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/templates/README.md",
           "packages/templates/package.json",
@@ -2016,8 +2016,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-11-12",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-11-13",
         "sources": [
           "packages/tools/README.md",
           "packages/tools/package.json",
@@ -2095,8 +2095,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/validation/README.md",
           "packages/validation/package.json",
@@ -2174,8 +2174,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2027-01-11",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2027-01-12",
         "sources": [
           "packages/vue/README.md",
           "packages/vue/package.json",
@@ -2244,8 +2244,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-10-13",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-10-14",
         "sources": [
           "apps/docs-next/README.md",
           "apps/docs-next/package.json",
@@ -2253,7 +2253,7 @@
           "ecosystem-claims.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:ff37f962e973d4248e787605e5bfc1cf963e95c1db960d8dcdc7ced75bbb4e15"
+        "sourceHash": "sha256:fb87a374f7b23dd5cedf54318dc547fd529d1474daa1a8452459401579a9ff72"
       },
       "exceptions": [
         {
@@ -2329,8 +2329,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-10-13",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-10-14",
         "sources": [
           "apps/landing/README.md",
           "apps/landing/package.json",
@@ -2414,8 +2414,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-10-13",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-10-14",
         "sources": [
           "apps/registry/README.md",
           "apps/registry/package.json",
@@ -2423,7 +2423,7 @@
           "ecosystem-claims.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:765453f0c40fa06810bcadbc0fdc02d19d15f23f62146d6d76437f3a029624bd"
+        "sourceHash": "sha256:6630a0c72f1e05ad36847a7b178e9ae39d51e54c70dd06a826dbf4b400c5b3b6"
       },
       "exceptions": [
         {
@@ -2499,8 +2499,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-15",
-        "reviewDueOn": "2026-10-13",
+        "reviewedOn": "2026-07-16",
+        "reviewDueOn": "2026-10-14",
         "sources": [
           "apps/ask-backend/README.md",
           "apps/ask-backend/package.json",

--- a/scripts/check-product-chat-adoption.mjs
+++ b/scripts/check-product-chat-adoption.mjs
@@ -4,7 +4,7 @@
  *
  * Fails when Docs or Registry product widgets reintroduce legacy standalone
  * packages (`@agentskit/chat-protocol`, `@agentskit/chat-react`) or drift from
- * the exact `@agentskit/chat@0.3.0` pin / supported subpaths.
+ * the exact `@agentskit/chat@0.4.0` pin / supported subpaths.
  *
  * Low-level binding examples are classified and excluded — they are educational
  * demos of `@agentskit/react` (etc.), not product-chat framework hosts.

--- a/scripts/check-quality-gates.mjs
+++ b/scripts/check-quality-gates.mjs
@@ -33,7 +33,7 @@ const GATES = [
   ['ecosystem count drift', 'check-count-drift.mjs'],
   ['ecosystem claims freshness', 'gen-ecosystem-claims.mjs', ['--check']],
   ['ecosystem registry sync', 'sync-ecosystem.mjs', ['--check']],
-  ['product-chat Chat 0.3 adoption', 'check-product-chat-adoption.mjs'],
+  ['product-chat Chat 0.4 adoption', 'check-product-chat-adoption.mjs'],
   ['product-chat adoption tests', 'product-chat-adoption.test.mjs', [], 'vitest'],
   ['brand token sync', 'sync-brand.mjs', ['--property', 'agentskit', '--out', 'apps/docs-next/app/brand-tokens.css', '--check']],
   ['brand token sync (landing)', 'sync-brand.mjs', ['--property', 'agentskit', '--format', 'landing', '--out', 'apps/landing/app/globals.css', '--check']],

--- a/scripts/lib/product-chat-adoption.mjs
+++ b/scripts/lib/product-chat-adoption.mjs
@@ -1,7 +1,7 @@
 /**
  * Deterministic classification + audit for AgentsKit product-chat surfaces.
  *
- * Product chats (Docs Ask + Registry Ask) must pin exact `@agentskit/chat@0.3.0`
+ * Product chats (Docs Ask + Registry Ask) must pin exact `@agentskit/chat@0.4.0`
  * and may only import supported subpaths. Legacy standalone packages
  * (`@agentskit/chat-protocol`, `@agentskit/chat-react`) are forbidden.
  *
@@ -13,7 +13,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative, sep } from 'node:path'
 
-export const EXACT_CHAT_VERSION = '0.3.0'
+export const EXACT_CHAT_VERSION = '0.4.0'
 
 export const LEGACY_CHAT_PACKAGES = Object.freeze([
   '@agentskit/chat-protocol',


### PR DESCRIPTION
## Summary
- pin the Docs and Registry product chat surfaces to @agentskit/chat 0.4.0
- update adoption gates, examples, lockfile, and deterministic knowledge artifacts
- refresh README Standard evidence after the Registry documentation change

## Validation
- product-chat adoption gate and 11/11 tests
- Docs and Registry lint
- Doc Bridge gate (Documentation Standard v1: 7/7)
- full pre-push suite: 51 quality gates, 56 lint tasks, 42 build tasks
- Docs production build: 1183 static pages

Contributes adoption evidence to AgentsKit-io/agentskit-chat#104 and AgentsKit-io/agentskit-chat#99.