### PR TITLE
fix(docs): polish ecosystem bar, journey, and ask chat footer

### DIFF
--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -4,7 +4,6 @@ import { Inter, JetBrains_Mono, Space_Grotesk } from 'next/font/google'
 import type { ReactNode } from 'react'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import Script from 'next/script'
 import { alternatesFor } from '@/lib/locales'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
@@ -109,7 +108,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </RootProvider>
         <Analytics />
         <SpeedInsights />
-        <Script src="/ecosystem-bar.js" strategy="afterInteractive" data-current="agentskit" />
+        <script src="/ecosystem-bar.js" defer data-current="agentskit" />
       </body>
     </html>
   )

--- a/apps/docs-next/components/docs/ask-widget.tsx
+++ b/apps/docs-next/components/docs/ask-widget.tsx
@@ -246,7 +246,7 @@ export function AskDocsWidget({
   const effectiveEmptyState = emptyState ?? brand?.emptyState
   const effectiveLogo = logo ?? brand?.logo
   const effectivePlaceholder = placeholder ?? brand?.placeholder ?? 'Ask a question...'
-  const effectiveDocsHref = docsHref === undefined ? (brand?.docsHref ?? '/docs/cookbook/ask-the-docs') : docsHref
+  const effectiveDocsHref = docsHref === undefined ? (brand?.docsHref ?? 'https://chat.agentskit.io/') : docsHref
   const effectiveDocsLabel = docsLabel ?? brand?.docsLabel ?? 'Build a chat like this - step by step ->'
   const askLabel = typeof effectiveFabLabel === 'string' ? effectiveFabLabel : 'Ask the docs'
   const storageIdentity = [corpus, persona].filter(Boolean).join(':')
@@ -323,7 +323,11 @@ export function AskDocsWidget({
         </div>
         <div className="border-t border-ak-border p-2">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1">
-            {effectiveDocsHref ? <Link href={effectiveDocsHref} data-ak-ask-docs-link="" className="flex items-center gap-1.5 font-mono text-[10px] text-ak-graphite"><AnimatedLogo variant="nav" size={12} />{effectiveDocsLabel}</Link> : null}
+            {effectiveDocsHref ? (
+              effectiveDocsHref.startsWith('http')
+                ? <a href={effectiveDocsHref} data-ak-ask-docs-link="" className="flex items-center gap-1.5 font-mono text-[10px] text-ak-graphite"><AnimatedLogo variant="nav" size={12} />{effectiveDocsLabel}</a>
+                : <Link href={effectiveDocsHref} data-ak-ask-docs-link="" className="flex items-center gap-1.5 font-mono text-[10px] text-ak-graphite"><AnimatedLogo variant="nav" size={12} />{effectiveDocsLabel}</Link>
+            ) : null}
             {cta ? <a href={cta.href} target={cta.target} rel={cta.target === '_blank' ? 'noreferrer' : undefined} data-ak-ask-cta="" className="font-mono text-[10px] font-semibold uppercase tracking-widest text-ak-blue">{cta.label}</a> : null}
           </div>
         </div>

--- a/apps/docs-next/components/home/reference-journey.tsx
+++ b/apps/docs-next/components/home/reference-journey.tsx
@@ -8,10 +8,7 @@ export function ReferenceJourney() {
       className="border-y border-ak-border bg-ak-bg px-4 py-16 sm:px-6 sm:py-20"
     >
       <div className="mx-auto max-w-6xl">
-        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-ak-muted sm:text-xs">
-          Continue with context
-        </p>
-        <div className="mt-3 grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)] md:items-end md:gap-10">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)] md:items-end md:gap-10">
           <h2
             id="reference-journey-title"
             className="max-w-3xl font-display text-3xl font-bold tracking-tight text-ak-fg sm:text-4xl"

--- a/apps/docs-next/lib/deterministic-knowledge.generated.json
+++ b/apps/docs-next/lib/deterministic-knowledge.generated.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-15T22:24:19-03:00",
+  "generatedAt": "2026-07-16T16:49:56-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
+  "contentHash": "sha256:2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8"
 }

--- a/apps/docs-next/lib/deterministic-site.generated.json
+++ b/apps/docs-next/lib/deterministic-site.generated.json
@@ -3,8 +3,8 @@
   "version": 1,
   "siteId": "agentskit-docs",
   "artifact": {
-    "href": "/deterministic-knowledge/1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865.json",
-    "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
+    "href": "/deterministic-knowledge/2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8.json",
+    "contentHash": "sha256:2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8"
   },
   "fallback": {
     "mode": "backend"

--- a/apps/docs-next/lib/ecosystem.json
+++ b/apps/docs-next/lib/ecosystem.json
@@ -142,7 +142,7 @@
         "chat": "none"
       },
       "navigation": {
-        "showInBar": true,
+        "showInBar": false,
         "order": 5,
         "next": ["agentskit", "registry", "agentskit-chat", "playbook", "doc-bridge", "akos"]
       }

--- a/apps/docs-next/public/deterministic-knowledge/2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8.json
+++ b/apps/docs-next/public/deterministic-knowledge/2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-15T22:24:19-03:00",
+  "generatedAt": "2026-07-16T16:49:56-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:1fd87ceb39f7ee4706140ffb45ba0082581e18f974d30b5c08e50e1968a19865"
+  "contentHash": "sha256:2b17ff80dc979139d687833330f199fb4e261fe2e07a4f034546cd125d4774d8"
 }

--- a/apps/docs-next/public/ecosystem-bar.js
+++ b/apps/docs-next/public/ecosystem-bar.js
@@ -16,7 +16,6 @@
     { id: "agentskit-chat", label: "Chat", host: "chat.agentskit.io", url: "https://chat.agentskit.io" },
     { id: "playbook", label: "Playbook", host: "playbook.agentskit.io", url: "https://playbook.agentskit.io" },
     { id: "doc-bridge", label: "Doc Bridge", host: "agentskit-io.github.io", url: "https://agentskit-io.github.io/doc-bridge/" },
-    { id: "code-review", label: "Code Review", host: "github.com", url: "https://github.com/AgentsKit-io/code-review-cli" },
     { id: "akos", label: "AKOS", host: "akos.agentskit.io", url: "https://akos.agentskit.io" },
   ]
   // ecobar:props-end
