### PR TITLE
fix(sandbox): map E2B execution results

### DIFF
--- a/.changeset/calm-sandboxes-report.md
+++ b/.changeset/calm-sandboxes-report.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/sandbox': patch
+---
+
+Map E2B code interpreter results to numeric exit codes and expose execution errors through stderr.

--- a/packages/sandbox/src/e2b-backend.ts
+++ b/packages/sandbox/src/e2b-backend.ts
@@ -34,7 +34,13 @@ interface E2BSandboxInstance {
       onStdout?: (data: { line: string }) => void
       onStderr?: (data: { line: string }) => void
     },
-  ): Promise<{ exitCode: number }>
+  ): Promise<{
+    error?: {
+      name: string
+      value: string
+      traceback: string
+    }
+  }>
   kill(): Promise<void>
 }
 
@@ -300,6 +306,22 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
 
         let out = stdout.trimEnd()
         let err = stderr.trimEnd()
+        if (result.error) {
+          const executionError =
+            result.error.traceback || `${result.error.name}: ${result.error.value}`
+          if (!err.includes(executionError)) {
+            if (err) {
+              err = appendCapped(err, '\n', totalBytes, maxOutputBytes, markTruncated)
+            }
+            err = appendCapped(
+              err,
+              executionError,
+              totalBytes,
+              maxOutputBytes,
+              markTruncated,
+            ).trimEnd()
+          }
+        }
         if (truncated) {
           err = (err ? err + '\n' : '') + `[output truncated at ${maxOutputBytes} bytes]`
         }
@@ -307,7 +329,7 @@ export function createE2BBackend(config: E2BConfig): SandboxBackend {
         return {
           stdout: out,
           stderr: err,
-          exitCode: result.exitCode,
+          exitCode: result.error ? 1 : 0,
           durationMs: Date.now() - startTime,
         }
       } catch (err) {

--- a/packages/sandbox/tests/e2b-backend.test.ts
+++ b/packages/sandbox/tests/e2b-backend.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
     }) => {
       opts?.onStdout?.({ line: 'hello' })
       opts?.onStderr?.({ line: 'warn' })
-      return { exitCode: 0 }
+      return {}
     }),
     kill: vi.fn(async () => undefined),
   }
@@ -76,7 +76,7 @@ describe('createE2BBackend', () => {
     await expect(backend.dispose()).resolves.toBeUndefined()
   })
 
-  it('execute streams stdout/stderr and returns exit code', async () => {
+  it('maps a successful E2B execution to exit code 0', async () => {
     const { createE2BBackend: factory } = await import('../src/e2b-backend')
     const backend = factory({ apiKey: 'sk-test' })
     const result = await backend.execute('print(1)', { language: 'python' })
@@ -88,6 +88,21 @@ describe('createE2BBackend', () => {
       'print(1)',
       expect.objectContaining({ language: 'python' }),
     )
+  })
+
+  it('maps an E2B execution error to exit code 1 and stderr', async () => {
+    fakeSandbox.runCode = vi.fn(async () => ({
+      error: {
+        name: 'ZeroDivisionError',
+        value: 'division by zero',
+        traceback: 'Traceback: ZeroDivisionError: division by zero',
+      },
+    }))
+    const { createE2BBackend: factory } = await import('../src/e2b-backend')
+    const backend = factory({ apiKey: 'sk-test' })
+    const result = await backend.execute('1 / 0', { language: 'python' })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toBe('Traceback: ZeroDivisionError: division by zero')
   })
 
   it('default language is javascript', async () => {
@@ -175,7 +190,7 @@ describe('createE2BBackend', () => {
     expect(result.stderr).toMatch(/timed out/)
     expect(fakeSandbox.kill).toHaveBeenCalled()
     // next execute recreates
-    fakeSandbox.runCode = vi.fn(async () => ({ exitCode: 0 }))
+    fakeSandbox.runCode = vi.fn(async () => ({}))
     await backend.execute('next')
     expect(createMock).toHaveBeenCalledTimes(2)
   })
@@ -232,7 +247,7 @@ describe('createE2BBackend', () => {
     }) => {
       opts?.onStdout?.({ line: 'x'.repeat(80) })
       opts?.onStderr?.({ line: 'y'.repeat(80) })
-      return { exitCode: 0 }
+      return {}
     })
     const { createE2BBackend: factory } = await import('../src/e2b-backend')
     const backend = factory({ apiKey: 'sk-test', maxOutputBytes: 50 })


### PR DESCRIPTION
## What changed

- model the optional `error` returned by E2B Code Interpreter executions
- map successful executions to exit code `0`
- map cell errors to exit code `1` and include their traceback in `stderr`
- add regression coverage for successful and failed executions
- include a patch changeset for `@agentskit/sandbox`

## Why

E2B Code Interpreter does not expose an `exitCode` on its execution result. The previous adapter read that missing field, so callers could receive an undefined exit status and lose useful failure details.

## Impact

Consumers of the E2B sandbox backend now receive the documented numeric exit code contract and actionable traceback output for cell failures.

## Validation

- `pnpm --filter @agentskit/sandbox test` — 131 tests passed
- `pnpm --filter @agentskit/sandbox lint`
- `pnpm --filter @agentskit/sandbox build`
- `pnpm --filter @agentskit/sandbox test:coverage` — 90.09% statements, 92.61% lines
- `pnpm docs:bridge:gate`
- repository pre-push quality gates and full build
- live E2B proof: JavaScript success (exit 0), Python success (exit 0), Python `ZeroDivisionError` (exit 1 with traceback), and sandbox disposal
