### PR TITLE
fix(memory): support arbitrary Qdrant document ids

### DIFF
--- a/.changeset/calm-points-travel.md
+++ b/.changeset/calm-points-travel.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/memory": patch
+---
+
+Map arbitrary vector document ids to deterministic Qdrant-compatible UUIDs while preserving the original ids across search and delete operations.

--- a/packages/memory/src/vector/qdrant.ts
+++ b/packages/memory/src/vector/qdrant.ts
@@ -10,6 +10,26 @@ export interface QdrantConfig {
   fetch?: typeof globalThis.fetch
 }
 
+const qdrantSourceId = '__agentskitSourceId'
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+async function qdrantPointId(id: string): Promise<string | number> {
+  if (uuidPattern.test(id)) return id
+
+  if (/^\d+$/.test(id)) {
+    const numericId = Number(id)
+    if (Number.isSafeInteger(numericId)) return numericId
+  }
+
+  const digest = new Uint8Array(
+    await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(id)),
+  ).slice(0, 16)
+  digest[6] = (digest[6]! & 0x0f) | 0x50
+  digest[8] = (digest[8]! & 0x3f) | 0x80
+  const hex = Array.from(digest, byte => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
 async function call<T>(
   config: QdrantConfig,
   method: 'GET' | 'POST' | 'PUT' | 'DELETE',
@@ -42,12 +62,13 @@ export function qdrant(config: QdrantConfig): VectorMemory {
   return {
     async store(docs: VectorDocument[]) {
       if (docs.length === 0) return
+      const points = await Promise.all(docs.map(async d => ({
+        id: await qdrantPointId(d.id),
+        vector: d.embedding,
+        payload: { content: d.content, ...(d.metadata ?? {}), [qdrantSourceId]: d.id },
+      })))
       await call(config, 'PUT', `/collections/${config.collection}/points`, {
-        points: docs.map(d => ({
-          id: d.id,
-          vector: d.embedding,
-          payload: { content: d.content, ...(d.metadata ?? {}) },
-        })),
+        points,
       })
     },
 
@@ -67,18 +88,24 @@ export function qdrant(config: QdrantConfig): VectorMemory {
       })
       return (result.result ?? [])
         .filter(m => m.score >= threshold)
-        .map(m => ({
-          id: String(m.id),
-          content: String((m.payload ?? {}).content ?? ''),
-          metadata: m.payload,
-          score: m.score,
-        }))
+        .map(m => {
+          const payload = { ...(m.payload ?? {}) }
+          const sourceId = payload[qdrantSourceId]
+          delete payload[qdrantSourceId]
+          return {
+            id: typeof sourceId === 'string' ? sourceId : String(m.id),
+            content: String(payload.content ?? ''),
+            metadata: payload,
+            score: m.score,
+          }
+        })
     },
 
     async delete(ids: string[]) {
       if (ids.length === 0) return
+      const points = await Promise.all(ids.map(qdrantPointId))
       await call(config, 'POST', `/collections/${config.collection}/points/delete`, {
-        points: ids,
+        points,
       })
     },
   }

--- a/packages/memory/tests/vector-extra.test.ts
+++ b/packages/memory/tests/vector-extra.test.ts
@@ -149,12 +149,30 @@ describe('qdrant — extra', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('delete posts point ids', async () => {
+  it('delete maps source ids to the same deterministic point ids used by store', async () => {
     const { fetch, calls } = mockFetch({})
     const store = qdrant({ url: 'https://qdrant', collection: 'c', fetch })
-    await store.delete!(['p1', 'p2'])
-    const body = JSON.parse(calls[0]!.init!.body as string) as { points: string[] }
-    expect(body.points).toEqual(['p1', 'p2'])
+    await store.store([{ id: 'p1', content: 'one', embedding: [1] }])
+    await store.delete!(['p1'])
+    const stored = JSON.parse(calls[0]!.init!.body as string) as {
+      points: Array<{ id: string }>
+    }
+    const deleted = JSON.parse(calls[1]!.init!.body as string) as { points: string[] }
+    expect(deleted.points).toEqual([stored.points[0]!.id])
+  })
+
+  it('preserves valid UUIDs and converts safe numeric ids', async () => {
+    const { fetch, calls } = mockFetch({})
+    const store = qdrant({ url: 'https://qdrant', collection: 'c', fetch })
+    const uuid = '00000000-0000-4000-8000-000000000001'
+    await store.store([
+      { id: uuid, content: 'uuid', embedding: [1] },
+      { id: '42', content: 'number', embedding: [1] },
+    ])
+    const body = JSON.parse(calls[0]!.init!.body as string) as {
+      points: Array<{ id: string | number }>
+    }
+    expect(body.points.map(point => point.id)).toEqual([uuid, 42])
   })
 
   it('store is no-op when docs array is empty', async () => {

--- a/packages/memory/tests/vector.test.ts
+++ b/packages/memory/tests/vector.test.ts
@@ -80,21 +80,38 @@ describe('pinecone', () => {
 })
 
 describe('qdrant', () => {
-  it('store uses PUT collections/*/points', async () => {
+  it('store uses a deterministic Qdrant UUID while preserving the source id', async () => {
     const { fetch, calls } = mockFetch({})
     const store = qdrant({ url: 'https://q', collection: 'c', fetch })
     await store.store([{ id: 'a', content: 'x', embedding: [1] }])
     expect(calls[0]!.init!.method).toBe('PUT')
     expect(calls[0]!.url).toContain('/collections/c/points')
+    const body = JSON.parse(calls[0]!.init!.body as string) as {
+      points: Array<{ id: string; payload: Record<string, unknown> }>
+    }
+    expect(body.points[0]!.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+    expect(body.points[0]!.payload).toMatchObject({ content: 'x', __agentskitSourceId: 'a' })
   })
 
-  it('search maps scored points', async () => {
+  it('search restores the source id without leaking adapter metadata', async () => {
     const { fetch } = mockFetch({
-      result: [{ id: 42, score: 0.77, payload: { content: 'hello' } }],
+      result: [{
+        id: 'ca978112-ca1b-5dca-bac2-31b39a23dc4d',
+        score: 0.77,
+        payload: { content: 'hello', topic: 'support', __agentskitSourceId: 'a' },
+      }],
     })
     const store = qdrant({ url: 'https://q', collection: 'c', fetch, apiKey: 'k' })
     const out = await store.search([1])
-    expect(out[0]).toMatchObject({ id: '42', content: 'hello', score: 0.77 })
+    expect(out[0]).toMatchObject({
+      id: 'a',
+      content: 'hello',
+      metadata: { content: 'hello', topic: 'support' },
+      score: 0.77,
+    })
+    expect(out[0]!.metadata).not.toHaveProperty('__agentskitSourceId')
   })
 })
 


### PR DESCRIPTION
## Summary

- map arbitrary vector document IDs to deterministic Qdrant-compatible UUIDs
- preserve safe numeric IDs and valid UUIDs
- restore original source IDs on search and use the same mapping on delete
- keep adapter metadata internal
- add the required patch changeset

## Root cause

Qdrant accepts point IDs only as unsigned integers or UUIDs. AgentsKit RAG creates
chunk IDs such as `doc-1_chunk_0`, which the Qdrant adapter previously forwarded
unchanged and Qdrant rejected with HTTP 400.

## Validation

- `pnpm --filter @agentskit/core build`
- `pnpm --filter @agentskit/memory test` — 209 passed
- `pnpm --filter @agentskit/memory lint`
- `pnpm --filter @agentskit/memory build`
- live Qdrant 1.15.4 proof stored, restored, and deleted `doc-1_chunk_0`
- `git diff --check`

This draft does not authorize merge, release, tag, npm publication, or the external
Qdrant example pull request.