@@ -35,13 +34,17 @@
     '#ak-eco{position:relative;z-index:30;display:flex;gap:4px;align-items:center;' +
     'font:500 13px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;padding:8px 16px;' +
     'background:#0b0b0f;color:#e7e7ea;border-bottom:1px solid #23232b}' +
-    '#ak-eco .ak-eco-brand{font-weight:700;letter-spacing:-.01em;margin-right:8px;color:#fff;text-decoration:none}' +
+    '#ak-eco .ak-eco-brand{display:inline-flex;align-items:center;justify-content:center;' +
+    'margin-right:8px;color:#fff;text-decoration:none;line-height:0}' +
+    '#ak-eco .ak-eco-brand svg{width:18px;height:16px;display:block}' +
     '#ak-eco a.ak-eco-link{color:#a9a9b3;text-decoration:none;padding:5px 10px;border-radius:7px}' +
     '#ak-eco a.ak-eco-link:hover{color:#fff;background:#1c1c24}' +
     '#ak-eco a.ak-eco-link[aria-current="page"]{color:#fff;background:#2a2a35}' +
     '#ak-eco .ak-eco-spacer{flex:1}' +
     '#ak-eco a.ak-eco-cta{display:inline-flex;align-items:center;gap:6px}' +
     '#ak-eco a.ak-eco-cta svg{width:14px;height:14px;fill:currentColor}' +
+    // Discord is kept in the DOM for an easy restore; hidden until community is ready.
+    '#ak-eco a.ak-eco-cta[data-ak-eco-discord]{display:none}' +
     '@media(max-width:767px){#ak-eco{box-sizing:border-box;width:100%;max-width:100vw;overflow-x:auto;' +
     'overscroll-behavior-x:contain;scrollbar-width:none}#ak-eco::-webkit-scrollbar{display:none}' +
     '#ak-eco .ak-eco-brand{position:sticky;left:0;z-index:1;background:inherit}' +
