### PR TITLE
Fix canonical metadata for public routes

### DIFF
--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -12,10 +12,16 @@ import { BrandIcon } from '@/components/home/brand-icon'
 import { ReferenceJourney } from '@/components/home/reference-journey'
 import { counts, approx } from '@/lib/ecosystem-stats'
 import { agentsKitIdentity } from '@/lib/reference-journey'
+import { canonicalUrl } from '@/lib/canonical-url'
+import { alternatesFor } from '@/lib/locales'
 
 export const metadata = {
   title: `${agentsKitIdentity.name}.js — ${agentsKitIdentity.promise}`,
   description: `${agentsKitIdentity.promise} A composable TypeScript foundation for runtime, tools, memory, RAG, and chat interfaces.`,
+  alternates: {
+    canonical: canonicalUrl('/'),
+    languages: alternatesFor('/'),
+  },
   openGraph: {
     title: 'AgentsKit.js — Ship AI agents in JavaScript',
     description:

--- a/apps/docs-next/app/community/page.tsx
+++ b/apps/docs-next/app/community/page.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link'
 import community from '@/data/community.json'
 import { PartnerStrip } from '@/components/brand/partner-strip'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata = {
   title: 'Community — AgentsKit ecosystem',
   description:
     'Campaign landing for the AgentsKit ecosystem: understand the products, run a verified demo, contribute, and showcase what you built.',
+  alternates: { canonical: canonicalUrl('/community') },
 }
 
 type Project = { name: string; description: string; url: string; tags: string[]; by: string }

--- a/apps/docs-next/app/ecosystem/page.tsx
+++ b/apps/docs-next/app/ecosystem/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { lists, counts } from '@/lib/ecosystem-stats'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata: Metadata = {
   title: 'Ecosystem — products and packages',
   description:
     'AgentsKit product mesh (seven properties) plus the monorepo package matrix — stability, integrations, providers, models, adapters, and skills.',
+  alternates: { canonical: canonicalUrl('/ecosystem') },
 }
 
 /** Canonical seven-product mesh (roles from ecosystem.json). */

--- a/apps/docs-next/app/evals/page.tsx
+++ b/apps/docs-next/app/evals/page.tsx
@@ -1,8 +1,10 @@
 import evals from '@/data/evals.json'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata = {
   title: 'Adapter evals — AgentsKit.js',
   description: 'Side-by-side accuracy and latency scores per adapter. Seed data today; regenerated from @agentskit/eval in CI tomorrow.',
+  alternates: { canonical: canonicalUrl('/evals') },
 }
 
 type Suite = {

--- a/apps/docs-next/app/layout.tsx
+++ b/apps/docs-next/app/layout.tsx
@@ -4,13 +4,12 @@ import { Inter, JetBrains_Mono, Space_Grotesk } from 'next/font/google'
 import type { ReactNode } from 'react'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import { alternatesFor } from '@/lib/locales'
+import { SITE_URL } from '@/lib/canonical-url'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
 const jetbrainsMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
 const spaceGrotesk = Space_Grotesk({ subsets: ['latin'], variable: '--font-display', display: 'swap' })
 
-const SITE_URL = 'https://www.agentskit.io'
 const DESCRIPTION =
   'AgentsKit is the foundation library for JavaScript agents — runtime, tools, memory, RAG, and UI bindings. Product chat lives in AgentsKit Chat.'
 
@@ -36,10 +35,6 @@ export const metadata = {
   authors: [{ name: 'Emerson Braun', url: 'https://github.com/EmersonBraun' }],
   creator: 'Emerson Braun',
   category: 'technology',
-  alternates: {
-    canonical: SITE_URL,
-    languages: alternatesFor('/'),
-  },
   verification: {
     // Fill after verifying site in Google Search Console + Bing Webmaster:
     // google: 'YOUR_GSC_META_CONTENT',

--- a/apps/docs-next/app/learn/[step]/page.tsx
+++ b/apps/docs-next/app/learn/[step]/page.tsx
@@ -10,6 +10,7 @@ import {
   ProviderBlock,
   MemoryBlock,
 } from '@/components/learn/selector-tabs'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export function generateStaticParams() {
   return STEPS.map((s) => ({ step: s.slug }))
@@ -19,7 +20,11 @@ export async function generateMetadata({ params }: { params: Promise<{ step: str
   const { step } = await params
   const s = STEPS.find((x) => x.slug === step)
   if (!s) return { title: 'Learn AgentsKit' }
-  return { title: `${s.title} — Learn AgentsKit`, description: s.intro }
+  return {
+    title: `${s.title} — Learn AgentsKit`,
+    description: s.intro,
+    alternates: { canonical: canonicalUrl(`/learn/${step}`) },
+  }
 }
 
 function renderBody(body: string) {

--- a/apps/docs-next/app/learn/page.tsx
+++ b/apps/docs-next/app/learn/page.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link'
 import { STEPS } from '@/lib/learn-steps'
 import { Stepper } from '@/components/learn/stepper'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata = {
   title: 'Learn AgentsKit — interactive tutorial',
   description:
     'Ship a streaming chat, swap providers, register tools, and persist memory. Runs in your browser. Progress saved locally.',
+  alternates: { canonical: canonicalUrl('/learn') },
 }
 
 export default function LearnIndex() {

--- a/apps/docs-next/app/showcase/[slug]/page.tsx
+++ b/apps/docs-next/app/showcase/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { SHOWCASE, findShowcase, type ShowcaseFramework } from '@/lib/showcase'
 import { LiveExample } from '@/components/showcase/live'
 import { ShowcaseFrameworkTabs } from '@/components/showcase/framework-tabs'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 const SHARED_FILES: { label: string; path: string }[] = [
   { label: '_shared/mock-adapter.ts', path: 'components/examples/_shared/mock-adapter.ts' },
@@ -48,7 +49,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params
   const entry = findShowcase(slug)
   if (!entry) return { title: 'Showcase' }
-  return { title: `${entry.name} — AgentsKit showcase`, description: entry.description }
+  return {
+    title: `${entry.name} — AgentsKit showcase`,
+    description: entry.description,
+    alternates: { canonical: canonicalUrl(`/showcase/${slug}`) },
+  }
 }
 
 export default async function ShowcaseDetail({ params }: { params: Promise<{ slug: string }> }) {

--- a/apps/docs-next/app/showcase/page.tsx
+++ b/apps/docs-next/app/showcase/page.tsx
@@ -1,10 +1,12 @@
 import { SHOWCASE } from '@/lib/showcase'
 import { ShowcaseGrid } from '@/components/showcase/grid'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata = {
   title: 'Showcase — runnable AgentsKit examples',
   description:
     'Browse runnable AgentsKit examples and open any card in its full browser playground. Filter by tag.',
+  alternates: { canonical: canonicalUrl('/showcase') },
 }
 
 export default function ShowcasePage() {

--- a/apps/docs-next/app/stack/page.tsx
+++ b/apps/docs-next/app/stack/page.tsx
@@ -1,9 +1,11 @@
 import { StackBuilder } from '@/components/mdx/stack-builder'
+import { canonicalUrl } from '@/lib/canonical-url'
 
 export const metadata = {
   title: 'Stack builder — pick your AgentsKit',
   description:
     'Choose framework, provider, memory, and capabilities. Get install command + starter code. Your choices sync with every framework tab across the docs.',
+  alternates: { canonical: canonicalUrl('/stack') },
 }
 
 export default function StackPage() {

--- a/apps/docs-next/lib/canonical-url.ts
+++ b/apps/docs-next/lib/canonical-url.ts
@@ -1,0 +1,5 @@
+export const SITE_URL = 'https://www.agentskit.io'
+
+export function canonicalUrl(pathname: string): string {
+  return pathname === '/' ? SITE_URL : new URL(pathname, SITE_URL).toString()
+}

--- a/apps/docs-next/tests/canonical-metadata.test.ts
+++ b/apps/docs-next/tests/canonical-metadata.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { STEPS } from '../lib/learn-steps'
+import { SHOWCASE } from '../lib/showcase'
+import { canonicalUrl } from '../lib/canonical-url'
+
+describe('canonical metadata', () => {
+  it('builds a self-referencing canonical for every affected route', () => {
+    const routes = [
+      '/learn',
+      '/showcase',
+      '/stack',
+      '/community',
+      '/evals',
+      '/ecosystem',
+      ...STEPS.map((step) => `/learn/${step.slug}`),
+      ...SHOWCASE.map((entry) => `/showcase/${entry.slug}`),
+    ]
+
+    expect(routes).toHaveLength(32)
+    expect(new Set(routes).size).toBe(routes.length)
+
+    for (const route of routes) {
+      expect(canonicalUrl(route)).toBe(`https://www.agentskit.io${route}`)
+    }
+  })
+
+  it('keeps the homepage canonical at the site root', () => {
+    expect(canonicalUrl('/')).toBe('https://www.agentskit.io')
+  })
+})


### PR DESCRIPTION
## What changed

- stop inheriting the homepage canonical across public routes
- add self-referencing canonicals for the homepage, ecosystem, community, evals, stack, learn, and showcase surfaces
- cover all generated learn and showcase routes with a canonical metadata regression test

## Why

The root layout declared the homepage canonical globally. Next.js propagated it to child routes that did not override `alternates.canonical`, causing distinct public pages to advertise the homepage as their preferred URL.

## Impact

Thirty-two affected public routes now emit their own canonical URL, while the homepage keeps the existing root canonical and localized alternates.

## Validation

- `npm exec -- vitest run apps/docs-next/tests/canonical-metadata.test.ts --coverage --coverage.include=apps/docs-next/lib/canonical-url.ts`
- `pnpm --filter @agentskit/docs-next lint`
- `pnpm docs:bridge:gate`
- production Next.js build
- inspected 33 generated HTML files and verified each canonical exactly matches its route

