### PR TITLE
fix(core): retire tool lifecycles after active work

### DIFF
--- a/.changeset/quiet-tools-retire.md
+++ b/.changeset/quiet-tools-retire.md
@@ -1,0 +1,5 @@
+---
+'@agentskit/core': patch
+---
+
+Retire tool lifecycles only after in-flight executions settle, and preserve equivalent tool lifecycles across configuration rerenders.

--- a/packages/core/src/agent-loop.ts
+++ b/packages/core/src/agent-loop.ts
@@ -167,11 +167,12 @@ export async function executeSafeTool(
     })
     return { status: 'complete', result, durationMs: Date.now() - began }
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
     const err = error instanceof ToolError
       ? error
       : new ToolError({
           code: ErrorCodes.AK_TOOL_EXEC_FAILED,
-          message: `Tool "${toolCall.name}" threw during execution: ${error instanceof Error ? error.message : String(error)}`,
+          message: `Tool "${toolCall.name}" threw during execution: ${detail}`,
           hint: 'Check the tool execute() implementation.',
           cause: error,
         })

--- a/packages/core/src/agent-loop.ts
+++ b/packages/core/src/agent-loop.ts
@@ -1,5 +1,5 @@
 import { ToolError, ErrorCodes } from './errors'
-import { executeToolCall, createToolLifecycle, createEventEmitter } from './primitives'
+import { acquireToolLifecycle, executeToolCall, createToolLifecycle, createEventEmitter } from './primitives'
 import type {
   ArgsValidator,
   MaybePromise,
@@ -134,7 +134,21 @@ export async function executeSafeTool(
     return { status: 'error', error: err.toString(), durationMs: Date.now() - began }
   }
 
-  await lifecycle.init(tool)
+  const releaseLifecycle = acquireToolLifecycle(lifecycle)
+  if (!releaseLifecycle) {
+    return {
+      status: 'skipped',
+      result: 'Tool execution superseded by a configuration update',
+      durationMs: Date.now() - began,
+    }
+  }
+
+  try {
+    await lifecycle.init(tool)
+  } catch (error) {
+    await releaseLifecycle()
+    throw error
+  }
 
   emitter.emit({ type: 'tool:start', name: toolCall.name, args: toolCall.args })
 
@@ -170,5 +184,7 @@ export async function executeSafeTool(
       durationMs: Date.now() - began,
     })
     return { status: 'error', error: err.toString(), durationMs: Date.now() - began }
+  } finally {
+    await releaseLifecycle()
   }
 }

--- a/packages/core/src/controller-helpers.ts
+++ b/packages/core/src/controller-helpers.ts
@@ -58,6 +58,23 @@ export function mapToolCallById(
   }))
 }
 
