### PR TITLE
docs(adapters): correct Vercel AI route contract

### DIFF
--- a/.changeset/correct-vercel-ai-route-docs.md
+++ b/.changeset/correct-vercel-ai-route-docs.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/adapters': patch
+---
+
+Correct the Vercel AI adapter documentation to use its route-based `api` configuration and document the supported UI message stream contract.

--- a/apps/docs-next/content/docs/data/providers/vercel-ai.mdx
+++ b/apps/docs-next/content/docs/data/providers/vercel-ai.mdx
@@ -1,28 +1,71 @@
 ---
 title: vercelAI
-description: Wrap a Vercel AI SDK `LanguageModel` as an AgentsKit adapter.
+description: Connect AgentsKit to an existing Vercel AI SDK route without replacing its provider setup.
 ---
+
+`vercelAI` is an HTTP route adapter. Point it at a route handler that already uses the Vercel AI SDK; AgentsKit sends the conversation to that route and consumes its streamed response.
 
 ```ts
 import { vercelAI } from '@agentskit/adapters'
-import { openai as vercelOpenAI } from '@ai-sdk/openai'
 
 const adapter = vercelAI({
-  model: vercelOpenAI('gpt-4o'),
+  api: '/api/chat',
 })
 ```
 
+This adapter does not wrap a `LanguageModel` object. Your Vercel AI SDK model and provider configuration stay inside the route handler.
+
+## Route handler
+
+The adapter posts `messages`, `systemPrompt`, and any declared AgentsKit `tools`. For a conversation without tool results, a minimal Next.js route can keep the existing model boundary and return the AI SDK UI Message Stream:
+
+```ts title="app/api/chat/route.ts"
+import { streamText } from 'ai'
+
+type TextMessage =
+  | { role: 'user'; content: string }
+  | { role: 'assistant'; content: string }
+  | { role: 'system'; content: string }
+
+type AgentsKitRouteBody = {
+  messages: TextMessage[]
+  systemPrompt?: string
+}
+
+export async function POST(request: Request) {
+  const { messages, systemPrompt }: AgentsKitRouteBody = await request.json()
+  const result = streamText({
+    model: 'anthropic/claude-sonnet-4.5',
+    system: systemPrompt,
+    messages,
+  })
+
+  return result.toUIMessageStreamResponse()
+}
+```
+
+`toUIMessageStreamResponse()` sets `x-vercel-ai-ui-message-stream: v1`; the adapter consumes its SSE text and reasoning deltas until `[DONE]`. A route that returns plain text is also supported, but it does not carry UI-stream metadata.
+
+Keep tool execution inside the route if you need it: configure AI SDK tools there, run them under your server policy, and return their final streamed text. The current adapter does not preserve AgentsKit `toolCallId` values or assistant tool-call parts across this HTTP boundary, so it cannot round-trip an AgentsKit tool history into AI SDK structured parts. `vercelAI` therefore declares no tool capability by default. Use a direct provider adapter when the AgentsKit runtime must own the tool loop.
+
 ## Options
 
-| Option | Type |
-|---|---|
-| `model` | `LanguageModel` (from `ai` SDK) |
+| Option | Type | Required | Purpose |
+|---|---|---:|---|
+| `api` | `string` | Yes | URL of the existing route handler. |
+| `headers` | `Record<string, string>` | No | Additional request headers, such as route authentication. |
+| `retry` | `RetryOptions` | No | Retry policy for route requests. |
 
-## Why vercelAI
+Use same-origin routes when possible. For a remote route, authenticate it through `headers`, enforce authorization server-side, and avoid exposing reusable secrets in browser bundles.
 
-- Migrate from Vercel AI SDK incrementally.
-- Keep your existing `@ai-sdk/*` provider choices.
+## Why use this adapter
+
+- Keep the Vercel AI SDK route and provider choices you already operate.
+- Add an AgentsKit runtime or another AgentsKit surface without rewriting the model boundary.
+- Change the provider behind the route without changing AgentsKit consumers.
+- Migrate incrementally instead of coupling application code to a second provider SDK.
 
 ## Related
 
