### PR TITLE
fix(runtime): preserve structured tool results

### DIFF
--- a/.changeset/bright-tools-speak.md
+++ b/.changeset/bright-tools-speak.md
@@ -1,0 +1,7 @@
+---
+"@agentskit/core": patch
+"@agentskit/runtime": patch
+---
+
+Serialize structured tool results as JSON and preserve their call IDs when
+returning them to model adapters.

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -63,6 +63,17 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   return value != null && typeof value === 'object' && Symbol.asyncIterator in value
 }
 
+function serializeToolResult(result: unknown): string {
+  if (result == null) return ''
+  if (typeof result === 'string' || result instanceof Error) return String(result)
+
+  try {
+    return JSON.stringify(result) ?? String(result)
+  } catch {
+    return String(result)
+  }
+}
+
 export async function executeToolCall(
   tool: ToolDefinition,
   args: Record<string, unknown>,
@@ -81,7 +92,7 @@ export async function executeToolCall(
   }
 
   const result = await raw
-  return result == null ? '' : String(result)
+  return serializeToolResult(result)
 }
 
 export function safeParseArgs(args: string): Record<string, unknown> {

--- a/packages/core/tests/primitives.test.ts
+++ b/packages/core/tests/primitives.test.ts
@@ -124,6 +124,25 @@ describe('executeToolCall', () => {
     expect(result).toBe('result: hello')
   })
 
+  it('serializes structured tool results as JSON for the next model turn', async () => {
+    const result = await executeToolCall(
+      {
+        name: 'search',
+        execute: () => ({
+          results: [{ title: 'AgentsKit', score: 0.98 }],
+          cached: false,
+        }),
+      },
+      {},
+      {
+        messages: [],
+        call: { id: 'call-1', name: 'search', args: {}, status: 'running' },
+      },
+    )
+
+    expect(result).toBe('{"results":[{"title":"AgentsKit","score":0.98}],"cached":false}')
+  })
+
   it('executes an async tool', async () => {
     const tool: ToolDefinition = {
       name: 'test',

--- a/packages/runtime/src/runner.ts
+++ b/packages/runtime/src/runner.ts
@@ -315,14 +315,26 @@ export function createRuntime(config: RuntimeConfig) {
           toolCall.status = execResult.status === 'complete' ? 'complete' : 'error'
           if (execResult.status === 'complete') {
             toolCall.result = execResult.result
-            messages.push(buildMessage({ role: 'tool', content: execResult.result ?? '' }))
+            messages.push(buildMessage({
+              role: 'tool',
+              content: execResult.result ?? '',
+              toolCallId: toolCall.id,
+            }))
           } else if (execResult.status === 'skipped') {
             toolCall.status = 'error'
             toolCall.error = execResult.result
-            messages.push(buildMessage({ role: 'tool', content: execResult.result ?? 'Tool execution skipped' }))
+            messages.push(buildMessage({
+              role: 'tool',
+              content: execResult.result ?? 'Tool execution skipped',
+              toolCallId: toolCall.id,
+            }))
           } else {
             toolCall.error = execResult.error
-            messages.push(buildMessage({ role: 'tool', content: `Error: ${execResult.error}` }))
+            messages.push(buildMessage({
+              role: 'tool',
+              content: `Error: ${execResult.error}`,
+              toolCallId: toolCall.id,
+            }))
           }
         }
 

--- a/packages/runtime/tests/runner.test.ts
+++ b/packages/runtime/tests/runner.test.ts
@@ -107,6 +107,38 @@ describe('createRuntime', () => {
       expect(result.messages.filter(m => m.role === 'tool')[0].content).toBe('Sunny in SP')
     })
 
+    it('feeds structured tool results back to the adapter as JSON', async () => {
+      const adapter = createSequentialAdapter([
+        [
+          { type: 'tool_call', toolCall: { id: 'tc1', name: 'scrape', args: '{"url":"https://example.com"}' } },
+          { type: 'done' },
+        ],
+        [
+          { type: 'text', content: 'The page is titled Example.' },
+          { type: 'done' },
+        ],
+      ])
+
+      const runtime = createRuntime({
+        adapter,
+        tools: [{
+          name: 'scrape',
+          execute: async () => ({
+            markdown: '# Example',
+            metadata: { title: 'Example' },
+          }),
+        }],
+      })
+
+      const result = await runtime.run('Read the page')
+      const toolMessage = result.messages.find(message => message.role === 'tool')
+
+      expect(toolMessage?.content).toBe('{"markdown":"# Example","metadata":{"title":"Example"}}')
+      expect(toolMessage?.toolCallId).toBe('tc1')
+      expect(result.toolCalls[0]?.result).toBe('{"markdown":"# Example","metadata":{"title":"Example"}}')
+      expect(result.content).toBe('The page is titled Example.')
+    })
+
     it('handles text alongside tool calls', async () => {
       const adapter = createSequentialAdapter([
         [
@@ -247,6 +279,7 @@ describe('createRuntime', () => {
       // Tool error injected as message
       const toolMsg = result.messages.find(m => m.role === 'tool')
       expect(toolMsg?.content).toContain('API timeout')
+      expect(toolMsg?.toolCallId).toBe('tc1')
     })
 
     it('injects error for missing tool', async () => {
@@ -267,6 +300,7 @@ describe('createRuntime', () => {
       expect(result.toolCalls[0].status).toBe('error')
       const toolMsg = result.messages.find(m => m.role === 'tool')
       expect(toolMsg?.content).toContain('not found')
+      expect(toolMsg?.toolCallId).toBe('tc1')
     })
   })
 


### PR DESCRIPTION
## Summary

- serialize non-string tool results as JSON before feeding them into the next model turn
- preserve `toolCallId` on success, refusal, and error messages so provider adapters can correlate function responses
- cover structured results and tool-message correlation in core and runtime tests

## Why

A live Gemini + Firecrawl validation showed that the model correctly called `firecrawl_scrape`, but the runtime converted the returned object to `[object Object]` and omitted the tool response from Gemini history because the generated tool message had no call ID. The second model turn therefore returned an empty answer. With this patch, the same tool loop receives the complete JSON result and produces a grounded summary.

## Validation

- `pnpm --filter @agentskit/core test` — 386 passed
- `pnpm --filter @agentskit/runtime test` — 179 passed
- `pnpm --filter @agentskit/adapters test` — 509 passed
- core and runtime TypeScript checks passed
- all size-limit budgets passed; core is 5.26 kB ESM gzipped and runtime is 14.86 kB ESM gzipped
- live Gemini 2.5 Flash loop called the mocked Firecrawl endpoint exactly once and summarized all three structured fixture themes
- `git diff --check` passed

RT1–RT14 remain unchanged: this patch only preserves the already-defined tool result and correlation metadata while the existing bounded loop, confirmation, memory, retrieval, observer, delegation, abort, and error paths remain intact.