+export function sameToolLifecycle(
+  previous: Map<string, ToolDefinition>,
+  next: Map<string, ToolDefinition>,
+): boolean {
+  if (previous.size !== next.size) return false
+  for (const [name, tool] of previous) {
+    const replacement = next.get(name)
+    if (
+      !replacement
+      || replacement.execute !== tool.execute
+      || replacement.init !== tool.init
+      || replacement.dispose !== tool.dispose
+    ) return false
+  }
+  return true
+}
+
 /** Build tool-result messages + a fresh streaming assistant for multi-turn tool loops. */
 export function buildToolContinuation(
   messages: Message[],

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -7,6 +7,7 @@ import {
   mapMessageById,
   mapToolCallById,
   normalizeLlmUsage,
+  sameToolLifecycle,
 } from './controller-helpers'
 import type {
   ChatConfig,
@@ -35,6 +36,7 @@ export function createChatController(initial: ChatConfig): ChatController {
   const emitter = createEventEmitter()
   let toolMap = buildToolMap(config.tools)
   let lifecycle = createToolLifecycle(toolMap)
+  let skillTools: ToolDefinition[] = []
   let hydrated = false
   let active = false
   let saving = false
@@ -45,9 +47,14 @@ export function createChatController(initial: ChatConfig): ChatController {
     return fn === config.authorizeToolCall && toolMap.get(call.name)?.execute === context.tool?.execute ? decision : { allowed: false }
   }
 
-  const rebuild = (extraTools?: ToolDefinition[]) => {
-    toolMap = buildToolMap(config.tools, extraTools)
-    lifecycle = createToolLifecycle(toolMap)
+  const rebuild = () => {
+    const nextToolMap = buildToolMap(config.tools, skillTools)
+    if (!sameToolLifecycle(toolMap, nextToolMap)) {
+      const previousLifecycle = lifecycle
+      lifecycle = createToolLifecycle(nextToolMap)
+      void previousLifecycle.disposeAll()
+    }
+    toolMap = nextToolMap
   }
 
   const activate = async () => {
@@ -55,7 +62,8 @@ export function createChatController(initial: ChatConfig): ChatController {
     active = true
     const result = await activateSkills(config.skills ?? [], config.systemPrompt)
     system = result.systemPrompt
-    if (result.skillTools.length > 0) rebuild(result.skillTools)
+    skillTools = result.skillTools
+    rebuild()
   }
   void activate()
 
@@ -529,7 +537,6 @@ export function createChatController(initial: ChatConfig): ChatController {
       await resume(msg.id, gen)
     },
     updateConfig(nextConfig) {
-      void lifecycle.disposeAll()
       config = { ...config, ...nextConfig }
       active = false
       rebuild()

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -104,26 +104,117 @@ export function safeParseArgs(args: string): Record<string, unknown> {
   }
 }
 
-export function createToolLifecycle(tools: Map<string, ToolDefinition>) {
-  const initialized = new Set<string>()
+interface ToolLifecycleState {
+  initialized: Set<string>
+  initializing: Map<string, Promise<void>>
+  activeExecutions: number
+  retired: boolean
+  disposal: Promise<void> | undefined
+  retirement: Promise<void> | undefined
+  resolveRetirement: (() => void) | undefined
+  tools: Map<string, ToolDefinition>
+}
 
-  return {
+const lifecycleStates = new WeakMap<object, ToolLifecycleState>()
+
+function retirementPromise(state: ToolLifecycleState): Promise<void> {
+  if (!state.retirement) {
+    state.retirement = new Promise<void>(resolve => {
+      state.resolveRetirement = resolve
+    })
+  }
+  return state.retirement
+}
+
+function scheduleLifecycleDisposal(state: ToolLifecycleState): void {
+  if (
+    !state.retired
+    || state.activeExecutions > 0
+    || state.initializing.size > 0
+    || state.disposal
+  ) return
+
+  state.disposal = (async () => {
+    const names = [...state.initialized]
+    state.initialized.clear()
+    for (const name of names) {
+      try {
+        await state.tools.get(name)?.dispose?.()
+      } catch {
+        // Dispose errors should not propagate.
+      }
+    }
+  })().finally(() => {
+    state.disposal = undefined
+    state.resolveRetirement?.()
+    state.resolveRetirement = undefined
+  })
+}
+
+export function createToolLifecycle(tools: Map<string, ToolDefinition>) {
+  const state: ToolLifecycleState = {
+    initialized: new Set<string>(),
+    initializing: new Map<string, Promise<void>>(),
+    activeExecutions: 0,
+    retired: false,
+    disposal: undefined,
+    retirement: undefined,
+    resolveRetirement: undefined,
+    tools,
+  }
+
+  const lifecycle = {
     async init(tool: ToolDefinition): Promise<void> {
-      if (tool.init && !initialized.has(tool.name)) {
-        await tool.init()
-        initialized.add(tool.name)
+      // A retired lifecycle cannot start new work. An execution that acquired
+      // it before retirement may still finish initialization safely.
+      if (state.retired && state.activeExecutions === 0) return
+      if (!tool.init || state.initialized.has(tool.name)) return
+
+      const pending = state.initializing.get(tool.name)
+      if (pending) {
+        await pending
+        return
+      }
+
+      const initialization = (async () => {
+        await tool.init?.()
+        state.initialized.add(tool.name)
+      })()
+      state.initializing.set(tool.name, initialization)
+      try {
+        await initialization
+      } finally {
+        state.initializing.delete(tool.name)
+        scheduleLifecycleDisposal(state)
       }
     },
     async disposeAll(): Promise<void> {
-      for (const name of initialized) {
-        try {
-          await tools.get(name)?.dispose?.()
-        } catch {
-          // Dispose errors should not propagate.
-        }
-      }
-      initialized.clear()
+      state.retired = true
+      const completion = retirementPromise(state)
+      scheduleLifecycleDisposal(state)
+      await completion
     },
+  }
+
+  lifecycleStates.set(lifecycle, state)
+  return lifecycle
+}
+
+/** Hold a lifecycle open for one tool execution without changing its public shape. */
+export function acquireToolLifecycle(
+  lifecycle: ReturnType<typeof createToolLifecycle>,
+): (() => Promise<void>) | undefined {
+  const state = lifecycleStates.get(lifecycle)
+  if (!state || state.retired) return undefined
+
+  state.activeExecutions++
+  let released = false
+  return async () => {
+    if (released) return
+    released = true
+    state.activeExecutions--
+    scheduleLifecycleDisposal(state)
+    if (state.retirement) await state.retirement
   }
 }
 

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -263,11 +263,12 @@ export async function consumeStream(
     }
     handlers.onDone(accumulatedText)
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
     const err = error instanceof AgentsKitError
       ? error
       : new AdapterError({
           code: ErrorCodes.AK_ADAPTER_STREAM_FAILED,
-          message: `Stream failed: ${error instanceof Error ? error.message : String(error)}`,
+          message: `Stream failed: ${detail}`,
           hint: 'Adapter/provider',
           cause: error,
         })

--- a/packages/core/tests/agent-loop.test.ts
+++ b/packages/core/tests/agent-loop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { SkillDefinition, ToolCall, ToolDefinition } from '../src/types'
 import { buildToolMap, activateSkills, executeSafeTool } from '../src/agent-loop'
 import { createEventEmitter, createToolLifecycle } from '../src/primitives'
@@ -318,5 +318,93 @@ describe('executeSafeTool', () => {
     expect(result.status).toBe('skipped')
     expect(result.result?.toLowerCase()).toMatch(/confirm|refus|approv|declin/)
     expect(result.result?.toLowerCase()).toContain('handler')
+  })
+
+  it('defers disposal until an active execution settles', async () => {
+    let markStarted = () => undefined
+    let releaseExecution = () => undefined
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const blocked = new Promise<void>(resolve => { releaseExecution = resolve })
+    const dispose = vi.fn()
+    const tool: ToolDefinition = {
+      name: 'slow',
+      init: vi.fn(),
+      execute: async () => {
+        markStarted()
+        await blocked
+        return 'done'
+      },
+      dispose,
+    }
+    const lifecycle = createToolLifecycle(buildToolMap([tool]))
+    const running = executeSafeTool({
+      tool,
+      toolCall: makeToolCall('slow'),
+      context: { messages: [], call: makeToolCall('slow') },
+      emitter: createEventEmitter(),
+      lifecycle,
+    })
+
+    await started
+    const retired = lifecycle.disposeAll()
+    await Promise.resolve()
+    expect(dispose).not.toHaveBeenCalled()
+
+    releaseExecution()
+    await running
+    await retired
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('initializes concurrent executions once and disposes once after retirement', async () => {
+    let releaseInit = () => undefined
+    const initStarted = new Promise<void>(resolve => {
+      const original = resolve
+      releaseInit = original
+    })
+    const init = vi.fn(async () => { await initStarted })
+    const dispose = vi.fn()
+    const tool: ToolDefinition = {
+      name: 'shared',
+      init,
+      execute: async () => 'ok',
+      dispose,
+    }
+    const lifecycle = createToolLifecycle(buildToolMap([tool]))
+    const options = {
+      tool,
+      toolCall: makeToolCall('shared'),
+      context: { messages: [], call: makeToolCall('shared') },
+      emitter: createEventEmitter(),
+      lifecycle,
+    }
+
+    const first = executeSafeTool(options)
+    await vi.waitFor(() => expect(init).toHaveBeenCalledOnce())
+    const second = executeSafeTool(options)
+    const retired = lifecycle.disposeAll()
+    releaseInit()
+
+    await Promise.all([first, second, retired])
+    expect(init).toHaveBeenCalledOnce()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('skips executions that arrive after lifecycle retirement', async () => {
+    const init = vi.fn()
+    const tool: ToolDefinition = { name: 'retired', init, execute: async () => 'nope' }
+    const lifecycle = createToolLifecycle(buildToolMap([tool]))
+    await lifecycle.disposeAll()
+
+    const result = await executeSafeTool({
+      tool,
+      toolCall: makeToolCall('retired'),
+      context: { messages: [], call: makeToolCall('retired') },
+      emitter: createEventEmitter(),
+      lifecycle,
+    })
+
+    expect(result.status).toBe('skipped')
+    expect(init).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/tests/controller.test.ts
+++ b/packages/core/tests/controller.test.ts
@@ -876,3 +876,67 @@ describe('ChatController skills support', () => {
     expect(content).toContain('You are skill B.')
   })
 })
+
+describe('ChatController tool lifecycle retirement', () => {
+  it('keeps an active lifecycle across equivalent config rerenders', async () => {
+    let markStarted = () => undefined
+    let releaseExecution = () => undefined
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const blocked = new Promise<void>(resolve => { releaseExecution = resolve })
+    const execute = vi.fn(async () => {
+      markStarted()
+      await blocked
+      return 'done'
+    })
+    const init = vi.fn()
+    const dispose = vi.fn()
+    const tool = { name: 'slow', requiresConfirmation: true, init, execute, dispose }
+    const ctrl = createChatController({
+      adapter: createMockAdapter([]),
+      tools: [tool],
+    })
+
+    await proposeToolCall(ctrl, { id: 'slow-1', name: 'slow', args: {} })
+    const sending = ctrl.approve('slow-1')
+    await started
+    ctrl.updateConfig({ tools: [{ ...tool, description: 'same lifecycle' }] })
+    expect(dispose).not.toHaveBeenCalled()
+
+    releaseExecution()
+    await sending
+    expect(execute).toHaveBeenCalledOnce()
+    expect(dispose).not.toHaveBeenCalled()
+
+    await ctrl.clear()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('retires replaced lifecycles after the active execution settles', async () => {
+    let markStarted = () => undefined
+    let releaseExecution = () => undefined
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const blocked = new Promise<void>(resolve => { releaseExecution = resolve })
+    const execute = vi.fn(async () => {
+      markStarted()
+      await blocked
+      return 'done'
+    })
+    const init = vi.fn()
+    const dispose = vi.fn()
+    const tool = { name: 'replaceable', requiresConfirmation: true, init, execute, dispose }
+    const ctrl = createChatController({
+      adapter: createMockAdapter([]),
+      tools: [tool],
+    })
+
+    await proposeToolCall(ctrl, { id: 'replace-1', name: 'replaceable', args: {} })
+    const sending = ctrl.approve('replace-1')
+    await started
+    ctrl.updateConfig({ tools: [{ name: 'replaceable', execute: async () => 'new' }] })
+    expect(dispose).not.toHaveBeenCalled()
+
+    releaseExecution()
+    await sending
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1187.

- Retires a tool lifecycle without disposing resources while an execution or initialization is still in flight.
- Shares concurrent initialization and disposes each initialized tool exactly once.
- Keeps equivalent tool lifecycles across framework/config rerenders; replaced tools get a retired lifecycle.
- Adds a patch changeset for `@agentskit/core`.

## Validation

- `pnpm --filter @agentskit/core test` — 391 passing
- `pnpm --filter @agentskit/core lint` — passed
- `pnpm --filter @agentskit/react test` — 90 passing
- `pnpm --filter @agentskit/ink test` — 116 passing
- `pnpm exec size-limit` — core 5.37 kB ESM / 8.12 kB CJS gzipped, within 10 kB
- `pnpm check:quality-gates` — all completed gates clean through the content-pipeline suite; the repository's long-running verified-recipe subprocess was stopped after it remained active
- `git diff --check` — passed

The Grok CLI was requested for a bounded audit, but its local device backend returned `Device not configured`; implementation and review were completed locally against the issue's test plan.