-- [Providers overview](./) · [Migrating → Vercel AI SDK](/docs/get-started/migrating/from-vercel-ai-sdk)
+- [Providers overview](./) · [Migrating from Vercel AI SDK](/docs/get-started/migrating/from-vercel-ai-sdk)
+- [AI SDK UI stream protocol](https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol)

--- a/apps/docs-next/tests/vercel-ai-provider-docs.test.mjs
+++ b/apps/docs-next/tests/vercel-ai-provider-docs.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import { REPO_ROOT } from '../../../scripts/compute-stats.mjs'
+
+const read = path => readFileSync(join(REPO_ROOT, path), 'utf8')
+
+test('the Vercel AI provider guide matches the route adapter contract', () => {
+  const guide = read('apps/docs-next/content/docs/data/providers/vercel-ai.mdx')
+  const source = read('packages/adapters/src/vercel-ai.ts')
+  const routeExample = guide.match(/```ts title="app\/api\/chat\/route\.ts"\n([\s\S]*?)\n```/)?.[1]
+
+  assert.match(source, /export interface VercelAIConfig\s*{\s*api: string/)
+  assert.match(guide, /vercelAI\(\{\s*api: '\/api\/chat'/)
+  assert.ok(routeExample)
+  assert.match(routeExample, /const\s+\{\s*messages,\s*systemPrompt\s*\}/)
+  assert.match(routeExample, /streamText\(\{[\s\S]*?system:\s*systemPrompt,[\s\S]*?messages,/)
+  assert.match(routeExample, /return result\.toUIMessageStreamResponse\(\)/)
+  assert.match(guide, /x-vercel-ai-ui-message-stream: v1/)
+  assert.match(routeExample, /\| \{ role: 'user'; content: string \}/)
+  assert.match(routeExample, /\| \{ role: 'assistant'; content: string \}/)
+  assert.match(routeExample, /\| \{ role: 'system'; content: string \}/)
+  assert.match(guide, /does not preserve AgentsKit `toolCallId` values/)
+  assert.match(guide, /Use a direct provider adapter when the AgentsKit runtime must own the tool loop/)
+  assert.match(guide, /\| `headers` \| `Record<string, string>`/)
+  assert.match(guide, /\| `retry` \| `RetryOptions`/)
+  assert.doesNotMatch(guide, /vercelAI\(\{\s*model:/)
+  assert.doesNotMatch(routeExample, /ModelMessage/)
+  assert.doesNotMatch(guide, /Wrap a Vercel AI SDK `LanguageModel`/)
+})


### PR DESCRIPTION
## Summary

- correct the canonical `vercelAI` guide to use the shipped route-based `{ api, headers?, retry? }` configuration
- add a minimal Next.js `streamText()` route that returns UI Message Stream v1
- document the text-only boundary, plain-text fallback, authentication guidance, and the current tool-history limitation
- add an offline documentation contract test and an adapters patch changeset

## Root cause

The provider page described an unsupported `{ model: LanguageModel }` constructor even though the adapter has always called an existing HTTP route through `{ api }`. This made the canonical example fail type checking and obscured the real incremental-migration boundary.

## Impact

Users can keep their existing Vercel AI provider and route configuration while adding AgentsKit consumers. The guide now avoids claiming that AgentsKit tool-call history can be reconstructed after the adapter has reduced messages to role and string content.

## Validation

- focused provider documentation contract: 1/1
- `@agentskit/adapters` tests: 509/509
- `@agentskit/adapters` TypeScript lint
- docs MDX lint: 418 files
- Doc Bridge gate
- `git diff --check`
- five-perspective review with no remaining finding at confidence 80 or higher
- repository pre-push quality gates and full production build passed