### PR TITLE
fix: make release intent detection pipe-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,11 @@ jobs:
           fi
 
           has_version_changes=false
-          if git rev-parse --verify HEAD^ >/dev/null 2>&1 && \
-            git diff --unified=0 HEAD^ HEAD -- 'packages/*/package.json' | \
-            grep -Eq '^[+-][[:space:]]*"version"[[:space:]]*:'; then
-            has_version_changes=true
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            version_diff=$(git diff --unified=0 HEAD^ HEAD -- 'packages/*/package.json')
+            if grep -Eq '^[+-][[:space:]]*"version"[[:space:]]*:' <<< "$version_diff"; then
+              has_version_changes=true
+            fi
           fi
 
           recover_unpublished=false


### PR DESCRIPTION
## Summary
- capture the package version diff before matching release intent
- avoid a pipeline whose status can be affected by `pipefail`
- preserve the existing changeset and recovery paths

## Evidence
- reproduced detection against merge commit `8321a73`
- detector reports `has_version_changes=true`
- `git diff --check` passed
- pre-push quality gates and full build passed

This prevents a merged Changesets release PR from becoming a silent no-op and requiring recovery mode.