### PR TITLE
fix: override vulnerable adm-zip

### DIFF
--- a/.changeset/cyan-horses-grow.md
+++ b/.changeset/cyan-horses-grow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Prevent React coverage from rebuilding and temporarily removing its declaration output while dependent workspace apps compile.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
       "esbuild": ">=0.28.1 <1",
       "form-data": ">=4.0.6 <5",
       "dompurify": "3.4.11",
-      "read-yaml-file": "2.1.0"
+      "read-yaml-file": "2.1.0",
+      "adm-zip": "0.6.0"
     }
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "tsup",
     "test": "pnpm build && vitest run",
-    "test:coverage": "pnpm build && vitest run --coverage",
+    "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "dev": "tsup --watch"
   },

--- a/packages/react/tests/package-manifest.test.ts
+++ b/packages/react/tests/package-manifest.test.ts
@@ -15,6 +15,7 @@ describe('@agentskit/react package manifest + import safety', () => {
         '.': { types: string; import: string; require: string }
         './theme': string
       }
+      scripts: Record<string, string>
       dependencies: Record<string, string>
       peerDependencies: Record<string, string>
     }
@@ -27,6 +28,7 @@ describe('@agentskit/react package manifest + import safety', () => {
     expect(pkg.exports['.'].import).toBe(pkg.module)
     expect(pkg.exports['.'].require).toBe(pkg.main)
     expect(pkg.exports['./theme']).toBe('./dist/theme/default.css')
+    expect(pkg.scripts['test:coverage']).toBe('vitest run --coverage')
     expect(pkg.dependencies).toEqual({ '@agentskit/core': 'workspace:*' })
     expect(pkg.peerDependencies.react).toBeDefined()
     expect(pkg.peerDependencies['react-dom']).toBeDefined()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   form-data: '>=4.0.6 <5'
   dompurify: 3.4.11
   read-yaml-file: 2.1.0
+  adm-zip: 0.6.0
 
 importers:
 
@@ -4666,9 +4667,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -12017,7 +12018,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -15356,7 +15357,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -1314,7 +1314,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:2068ee075a02c720e3ab2dd7b729230b3e22be1f4ff84aff181908720318f066"
+        "sourceHash": "sha256:7297b7176a57f4f6b173f5ab777105e2aad4d6084bc357e664e6eecdb7bc6fc8"
       },
       "exceptions": []
     },


### PR DESCRIPTION
## What changed

- pins the transitive `adm-zip` dependency to `0.6.0` through the existing root pnpm overrides
- refreshes the lockfile so `onnxruntime-node` resolves the patched version
- removes a redundant React rebuild that could delete declarations while dependent apps compile during coverage
- adds a manifest regression assertion and an empty changeset for the CI-only React adjustment

## Why

Dependabot alert #77 reports CVE-2026-39244 / GHSA-xcpc-8h2w-3j85 in `adm-zip < 0.6.0`. The vulnerable package is pulled transitively through `@huggingface/transformers -> onnxruntime-node`, and the current upstream versions still request the vulnerable range.

The central override removes the vulnerable version across every consumer without changing package APIs or publication versions. AgentsKit's Node.js floor is newer than the patched package's Node.js 14 minimum.

The first coverage run also exposed a deterministic workspace race: Turbo had already built `@agentskit/react`, but its coverage script launched a second `tsup` build that cleaned `dist/` while `example-multi-agent` read the declaration output. Coverage now relies on Turbo's declared `build` dependency and no longer mutates `dist/` concurrently.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level high` — no known vulnerabilities
- `pnpm check:quality-gates` — all 28 gates pass
- full pre-push lint — 56/56 tasks pass
- full pre-push build — 42/42 tasks pass
- forced global coverage graph reached and passed the original `example-multi-agent` failure point
- `pnpm --filter @agentskit/react test:coverage` — 90 tests pass
- `pnpm --filter @agentskit/react lint`
- `pnpm --filter @agentskit/ask-backend test` — 29 tests pass
- `pnpm --filter @agentskit/ask-backend lint`
- runtime import of `@huggingface/transformers` and its nested `onnxruntime-node`

Closes Dependabot alert #77 after merge.
