### PR TITLE
fix(security): update nanoid override to 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "brace-expansion": "5.0.9",
       "fast-uri": "3.1.5",
       "undici": "7.29.0",
-      "nanoid": "3.3.17",
+      "nanoid": "3.3.18",
       "js-yaml@>=4.0.0 <5": "4.3.1",
       "js-yaml@>=5.0.0 <6": "5.2.2",
       "protobufjs@>=7.5.0 <8": "7.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   brace-expansion: 5.0.9
   fast-uri: 3.1.5
   undici: 7.29.0
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   js-yaml@>=4.0.0 <5: 4.3.1
   js-yaml@>=5.0.0 <6: 5.2.2
   protobufjs@>=7.5.0 <8: 7.6.5
@@ -7481,8 +7481,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -16295,7 +16295,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -16716,7 +16716,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Updates the root nanoid override from 3.3.17 to 3.3.18, the patched release for GHSA-2v37-7h3g-55p8.

Validation:
- pnpm audit --prod: only the two unpatched image-size advisories remain
- pnpm check:quality-gates: 37/37 gates passed

The existing image-size patch remains unchanged.