### PR TITLE
docs(narrative): registry mesh, 140 providers, drop shadcn framing

### DIFF
--- a/apps/registry/app/(home)/_components/ecosystem-mesh.tsx
+++ b/apps/registry/app/(home)/_components/ecosystem-mesh.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link'
+
+/** Canonical peer products (Registry is the current surface — not listed). */
+export const ecosystemPeers = [
+  {
+    name: 'AgentsKit',
+    role: 'foundation',
+    href: 'https://www.agentskit.io',
+    action: 'Build and extend agents with core, tools, memory, and RAG.',
+  },
+  {
+    name: 'AgentsKit Chat',
+    role: 'experience',
+    href: 'https://chat.agentskit.io',
+    action: 'Deliver a native chat experience over the same runtime.',
+  },
+  {
+    name: 'Agents Playbook',
+    role: 'discipline',
+    href: 'https://playbook.agentskit.io',
+    action: 'Apply engineering and delivery standards for agent work.',
+  },
+  {
+    name: 'Doc Bridge',
+    role: 'understanding',
+    href: 'https://agentskit-io.github.io/doc-bridge/',
+    action: 'Keep documentation handoffs agent-ready and deterministic.',
+  },
+  {
+    name: 'Code Review',
+    role: 'verification',
+    href: 'https://github.com/AgentsKit-io/code-review-cli',
+    action: 'Review agent-generated diffs before merge.',
+  },
+  {
+    name: 'AKOS',
+    role: 'operation',
+    href: 'https://akos.agentskit.io',
+    action: 'Operate with enterprise controls and governance.',
+  },
+] as const
+
+export function EcosystemMesh({
+  headingId = 'continue-ecosystem',
+}: {
+  headingId?: string
+}) {
+  return (
+    <section aria-labelledby={headingId} className="border-t border-ak-border px-4 py-14 sm:px-6 sm:py-20">
+      <div className="mx-auto max-w-5xl">
+        <p className="font-mono text-xs uppercase tracking-wider text-ak-blue">Continue with context</p>
+        <h2 id={headingId} className="mt-3 max-w-2xl font-display text-3xl font-semibold text-ak-foam">
+          Registry is the starting point. The next tool should match the next problem.
+        </h2>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-ak-graphite">
+          You are on <strong className="font-medium text-ak-foam">AgentsKit Registry</strong> — ready-to-use agents
+          you copy into your repo. Peers in the same ecosystem:
+        </p>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {ecosystemPeers.map((step) => (
+            <Link
+              key={step.name}
+              href={step.href}
+              className="group min-h-36 border-t-2 border-ak-border bg-ak-surface p-5 transition hover:border-ak-blue focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ak-blue"
+            >
+              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-ak-graphite">{step.role}</p>
+              <h3 className="mt-1 font-semibold text-ak-foam group-hover:text-ak-blue">{step.name}</h3>
+              <p className="mt-3 text-sm leading-6 text-ak-graphite">{step.action}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/registry/app/(home)/_components/extras.tsx
+++ b/apps/registry/app/(home)/_components/extras.tsx
@@ -12,7 +12,7 @@ export function WhatIs() {
   return (
     <section className="px-4 py-16 sm:px-6 sm:py-20">
       <div className="mx-auto max-w-5xl">
-        <div className="rg-reveal font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">The shadcn for AI agents</div>
+        <div className="rg-reveal font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">Copy the source. Own the agent.</div>
         <h2 className="rg-reveal mt-2 text-2xl font-bold tracking-tight text-ak-foam sm:text-3xl">Install an agent the way you install a component</h2>
         <p className="rg-reveal mt-2 max-w-2xl text-ak-graphite">
           Each agent is a small, self-contained factory wiring published @agentskit/* packages into a one-call

--- a/apps/registry/app/(home)/_components/install-steps.tsx
+++ b/apps/registry/app/(home)/_components/install-steps.tsx
@@ -29,7 +29,7 @@ console.log(content)`
 
 const STEPS = [
   { n: 1, t: 'Add it', d: 'Run one command. The CLI copies the full agent source into ./agents/<id>/ in your repo. From here, the code is yours — read it, edit it, commit it.', code: 'npx agentskit add research' },
-  { n: 2, t: 'Wire it', d: 'It is plain TypeScript in your project. Import the factory and pass any adapter — OpenAI, Anthropic, or any of 100+ providers. Swap the model whenever you want.', code: WIRE },
+  { n: 2, t: 'Wire it', d: 'It is plain TypeScript in your project. Import the factory and pass any adapter — OpenAI, Anthropic, or any of 140+ catalog providers. Swap the model whenever you want.', code: WIRE },
   { n: 3, t: 'Run it anywhere', d: 'Call agent.run() from Node, a serverless function, an edge runtime, or your terminal. It is your code on your infrastructure — nothing phones home to this registry.', code: RUN },
 ]
 

--- a/apps/registry/app/(home)/_components/works-with.tsx
+++ b/apps/registry/app/(home)/_components/works-with.tsx
@@ -41,15 +41,16 @@ export function WorksWith() {
         <div className="rg-reveal font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">Works with everything</div>
         <h2 className="rg-reveal mt-2 text-2xl font-bold tracking-tight text-ak-foam sm:text-3xl">One contract. Every tool, every model.</h2>
         <p className="rg-reveal mt-2 max-w-2xl text-ak-graphite">
-          Every agent you copy runs on the AgentsKit core — 50+ built-in integrations and 100+ providers (5,000+ models)
-          behind a single contract. Swap the model, provider, or tool without touching the rest.
+          Every agent you copy runs on the AgentsKit core — 50 built-in integrations and 140+ catalog
+          providers (5,162 models) behind a single contract. Swap the model, provider, or tool without
+          touching the rest.
         </p>
         <div className="rg-reveal mt-5 flex flex-wrap gap-x-6 gap-y-2">
           <a href={intUrl} rel="noopener" className="inline-flex items-center gap-1.5 text-sm font-semibold text-ak-blue hover:underline">
             All 50 integrations <Icon name="arrow-right" size={15} />
           </a>
           <a href={provUrl} rel="noopener" className="inline-flex items-center gap-1.5 text-sm font-semibold text-ak-blue hover:underline">
-            All 100+ providers <Icon name="arrow-right" size={15} />
+            All 140+ providers <Icon name="arrow-right" size={15} />
           </a>
         </div>
 

--- a/apps/registry/app/(home)/page.tsx
+++ b/apps/registry/app/(home)/page.tsx
@@ -5,13 +5,14 @@ import { LandingFx } from './_components/landing-fx'
 import { Hero } from './_components/hero'
 import { Browse } from './_components/browse'
 import { InstallSteps } from './_components/install-steps'
+import { EcosystemMesh } from './_components/ecosystem-mesh'
 
 export const revalidate = 3600
 
 export const metadata = {
   title: 'AgentsKit Registry — ready-to-use AI agents',
   description:
-    'The shadcn for AI agents. Copy a production-grade agent into your project with one command — you own the code, no lock-in.',
+    'Ready-to-use AI agents for AgentsKit. Copy production-grade source into your project with one command — you own the code, no lock-in.',
   alternates: { canonical: 'https://registry.agentskit.io' },
 }
 
@@ -31,6 +32,7 @@ export default async function HomePage() {
         <Browse agents={agents} />
       </Suspense>
       <InstallSteps />
+      <EcosystemMesh />
     </main>
   )
 }

--- a/apps/registry/app/agents/page.tsx
+++ b/apps/registry/app/agents/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { Suspense } from 'react'
 import { HomeLayout } from 'fumadocs-ui/layouts/home'
 import { Browse } from '../(home)/_components/browse'
+import { EcosystemMesh } from '../(home)/_components/ecosystem-mesh'
 import { baseOptions } from '../layout.config'
 import { getRegistryIndex } from '@/lib/registry'
 
@@ -13,15 +13,6 @@ export const metadata: Metadata = {
   description: 'Search, qualify, compare, and copy ready-to-use AgentsKit agents into your project.',
   alternates: { canonical: 'https://registry.agentskit.io/agents' },
 }
-
-const ecosystemSteps = [
-  { name: 'AgentsKit', href: 'https://www.agentskit.io', action: 'Build and extend the agent.' },
-  { name: 'AgentsKit Chat', href: 'https://chat.agentskit.io/docs', action: 'Deliver a native chat experience.' },
-  { name: 'Agents Playbook', href: 'https://playbook.agentskit.io', action: 'Apply engineering and delivery standards.' },
-  { name: 'Doc Bridge', href: 'https://agentskit-io.github.io/doc-bridge/', action: 'Keep documentation handoffs agent-ready.' },
-  { name: 'Code Review', href: 'https://github.com/AgentsKit-io/code-review-cli', action: 'Review the diff before merge.' },
-  { name: 'AKOS', href: 'https://akos.agentskit.io', action: 'Operate with enterprise controls.' },
-] as const
 
 export default async function AgentsPage() {
   const agents = await getRegistryIndex()
@@ -43,20 +34,7 @@ export default async function AgentsPage() {
           <Browse agents={agents} basePath="/agents" />
         </Suspense>
 
-        <section aria-labelledby="continue-ecosystem" className="border-t border-ak-border px-4 py-14 sm:px-6 sm:py-20">
-          <div className="mx-auto max-w-5xl">
-            <p className="font-mono text-xs uppercase tracking-wider text-ak-blue">Continue with context</p>
-            <h2 id="continue-ecosystem" className="mt-3 max-w-2xl font-display text-3xl font-semibold text-ak-foam">The next tool should match the next problem.</h2>
-            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {ecosystemSteps.map((step) => (
-                <Link key={step.name} href={step.href} className="group min-h-36 border-t-2 border-ak-border bg-ak-surface p-5 transition hover:border-ak-blue focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ak-blue">
-                  <h3 className="font-semibold text-ak-foam group-hover:text-ak-blue">{step.name}</h3>
-                  <p className="mt-3 text-sm leading-6 text-ak-graphite">{step.action}</p>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
+        <EcosystemMesh />
       </main>
     </HomeLayout>
   )

--- a/apps/registry/app/layout.config.tsx
+++ b/apps/registry/app/layout.config.tsx
@@ -11,7 +11,7 @@ export const baseOptions: BaseLayoutProps = {
     { text: 'Agents', url: '/agents', active: 'nested-url' },
     { text: 'Docs', url: '/docs', active: 'nested-url' },
     { text: 'llms.txt', url: '/llms.txt', active: 'none' },
-    { text: 'Framework', url: 'https://www.agentskit.io', external: true },
+    { text: 'AgentsKit', url: 'https://www.agentskit.io', external: true },
   ],
   githubUrl: 'https://github.com/AgentsKit-io/agentskit-registry',
 }

--- a/apps/registry/content/docs/for-agents.mdx
+++ b/apps/registry/content/docs/for-agents.mdx
@@ -13,4 +13,11 @@ Use the smallest surface that answers the task:
 - [`/deterministic/knowledge.json`](/deterministic/knowledge.json) for grounded local retrieval.
 - [`/api/mcp`](/api/mcp) for MCP discovery.
 
-Copy an agent when you need a starting point; keep ownership of the generated source. For framework primitives, use [AgentsKit](https://www.agentskit.io/docs). For conversational delivery, use [AgentsKit Chat](https://chat.agentskit.io/docs). For repository documentation handoffs, use [Doc Bridge](https://agentskit-io.github.io/doc-bridge/). For enterprise operation and governance, use [AKOS](https://akos.agentskit.io/docs).
+Copy an agent when you need a starting point; keep ownership of the generated source. Peer products:
+
+- **Foundation:** [AgentsKit](https://www.agentskit.io/docs) — core, tools, memory, RAG.
+- **Experience:** [AgentsKit Chat](https://chat.agentskit.io/docs) — conversational delivery.
+- **Discipline:** [Agents Playbook](https://playbook.agentskit.io) — engineering and delivery standards.
+- **Understanding:** [Doc Bridge](https://agentskit-io.github.io/doc-bridge/) — repository documentation handoffs.
+- **Verification:** [Code Review](https://github.com/AgentsKit-io/code-review-cli) — review agent diffs before merge.
+- **Operation:** [AKOS](https://akos.agentskit.io/docs) — enterprise operation and governance.

--- a/apps/registry/content/docs/index.mdx
+++ b/apps/registry/content/docs/index.mdx
@@ -5,8 +5,8 @@ description: Ready-to-use AI agents you copy into your project — you own the c
 
 The Registry is the fastest path from a task to an agent you can own. Each entry is a
 provider-agnostic TypeScript factory with a typed contract, tests, evaluation coverage, and
-source code. The CLI copies it into your repository — shadcn-style — so there is no registry
-runtime and no lock-in.
+source code. The CLI copies that source into your repository (you own every line) — there is no
+registry runtime and no lock-in.
 
 ## Choose a path
 

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:c9217e2f71f18ace4c3e346b653bba1c9472eba61da0c15118268f20f3a04963"
+        "sourceHash": "sha256:2d9b711c4ef5f4816e8ff98f1a91e84535359701e7256cf571798087100c52a4"
       },
       "exceptions": []
     },
@@ -445,7 +445,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:4e5e09e30fbd0b96dc906ba47afbc32bf1fc2225d1c20630b1ba51e09c0ca82a"
+        "sourceHash": "sha256:06bcbf43ff45b3f01d4e8a1bb2c62e0349f9a87c5cb702c2591f45354090acd2"
       },
       "exceptions": []
     },
@@ -840,7 +840,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:23337f78a508a14fead33367d9bca75931ffde62ceec4d952e5ba3c65ee660ff"
+        "sourceHash": "sha256:c436b89a1c0cc65dbe281b1fee85402ee944888cd37a51fbf3de1152c5ca6dcb"
       },
       "exceptions": []
     },
@@ -919,7 +919,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:cc7230a734d80ccd8ead3bfe93ef364d6245c1b94177ea0ce4543969fbebedf9"
+        "sourceHash": "sha256:3e49870c8b509d087755cf884e292153d444d3d83e49c3ff8e6653d0adc1afe1"
       },
       "exceptions": []
     },
@@ -998,7 +998,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:a2f96165e2fa3df19e53cd104be4150f3728f6b79172c9e736e51ac8caeba36b"
+        "sourceHash": "sha256:2954ef1f088f10f2c551e83da566513c8260692a87bdd34e346ecb5dab82c987"
       },
       "exceptions": []
     },
@@ -1077,7 +1077,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:9b9649d43fcc51db8c517463eb1c759cb67b9e24fcd8b03eabb84e6e005bc46f"
+        "sourceHash": "sha256:1edc86734f080ef6da95a9f954f44a7d43deb59c5cd28c375214beafb3a6bd4c"
       },
       "exceptions": []
     },
@@ -1156,7 +1156,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:ef20bc785d9d4ccdc90e1b8bc87d737558b4a4b4af31941c471efeab1a8bea3a"
+        "sourceHash": "sha256:b38b3a757e9dbe8ceb7846a85e4da9fe37a4acc86827a57057e6ceb202f85ff0"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:473ab76a3f81a4bcf6e74d5319945eac4a2777440f81fe91df82b3fcef2182a0"
+        "sourceHash": "sha256:b44dac332f3f185096907af8ee1c8d6ac85603ac850e55b077daf0a947db8452"
       },
       "exceptions": []
     },
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:6cea6748e390e32a8b01578dc2e2e09bf828fcfbc6641c36d04e63f902ef46e5"
+        "sourceHash": "sha256:d3640946d0fec42706442c6c042aca5ea318ff67a7244801fc7049f80656d656"
       },
       "exceptions": []
     },
@@ -2025,7 +2025,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:be386838520ee2f6df8ab24641c6ee4d772272b2c5110113217a620f4e0a96f7"
+        "sourceHash": "sha256:6abe8b7c0d64f0e7dcc5ecc2a2ab0f7258365d99c933538dc3cf0cbc8c731f24"
       },
       "exceptions": []
     },


### PR DESCRIPTION
## Summary
Next Fase A batch (epic #1254) for **Registry** landing/docs:

- Home **Continue with context** mesh (6 peers + roles) — parity with `/agents` and for-agents
- Nav **Framework** → **AgentsKit**
- Counts: **140+** catalog providers / **5,162** models; integrations stay **50**
- Docs: drop “shadcn-style” framing; ownership copy-the-source language
- for-agents: full peer list with canonical roles
- chore: refresh README Standard source hashes (pre-push freshness drift on main)

Related: #1276 #1277 #1278 #1279 · parent #1257

### Sibling this batch
- Doc Bridge: https://github.com/AgentsKit-io/doc-bridge/pull/44 (#1289 #1290)

## Test plan
- [ ] registry.agentskit.io home shows ecosystem mesh below install steps
- [ ] Nav link reads AgentsKit → www.agentskit.io
- [ ] Docs index no longer says shadcn-style
- [ ] Provider CTAs say 140+