### PR TITLE
fix(integrations): use Firecrawl v2 endpoints

### DIFF
--- a/.changeset/calm-firecrawl-paths.md
+++ b/.changeset/calm-firecrawl-paths.md
@@ -1,0 +1,5 @@
+---
+"@agentskit/integrations": patch
+---
+
+Route Firecrawl scrape and crawl actions through the current v2 API endpoints.

--- a/packages/integrations/src/services/firecrawl/actions.ts
+++ b/packages/integrations/src/services/firecrawl/actions.ts
@@ -15,7 +15,7 @@ export const firecrawlScrape = defineAction({
   async execute(args, { http }) {
     const result = await http<{ data?: { markdown?: string; html?: string; metadata?: Record<string, unknown> } }>({
       method: 'POST',
-      path: '/scrape',
+      path: 'scrape',
       body: { url: args.url, formats: ['markdown'], onlyMainContent: args.only_main ?? true },
     })
     return { markdown: result.data?.markdown ?? '', metadata: result.data?.metadata ?? {} }
@@ -34,7 +34,7 @@ export const firecrawlCrawl = defineAction({
   async execute(args, { http }) {
     const result = await http<{ id?: string; jobId?: string; url?: string }>({
       method: 'POST',
-      path: '/crawl',
+      path: 'crawl',
       body: { url: args.url, limit: (args.limit as number) ?? 50 },
     })
     return { jobId: result.id ?? result.jobId, statusUrl: result.url }

--- a/packages/integrations/src/services/firecrawl/index.ts
+++ b/packages/integrations/src/services/firecrawl/index.ts
@@ -6,7 +6,7 @@ export const firecrawlIntegration = defineIntegration({
   name: 'firecrawl',
   displayName: 'Firecrawl',
   categories: ['web'],
-  http: { baseUrl: 'https://api.firecrawl.dev/v1' },
+  http: { baseUrl: 'https://api.firecrawl.dev/v2/' },
   auth: { kind: 'apiKey', header: 'authorization', prefix: 'Bearer ', envHint: 'FIRECRAWL_API_KEY' },
   actions: firecrawlActions,
 })

--- a/packages/integrations/tests/ai-web.test.ts
+++ b/packages/integrations/tests/ai-web.test.ts
@@ -30,10 +30,18 @@ describe('openai-images', () => {
 describe('firecrawl', () => {
   it('valid + scrape/crawl', async () => {
     expect(() => assertValidIntegration(firecrawlIntegration)).not.toThrow()
-    const fetch = fakeFetch((u) => u.includes('/scrape') ? json({ data: { markdown: '# t', metadata: { title: 'T' } } }) : json({ id: 'job1', url: 'su' }))
+    const urls: string[] = []
+    const fetch = fakeFetch((u) => {
+      urls.push(u)
+      return u.endsWith('/scrape') ? json({ data: { markdown: '# t', metadata: { title: 'T' } } }) : json({ id: 'job1', url: 'su' })
+    })
     const tools = toToolDefinitions(firecrawlIntegration, { credential: 'fc', fetch })
     expect(await run(tools.find((t) => t.name === 'firecrawl_scrape')!, { url: 'http://x' })).toEqual({ markdown: '# t', metadata: { title: 'T' } })
     expect(await run(tools.find((t) => t.name === 'firecrawl_crawl')!, { url: 'http://x' })).toEqual({ jobId: 'job1', statusUrl: 'su' })
+    expect(urls).toEqual([
+      'https://api.firecrawl.dev/v2/scrape',
+      'https://api.firecrawl.dev/v2/crawl',
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

- move the Firecrawl descriptor from the legacy v1 base to the documented v2 API
- make scrape and crawl paths relative so URL resolution preserves the `/v2/` prefix
- assert the exact `https://api.firecrawl.dev/v2/scrape` and `/v2/crawl` request URLs

## Why

The current Firecrawl actions use root-relative paths (`/scrape` and `/crawl`). URL resolution therefore discards the version segment from the configured base URL and sends requests to unversioned endpoints. Firecrawl's current API reference documents `POST /v2/scrape` and `POST /v2/crawl`. This blocked validation of a real AgentsKit example for the Firecrawl repository even after structured tool results were fixed and released.

## Validation

- `pnpm --filter @agentskit/integrations test` — 22 files and 126 tests passed
- `pnpm --filter @agentskit/integrations lint` — passed
- `pnpm --filter @agentskit/integrations build` — passed
- `pnpm docs:bridge:gate` — passed
- exact mocked request proof: `/v2/scrape` and `/v2/crawl`
- `git diff --check` — passed

The patch includes a changeset for `@agentskit/integrations`; Changesets calculates coordinated patch releases for integrations, tools, MCP, and CLI.
