### PR TITLE
feat: add canonical software metadata

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,0 +1,32 @@
+name: Citation metadata
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - CITATION.cff
+      - ecosystem.json
+      - packages/core/package.json
+      - scripts/generate-software-metadata.mjs
+      - scripts/lib/software-metadata.mjs
+  pull_request:
+    branches: [main]
+    paths:
+      - CITATION.cff
+      - ecosystem.json
+      - packages/core/package.json
+      - scripts/generate-software-metadata.mjs
+      - scripts/lib/software-metadata.mjs
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate CITATION.cff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084 # v2.0.0
+        with:
+          args: --validate

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use AgentsKit in your work, please cite it using this metadata."
+title: "AgentsKit"
+type: software
+authors:
+  - family-names: "Braun"
+    given-names: "Emerson"
+    website: "https://github.com/EmersonBraun"
+version: "1.12.7"
+license: MIT
+repository-code: "https://github.com/AgentsKit-io/agentskit"
+url: "https://www.agentskit.io"
+keywords:
+  - "AI agents"
+  - "agent framework"
+  - "TypeScript"
+  - "JavaScript"
+  - "LLM"
+  - "multi-agent"
+  - "tools"
+  - "memory"
+  - "RAG"
+  - "observability"
+  - "sandboxing"
+  - "evaluation"
+  - "MCP"

--- a/apps/docs-next/app/(home)/page.tsx
+++ b/apps/docs-next/app/(home)/page.tsx
@@ -14,6 +14,7 @@ import { counts, approx } from '@/lib/ecosystem-stats'
 import { agentsKitIdentity } from '@/lib/reference-journey'
 import { canonicalUrl } from '@/lib/canonical-url'
 import { alternatesFor } from '@/lib/locales'
