### PR TITLE
feat(registry): publish catalog structured data

### DIFF
--- a/apps/registry/app/layout.tsx
+++ b/apps/registry/app/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import type { Metadata } from 'next'
 import { PostHogProvider } from './posthog-provider'
 import { RegistryAskWidget } from '@/components/ask-widget'
+import { serializedRegistryStructuredData } from '@/lib/structured-data'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
 const jetbrainsMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
@@ -32,6 +33,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <link rel="alternate" type="text/plain" href="/llms.txt" title="Agent and docs index for LLMs" />
         <link rel="alternate" type="text/plain" href="/llms-full.txt" title="Full agent context for LLMs" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializedRegistryStructuredData }}
+        />
       </head>
       <body className="flex min-h-screen flex-col overflow-x-clip font-sans">
         <PostHogProvider>

--- a/apps/registry/lib/structured-data.test.ts
+++ b/apps/registry/lib/structured-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { registryStructuredData, serializedRegistryStructuredData } from './structured-data'
+
+describe('registry structured data', () => {
+  it('publishes canonical website, collection, source, and organization identities', () => {
+    expect(JSON.parse(serializedRegistryStructuredData)).toEqual(registryStructuredData)
+    expect(registryStructuredData['@graph']).toContainEqual(expect.objectContaining({
+      '@type': 'WebSite',
+      '@id': 'https://registry.agentskit.io/#website',
+      url: 'https://registry.agentskit.io',
+    }))
+    expect(registryStructuredData['@graph']).toContainEqual(expect.objectContaining({
+      '@type': 'CollectionPage',
+      '@id': 'https://registry.agentskit.io/#collection',
+      isPartOf: { '@id': 'https://registry.agentskit.io/#website' },
+    }))
+    expect(registryStructuredData['@graph']).toContainEqual(expect.objectContaining({
+      '@type': 'SoftwareSourceCode',
+      codeRepository: 'https://github.com/AgentsKit-io/agentskit-registry',
+      license: 'https://github.com/AgentsKit-io/agentskit-registry/blob/main/LICENSE',
+      programmingLanguage: 'TypeScript',
+    }))
+  })
+})

--- a/apps/registry/lib/structured-data.ts
+++ b/apps/registry/lib/structured-data.ts
@@ -1,0 +1,41 @@
+export const registryStructuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': 'https://www.agentskit.io/#organization',
+      name: 'AgentsKit',
+      url: 'https://www.agentskit.io',
+      sameAs: ['https://github.com/AgentsKit-io'],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': 'https://registry.agentskit.io/#website',
+      name: 'AgentsKit Registry',
+      description: 'A public catalog of validated, source-owned AI agents for AgentsKit.',
+      url: 'https://registry.agentskit.io',
+      publisher: { '@id': 'https://www.agentskit.io/#organization' },
+      inLanguage: 'en',
+    },
+    {
+      '@type': 'CollectionPage',
+      '@id': 'https://registry.agentskit.io/#collection',
+      name: 'AgentsKit Registry agent catalog',
+      description: 'Browse validated TypeScript agents, copy their source, and adapt them inside your project.',
+      url: 'https://registry.agentskit.io',
+      isPartOf: { '@id': 'https://registry.agentskit.io/#website' },
+      about: { '@id': 'https://registry.agentskit.io/#source' },
+    },
+    {
+      '@type': 'SoftwareSourceCode',
+      '@id': 'https://registry.agentskit.io/#source',
+      name: 'AgentsKit Registry',
+      codeRepository: 'https://github.com/AgentsKit-io/agentskit-registry',
+      license: 'https://github.com/AgentsKit-io/agentskit-registry/blob/main/LICENSE',
+      programmingLanguage: 'TypeScript',
+      author: { '@id': 'https://www.agentskit.io/#organization' },
+    },
+  ],
+} as const
+
+export const serializedRegistryStructuredData = JSON.stringify(registryStructuredData).replaceAll('<', '\\u003c')


### PR DESCRIPTION
## Summary

- publish Organization, WebSite, CollectionPage, and SoftwareSourceCode JSON-LD for the Registry
- connect the public catalog to its canonical open-source repository and license
- verify the serialized graph with unit coverage and rendered production HTML

## Validation

- `pnpm --filter @agentskit/registry-app test`
- `pnpm --filter @agentskit/registry-app lint`
- `pnpm --filter @agentskit/registry-app build`
- `pnpm docs:bridge:gate`
- `git diff --check`

No package release or changeset is required because this only changes metadata in the private Registry app.