### PR TITLE
Consolidate the public ecosystem experience

### DIFF
--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -117,6 +117,21 @@ function Hero() {
             terminal, in-memory for vector DB — without a rewrite.
           </p>
 
+          <div className="mb-7 flex flex-wrap items-center gap-2.5 lg:hidden">
+            <Link
+              href="/docs/get-started/getting-started/build-your-first-agent"
+              className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-4 py-2.5 text-sm font-semibold text-ak-midnight transition hover:bg-white"
+            >
+              Build your first agent →
+            </Link>
+            <Link
+              href="/docs/reference/examples"
+              className="inline-flex items-center gap-2 px-2 py-2.5 text-sm font-medium text-ak-graphite transition hover:text-ak-foam"
+            >
+              See live examples →
+            </Link>
+          </div>
+
           <InstallCommand />
           <HeroFrameworks />
           <p className="mt-6 max-w-xl border-l-2 border-ak-green pl-4 text-sm leading-relaxed text-ak-graphite">
@@ -134,7 +149,7 @@ function Hero() {
             </a>
           </p>
 
-          <div className="mt-5 flex flex-wrap items-center justify-center gap-2.5 sm:gap-3">
+          <div className="mt-5 hidden flex-wrap items-center justify-center gap-2.5 sm:gap-3 lg:flex">
             <Link
               href="/docs/get-started/getting-started/build-your-first-agent"
               className="inline-flex items-center gap-2 rounded-md bg-ak-foam px-4 py-2.5 text-sm font-semibold text-ak-midnight transition hover:bg-white sm:px-5"
@@ -364,7 +379,9 @@ function SiteFooter() {
       links: [
         { text: 'Libs', href: '/' },
         { text: 'Registry · agents', href: 'https://registry.agentskit.io' },
+        { text: 'Chat · interfaces', href: 'https://chat.agentskit.io' },
         { text: 'Playbook · standards', href: 'https://playbook.agentskit.io' },
+        { text: 'Doc Bridge · knowledge', href: 'https://doc-bridge.agentskit.io' },
         { text: 'AKOS · production OS', href: 'https://akos.agentskit.io' },
       ],
     },

--- a/apps/docs-next/app/api/ecosystem.json/route.ts
+++ b/apps/docs-next/app/api/ecosystem.json/route.ts
@@ -1,0 +1,28 @@
+import ecosystem from '@/lib/ecosystem.json'
+
+export const dynamic = 'force-static'
+
+export function GET() {
+  const publicProducts = ecosystem.products
+    .filter((product) => product.navigation.showInBar)
+    .sort((left, right) => left.navigation.order - right.navigation.order)
+  const publicIds = new Set(publicProducts.map((product) => product.id))
+  const products = publicProducts.map((product) => ({
+    ...product,
+    navigation: {
+      ...product.navigation,
+      next: product.navigation.next.filter((id) => publicIds.has(id)),
+    },
+  }))
+
+  return Response.json({
+    schemaVersion: ecosystem.schemaVersion,
+    parentBrand: ecosystem.parentBrand,
+    products,
+  }, {
+    headers: {
+      'access-control-allow-origin': '*',
+      'cache-control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  })
+}

--- a/apps/docs-next/lib/deterministic-knowledge.generated.json
+++ b/apps/docs-next/lib/deterministic-knowledge.generated.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-20T16:43:10-03:00",
+  "generatedAt": "2026-07-20T18:42:13-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -1030,7 +1030,7 @@
         ]
       },
       "answer": {
-        "markdown": "**Agents Playbook** is the ecosystem's discipline: Make agents ship code a human would actually merge. Maturity: **stable**.",
+        "markdown": "**Agents Playbook** is the ecosystem's discipline: Train coding agents to ship code your team would merge. Maturity: **stable**.",
         "citations": [
           {
             "id": "ecosystem-playbook",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:88975fb1d074fb3270d55b421fc213223b9082f6443db80faa524c32bf230e92"
+  "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
 }

--- a/apps/docs-next/lib/deterministic-knowledge.generated.json
+++ b/apps/docs-next/lib/deterministic-knowledge.generated.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-20T18:42:13-03:00",
+  "generatedAt": "2026-07-20T20:49:51-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
+  "contentHash": "sha256:360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8"
 }

--- a/apps/docs-next/lib/deterministic-site.generated.json
+++ b/apps/docs-next/lib/deterministic-site.generated.json
@@ -3,8 +3,8 @@
   "version": 1,
   "siteId": "agentskit-docs",
   "artifact": {
-    "href": "/deterministic-knowledge/88975fb1d074fb3270d55b421fc213223b9082f6443db80faa524c32bf230e92.json",
-    "contentHash": "sha256:88975fb1d074fb3270d55b421fc213223b9082f6443db80faa524c32bf230e92"
+    "href": "/deterministic-knowledge/fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847.json",
+    "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
   },
   "fallback": {
     "mode": "backend"

--- a/apps/docs-next/lib/deterministic-site.generated.json
+++ b/apps/docs-next/lib/deterministic-site.generated.json
@@ -3,8 +3,8 @@
   "version": 1,
   "siteId": "agentskit-docs",
   "artifact": {
-    "href": "/deterministic-knowledge/fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847.json",
-    "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
+    "href": "/deterministic-knowledge/360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8.json",
+    "contentHash": "sha256:360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8"
   },
   "fallback": {
     "mode": "backend"

--- a/apps/docs-next/lib/ecosystem.json
+++ b/apps/docs-next/lib/ecosystem.json
@@ -179,15 +179,15 @@
       "shortName": "Playbook",
       "kind": "methodology",
       "role": "discipline",
-      "promise": "Make agents ship code a human would actually merge.",
+      "promise": "Train coding agents to ship code your team would merge.",
       "maturity": "stable",
       "repo": "AgentsKit-io/agents-playbook",
       "accent": "#8B5CF6",
       "showcase": {
         "stage": "Standardize",
-        "headline": "Engineering standards agents can execute.",
-        "detail": "Turn repeatable practices into guidance that coding agents can follow in every repository.",
-        "proof": "Convention → executable guidance",
+        "headline": "The open engineering harness for coding agents.",
+        "detail": "Open rules, prompts, memory, evals, and executable gates turn every correction into behavior coding agents can repeat.",
+        "proof": "Train the behavior · not the model",
         "sales": {
           "kind": "standards-flow",
           "headline": "Your standards. Every agent. Every repository.",
@@ -202,7 +202,7 @@
           "capabilities": ["Repository rules", "Review criteria", "Agent guidance", "Team conventions"],
           "steps": ["Define the standard once", "Agents receive executable guidance", "Review consistent output"]
         },
-        "cta": "Explore the Playbook",
+        "cta": "Explore the harness",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -255,7 +255,7 @@
           "capabilities": ["ADRs", "Handoffs", "Agent findings", "Human-readable docs"],
           "steps": ["Humans document decisions", "Agents receive precise context", "Agent findings return to humans"]
         },
-        "cta": "Explore Doc Bridge",
+        "cta": "Generate your first handoff",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -400,7 +400,7 @@
       "domain": "playbook.agentskit.io",
       "url": "https://playbook.agentskit.io",
       "repo": "AgentsKit-io/agents-playbook",
-      "tagline": "Make agents ship code a human would actually merge.",
+      "tagline": "Train coding agents to ship code your team would merge.",
       "kind": "methodology",
       "accent": "#8B5CF6",
       "llms": "https://playbook.agentskit.io/llms.txt",

--- a/apps/docs-next/public/deterministic-knowledge/360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8.json
+++ b/apps/docs-next/public/deterministic-knowledge/360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-20T18:42:13-03:00",
+  "generatedAt": "2026-07-20T20:49:51-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
+  "contentHash": "sha256:360c7185e3dd87a0b7971104ce95160e68511db9817323439e63edfb9c08d7f8"
 }

--- a/apps/docs-next/public/deterministic-knowledge/fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847.json
+++ b/apps/docs-next/public/deterministic-knowledge/fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847.json
@@ -3,7 +3,7 @@
   "version": 1,
   "artifactId": "agentskit-docs-v1",
   "siteId": "agentskit-docs",
-  "generatedAt": "2026-07-20T16:43:10-03:00",
+  "generatedAt": "2026-07-20T18:42:13-03:00",
   "entries": [
     {
       "id": "claim.catalog-models",
@@ -1030,7 +1030,7 @@
         ]
       },
       "answer": {
-        "markdown": "**Agents Playbook** is the ecosystem's discipline: Make agents ship code a human would actually merge. Maturity: **stable**.",
+        "markdown": "**Agents Playbook** is the ecosystem's discipline: Train coding agents to ship code your team would merge. Maturity: **stable**.",
         "citations": [
           {
             "id": "ecosystem-playbook",
@@ -2260,5 +2260,5 @@
       }
     }
   ],
-  "contentHash": "sha256:88975fb1d074fb3270d55b421fc213223b9082f6443db80faa524c32bf230e92"
+  "contentHash": "sha256:fac9e8cc189e8b473ffc1342c775c151589139766643c1e4a80e736e14cd5847"
 }

--- a/apps/docs-next/public/ecosystem-bar.README.md
+++ b/apps/docs-next/public/ecosystem-bar.README.md
@@ -11,6 +11,13 @@ uses claim templates from `ecosystem.json`, a generated snapshot from
 That artifact resolves AgentsKit values from `/api/stats.json` and Registry values
 from `/r/index.json`, so consuming sites never maintain their own copies.
 
+Product identity is available from `/api/ecosystem.json`. The endpoint exposes
+only the six public products (`navigation.showInBar: true`), is CORS-enabled, and
+uses a cacheable response with stale-while-revalidate. Consumers should use this
+projection for names, URLs, accents, lifecycle stages, and shared CTAs instead of
+copying those values into their own source trees. Keep the generated local
+snapshot as the no-network fallback.
+
 On the right side it also surfaces two community CTAs — **Star on GitHub**
 (`github.com/AgentsKit-io/agentskit`) and **Discord** (`discord.gg/zx6z2p4jVb`).
 These are project surfaces only; no personal-brand links belong in the bar. The
@@ -28,6 +35,36 @@ Add to each product surface. Repository-native Code Review links to its GitHub h
 Set `data-current` to one of: `agentskit` · `registry` · `agentskit-chat` ·
 `playbook` · `doc-bridge` · `code-review` · `akos`
 (or omit it — the bar auto-detects by hostname). The current property is highlighted.
+
+## Semantic ecosystem footer
+
+The same script registers `<agentskit-ecosystem-footer>`. The footer derives its
+product identity and six-product navigation exclusively from the generated
+`PROPS` snapshot. Code Review is not rendered because it is not a public web
+property.
+
+Each consumer supplies only its local tagline and links:
+
+```html
+<agentskit-ecosystem-footer
+  data-current="agentskit-chat"
+  tagline="One agent experience. Every surface."
+>
+  <a slot="local" href="/docs">Documentation</a>
+  <a slot="local" href="/docs/cli">CLI</a>
+  <a slot="resources" href="/llms.txt">llms.txt</a>
+  <a slot="resources" href="https://github.com/AgentsKit-io/agentskit-chat">GitHub</a>
+</agentskit-ecosystem-footer>
+```
+
+- `data-current` accepts one of the six public product IDs. It falls back to the
+  script's `data-current`, then hostname detection.
+- `tagline` supplies plain fallback text. Rich but accessible local markup may
+  instead use the `tagline` slot.
+- `local` and `resources` accept links owned by the consuming product. Empty
+  groups are not displayed.
+- The component uses a semantic `<footer>`, labelled navigation regions,
+  keyboard-visible focus, responsive layouts, and light/dark system colors.
 
 ## Why no Subresource Integrity (SRI)
 

--- a/apps/docs-next/public/ecosystem-bar.js
+++ b/apps/docs-next/public/ecosystem-bar.js
@@ -1,5 +1,5 @@
 /**
- * AgentsKit ecosystem bar — one shared top nav across the seven products.
+ * AgentsKit ecosystem bar — one shared top nav across the six public products.
  * Embed on any site with: <script src="https://www.agentskit.io/ecosystem-bar.js" defer></script>
  *
  * Self-contained, zero deps. Detects the current property by hostname and
@@ -187,9 +187,9 @@
       "accent": "#8B5CF6",
       "href": "https://playbook.agentskit.io",
       "stage": "Standardize",
-      "headline": "Engineering standards agents can execute.",
-      "detail": "Turn repeatable practices into guidance that coding agents can follow in every repository.",
-      "proof": "Convention → executable guidance",
+      "headline": "The open engineering harness for coding agents.",
+      "detail": "Open rules, prompts, memory, evals, and executable gates turn every correction into behavior coding agents can repeat.",
+      "proof": "Train the behavior · not the model",
       "sales": {
         "kind": "standards-flow",
         "headline": "Your standards. Every agent. Every repository.",
@@ -225,7 +225,7 @@
           "Review consistent output"
         ]
       },
-      "cta": "Explore the Playbook",
+      "cta": "Explore the harness",
       "ctaSurface": "home"
     },
     {
@@ -273,7 +273,7 @@
           "Agent findings return to humans"
         ]
       },
-      "cta": "Explore Doc Bridge",
+      "cta": "Generate your first handoff",
       "ctaSurface": "home"
     },
     {
@@ -894,6 +894,174 @@
   }
 
   registerEcosystemShowcase()
+
+  function registerEcosystemFooter() {
+    if (!window.customElements || customElements.get('agentskit-ecosystem-footer')) return
+
+    var footerCss = `
+      :host{display:block;color-scheme:dark;--akf-bg:#0b0f14;--akf-surface:#11171e;--akf-line:#27313a;--akf-fg:#e7edf4;--akf-muted:#8b98a6;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+      *{box-sizing:border-box}
+      a{font:inherit}
+      .akf-footer{border-top:1px solid var(--akf-line);background:var(--akf-bg);color:var(--akf-fg)}
+      .akf-inner{max-width:1152px;margin:0 auto;padding:56px 24px 28px}
+      .akf-main{display:grid;grid-template-columns:minmax(14rem,.8fr) minmax(0,1.7fr);gap:64px}
+      .akf-eyebrow,.akf-heading{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;text-transform:uppercase;letter-spacing:.16em}
+      .akf-eyebrow{margin:0 0 14px;color:var(--akf-muted);font-size:10px}
+      .akf-product{margin:0;font-size:24px;line-height:1.15;letter-spacing:-.025em}
+      .akf-tagline{max-width:31rem;margin:14px 0 0;color:var(--akf-muted);font-size:14px;line-height:1.65}
+      .akf-navs{display:grid;grid-template-columns:minmax(0,2fr) repeat(2,minmax(8rem,1fr));gap:40px}
+      .akf-section[hidden]{display:none}
+      .akf-heading{margin:0 0 16px;color:var(--akf-muted);font-size:10px}
+      .akf-products{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:4px 20px;margin:0;padding:0;list-style:none}
+      .akf-link{display:inline-flex;min-height:36px;align-items:center;color:var(--akf-muted);font-size:13px;text-decoration:none;transition:color 160ms cubic-bezier(.25,1,.5,1)}
+      .akf-link:hover{color:var(--akf-fg)}
+      .akf-link:focus-visible{border-radius:3px;outline:2px solid currentColor;outline-offset:3px}
+      .akf-link[aria-current="page"]{color:var(--akf-fg);font-weight:650}
+      .akf-slots{display:flex;flex-direction:column;align-items:flex-start;gap:4px}
+      ::slotted(a){display:inline-flex;min-height:36px;align-items:center;color:var(--akf-muted);font-size:13px;text-decoration:none;transition:color 160ms cubic-bezier(.25,1,.5,1)}
+      ::slotted(a:hover){color:var(--akf-fg)}
+      ::slotted(a:focus-visible){border-radius:3px;outline:2px solid currentColor;outline-offset:3px}
+      .akf-meta{display:flex;align-items:center;justify-content:space-between;gap:24px;margin-top:44px;padding-top:20px;border-top:1px solid var(--akf-line);color:var(--akf-muted);font-size:11px}
+      .akf-home{color:inherit;text-decoration:none}
+      .akf-home:hover{color:var(--akf-fg)}
+      .akf-home:focus-visible{border-radius:3px;outline:2px solid currentColor;outline-offset:3px}
+      @media(max-width:860px){.akf-main{grid-template-columns:1fr;gap:40px}.akf-navs{grid-template-columns:minmax(0,1.6fr) repeat(2,minmax(7rem,1fr));gap:28px}}
+      @media(max-width:640px){.akf-inner{padding:44px 20px 24px}.akf-navs{grid-template-columns:repeat(2,minmax(0,1fr));gap:32px 24px}.akf-section:first-child{grid-column:1/-1}.akf-products{grid-template-columns:repeat(2,minmax(0,1fr))}.akf-meta{align-items:flex-start;flex-direction:column;gap:8px}}
+      @media(prefers-color-scheme:light){:host{color-scheme:light;--akf-bg:#fff;--akf-surface:#f6f8fa;--akf-line:#d0d7de;--akf-fg:#0d1117;--akf-muted:#57606a}}
+    `
+
+    class AgentsKitEcosystemFooter extends HTMLElement {
+      static get observedAttributes() {
+        return ['data-current', 'tagline']
+      }
+
+      constructor() {
+        super()
+        this.attachShadow({ mode: 'open' })
+      }
+
+      connectedCallback() {
+        this.render()
+      }
+
+      attributeChangedCallback() {
+        if (this.isConnected) this.render()
+      }
+
+      render() {
+        var root = this.shadowRoot
+        while (root.firstChild) root.removeChild(root.firstChild)
+
+        var currentId = this.getAttribute('data-current') || current
+        var currentProduct = PROPS.filter(function (product) { return product.id === currentId })[0] || PROPS[0]
+
+        var style = document.createElement('style')
+        style.textContent = footerCss
+        root.appendChild(style)
+
+        var footer = document.createElement('footer')
+        footer.className = 'akf-footer'
+        footer.setAttribute('aria-label', 'AgentsKit ecosystem footer')
+        var inner = document.createElement('div')
+        inner.className = 'akf-inner'
+        var main = document.createElement('div')
+        main.className = 'akf-main'
+
+        var identity = document.createElement('section')
+        var eyebrow = document.createElement('p')
+        eyebrow.className = 'akf-eyebrow'
+        eyebrow.textContent = 'AgentsKit ecosystem'
+        var productName = document.createElement('h2')
+        productName.className = 'akf-product'
+        productName.textContent = currentProduct.label
+        var tagline = document.createElement('p')
+        tagline.className = 'akf-tagline'
+        var taglineSlot = document.createElement('slot')
+        taglineSlot.name = 'tagline'
+        var taglineFallback = document.createElement('span')
+        taglineFallback.textContent = this.getAttribute('tagline') || 'Part of the AgentsKit ecosystem.'
+        taglineSlot.appendChild(taglineFallback)
+        tagline.appendChild(taglineSlot)
+        identity.appendChild(eyebrow)
+        identity.appendChild(productName)
+        identity.appendChild(tagline)
+        main.appendChild(identity)
+
+        var navs = document.createElement('div')
+        navs.className = 'akf-navs'
+
+        var ecosystemSection = document.createElement('section')
+        ecosystemSection.className = 'akf-section'
+        var ecosystemHeading = document.createElement('h3')
+        ecosystemHeading.className = 'akf-heading'
+        ecosystemHeading.textContent = 'Products'
+        var ecosystemNav = document.createElement('nav')
+        ecosystemNav.setAttribute('aria-label', 'AgentsKit products')
+        var products = document.createElement('ul')
+        products.className = 'akf-products'
+        PROPS.forEach(function (product) {
+          var item = document.createElement('li')
+          var link = document.createElement('a')
+          link.className = 'akf-link'
+          link.href = product.url
+          link.textContent = product.label
+          if (product.id === currentProduct.id) link.setAttribute('aria-current', 'page')
+          item.appendChild(link)
+          products.appendChild(item)
+        })
+        ecosystemNav.appendChild(products)
+        ecosystemSection.appendChild(ecosystemHeading)
+        ecosystemSection.appendChild(ecosystemNav)
+        navs.appendChild(ecosystemSection)
+
+        function appendSlottedSection(name, label) {
+          var section = document.createElement('section')
+          section.className = 'akf-section'
+          section.hidden = true
+          var heading = document.createElement('h3')
+          heading.className = 'akf-heading'
+          heading.textContent = label
+          var links = document.createElement('div')
+          links.className = 'akf-slots'
+          var slot = document.createElement('slot')
+          slot.name = name
+          var syncVisibility = function () {
+            section.hidden = slot.assignedElements().length === 0
+          }
+          slot.addEventListener('slotchange', syncVisibility)
+          links.appendChild(slot)
+          section.appendChild(heading)
+          section.appendChild(links)
+          navs.appendChild(section)
+          window.setTimeout(syncVisibility, 0)
+        }
+
+        appendSlottedSection('local', 'Product')
+        appendSlottedSection('resources', 'Resources')
+        main.appendChild(navs)
+
+        var meta = document.createElement('div')
+        meta.className = 'akf-meta'
+        var ownership = document.createElement('span')
+        ownership.textContent = 'One ecosystem. Every product stays focused.'
+        var home = document.createElement('a')
+        home.className = 'akf-home'
+        home.href = PROPS[0].url
+        home.textContent = 'AgentsKit home'
+        meta.appendChild(ownership)
+        meta.appendChild(home)
+
+        inner.appendChild(main)
+        inner.appendChild(meta)
+        footer.appendChild(inner)
+        root.appendChild(footer)
+      }
+    }
+
+    customElements.define('agentskit-ecosystem-footer', AgentsKitEcosystemFooter)
+  }
+
+  registerEcosystemFooter()
 
   function build() {
     var style = document.createElement('style')

--- a/apps/landing/lib/ecosystem.json
+++ b/apps/landing/lib/ecosystem.json
@@ -179,15 +179,15 @@
       "shortName": "Playbook",
       "kind": "methodology",
       "role": "discipline",
-      "promise": "Make agents ship code a human would actually merge.",
+      "promise": "Train coding agents to ship code your team would merge.",
       "maturity": "stable",
       "repo": "AgentsKit-io/agents-playbook",
       "accent": "#8B5CF6",
       "showcase": {
         "stage": "Standardize",
-        "headline": "Engineering standards agents can execute.",
-        "detail": "Turn repeatable practices into guidance that coding agents can follow in every repository.",
-        "proof": "Convention → executable guidance",
+        "headline": "The open engineering harness for coding agents.",
+        "detail": "Open rules, prompts, memory, evals, and executable gates turn every correction into behavior coding agents can repeat.",
+        "proof": "Train the behavior · not the model",
         "sales": {
           "kind": "standards-flow",
           "headline": "Your standards. Every agent. Every repository.",
@@ -202,7 +202,7 @@
           "capabilities": ["Repository rules", "Review criteria", "Agent guidance", "Team conventions"],
           "steps": ["Define the standard once", "Agents receive executable guidance", "Review consistent output"]
         },
-        "cta": "Explore the Playbook",
+        "cta": "Explore the harness",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -255,7 +255,7 @@
           "capabilities": ["ADRs", "Handoffs", "Agent findings", "Human-readable docs"],
           "steps": ["Humans document decisions", "Agents receive precise context", "Agent findings return to humans"]
         },
-        "cta": "Explore Doc Bridge",
+        "cta": "Generate your first handoff",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -400,7 +400,7 @@
       "domain": "playbook.agentskit.io",
       "url": "https://playbook.agentskit.io",
       "repo": "AgentsKit-io/agents-playbook",
-      "tagline": "Make agents ship code a human would actually merge.",
+      "tagline": "Train coding agents to ship code your team would merge.",
       "kind": "methodology",
       "accent": "#8B5CF6",
       "llms": "https://playbook.agentskit.io/llms.txt",

--- a/apps/registry/app/(home)/_components/closing-cta.tsx
+++ b/apps/registry/app/(home)/_components/closing-cta.tsx
@@ -1,0 +1,33 @@
+import { Icon } from './ui'
+
+export function ClosingCta({ agentCount }: { agentCount: number }) {
+  return (
+    <section aria-labelledby="registry-closing-cta" className="border-t border-ak-border px-4 py-16 sm:px-6 sm:py-24">
+      <div className="mx-auto grid max-w-5xl gap-8 border-y border-ak-border py-10 md:grid-cols-[1fr_auto] md:items-end">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-ak-blue">Your next agent starts as owned source</p>
+          <h2 id="registry-closing-cta" className="mt-3 max-w-2xl font-display text-3xl font-semibold text-ak-foam sm:text-4xl">
+            Find your starting point. Own what happens next.
+          </h2>
+          <p className="mt-4 max-w-2xl text-ak-graphite">
+            Choose from {agentCount} validated agents, install one command, and adapt every line to your stack and policy.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3 md:justify-end">
+          <a
+            href="#agents"
+            className="inline-flex items-center gap-2 rounded-lg bg-ak-blue px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            Browse {agentCount} agents <Icon name="arrow-right" size={17} />
+          </a>
+          <a
+            href="/docs/quick-start"
+            className="inline-flex items-center gap-2 rounded-lg border border-ak-border bg-ak-surface px-4 py-2.5 text-sm font-semibold text-ak-foam transition hover:border-ak-blue"
+          >
+            Read the quick start
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/registry/app/(home)/_components/ecosystem-mesh.tsx
+++ b/apps/registry/app/(home)/_components/ecosystem-mesh.tsx
@@ -1,44 +1,16 @@
 import Link from 'next/link'
+import ecosystemManifest from '../../../../../ecosystem.json'
 
 /** Canonical peer products (Registry is the current surface — not listed). */
-export const ecosystemPeers = [
-  {
-    name: 'AgentsKit',
-    role: 'foundation',
-    href: 'https://www.agentskit.io',
-    action: 'Build and extend agents with core, tools, memory, and RAG.',
-  },
-  {
-    name: 'AgentsKit Chat',
-    role: 'experience',
-    href: 'https://chat.agentskit.io',
-    action: 'Deliver a native chat experience over the same runtime.',
-  },
-  {
-    name: 'Agents Playbook',
-    role: 'discipline',
-    href: 'https://playbook.agentskit.io',
-    action: 'Apply engineering and delivery standards for agent work.',
-  },
-  {
-    name: 'Doc Bridge',
-    role: 'understanding',
-    href: 'https://doc-bridge.agentskit.io/',
-    action: 'Keep documentation handoffs agent-ready and deterministic.',
-  },
-  {
-    name: 'Code Review',
-    role: 'verification',
-    href: 'https://github.com/AgentsKit-io/code-review-cli',
-    action: 'Review agent-generated diffs before merge.',
-  },
-  {
-    name: 'AKOS',
-    role: 'operation',
-    href: 'https://akos.agentskit.io',
-    action: 'Operate with enterprise controls and governance.',
-  },
-] as const
+export const ecosystemPeers = ecosystemManifest.products
+  .filter((product) => product.id !== 'registry' && product.navigation.showInBar)
+  .sort((left, right) => (left.navigation.order ?? 0) - (right.navigation.order ?? 0))
+  .map((product) => ({
+    name: product.name,
+    role: product.role,
+    href: product.surfaces.home,
+    action: product.showcase?.detail ?? product.promise,
+  }))
 
 export function EcosystemMesh({
   headingId = 'continue-ecosystem',

--- a/apps/registry/app/(home)/_components/ecosystem-showcase.tsx
+++ b/apps/registry/app/(home)/_components/ecosystem-showcase.tsx
@@ -8,10 +8,10 @@ export function EcosystemShowcase() {
       <div className="mx-auto max-w-5xl">
         <p className="font-mono text-xs uppercase tracking-wider text-ak-blue">The AgentsKit ecosystem</p>
         <h2 className="mt-3 max-w-3xl font-display text-3xl font-semibold sm:text-4xl">
-          Build the agent. Then take it all the way.
+          Start from working source. Take the agent all the way.
         </h2>
         <p className="mt-4 max-w-2xl text-ak-graphite">
-          One connected toolkit from ready-made source to governed production.
+          Registry is the discovery layer in one connected toolkit, from JavaScript foundation to governed production.
         </p>
       </div>
     </section>,

--- a/apps/registry/app/(home)/_components/hero.tsx
+++ b/apps/registry/app/(home)/_components/hero.tsx
@@ -1,7 +1,5 @@
 import { Icon } from './ui'
 
-const GH = 'https://github.com/AgentsKit-io/agentskit-registry'
-
 export function Hero({ agentCount, categoryCount, sampleIds }: { agentCount: number; categoryCount: number; sampleIds: string[] }) {
   const id = sampleIds[0] ?? 'research'
   const cmd = `npx agentskit add ${id}`
@@ -10,33 +8,32 @@ export function Hero({ agentCount, categoryCount, sampleIds }: { agentCount: num
     <section className="border-b border-ak-border px-4 py-14 sm:px-6 sm:py-20">
       <div className="mx-auto grid max-w-5xl items-end gap-10 lg:grid-cols-[1fr_26rem]">
         <div>
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-ak-blue">Ready-to-use AI agents</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-ak-blue">Shadcn-like agents for JavaScript</p>
           <h1 className="mt-3 max-w-3xl text-[2.35rem] font-bold leading-[1.08] tracking-tight text-ak-foam sm:text-5xl">
             Find an agent. Copy the source. Own the code.
           </h1>
           <p className="mt-5 max-w-2xl text-base text-ak-graphite sm:text-lg">
-            Browse {agentCount} validated, provider-agnostic agents. Install one command, then read and adapt every line.
+            Browse {agentCount} validated, provider-agnostic agents. One command copies readable TypeScript into your
+            project, ready for your team to adapt.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-3">
-          <a
-            href="#agents"
-            className="inline-flex items-center gap-2 rounded-lg bg-ak-blue px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90"
-          >
-            Browse agents <Icon name="arrow-right" size={17} />
-          </a>
-          <a
-            href={GH}
-            target="_blank"
-            rel="noopener"
-            className="inline-flex items-center gap-2 rounded-lg border border-ak-border bg-ak-surface px-4 py-2.5 text-sm font-semibold text-ak-foam transition hover:border-ak-blue"
-          >
-            <Icon name="github" size={16} /> View on GitHub
-          </a>
+            <a
+              href="#agents"
+              className="inline-flex items-center gap-2 rounded-lg bg-ak-blue px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Browse {agentCount} agents <Icon name="arrow-right" size={17} />
+            </a>
+            <a
+              href="#how-it-works"
+              className="inline-flex items-center gap-2 rounded-lg border border-ak-border bg-ak-surface px-4 py-2.5 text-sm font-semibold text-ak-foam transition hover:border-ak-blue"
+            >
+              See how source ownership works
+            </a>
           </div>
           <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm text-ak-graphite">
-            <span><b className="text-ak-foam">{agentCount}</b> agents</span>
+            <span><b className="text-ak-foam">{agentCount}</b> validated agents</span>
             <span><b className="text-ak-foam">{categoryCount}</b> categories</span>
-            <span><b className="text-ak-green">Validated v1</b></span>
+            <span><b className="text-ak-green">Source-owned</b></span>
           </div>
         </div>
         <div className="overflow-hidden rounded-lg border border-ak-border bg-ak-surface">
@@ -57,7 +54,9 @@ export function Hero({ agentCount, categoryCount, sampleIds }: { agentCount: num
               <span className="ck"><Icon name="check" size={15} /></span>
             </button>
           </div>
-          <p className="border-t border-ak-border px-4 py-3 text-xs text-ak-graphite">Source lands in your repository. No registry runtime or lock-in.</p>
+          <p className="border-t border-ak-border px-4 py-3 text-xs text-ak-graphite">
+            Like shadcn/ui for agents: source lands in your repository. No registry runtime or lock-in.
+          </p>
         </div>
       </div>
     </section>

--- a/apps/registry/app/(home)/_components/install-steps.tsx
+++ b/apps/registry/app/(home)/_components/install-steps.tsx
@@ -82,9 +82,9 @@ function RunTerminal() {
 
 export function InstallSteps() {
   return (
-    <section className="px-4 py-16 sm:px-6 sm:py-20">
+    <section id="how-it-works" className="scroll-mt-20 px-4 py-16 sm:px-6 sm:py-20">
       <div className="mx-auto max-w-5xl">
-        <div className="rg-reveal font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">One command. The code is yours.</div>
+        <div className="rg-reveal font-mono text-xs uppercase tracking-[0.2em] text-ak-blue">From catalog to owned source</div>
         <h2 className="rg-reveal mt-2 text-2xl font-bold tracking-tight text-ak-foam sm:text-3xl">One command. The code is yours.</h2>
         <p className="rg-reveal mt-2 max-w-xl text-ak-graphite">Three steps from registry to running in your own stack — no lock-in, no hidden runtime.</p>
 

--- a/apps/registry/app/(home)/_components/site-footer.tsx
+++ b/apps/registry/app/(home)/_components/site-footer.tsx
@@ -1,0 +1,68 @@
+import ecosystemManifest from '../../../../../ecosystem.json'
+
+const publicProducts = ecosystemManifest.products
+  .filter((product) => product.navigation.showInBar)
+  .sort((left, right) => (left.navigation.order ?? 0) - (right.navigation.order ?? 0))
+
+const productLinks = [
+  { label: 'Browse agents', href: '/agents' },
+  { label: 'Quick start', href: '/docs/quick-start' },
+  { label: 'Documentation', href: '/docs' },
+  { label: 'Contribute an agent', href: 'https://github.com/AgentsKit-io/agentskit-registry/blob/main/CONTRIBUTING.md' },
+]
+
+const resourceLinks = [
+  { label: 'llms.txt', href: '/llms.txt' },
+  { label: 'Registry JSON', href: '/r/index.json' },
+  { label: 'MCP endpoint', href: '/api/mcp' },
+  { label: 'GitHub', href: 'https://github.com/AgentsKit-io/agentskit-registry' },
+]
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-ak-border bg-ak-surface px-4 py-12 sm:px-6">
+      <div className="mx-auto grid max-w-5xl gap-10 md:grid-cols-[1.35fr_1fr_1fr_1fr]">
+        <div>
+          <p className="font-display text-lg font-semibold text-ak-foam">AgentsKit Registry</p>
+          <p className="mt-3 max-w-xs text-sm leading-6 text-ak-graphite">
+            Shadcn-like agents installed as readable TypeScript. Start from working source and keep ownership of every line.
+          </p>
+          <p className="mt-5 font-mono text-[11px] uppercase tracking-[0.14em] text-ak-graphite">
+            MIT · source-owned · no registry runtime
+          </p>
+        </div>
+        <FooterColumn title="Registry" links={productLinks} />
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-ak-foam">Ecosystem</p>
+          <ul className="mt-4 space-y-2.5 text-sm text-ak-graphite">
+            {publicProducts.map((product) => (
+              <li key={product.id}>
+                {product.id === 'registry' ? (
+                  <span className="font-medium text-ak-blue" aria-current="page">{product.shortName}</span>
+                ) : (
+                  <a className="transition hover:text-ak-foam" href={product.surfaces.home}>{product.shortName}</a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <FooterColumn title="Resources" links={resourceLinks} />
+      </div>
+    </footer>
+  )
+}
+
+function FooterColumn({ title, links }: { title: string; links: { label: string; href: string }[] }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-ak-foam">{title}</p>
+      <ul className="mt-4 space-y-2.5 text-sm text-ak-graphite">
+        {links.map((link) => (
+          <li key={link.href}>
+            <a className="transition hover:text-ak-foam" href={link.href}>{link.label}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/registry/app/(home)/page.tsx
+++ b/apps/registry/app/(home)/page.tsx
@@ -6,13 +6,15 @@ import { Hero } from './_components/hero'
 import { Browse } from './_components/browse'
 import { InstallSteps } from './_components/install-steps'
 import { EcosystemShowcase } from './_components/ecosystem-showcase'
+import { ClosingCta } from './_components/closing-cta'
+import { SiteFooter } from './_components/site-footer'
 
 export const revalidate = 3600
 
 export const metadata = {
-  title: 'AgentsKit Registry — ready-to-use AI agents',
+  title: 'Shadcn-like AI agents',
   description:
-    'Ready-to-use AI agents for AgentsKit. Copy production-grade source into your project with one command — you own the code, no lock-in.',
+    'Shadcn-like AI agents for AgentsKit. Copy validated TypeScript source into your project with one command — you own the code, no lock-in.',
   alternates: { canonical: 'https://registry.agentskit.io' },
 }
 
@@ -33,6 +35,8 @@ export default async function HomePage() {
       </Suspense>
       <InstallSteps />
       <EcosystemShowcase />
+      <ClosingCta agentCount={agents.length} />
+      <SiteFooter />
     </main>
   )
 }

--- a/apps/registry/app/layout.tsx
+++ b/apps/registry/app/layout.tsx
@@ -11,11 +11,11 @@ const jetbrainsMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mon
 const spaceGrotesk = Space_Grotesk({ subsets: ['latin'], variable: '--font-display', display: 'swap' })
 
 const SITE_URL = 'https://registry.agentskit.io'
-const DESCRIPTION = 'Ready-to-use AI agents for AgentsKit. Copy the source into your project — you own the code.'
+const DESCRIPTION = 'Shadcn-like AI agents for AgentsKit. Copy validated TypeScript source into your project — you own the code.'
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: { default: 'AgentsKit Registry — ready-to-use AI agents', template: '%s — AgentsKit Registry' },
+  title: { default: 'AgentsKit Registry — shadcn-like AI agents', template: '%s — AgentsKit Registry' },
   description: DESCRIPTION,
   openGraph: { title: 'AgentsKit Registry', description: DESCRIPTION, url: SITE_URL, siteName: 'AgentsKit Registry' },
   twitter: { card: 'summary_large_image', title: 'AgentsKit Registry', description: DESCRIPTION, creator: '@agentskit' },

--- a/docs/architecture/adrs/0029-shared-ecosystem-web-shell.md
+++ b/docs/architecture/adrs/0029-shared-ecosystem-web-shell.md
@@ -1,0 +1,104 @@
+# ADR 0029 — Shared ecosystem web shell
+
+- **Status**: Accepted
+- **Date**: 2026-07-20
+- **Supersedes**: —
+- **Related ADRs**: ADR 0021
+
+## Context
+
+The six public AgentsKit sites already consume one hosted ecosystem bar and one
+canonical product manifest. Their product headers, search affordances, closing
+calls to action, and footers are still implemented independently. The result is
+structural drift: some sites have no product masthead, some have no search or
+semantic footer, and the same product identity is expressed with different
+spacing, typography, and link groups.
+
+The sites use different application stacks and deploy independently. A React-only
+package would not cover every consumer, while copying components into each
+repository would recreate the drift the shared bar already solved.
+
+## Decision
+
+AgentsKit will extend the existing hosted, zero-dependency web shell rather than
+introduce a framework-specific runtime package.
+
+The shell has four shared surfaces:
+
+1. the existing ecosystem bar;
+2. a product masthead with local-navigation slots and a standard search trigger;
+3. a command palette that searches the current product first and can expand to
+   the six public ecosystem indexes;
+4. a semantic ecosystem footer with product-local, ecosystem, and resource slots.
+
+The canonical public projection is served from `/api/ecosystem.json`. It contains
+only products whose `navigation.showInBar` value is true, preserving Code Review
+as a repository-native catalog entry without presenting it as a seventh public
+site.
+
+Identity, URLs, accents, lifecycle stages, and shared calls to action come from
+the canonical manifest. Numeric claims continue to come from their owning product
+and the generated claims system established by ADR 0021. Consumers do not keep
+independent copies of either kind of data.
+
+Each product supplies only local navigation and a local search index. Search
+falls back to the current product when another product index is unavailable. A
+failure to load the hosted shell or live manifest must leave usable local
+navigation and the last generated identity snapshot in place.
+
+Heroes and closing calls to action follow shared layout and writing contracts but
+remain product-owned. They are not rendered by the remote shell because their
+demonstrations and conversion goals differ materially.
+
+## Rationale
+
+1. **Build on the proven distribution path.** The hosted ecosystem bar already
+   updates multiple stacks from one source.
+2. **Keep local navigation local.** Slots let each product own routes without
+   forking layout and interaction behavior.
+3. **Separate identity from availability.** A cacheable public projection and a
+   generated fallback avoid turning a marketing shell into a hard runtime
+   dependency.
+4. **Preserve product character.** Shared structure creates recognition while
+   product-owned heroes, proofs, and accents prevent six identical sites.
+5. **Avoid unnecessary deployment coupling.** Identity and numeric updates can
+   propagate without rebuilding every sibling application.
+
+## Consequences
+
+### Positive
+
+- All six public sites share the same structural and accessibility contract.
+- Search and ecosystem discovery become predictable across products.
+- Header and footer changes can ship once with a versioned rollback path.
+- Product-specific pages keep control of their narrative and demonstrations.
+
+### Negative
+
+- The hosted shell becomes shared first-party infrastructure and needs explicit
+  compatibility tests.
+- Local search indexes need a small common result contract.
+- Consumers must preserve a local fallback for shell or network failure.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Copy React components into every repository | Excludes non-React consumers and recreates drift |
+| Publish an npm package only | Requires coordinated dependency releases and redeploys for visual fixes |
+| Render entire landing pages remotely | Removes product ownership and creates a large shared failure domain |
+| Keep only the shared ecosystem bar | Does not solve masthead, search, CTA, or footer inconsistency |
+
+## Open questions
+
+- Whether the federated search index remains client-aggregated or receives a
+  cacheable first-party aggregation endpoint after the local-search rollout.
+- Whether the shared shell graduates from a stable `/v1/` asset to an npm package
+  as well, for consumers that require vendored assets.
+
+## References
+
+- `ecosystem.json`
+- `ecosystem-claims.json`
+- `apps/docs-next/public/ecosystem-bar.js`
+- ADR 0021

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -65,5 +65,6 @@ Do NOT write an ADR for: routine features, bug fixes, internal refactors, or any
 | [0026](./0026-integration-execution-boundaries.md) | Integration execution safety boundaries | Accepted |
 | [0027](./0027-statechart-beta-boundaries.md) | Statechart beta safety boundaries | Accepted |
 | [0028](./0028-mcp-beta-boundaries.md) | MCP bridge beta boundaries | Accepted |
+| [0029](./0029-shared-ecosystem-web-shell.md) | Shared ecosystem web shell | Proposed |
 
 The 6 core contracts are formalized. Future ADRs will cover specific decisions (semver policy, licensing strategy, etc.) rather than additional foundational contracts.

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -179,15 +179,15 @@
       "shortName": "Playbook",
       "kind": "methodology",
       "role": "discipline",
-      "promise": "Make agents ship code a human would actually merge.",
+      "promise": "Train coding agents to ship code your team would merge.",
       "maturity": "stable",
       "repo": "AgentsKit-io/agents-playbook",
       "accent": "#8B5CF6",
       "showcase": {
         "stage": "Standardize",
-        "headline": "Engineering standards agents can execute.",
-        "detail": "Turn repeatable practices into guidance that coding agents can follow in every repository.",
-        "proof": "Convention → executable guidance",
+        "headline": "The open engineering harness for coding agents.",
+        "detail": "Open rules, prompts, memory, evals, and executable gates turn every correction into behavior coding agents can repeat.",
+        "proof": "Train the behavior · not the model",
         "sales": {
           "kind": "standards-flow",
           "headline": "Your standards. Every agent. Every repository.",
@@ -202,7 +202,7 @@
           "capabilities": ["Repository rules", "Review criteria", "Agent guidance", "Team conventions"],
           "steps": ["Define the standard once", "Agents receive executable guidance", "Review consistent output"]
         },
-        "cta": "Explore the Playbook",
+        "cta": "Explore the harness",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -255,7 +255,7 @@
           "capabilities": ["ADRs", "Handoffs", "Agent findings", "Human-readable docs"],
           "steps": ["Humans document decisions", "Agents receive precise context", "Agent findings return to humans"]
         },
-        "cta": "Explore Doc Bridge",
+        "cta": "Generate your first handoff",
         "ctaSurface": "home"
       },
       "surfaces": {
@@ -400,7 +400,7 @@
       "domain": "playbook.agentskit.io",
       "url": "https://playbook.agentskit.io",
       "repo": "AgentsKit-io/agents-playbook",
-      "tagline": "Make agents ship code a human would actually merge.",
+      "tagline": "Train coding agents to ship code your team would merge.",
       "kind": "methodology",
       "accent": "#8B5CF6",
       "llms": "https://playbook.agentskit.io/llms.txt",

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -208,7 +208,7 @@
           "ecosystem.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:b5c2adfc851ec10a087e634d17645a2af24643c384920c638227bf2e44b289cf"
+        "sourceHash": "sha256:8b631de848318e2ed56930b599ebc7977c9316cc8540cf132b924756407fd4e9"
       },
       "exceptions": []
     },

--- a/scripts/reference-docs-vertical.test.mjs
+++ b/scripts/reference-docs-vertical.test.mjs
@@ -67,6 +67,20 @@ test('the shared ecosystem bar resolves public numbers from canonical sources', 
   assert.doesNotMatch(bar, /fetch\(product\.claimSource\.url/)
 })
 
+test('the shared ecosystem footer derives the six public products from PROPS', () => {
+  const bar = read('apps/docs-next/public/ecosystem-bar.js')
+  const props = bar.match(/ecobar:props-start[^\n]*\n([\s\S]*?)\n\s*\/\/ ecobar:props-end/)?.[1] ?? ''
+
+  assert.match(bar, /customElements\.define\('agentskit-ecosystem-footer'/)
+  assert.match(bar, /footer\.setAttribute\('aria-label', 'AgentsKit ecosystem footer'\)/)
+  assert.match(bar, /ecosystemNav\.setAttribute\('aria-label', 'AgentsKit products'\)/)
+  assert.match(bar, /PROPS\.forEach\(function \(product\)/)
+  assert.match(bar, /slot\.name = name/)
+  assert.match(bar, /slot\.assignedElements\(\)\.length === 0/)
+  assert.equal((props.match(/\{ id:/g) || []).length, 6)
+  assert.doesNotMatch(props, /code-review|Code Review/)
+})
+
 test('Lighthouse keeps the Vercel bypass out of audited URLs', () => {
   const workflow = read('.github/workflows/lighthouse.yml')
   const config = read('apps/docs-next/lighthouserc.cjs')


### PR DESCRIPTION
## Summary
- publish a six-product canonical ecosystem projection and shared semantic footer
- align Playbook and Doc Bridge narrative in the canonical manifest
- strengthen Registry positioning, source ownership CTAs, and dynamic ecosystem links
- surface the primary AgentsKit CTA in the mobile hero and complete the ecosystem footer

## Validation
- full pre-push quality gates, lint, and monorepo build
- production build: docs-next 1,192 static pages; Registry 395 pages
- Registry 44 tests and 375/1440 no-overflow QA
- ecosystem contracts: 19/19
- shared bar/footer contract tests: 3/3
- Doc Bridge gate and generated claims checks
- Vercel feature-branch deployments remain disabled by vercel.json

## Notes
- Code Review remains cataloged as repository-native but is excluded from the six-product public projection.
- The full reference-docs suite still exposes the existing Vitest sourcemap parser error; focused shared shell tests pass.