### PR TITLE
chore: add root editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.mdx]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## What changed

Add the root `.editorconfig` requested in #1388.

It standardizes UTF-8, LF line endings, final newlines, two-space indentation, and trailing-whitespace trimming. Markdown and MDX keep trailing whitespace so intentional hard line breaks remain intact.

## Scope

Configuration-only: no existing files were reformatted, and no scripts, dependencies, or lint rules changed.

Closes #1388.

## Validation

- `git diff --check`
- `pnpm check:quality-gates` (33/33 gates passed)

Grok CLI was used to audit the contributor-quality gap; the session cancelled before editing, so the final file was reviewed and applied manually against the issue's acceptance criteria.