+import softwareIdentity from '@/lib/software-identity.generated.json'
 
 export const metadata = {
   title: `${agentsKitIdentity.name}.js — ${agentsKitIdentity.promise}`,
@@ -52,42 +53,15 @@ const GITHUB = 'https://github.com/AgentsKit-io/agentskit'
 const JSON_LD = {
   '@context': 'https://schema.org',
   '@graph': [
-    {
-      '@type': 'Organization',
-      '@id': 'https://www.agentskit.io/#org',
-      name: 'AgentsKit.js',
-      url: 'https://www.agentskit.io',
-      logo: {
-        '@type': 'ImageObject',
-        url: 'https://www.agentskit.io/apple-touch-icon.png',
-        width: 180,
-        height: 180,
-      },
-      sameAs: [
-        'https://github.com/AgentsKit-io/agentskit',
-        'https://www.npmjs.com/org/agentskit',
-      ],
-    },
-    {
-      '@type': 'SoftwareApplication',
-      '@id': 'https://www.agentskit.io/#software',
-      name: 'AgentsKit.js',
-      description: agentsKitIdentity.promise,
-      applicationCategory: 'DeveloperApplication',
-      operatingSystem: 'Cross-platform',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      url: 'https://www.agentskit.io',
-      license: 'https://github.com/AgentsKit-io/agentskit/blob/main/LICENSE',
-      author: { '@id': 'https://www.agentskit.io/#org' },
-      programmingLanguage: 'TypeScript',
-      keywords: 'AI agents, autonomous agent, multi-agent, JavaScript, TypeScript, LLM, streaming chat, RAG, tools, memory, observability, React, Vue, Svelte, Next.js, OpenAI, Anthropic Claude, Gemini, Ollama, LangChain',
-    },
+    softwareIdentity.organization,
+    softwareIdentity.sourceCode,
+    softwareIdentity.application,
     {
       '@type': 'WebSite',
       '@id': 'https://www.agentskit.io/#website',
       url: 'https://www.agentskit.io',
       name: 'AgentsKit.js',
-      publisher: { '@id': 'https://www.agentskit.io/#org' },
+      publisher: { '@id': softwareIdentity.organization['@id'] },
       potentialAction: {
         '@type': 'SearchAction',
         target: 'https://www.agentskit.io/docs?q={search_term_string}',

--- a/apps/docs-next/lib/ecosystem.json
+++ b/apps/docs-next/lib/ecosystem.json
@@ -16,6 +16,34 @@
       "maturity": "beta",
       "repo": "AgentsKit-io/agentskit",
       "accent": "#2EA043",
+      "metadata": {
+        "alternateName": "AgentsKit.js",
+        "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+        "dateCreated": "2026-04-02",
+        "applicationCategory": "DeveloperApplication",
+        "runtimePlatform": "JavaScript runtimes supporting ES2022",
+        "license": "MIT",
+        "author": {
+          "givenName": "Emerson",
+          "familyName": "Braun",
+          "url": "https://github.com/EmersonBraun"
+        },
+        "keywords": [
+          "AI agents",
+          "agent framework",
+          "TypeScript",
+          "JavaScript",
+          "LLM",
+          "multi-agent",
+          "tools",
+          "memory",
+          "RAG",
+          "observability",
+          "sandboxing",
+          "evaluation",
+          "MCP"
+        ]
+      },
       "showcase": {
         "claimSource": {
           "url": "https://www.agentskit.io/api/stats.json",

--- a/apps/docs-next/lib/software-identity.generated.json
+++ b/apps/docs-next/lib/software-identity.generated.json
@@ -1,0 +1,109 @@
+{
+  "organization": {
+    "@type": "Organization",
+    "@id": "https://www.agentskit.io/#org",
+    "name": "AgentsKit",
+    "url": "https://www.agentskit.io",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.agentskit.io/apple-touch-icon.png",
+      "width": 180,
+      "height": 180
+    },
+    "sameAs": [
+      "https://github.com/AgentsKit-io/agentskit",
+      "https://www.npmjs.com/org/agentskit"
+    ]
+  },
+  "sourceCode": {
+    "@type": "SoftwareSourceCode",
+    "@id": "https://www.agentskit.io/#source",
+    "name": "AgentsKit",
+    "alternateName": "AgentsKit.js",
+    "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+    "codeRepository": "https://github.com/AgentsKit-io/agentskit",
+    "url": "https://www.agentskit.io",
+    "mainEntityOfPage": "https://www.agentskit.io/docs",
+    "license": "https://github.com/AgentsKit-io/agentskit/blob/main/LICENSE",
+    "version": "1.12.7",
+    "dateCreated": "2026-04-02",
+    "programmingLanguage": [
+      "TypeScript",
+      "JavaScript"
+    ],
+    "runtimePlatform": "JavaScript runtimes supporting ES2022",
+    "applicationCategory": "DeveloperApplication",
+    "keywords": [
+      "AI agents",
+      "agent framework",
+      "TypeScript",
+      "JavaScript",
+      "LLM",
+      "multi-agent",
+      "tools",
+      "memory",
+      "RAG",
+      "observability",
+      "sandboxing",
+      "evaluation",
+      "MCP"
+    ],
+    "author": {
+      "@type": "Person",
+      "name": "Emerson Braun",
+      "givenName": "Emerson",
+      "familyName": "Braun",
+      "url": "https://github.com/EmersonBraun"
+    },
+    "publisher": {
+      "@id": "https://www.agentskit.io/#org"
+    },
+    "issueTracker": "https://github.com/AgentsKit-io/agentskit/issues"
+  },
+  "application": {
+    "@type": "SoftwareApplication",
+    "@id": "https://www.agentskit.io/#software",
+    "name": "AgentsKit",
+    "alternateName": "AgentsKit.js",
+    "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Cross-platform",
+    "softwareVersion": "1.12.7",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "url": "https://www.agentskit.io",
+    "downloadUrl": "https://www.npmjs.com/org/agentskit",
+    "license": "https://github.com/AgentsKit-io/agentskit/blob/main/LICENSE",
+    "author": {
+      "@type": "Person",
+      "name": "Emerson Braun",
+      "givenName": "Emerson",
+      "familyName": "Braun",
+      "url": "https://github.com/EmersonBraun"
+    },
+    "publisher": {
+      "@id": "https://www.agentskit.io/#org"
+    },
+    "isBasedOn": {
+      "@id": "https://www.agentskit.io/#source"
+    },
+    "keywords": [
+      "AI agents",
+      "agent framework",
+      "TypeScript",
+      "JavaScript",
+      "LLM",
+      "multi-agent",
+      "tools",
+      "memory",
+      "RAG",
+      "observability",
+      "sandboxing",
+      "evaluation",
+      "MCP"
+    ]
+  }
+}

--- a/apps/landing/lib/ecosystem.json
+++ b/apps/landing/lib/ecosystem.json
@@ -16,6 +16,34 @@
       "maturity": "beta",
       "repo": "AgentsKit-io/agentskit",
       "accent": "#2EA043",
+      "metadata": {
+        "alternateName": "AgentsKit.js",
+        "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+        "dateCreated": "2026-04-02",
+        "applicationCategory": "DeveloperApplication",
+        "runtimePlatform": "JavaScript runtimes supporting ES2022",
+        "license": "MIT",
+        "author": {
+          "givenName": "Emerson",
+          "familyName": "Braun",
+          "url": "https://github.com/EmersonBraun"
+        },
+        "keywords": [
+          "AI agents",
+          "agent framework",
+          "TypeScript",
+          "JavaScript",
+          "LLM",
+          "multi-agent",
+          "tools",
+          "memory",
+          "RAG",
+          "observability",
+          "sandboxing",
+          "evaluation",
+          "MCP"
+        ]
+      },
       "showcase": {
         "claimSource": {
           "url": "https://www.agentskit.io/api/stats.json",

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,71 @@
+{
+  "@context": "https://w3id.org/codemeta/3.1",
+  "@type": "SoftwareSourceCode",
+  "@id": "https://www.agentskit.io/#source",
+  "name": "AgentsKit",
+  "alternateName": "AgentsKit.js",
+  "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+  "codeRepository": "https://github.com/AgentsKit-io/agentskit",
+  "issueTracker": "https://github.com/AgentsKit-io/agentskit/issues",
+  "url": "https://www.agentskit.io",
+  "buildInstructions": "https://www.agentskit.io/docs/get-started/getting-started/installation",
+  "license": "https://spdx.org/licenses/MIT",
+  "version": "1.12.7",
+  "dateCreated": "2026-04-02",
+  "developmentStatus": "active",
+  "programmingLanguage": [
+    "TypeScript",
+    "JavaScript"
+  ],
+  "runtimePlatform": "JavaScript runtimes supporting ES2022",
+  "applicationCategory": "DeveloperApplication",
+  "keywords": [
+    "AI agents",
+    "agent framework",
+    "TypeScript",
+    "JavaScript",
+    "LLM",
+    "multi-agent",
+    "tools",
+    "memory",
+    "RAG",
+    "observability",
+    "sandboxing",
+    "evaluation",
+    "MCP"
+  ],
+  "author": {
+    "@type": "Person",
+    "name": "Emerson Braun",
+    "givenName": "Emerson",
+    "familyName": "Braun",
+    "url": "https://github.com/EmersonBraun"
+  },
+  "maintainer": {
+    "@type": "Person",
+    "name": "Emerson Braun",
+    "givenName": "Emerson",
+    "familyName": "Braun",
+    "url": "https://github.com/EmersonBraun"
+  },
+  "producer": {
+    "@type": "Organization",
+    "@id": "https://www.agentskit.io/#org",
+    "name": "AgentsKit",
+    "url": "https://www.agentskit.io",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.agentskit.io/apple-touch-icon.png",
+      "width": 180,
+      "height": 180
+    },
+    "sameAs": [
+      "https://github.com/AgentsKit-io/agentskit",
+      "https://www.npmjs.com/org/agentskit"
+    ]
+  },
+  "relatedLink": [
+    "https://www.agentskit.io/docs",
+    "https://www.agentskit.io/llms.txt"
+  ]
+}

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -16,6 +16,34 @@
       "maturity": "beta",
       "repo": "AgentsKit-io/agentskit",
       "accent": "#2EA043",
+      "metadata": {
+        "alternateName": "AgentsKit.js",
+        "description": "A free, MIT-licensed TypeScript ecosystem for production AI agents with replaceable contracts for models, runtimes, tools, memory, RAG, observability, sandboxing, evaluation, and interfaces.",
+        "dateCreated": "2026-04-02",
+        "applicationCategory": "DeveloperApplication",
+        "runtimePlatform": "JavaScript runtimes supporting ES2022",
+        "license": "MIT",
+        "author": {
+          "givenName": "Emerson",
+          "familyName": "Braun",
+          "url": "https://github.com/EmersonBraun"
+        },
+        "keywords": [
+          "AI agents",
+          "agent framework",
+          "TypeScript",
+          "JavaScript",
+          "LLM",
+          "multi-agent",
+          "tools",
+          "memory",
+          "RAG",
+          "observability",
+          "sandboxing",
+          "evaluation",
+          "MCP"
+        ]
+      },
       "showcase": {
         "claimSource": {
           "url": "https://www.agentskit.io/api/stats.json",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs:bridge:index": "ak-docs index",
     "docs:bridge:gate": "ak-docs gate run",
     "docs:bridge:doctor": "ak-docs doctor --text",
-    "release:version": "pnpm changeset version && pnpm readme:standard:refresh -- --preserve-review-dates",
+    "release:version": "pnpm changeset version && pnpm metadata:generate && pnpm readme:standard:refresh -- --preserve-review-dates",
     "release:preflight": "pnpm check:publication-surface && pnpm check:release-registry && pnpm check:packed-consumers && pnpm check:public-api-snapshot",
     "check:release-registry": "node scripts/check-release-registry.mjs",
     "test:release-registry": "node --test scripts/release-registry.test.mjs",
@@ -59,7 +59,9 @@
     "check:stability-evidence": "node scripts/check-stability-evidence.mjs",
     "report:stability-readiness": "node scripts/report-stability-readiness.mjs",
     "check:external-contributions": "node scripts/check-external-contributions.mjs",
-    "test:external-contributions": "vitest run scripts/external-contributions.test.mjs"
+    "test:external-contributions": "vitest run scripts/external-contributions.test.mjs",
+    "metadata:generate": "node scripts/generate-software-metadata.mjs",
+    "metadata:check": "node scripts/generate-software-metadata.mjs --check"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -198,8 +198,8 @@
         }
       ],
       "freshness": {
-        "reviewedOn": "2026-07-28",
-        "reviewDueOn": "2026-10-26",
+        "reviewedOn": "2026-08-12",
+        "reviewDueOn": "2026-11-10",
         "sources": [
           "README.md",
           "apps/docs-next/fixtures/first-agent/agent.ts",
@@ -208,7 +208,7 @@
           "ecosystem.json",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:68474b0c24444c9d2d57e17678db2138e5cf7f809f871c0520ab482410f935b5"
+        "sourceHash": "sha256:daab30a8d84ab6bd5718c18f6f952df2ec4cf21b9d1eb10cacdfb33ad8095b77"
       },
       "exceptions": []
     },

--- a/scripts/check-quality-gates.mjs
+++ b/scripts/check-quality-gates.mjs
@@ -32,6 +32,8 @@ const GATES = [
   ['ADR/RFC index sync', 'check-doc-index.mjs'],
   ['docs locale parity', 'check-intl-parity.mjs'],
   ['ecosystem contract tests', 'ecosystem-contract.test.mjs', [], 'vitest'],
+  ['software metadata tests', 'software-metadata.test.mjs', [], 'vitest'],
+  ['software metadata freshness', 'generate-software-metadata.mjs', ['--check']],
   ['ecosystem documentation quality contract', 'ecosystem-documentation-quality.test.mjs', [], 'vitest'],
   ['ecosystem documentation quality attestations', 'check-ecosystem-documentation-quality.mjs', ['--evidence-dir', 'docs/evidence/ecosystem-documentation-quality']],
   ['ecosystem count drift', 'check-count-drift.mjs'],

--- a/scripts/ecosystem-contract.test.mjs
+++ b/scripts/ecosystem-contract.test.mjs
@@ -81,6 +81,21 @@ test('duplicate product identities are rejected', () => {
   )
 })
 
+test('software identity metadata rejects invalid dates, licenses, and duplicate keywords', () => {
+  assert.throws(
+    () => parseEcosystemManifest(changed((copy) => { copy.products[0].metadata.dateCreated = 'April 2, 2026' })),
+    /must use YYYY-MM-DD/,
+  )
+  assert.throws(
+    () => parseEcosystemManifest(changed((copy) => { copy.products[0].metadata.license = 'MIT License' })),
+    /must be an SPDX identifier/,
+  )
+  assert.throws(
+    () => parseEcosystemManifest(changed((copy) => { copy.products[0].metadata.keywords.push('ai AGENTS') })),
+    /duplicates another keyword/,
+  )
+})
+
 test('unknown cross-product navigation targets are rejected', () => {
   assert.throws(
     () => parseEcosystemManifest(changed((copy) => { copy.products[0].navigation.next.push('missing') })),

--- a/scripts/generate-software-metadata.mjs
+++ b/scripts/generate-software-metadata.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildSoftwareMetadata, serializeSoftwareMetadata } from './lib/software-metadata.mjs'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const outputs = {
+  citation: join(root, 'CITATION.cff'),
+  codemeta: join(root, 'codemeta.json'),
+  siteIdentity: join(root, 'apps/docs-next/lib/software-identity.generated.json'),
+}
+const generated = serializeSoftwareMetadata(buildSoftwareMetadata(root))
+
+if (process.argv.includes('--check')) {
+  const stale = Object.entries(outputs)
+    .filter(([key, path]) => {
+      try { return readFileSync(path, 'utf8') !== generated[key] } catch { return true }
+    })
+    .map(([, path]) => path)
+  if (stale.length > 0) {
+    process.stderr.write(`Software metadata is stale: ${stale.map((path) => path.replace(`${root}/`, '')).join(', ')}\n`)
+    process.exitCode = 1
+  }
+} else {
+  for (const [key, path] of Object.entries(outputs)) writeFileSync(path, generated[key])
+}

--- a/scripts/lib/ecosystem-contract.mjs
+++ b/scripts/lib/ecosystem-contract.mjs
@@ -8,6 +8,7 @@ const SURFACE_KEYS = ['home', 'docs', 'llms', 'stats']
 /** properties[] is the seven-product v1 projection of products[] (same order). */
 const LEGACY_PRODUCT_IDS = ['agentskit', 'registry', 'agentskit-chat', 'playbook', 'doc-bridge', 'code-review', 'akos']
 const CANONICAL_PRODUCT_IDS = ['agentskit', 'registry', 'agentskit-chat', 'playbook', 'doc-bridge', 'code-review', 'akos']
+const SPDX_LICENSE = /^[A-Za-z0-9][A-Za-z0-9.+-]*$/
 
 function fail(path, message) {
   throw new TypeError(`ecosystem contract: ${path} ${message}`)
@@ -85,6 +86,34 @@ export function parseEcosystemManifest(input) {
     if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) fail(`${path}.repo`, 'must use owner/name')
     const accent = string(product.accent, `${path}.accent`)
     if (!/^#[0-9A-Fa-f]{6}$/.test(accent)) fail(`${path}.accent`, 'must be a six-digit hex color')
+
+    if (product.metadata !== undefined) {
+      if (id !== 'agentskit') fail(`${path}.metadata`, 'is currently supported only for the canonical AgentsKit product')
+      const metadata = object(product.metadata, `${path}.metadata`)
+      string(metadata.alternateName, `${path}.metadata.alternateName`)
+      string(metadata.description, `${path}.metadata.description`)
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(string(metadata.dateCreated, `${path}.metadata.dateCreated`))) {
+        fail(`${path}.metadata.dateCreated`, 'must use YYYY-MM-DD')
+      }
+      string(metadata.applicationCategory, `${path}.metadata.applicationCategory`)
+      string(metadata.runtimePlatform, `${path}.metadata.runtimePlatform`)
+      if (!SPDX_LICENSE.test(string(metadata.license, `${path}.metadata.license`))) {
+        fail(`${path}.metadata.license`, 'must be an SPDX identifier')
+      }
+      const author = object(metadata.author, `${path}.metadata.author`)
+      string(author.givenName, `${path}.metadata.author.givenName`)
+      string(author.familyName, `${path}.metadata.author.familyName`)
+      url(author.url, `${path}.metadata.author.url`)
+      if (!Array.isArray(metadata.keywords) || metadata.keywords.length < 3) {
+        fail(`${path}.metadata.keywords`, 'must contain at least three terms')
+      }
+      const keywords = new Set()
+      for (const [keywordIndex, keyword] of metadata.keywords.entries()) {
+        const normalized = string(keyword, `${path}.metadata.keywords[${keywordIndex}]`).toLowerCase()
+        if (keywords.has(normalized)) fail(`${path}.metadata.keywords[${keywordIndex}]`, 'duplicates another keyword')
+        keywords.add(normalized)
+      }
+    }
 
     if (product.navigation?.showInBar) {
       const showcase = object(product.showcase, `${path}.showcase`)
@@ -188,6 +217,7 @@ export function parseEcosystemManifest(input) {
   if (JSON.stringify([...ids]) !== JSON.stringify(CANONICAL_PRODUCT_IDS)) {
     fail('$.products', `must contain the canonical products in order: ${CANONICAL_PRODUCT_IDS.join(', ')}`)
   }
+  if (manifest.products[0].metadata === undefined) fail('$.products[0].metadata', 'is required for generated software identity surfaces')
   for (const [index, product] of manifest.products.entries()) {
     // Products may set showInBar:false to leave the shared header (e.g. early-stage tools).
     // Order stays stable so re-enabling a product does not reshuffle peers.

--- a/scripts/lib/software-metadata.mjs
+++ b/scripts/lib/software-metadata.mjs
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseEcosystemManifest } from './ecosystem-contract.mjs'
+
+function quoteYaml(value) {
+  return JSON.stringify(value)
+}
+
+export function buildSoftwareMetadata(root) {
+  const manifest = parseEcosystemManifest(JSON.parse(readFileSync(join(root, 'ecosystem.json'), 'utf8')))
+  const corePackage = JSON.parse(readFileSync(join(root, 'packages/core/package.json'), 'utf8'))
+  const product = manifest.products.find(({ id }) => id === 'agentskit')
+  const metadata = product.metadata
+  const repository = `https://github.com/${product.repo}`
+  const issues = `${repository}/issues`
+  const licenseUrl = `${repository}/blob/main/LICENSE`
+  const organizationId = `${product.surfaces.home}/#org`
+  const sourceId = `${product.surfaces.home}/#source`
+  const applicationId = `${product.surfaces.home}/#software`
+  const author = {
+    '@type': 'Person',
+    name: `${metadata.author.givenName} ${metadata.author.familyName}`,
+    givenName: metadata.author.givenName,
+    familyName: metadata.author.familyName,
+    url: metadata.author.url,
+  }
+  const organization = {
+    '@type': 'Organization',
+    '@id': organizationId,
+    name: manifest.parentBrand.name,
+    url: product.surfaces.home,
+    logo: {
+      '@type': 'ImageObject',
+      url: `${product.surfaces.home}/apple-touch-icon.png`,
+      width: 180,
+      height: 180,
+    },
+    sameAs: [repository, 'https://www.npmjs.com/org/agentskit'],
+  }
+  const sourceCode = {
+    '@type': 'SoftwareSourceCode',
+    '@id': sourceId,
+    name: product.name,
+    alternateName: metadata.alternateName,
+    description: metadata.description,
+    codeRepository: repository,
+    url: product.surfaces.home,
+    mainEntityOfPage: product.surfaces.docs,
+    license: licenseUrl,
+    version: corePackage.version,
+    dateCreated: metadata.dateCreated,
+    programmingLanguage: ['TypeScript', 'JavaScript'],
+    runtimePlatform: metadata.runtimePlatform,
+    applicationCategory: metadata.applicationCategory,
+    keywords: metadata.keywords,
+    author,
+    publisher: { '@id': organizationId },
+    issueTracker: issues,
+  }
+  const application = {
+    '@type': 'SoftwareApplication',
+    '@id': applicationId,
+    name: product.name,
+    alternateName: metadata.alternateName,
+    description: metadata.description,
+    applicationCategory: metadata.applicationCategory,
+    operatingSystem: 'Cross-platform',
+    softwareVersion: corePackage.version,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    url: product.surfaces.home,
+    downloadUrl: 'https://www.npmjs.com/org/agentskit',
+    license: licenseUrl,
+    author,
+    publisher: { '@id': organizationId },
+    isBasedOn: { '@id': sourceId },
+    keywords: metadata.keywords,
+  }
+  const codemeta = {
+    '@context': 'https://w3id.org/codemeta/3.1',
+    '@type': 'SoftwareSourceCode',
+    '@id': sourceId,
+    name: product.name,
+    alternateName: metadata.alternateName,
+    description: metadata.description,
+    codeRepository: repository,
+    issueTracker: issues,
+    url: product.surfaces.home,
+    buildInstructions: `${product.surfaces.docs}/get-started/getting-started/installation`,
+    license: `https://spdx.org/licenses/${metadata.license}`,
+    version: corePackage.version,
+    dateCreated: metadata.dateCreated,
+    developmentStatus: 'active',
+    programmingLanguage: ['TypeScript', 'JavaScript'],
+    runtimePlatform: metadata.runtimePlatform,
+    applicationCategory: metadata.applicationCategory,
+    keywords: metadata.keywords,
+    author,
+    maintainer: author,
+    producer: organization,
+    relatedLink: [product.surfaces.docs, product.surfaces.llms],
+  }
+  const citation = [
+    'cff-version: 1.2.0',
+    `message: ${quoteYaml('If you use AgentsKit in your work, please cite it using this metadata.')}`,
+    `title: ${quoteYaml(product.name)}`,
+    'type: software',
+    'authors:',
+    `  - family-names: ${quoteYaml(metadata.author.familyName)}`,
+    `    given-names: ${quoteYaml(metadata.author.givenName)}`,
+    `    website: ${quoteYaml(metadata.author.url)}`,
+    `version: ${quoteYaml(corePackage.version)}`,
+    `license: ${metadata.license}`,
+    `repository-code: ${quoteYaml(repository)}`,
+    `url: ${quoteYaml(product.surfaces.home)}`,
+    'keywords:',
+    ...metadata.keywords.map((keyword) => `  - ${quoteYaml(keyword)}`),
+    '',
+  ].join('\n')
+  return {
+    citation,
+    codemeta,
+    siteIdentity: { organization, sourceCode, application },
+  }
+}
+
+export function serializeSoftwareMetadata(metadata) {
+  return {
+    citation: metadata.citation,
+    codemeta: `${JSON.stringify(metadata.codemeta, null, 2)}\n`,
+    siteIdentity: `${JSON.stringify(metadata.siteIdentity, null, 2)}\n`,
+  }
+}

--- a/scripts/software-metadata.test.mjs
+++ b/scripts/software-metadata.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import { REPO_ROOT } from './compute-stats.mjs'
+import { buildSoftwareMetadata, serializeSoftwareMetadata } from './lib/software-metadata.mjs'
+
+const metadata = buildSoftwareMetadata(REPO_ROOT)
+const serialized = serializeSoftwareMetadata(metadata)
+
+test('generated software identity surfaces stay aligned with the canonical ecosystem manifest', () => {
+  assert.equal(readFileSync(join(REPO_ROOT, 'CITATION.cff'), 'utf8'), serialized.citation)
+  assert.equal(readFileSync(join(REPO_ROOT, 'codemeta.json'), 'utf8'), serialized.codemeta)
+  assert.equal(
+    readFileSync(join(REPO_ROOT, 'apps/docs-next/lib/software-identity.generated.json'), 'utf8'),
+    serialized.siteIdentity,
+  )
+})
+
+test('the source and application identities remain linked without conflating them', () => {
+  assert.equal(metadata.codemeta['@context'], 'https://w3id.org/codemeta/3.1')
+  assert.equal(metadata.codemeta['@type'], 'SoftwareSourceCode')
+  assert.equal(metadata.siteIdentity.application.isBasedOn['@id'], metadata.siteIdentity.sourceCode['@id'])
+  assert.equal(metadata.siteIdentity.sourceCode.publisher['@id'], metadata.siteIdentity.organization['@id'])
+  assert.equal(metadata.siteIdentity.application.offers.price, '0')
+})
+
+test('the home page emits the generated identity graph instead of maintaining a second copy', () => {
+  const home = readFileSync(join(REPO_ROOT, 'apps/docs-next/app/(home)/page.tsx'), 'utf8')
+  assert.match(home, /softwareIdentity\.organization/)
+  assert.match(home, /softwareIdentity\.sourceCode/)
+  assert.match(home, /softwareIdentity\.application/)
+  assert.doesNotMatch(home, /'@type': 'Organization'/)
+  assert.doesNotMatch(home, /'@type': 'SoftwareApplication'/)
+})
+
+test('citation authorship and public licensing are explicit', () => {
+  assert.match(metadata.citation, /family-names: "Braun"/)
+  assert.match(metadata.citation, /given-names: "Emerson"/)
+  assert.match(metadata.citation, /license: MIT/)
+  assert.equal(metadata.codemeta.license, 'https://spdx.org/licenses/MIT')
+})


### PR DESCRIPTION
## What changed

- establish `ecosystem.json` as the canonical source for AgentsKit software identity
- generate and commit root `CITATION.cff`, CodeMeta 3.1 metadata, and the website JSON-LD graph
- make the homepage consume generated Organization, SoftwareSourceCode, and SoftwareApplication entities
- regenerate metadata during versioning and fail quality gates when committed outputs drift
- validate CFF metadata in a path-scoped GitHub Actions workflow

## Why

AgentsKit had several independent descriptions across its site and repository but no machine-readable citation or source-code identity. A single generated source reduces narrative drift and gives crawlers, directories, researchers, and LLM-oriented discovery systems consistent authorship, licensing, repository, runtime, and capability signals.

## Impact

This is repository and documentation metadata only. It does not change package contracts or runtime behavior. Future core version changes regenerate the public metadata through the existing release workflow.

## Validation

- `pnpm build` — 42/42 tasks
- `pnpm check:quality-gates` — 31/31 gates
- `pnpm --filter @agentskit/docs-next lint`
- `pnpm docs:bridge:index`
- `pnpm docs:bridge:gate`
- `pnpm vitest run scripts/software-metadata.test.mjs scripts/ecosystem-contract.test.mjs` — 24/24 tests
- `pnpm metadata:check`
- official `citationcff/cffconvert --validate` — schema 1.2.0 valid
- `git diff --check`
