### PR TITLE
fix(docs): reveal active ecosystem link synchronously

### DIFF
--- a/apps/docs-next/public/ecosystem-bar.js
+++ b/apps/docs-next/public/ecosystem-bar.js
@@ -1113,11 +1113,9 @@
 
     var currentLink = bar.querySelector('a.ak-eco-link[aria-current="page"]')
     if (currentLink && window.matchMedia('(max-width: 767px)').matches) {
-      window.requestAnimationFrame(function () {
-        var maxScroll = Math.max(0, bar.scrollWidth - bar.clientWidth)
-        var centered = currentLink.offsetLeft - (bar.clientWidth - currentLink.offsetWidth) / 2
-        bar.scrollTo({ left: Math.max(0, Math.min(maxScroll, centered)), behavior: 'auto' })
-      })
+      var maxScroll = Math.max(0, bar.scrollWidth - bar.clientWidth)
+      var centered = currentLink.offsetLeft - (bar.clientWidth - currentLink.offsetWidth) / 2
+      bar.scrollTo({ left: Math.max(0, Math.min(maxScroll, centered)), behavior: 'auto' })
     }
   }
 

--- a/scripts/reference-docs-vertical.test.mjs
+++ b/scripts/reference-docs-vertical.test.mjs
@@ -55,6 +55,7 @@ test('the shared ecosystem bar contains its own mobile overflow', () => {
   assert.match(bar, /flex:0 0 auto;min-height:44px;white-space:nowrap/)
   assert.match(bar, /currentLink\.offsetLeft/)
   assert.match(bar, /bar\.scrollTo/)
+  assert.doesNotMatch(bar, /requestAnimationFrame\(function \(\) \{\s*var maxScroll/)
   assert.match(bar, /selectedTab\.offsetLeft/)
   assert.match(bar, /this\.tabsRoot\.scrollTo/)
   assert.doesNotMatch(bar, /role="tabpanel" aria-live="polite"/)


### PR DESCRIPTION
## Summary
- reveal the active mobile product without relying on requestAnimationFrame
- support background tabs and delayed rendering consistently
- add a regression assertion against deferred scrolling

## Validation
- focused Vitest passed
- full repository pre-push quality gates and build passed