@@ -50,6 +53,19 @@
     '#ak-eco .ak-eco-brand{color:#0b0b0f}#ak-eco a.ak-eco-link{color:#555}' +
     '#ak-eco a.ak-eco-link:hover{color:#000;background:#f1f1f4}' +
     '#ak-eco a.ak-eco-link[aria-current="page"]{color:#000;background:#ececf1}}'
+
+  // Brand mark only (no "AgentsKit" wordmark) — product list still includes AgentsKit.
+  var BRAND_ICON =
+    '<svg viewBox="0 0 72 64" fill="none" aria-hidden="true">' +
+    '<g stroke="currentColor" stroke-width="1.5" stroke-linecap="round">' +
+    '<line x1="12" y1="52" x2="36" y2="12"/>' +
+    '<line x1="36" y1="12" x2="60" y2="52"/>' +
+    '<line x1="12" y1="52" x2="60" y2="52"/>' +
+    '</g>' +
+    '<circle cx="36" cy="12" r="6" fill="currentColor"/>' +
+    '<circle cx="12" cy="52" r="6" fill="currentColor"/>' +
+    '<circle cx="60" cy="52" r="6" fill="currentColor"/>' +
+    '</svg>'
 
   // Community links — pinned to the right of the bar (after the spacer). Project
   // surfaces only: no personal-brand links. Icons are inline SVG (zero deps).
@@ -70,7 +86,9 @@
     var brand = document.createElement('a')
     brand.className = 'ak-eco-brand'
     brand.href = 'https://www.agentskit.io'
-    brand.textContent = 'AgentsKit'
+    brand.setAttribute('aria-label', 'AgentsKit')
+    brand.title = 'AgentsKit'
+    brand.innerHTML = BRAND_ICON
     bar.appendChild(brand)
 
     PROPS.forEach(function (p) {
@@ -88,7 +106,8 @@
 
     var community = [
       { label: 'Star on GitHub', icon: GH_ICON, url: 'https://github.com/AgentsKit-io/agentskit' },
-      { label: 'Discord', icon: DISCORD_ICON, url: 'https://discord.gg/zx6z2p4jVb' },
+      // Discord kept for restore — hidden via CSS (data-ak-eco-discord).
+      { label: 'Discord', icon: DISCORD_ICON, url: 'https://discord.gg/zx6z2p4jVb', discord: true },
     ]
     community.forEach(function (c) {
       var a = document.createElement('a')
@@ -96,6 +115,7 @@
       a.href = c.url
       a.target = '_blank'
       a.rel = 'noopener'
+      if (c.discord) a.setAttribute('data-ak-eco-discord', '')
       a.innerHTML = c.icon + '<span>' + c.label + '</span>'
       bar.appendChild(a)
     })

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Script from 'next/script'
 import './globals.css'
 import { PostHogProvider } from './_components/posthog-provider'
 
@@ -29,7 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         {/* Shared ecosystem bar — single source on www.agentskit.io, embedded across all properties. */}
-        <Script src="https://www.agentskit.io/ecosystem-bar.js" strategy="afterInteractive" data-current="agentskit" />
+        <script src="https://www.agentskit.io/ecosystem-bar.js" defer data-current="agentskit" />
         <PostHogProvider>{children}</PostHogProvider>
       </body>
     </html>

--- a/apps/landing/lib/ecosystem.json
+++ b/apps/landing/lib/ecosystem.json
@@ -142,7 +142,7 @@
         "chat": "none"
       },
       "navigation": {
-        "showInBar": true,
+        "showInBar": false,
         "order": 5,
         "next": ["agentskit", "registry", "agentskit-chat", "playbook", "doc-bridge", "akos"]
       }

--- a/apps/registry/app/layout.tsx
+++ b/apps/registry/app/layout.tsx
@@ -3,7 +3,6 @@ import { RootProvider } from 'fumadocs-ui/provider/next'
 import { Inter, JetBrains_Mono, Space_Grotesk } from 'next/font/google'
 import type { ReactNode } from 'react'
 import type { Metadata } from 'next'
-import Script from 'next/script'
 import { PostHogProvider } from './posthog-provider'
 import { RegistryAskWidget } from '@/components/ask-widget'
 
@@ -41,7 +40,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <RegistryAskWidget />
           </RootProvider>
         </PostHogProvider>
-        <Script src="https://www.agentskit.io/ecosystem-bar.js" strategy="afterInteractive" data-current="registry" />
+        <script src="https://www.agentskit.io/ecosystem-bar.js" defer data-current="registry" />
       </body>
     </html>
   )

