### PR TITLE
docs: synchronize package references and examples

### DIFF
--- a/.changeset/clear-readme-dependencies.md
+++ b/.changeset/clear-readme-dependencies.md
@@ -1,0 +1,6 @@
+---
+'@agentskit/adapters': patch
+'@agentskit/rag': patch
+---
+
+Clarify the runtime, RAG, and optional Vectra dependencies in the package README examples.

--- a/apps/docs-next/content/docs/reference/packages/adapters.mdx
+++ b/apps/docs-next/content/docs/reference/packages/adapters.mdx
@@ -104,7 +104,7 @@ Testing: `mockAdapter` · `recordingAdapter` · `replayAdapter` · `inMemorySink
 
 ## Stability
 
-- **Version:** `0.14.3`
+- **Version:** `0.15.0`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/angular.mdx
+++ b/apps/docs-next/content/docs/reference/packages/angular.mdx
@@ -46,7 +46,7 @@ export class ChatComponent {
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/cli.mdx
+++ b/apps/docs-next/content/docs/reference/packages/cli.mdx
@@ -54,7 +54,7 @@ The CLI makes AgentsKit feel like a product, not just a pile of packages. It sho
 
 ## Stability
 
-- **Version:** `0.13.34`
+- **Version:** `0.13.36`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/core.mdx
+++ b/apps/docs-next/content/docs/reference/packages/core.mdx
@@ -327,7 +327,7 @@ type SearchArgs = InferSchemaType<typeof schema>
 
 ## Stability
 
-- **Version:** `1.12.7`
+- **Version:** `1.12.8`
 - **Tier:** stable
 - **Contract:** frozen
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/eval-braintrust.mdx
+++ b/apps/docs-next/content/docs/reference/packages/eval-braintrust.mdx
@@ -114,7 +114,7 @@ You can also pass `apiKey` / `baseUrl` directly in `BraintrustRunOptions` — ex
 
 ## Stability
 
-- **Version:** `0.2.17`
+- **Version:** `0.2.18`
 - **Tier:** beta
 - **Contract:** scorer shapes stable; Braintrust SDK peer-resolved at runtime.
 

--- a/apps/docs-next/content/docs/reference/packages/eval.mdx
+++ b/apps/docs-next/content/docs/reference/packages/eval.mdx
@@ -63,7 +63,7 @@ That feedback loop is what lets a team keep improving an agent without losing co
 
 ## Stability
 
-- **Version:** `0.6.2`
+- **Version:** `0.6.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/ink.mdx
+++ b/apps/docs-next/content/docs/reference/packages/ink.mdx
@@ -35,7 +35,7 @@ render(<ChatContainer config={{ adapter: anthropic({ apiKey, model: 'claude-sonn
 
 ## Stability
 
-- **Version:** `0.10.8`
+- **Version:** `0.10.9`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/memory.mdx
+++ b/apps/docs-next/content/docs/reference/packages/memory.mdx
@@ -56,7 +56,7 @@ In most real products, memory is the difference between a clever demo and a usef
 
 ## Stability
 
-- **Version:** `0.11.7`
+- **Version:** `0.11.8`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/observability-langfuse.mdx
+++ b/apps/docs-next/content/docs/reference/packages/observability-langfuse.mdx
@@ -103,7 +103,7 @@ Explicit config fields always take precedence over env vars.
 
 ## Stability
 
-- **Version:** `0.2.18`
+- **Version:** `0.2.19`
 - **Tier:** beta
 - **Contract:** `Observer` interface stable; Langfuse SDK peer-resolved at runtime.
 

--- a/apps/docs-next/content/docs/reference/packages/observability.mdx
+++ b/apps/docs-next/content/docs/reference/packages/observability.mdx
@@ -57,7 +57,7 @@ For many teams, this is the point where an agent stops feeling magical and start
 
 ## Stability
 
-- **Version:** `0.11.2`
+- **Version:** `0.11.3`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/rag.mdx
+++ b/apps/docs-next/content/docs/reference/packages/rag.mdx
@@ -46,7 +46,7 @@ const hits = await rag.search('what is agentskit')
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/react-native.mdx
+++ b/apps/docs-next/content/docs/reference/packages/react-native.mdx
@@ -37,7 +37,7 @@ export function ChatScreen({ adapter }) {
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/react.mdx
+++ b/apps/docs-next/content/docs/reference/packages/react.mdx
@@ -62,7 +62,7 @@ This is the UI entry point for the ecosystem, not a separate product. The same c
 
 ## Stability
 
-- **Version:** `0.8.2`
+- **Version:** `0.8.3`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/runtime.mdx
+++ b/apps/docs-next/content/docs/reference/packages/runtime.mdx
@@ -60,7 +60,7 @@ That one `run()` call is the center of the agent stack. Everything else in the e
 
 ## Stability
 
-- **Version:** `0.10.14`
+- **Version:** `0.10.15`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/sandbox.mdx
+++ b/apps/docs-next/content/docs/reference/packages/sandbox.mdx
@@ -51,7 +51,7 @@ This is one of the clearest boundaries between a capable agent demo and a produc
 
 ## Stability
 
-- **Version:** `0.6.3`
+- **Version:** `0.6.4`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/skills.mdx
+++ b/apps/docs-next/content/docs/reference/packages/skills.mdx
@@ -41,7 +41,7 @@ execute those capabilities.
 
 ## Stability
 
-- **Version:** `0.9.2`
+- **Version:** `0.9.3`
 - **Tier:** beta
 - **Contract:** SkillDefinition semantics pinned by ADR 0005; package conveniences remain beta.
 - **Roadmap:** stable surface proposed in [RFC 0009](../../../../../../rfcs/0009-skills-stable.md); ADR 0024 evidence remains mandatory.

--- a/apps/docs-next/content/docs/reference/packages/solid.mdx
+++ b/apps/docs-next/content/docs/reference/packages/solid.mdx
@@ -28,7 +28,7 @@ const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/statechart.mdx
+++ b/apps/docs-next/content/docs/reference/packages/statechart.mdx
@@ -35,7 +35,8 @@ The package owns transition and snapshot semantics. Hosts own persistence, event
 
 ## Stability
 
-- **Current release:** `0.2.1`; this beta hardening targets the `0.3.0` minor
+- **Version:** `0.3.0`
+- **Current release:** `0.3.0`
 - **Tier:** beta
 - **Contracts:** [ADR-0020](../../../../../../docs/architecture/adrs/0020-serializable-interaction-state.md), [ADR-0027](../../../../../../docs/architecture/adrs/0027-statechart-beta-boundaries.md)
 

--- a/apps/docs-next/content/docs/reference/packages/svelte.mdx
+++ b/apps/docs-next/content/docs/reference/packages/svelte.mdx
@@ -37,7 +37,7 @@ const chat = createChatStore({ adapter: anthropic({ apiKey, model: 'claude-sonne
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/templates.mdx
+++ b/apps/docs-next/content/docs/reference/packages/templates.mdx
@@ -157,6 +157,7 @@ Register scaffolded packages like any other tool, skill, or adapter via
 
 ## Stability
 
+- **Version:** `0.5.3`
 - **Tier:** beta (hardened scaffold/validation surface; not yet stable)
 - **Promotion path:** [RFC 0014](../../../../../../rfcs/0014-templates-stable.md)
 - **Contract:** evolving under beta semver (breaking changes allowed in minors with CHANGELOG notes)

--- a/apps/docs-next/content/docs/reference/packages/tools.mdx
+++ b/apps/docs-next/content/docs/reference/packages/tools.mdx
@@ -58,7 +58,7 @@ Most production agents become valuable only once this layer is in place.
 
 ## Stability
 
-- **Version:** `0.13.3`
+- **Version:** `0.13.5`
 - **Tier:** beta
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/apps/docs-next/content/docs/reference/packages/vue.mdx
+++ b/apps/docs-next/content/docs/reference/packages/vue.mdx
@@ -31,7 +31,7 @@ const chat = useChat({ adapter: anthropic({ apiKey, model: 'claude-sonnet-4-6' }
 
 ## Stability
 
-- **Version:** `0.5.2`
+- **Version:** `0.5.3`
 - **Tier:** alpha
 - **Contract:** evolving
 - **Roadmap:** see [packages roadmap](./roadmap) for what this package needs to reach v1.0.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gen:integration": "node scripts/gen-integration.mjs",
     "check:quality-gates": "node scripts/check-quality-gates.mjs",
     "check:product-chat-adoption": "node scripts/check-product-chat-adoption.mjs",
+    "check:doc-package-versions": "node scripts/check-doc-package-versions.mjs",
     "test:product-chat-adoption": "vitest run scripts/product-chat-adoption.test.mjs",
     "check:all": "pnpm check:quality-gates && pnpm lint && pnpm build && pnpm test",
     "prepare": "husky",

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -46,6 +46,10 @@ Docs: [package guide](https://www.agentskit.io/docs/reference/packages/adapters)
 npm install @agentskit/adapters
 ```
 
+The runtime example below also needs `@agentskit/runtime`. The RAG example
+also needs `@agentskit/rag`, `@agentskit/memory`, and the optional `vectra`
+peer (`npm install @agentskit/rag @agentskit/memory vectra`).
+
 ## Quick example
 
 <!-- readme-example:quickstart -->

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -46,6 +46,10 @@ Docs: [package guide](https://www.agentskit.io/docs/reference/packages/rag) · [
 npm install @agentskit/rag @agentskit/memory @agentskit/adapters
 ```
 
+The file-backed example also needs the optional `vectra` peer. Add
+`vectra` to the install command when using `fileVectorMemory`; the runtime
+integration example additionally needs `@agentskit/runtime`.
+
 ## Quick example
 
 <!-- readme-example:quickstart -->

--- a/readme-standard-v1.json
+++ b/readme-standard-v1.json
@@ -287,7 +287,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:7912a72af85bb21181f58860fc75d833d0fea7673168d804cea53b0dee256f84"
+        "sourceHash": "sha256:f737e86fabe3a9e12ec7194b218653dee910a4cdd825a0302a4041e95a7f52d0"
       },
       "exceptions": []
     },
@@ -1235,7 +1235,7 @@
           "docs/STABILITY.md",
           "scripts/readme-fixtures.test.mjs"
         ],
-        "sourceHash": "sha256:af59e3bf13b5d1b30eccf961c89555586b798019a25b4d6753c2b6ce61bc77c3"
+        "sourceHash": "sha256:02ae18ac74a15764166c8340dfe0c175a4764d0d075c444e5f407ba7a5d2434c"
       },
       "exceptions": []
     },

--- a/scripts/check-doc-package-versions.mjs
+++ b/scripts/check-doc-package-versions.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/** Keep canonical package reference pages aligned with package.json versions. */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const packageRoot = join(root, 'packages')
+const docsRoot = join(root, 'apps', 'docs-next', 'content', 'docs', 'reference', 'packages')
+const versionPattern = /\*\*Version:\*\*\s*`([0-9]+\.[0-9]+\.[0-9]+)`/
+const errors = []
+let checked = 0
+
+for (const entry of readdirSync(packageRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue
+  const packageJsonPath = join(packageRoot, entry.name, 'package.json')
+  const docsPath = join(docsRoot, `${entry.name}.mdx`)
+  if (!existsSync(packageJsonPath) || !existsSync(docsPath)) continue
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  if (!packageJson.version) continue
+  checked += 1
+  const match = readFileSync(docsPath, 'utf8').match(versionPattern)
+  if (!match) errors.push(`${entry.name}: missing **Version:** line in ${docsPath}`)
+  else if (match[1] !== packageJson.version) errors.push(`${entry.name}: docs=${match[1]} package=${packageJson.version}`)
+}
+
+if (errors.length > 0) {
+  console.error(`doc package versions: ${errors.length} mismatch(es) across ${checked} package page(s)`)
+  for (const error of errors) console.error(`  - ${error}`)
+  process.exit(1)
+}
+
+console.log(`doc package versions: ${checked} package page(s) match package.json ✓`)

--- a/scripts/check-quality-gates.mjs
+++ b/scripts/check-quality-gates.mjs
@@ -46,6 +46,7 @@ const GATES = [
   ['ecosystem claims freshness', 'gen-ecosystem-claims.mjs', ['--check']],
   ['ecosystem registry sync', 'sync-ecosystem.mjs', ['--check']],
   ['product-chat Chat 0.4 adoption', 'check-product-chat-adoption.mjs'],
+  ['canonical package doc versions', 'check-doc-package-versions.mjs'],
   ['product-chat adoption tests', 'product-chat-adoption.test.mjs', [], 'vitest'],
   ['brand token sync', 'sync-brand.mjs', ['--property', 'agentskit', '--out', 'apps/docs-next/app/brand-tokens.css', '--check']],
   ['brand token sync (landing)', 'sync-brand.mjs', ['--property', 'agentskit', '--format', 'landing', '--out', 'apps/landing/app/globals.css', '--check']],


### PR DESCRIPTION
## Summary
- synchronize all 22 canonical package reference pages with the versions in `packages/*/package.json`
- add a quality gate that prevents package-reference version drift on future releases
- make adapter and RAG README examples explicit about runtime, RAG, and the optional `vectra` peer
- refresh README Standard evidence for the changed canonical READMEs

## Validation
- `node scripts/check-doc-package-versions.mjs`
- `node scripts/check-readme-standard.mjs`
- `git diff --check`

The full local quality orchestrator was also run; repository-wide dependency installation was blocked in this disposable worktree by the configured minimum-release-age policy for freshly published packages. CI should run with the repository's normal dependency cache/policy.
