### PR TITLE
fix(docs): keep ecosystem navigation visible on mobile

### DIFF
--- a/apps/docs-next/public/ecosystem-bar.README.md
+++ b/apps/docs-next/public/ecosystem-bar.README.md
@@ -35,6 +35,8 @@ Add to each product surface. Repository-native Code Review links to its GitHub h
 Set `data-current` to one of: `agentskit` · `registry` · `agentskit-chat` ·
 `playbook` · `doc-bridge` · `code-review` · `akos`
 (or omit it — the bar auto-detects by hostname). The current property is highlighted.
+On mobile, the bar remains a single horizontal 44px-target navigation row and
+automatically scrolls the current property into view when it loads.
 
 ## Semantic ecosystem footer
 

--- a/apps/docs-next/public/ecosystem-bar.js
+++ b/apps/docs-next/public/ecosystem-bar.js
@@ -457,10 +457,10 @@
     '#ak-eco a.ak-eco-cta svg{width:14px;height:14px;fill:currentColor}' +
     // Discord is kept in the DOM for an easy restore; hidden until community is ready.
     '#ak-eco a.ak-eco-cta[data-ak-eco-discord]{display:none}' +
-    '@media(max-width:767px){#ak-eco{box-sizing:border-box;width:100%;max-width:100vw;overflow-x:auto;' +
+    '@media(max-width:767px){#ak-eco{box-sizing:border-box;width:100%;max-width:100vw;flex-wrap:nowrap;overflow-x:auto;' +
     'overscroll-behavior-x:contain;scrollbar-width:none}#ak-eco::-webkit-scrollbar{display:none}' +
-    '#ak-eco .ak-eco-brand{position:sticky;left:0;z-index:1;min-width:44px;min-height:44px;background:inherit}' +
-    '#ak-eco a.ak-eco-link{min-height:44px}' +
+    '#ak-eco .ak-eco-brand{position:sticky;left:0;z-index:1;flex:0 0 44px;min-width:44px;min-height:44px;background:inherit}' +
+    '#ak-eco a.ak-eco-link{box-sizing:border-box;flex:0 0 auto;min-height:44px;white-space:nowrap}' +
     '#ak-eco .ak-eco-spacer,#ak-eco a.ak-eco-cta{display:none}}' +
     '@media(prefers-color-scheme:light){#ak-eco{background:#fff;color:#0b0b0f;border-bottom-color:#e6e6ea}' +
     '#ak-eco .ak-eco-brand{color:#0b0b0f}#ak-eco a.ak-eco-link{color:#555}' +
@@ -1110,6 +1110,15 @@
     })
 
     document.body.insertBefore(bar, document.body.firstChild)
+
+    var currentLink = bar.querySelector('a.ak-eco-link[aria-current="page"]')
+    if (currentLink && window.matchMedia('(max-width: 767px)').matches) {
+      window.requestAnimationFrame(function () {
+        var maxScroll = Math.max(0, bar.scrollWidth - bar.clientWidth)
+        var centered = currentLink.offsetLeft - (bar.clientWidth - currentLink.offsetWidth) / 2
+        bar.scrollTo({ left: Math.max(0, Math.min(maxScroll, centered)), behavior: 'auto' })
+      })
+    }
   }
 
   if (document.readyState === 'loading') {

--- a/scripts/reference-docs-vertical.test.mjs
+++ b/scripts/reference-docs-vertical.test.mjs
@@ -50,8 +50,11 @@ test('the primary guide starts locally and keeps the provider step as progressiv
 test('the shared ecosystem bar contains its own mobile overflow', () => {
   const bar = read('apps/docs-next/public/ecosystem-bar.js')
   assert.match(bar, /@media\(max-width:767px\)/)
-  assert.match(bar, /max-width:100vw;overflow-x:auto/)
+  assert.match(bar, /max-width:100vw;flex-wrap:nowrap;overflow-x:auto/)
   assert.match(bar, /scrollbar-width:none/)
+  assert.match(bar, /flex:0 0 auto;min-height:44px;white-space:nowrap/)
+  assert.match(bar, /currentLink\.offsetLeft/)
+  assert.match(bar, /bar\.scrollTo/)
   assert.match(bar, /selectedTab\.offsetLeft/)
   assert.match(bar, /this\.tabsRoot\.scrollTo/)
   assert.doesNotMatch(bar, /role="tabpanel" aria-live="polite"/)


### PR DESCRIPTION
## Summary\n- keep the shared ecosystem header in one horizontal mobile row\n- use 44px touch targets\n- automatically reveal the active product\n\n## Validation\n- focused Vitest passed\n- repository pre-push quality gates and build passed\n- Chromium validated at 320, 375, and 1440px