--- a/apps/registry/components/ask-widget.tsx
+++ b/apps/registry/components/ask-widget.tsx
@@ -202,7 +202,7 @@ export function RegistryAskWidget() {
 }
 
 function Styles() {
-  return <style jsx global>{`
+  return <style dangerouslySetInnerHTML={{ __html: `
     .rg-ask-fab,.rg-ask-panel{--ask-bg:var(--ak-midnight);--ask-surface:var(--ak-surface);--ask-border:var(--ak-border);--ask-text:var(--ak-foam);--ask-muted:var(--ak-graphite);--ask-accent:var(--ak-blue);--ask-danger:var(--ak-red);position:fixed;right:1rem;bottom:1rem;z-index:80;color:var(--ask-text);font-family:var(--font-mono),ui-monospace,monospace}
     .rg-ask-fab{display:inline-flex;min-height:44px;align-items:center;gap:.5rem;border:1px solid var(--ask-border);border-radius:999px;background:var(--ask-bg);padding:.625rem 1rem;box-shadow:0 12px 32px rgb(0 0 0/.2);font-size:.75rem;font-weight:700;cursor:pointer;transition:border-color 160ms ease,transform 160ms ease}.rg-ask-fab:hover{border-color:var(--ask-accent);transform:translateY(-1px)}
     .rg-ask-panel{display:flex;width:min(440px,calc(100vw - 2rem));height:min(620px,calc(100dvh - 2rem));flex-direction:column;overflow:hidden;border:1px solid var(--ask-border);border-radius:.75rem;background:var(--ask-bg);box-shadow:0 24px 70px rgb(0 0 0/.38)}
@@ -215,5 +215,5 @@ function Styles() {
     .rg-ask-compose{display:grid;grid-template-columns:1fr auto;gap:.5rem;border-top:1px solid var(--ask-border);padding-top:.625rem}.rg-ask-compose label{min-width:0}.rg-ask-compose textarea{box-sizing:border-box;width:100%;resize:none;border:1px solid var(--ask-border);border-radius:.625rem;background:var(--ask-surface);color:var(--ask-text);padding:.5rem;font:inherit;font-size:.75rem}.rg-ask-runtime [role=alert]{margin:.4rem 0;color:var(--ask-danger);font-size:.75rem}.rg-ask-runtime [aria-label="Response actions"]{display:flex;flex-wrap:wrap;gap:.25rem;border-top:1px solid var(--ask-border)}
     .rg-ask-footer{display:flex;min-height:44px;align-items:center;justify-content:space-between;gap:.5rem;border-top:1px solid var(--ask-border);padding:0 .75rem}.rg-ask-footer a{display:inline-flex;align-items:center;gap:.4rem}.rg-ask-footer [data-rg-answer-path]{color:var(--ask-muted);font-size:.625rem;letter-spacing:.08em;text-transform:uppercase}.rg-ask-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.rg-ask-panel button:focus-visible,.rg-ask-panel a:focus-visible,.rg-ask-panel textarea:focus-visible,.rg-ask-fab:focus-visible{outline:2px solid var(--ask-accent);outline-offset:2px}
     @media(max-width:639px){.rg-ask-panel{inset:.5rem;width:auto;height:auto}.rg-ask-fab{right:.75rem;bottom:.75rem}}@media(prefers-reduced-motion:reduce){.rg-ask-fab{transition:none}.rg-ask-fab:hover{transform:none}}
-  `}</style>
+  ` }} />
 }

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -142,7 +142,7 @@
         "chat": "none"
       },
       "navigation": {
-        "showInBar": true,
+        "showInBar": false,
         "order": 5,
         "next": ["agentskit", "registry", "agentskit-chat", "playbook", "doc-bridge", "akos"]
       }

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -208,7 +208,7 @@
           "ecosystem.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:11dde13afe6edacf0bf4d9431e674c1886f9bec53790b0183e407c501f25da60"
