### PR TITLE
docs: expose the ecosystem-wide contributor queue

### DIFF
--- a/apps/docs-next/content/docs/reference/contribute/good-first-issues.mdx
+++ b/apps/docs-next/content/docs/reference/contribute/good-first-issues.mdx
@@ -7,6 +7,20 @@ import { GoodFirstIssuesList } from '@/components/contribute/issues-list'
 
 Curated, tractable issues. Each ships end-to-end in a few hours. Comment on the issue to claim it — we'll reply within a day.
 
+## Ecosystem-wide live queue
+
+AgentsKit is a multi-repository ecosystem. The live list below covers the main toolkit; active newcomer tasks also live in Chat, Doc Bridge, Registry, Playbook, and the project CLIs.
+
+[Browse every open `good first issue` across AgentsKit →](https://github.com/search?q=org%3AAgentsKit-io+is%3Aissue+is%3Aopen+archived%3Afalse+label%3A%22good+first+issue%22&type=issues)
+
+### Current entry paths
+
+| Project | Starter task | Scope |
+|---|---|---|
+| AgentsKit Chat | [Add a Playwright support-flow smoke test for the Solid example](https://github.com/AgentsKit-io/agentskit-chat/issues/149) | Two-file browser test; no package or production changes |
+| Doc Bridge | [Update GitHub Action examples to v1.2.6](https://github.com/AgentsKit-io/doc-bridge/issues/71) | Documentation-only version correction |
+| Code Review CLI | [Add multi-language source-normalization fixtures](https://github.com/AgentsKit-io/code-review-cli/issues/21) | Credential-free fixtures and tests |
+
 <GoodFirstIssuesList />
 
 ## Curated starters with setup + test (launch package)
@@ -95,6 +109,6 @@ If the live list above is short, any of these are fair game — open an issue us
 
 ## Don't see anything?
 
-- Browse [all help-wanted issues](https://github.com/AgentsKit-io/agentskit/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- Browse [all open `good first issue` and `help wanted` tasks across the AgentsKit organization](https://github.com/search?q=org%3AAgentsKit-io+is%3Aissue+is%3Aopen+archived%3Afalse+%28label%3A%22good+first+issue%22+OR+label%3A%22help+wanted%22%29&type=issues)
 - Look at the [roadmap](/docs/reference/contribute/roadmap)
 - Propose something in [discussions](https://github.com/AgentsKit-io/agentskit/discussions)


### PR DESCRIPTION
## What changed

- adds an organization-wide good-first-issue queue to the existing contribution page
- highlights the three current bounded entry tasks in Chat, Doc Bridge, and Code Review CLI
- replaces the repository-local fallback with the organization-wide search

## Why

The current live component queries only `AgentsKit-io/agentskit`, so contributor traffic cannot see the entry tasks created across the ecosystem.

## Validation

- `pnpm --filter @agentskit/core build`
- `pnpm --filter @agentskit/react build`
- `pnpm --filter @agentskit/docs-next build`
- `pnpm docs:bridge:gate`

Only `apps/docs-next/content/docs/reference/contribute/good-first-issues.mdx` changed.