+        "sourceHash": "sha256:11bd7d2bb767f75b83293bc02665dab5e66d09687be46f925628124007038782"
       },
       "exceptions": []
     },

--- a/scripts/ecosystem-contract.test.mjs
+++ b/scripts/ecosystem-contract.test.mjs
@@ -31,13 +31,17 @@ test('repository-native products do not need a Fumadocs or chat deployment', () 
   const parsed = parseEcosystemManifest(manifest)
   const codeReview = parsed.products.find((product) => product.id === 'code-review')
   assert.equal(codeReview.surfaces.documentation, 'repository')
-  assert.equal(codeReview.navigation.showInBar, true)
+  // Code Review stays in the ecosystem catalog but is hidden from the shared header for now.
+  assert.equal(codeReview.navigation.showInBar, false)
 })
 
-test('global navigation lists seven products and every continuation except AKOS lists six peers', () => {
+test('global navigation keeps seven-product order; bar can hide early-stage tools', () => {
   const parsed = parseEcosystemManifest(manifest)
   assert.deepEqual(parsed.products.map((product) => product.navigation.order), [0, 1, 2, 3, 4, 5, 6])
-  assert.ok(parsed.products.every((product) => product.navigation.showInBar))
+  assert.deepEqual(
+    parsed.products.filter((product) => product.navigation.showInBar).map((product) => product.id),
+    ['agentskit', 'registry', 'agentskit-chat', 'playbook', 'doc-bridge', 'akos'],
+  )
   assert.ok(parsed.products.filter((product) => product.id !== 'akos').every((product) => product.navigation.next.length === 6))
   assert.deepEqual(parsed.products.find((product) => product.id === 'akos').navigation.next, [])
 })

--- a/scripts/lib/ecosystem-contract.mjs
+++ b/scripts/lib/ecosystem-contract.mjs
@@ -112,7 +112,8 @@ export function parseEcosystemManifest(input) {
     fail('$.products', `must contain the canonical products in order: ${CANONICAL_PRODUCT_IDS.join(', ')}`)
   }
   for (const [index, product] of manifest.products.entries()) {
-    if (!product.navigation.showInBar) fail(`$.products[${index}].navigation.showInBar`, 'must be true for global seven-product discovery')
+    // Products may set showInBar:false to leave the shared header (e.g. early-stage tools).
+    // Order stays stable so re-enabling a product does not reshuffle peers.
     if (product.navigation.order !== index) fail(`$.products[${index}].navigation.order`, `must equal ${index}`)
     const expectedPeers = product.id === 'akos'
       ? []


### PR DESCRIPTION
## Summary
- Remove **Code Review** from the shared ecosystem header (`showInBar: false`); it remains in the catalog and journey cards.
- Replace the left **AgentsKit** wordmark in the ecosystem bar with the brand mark icon only.
- Hide the **Discord** CTA via CSS without deleting the markup (easy restore).
- Remove the **Continue with context** eyebrow above the reference journey section.
- Point the Ask the docs chat footer to the chat framework home: https://chat.agentskit.io/
- Unblock local TypeScript lint under TS 6 / Next 16 by using plain `<script defer>` for the ecosystem bar (and a global style tag in the registry ask widget).

## Test plan
- [ ] Load docs home and confirm the ecosystem bar shows: icon · AgentsKit · Registry · Chat · Playbook · Doc Bridge · AKOS (no Code Review).
- [ ] Confirm Discord is not visible but still present if inspected / restored by removing the hide rule.
- [ ] Confirm the journey section no longer shows “Continue with context”.
- [ ] Open Ask the docs and click the footer link → https://chat.agentskit.io/
- [ ] Pre-push quality gates and app builds pass.