### PR TITLE
fix(security): activate verified npm client without unpinned command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,11 @@ jobs:
           curl --fail --location --retry 3 --output npm-11.18.0.tgz "$NPM_TARBALL_URL"
           actual_sha512="$(openssl dgst -sha512 -binary npm-11.18.0.tgz | base64 -w0)"
           test "$actual_sha512" = "$NPM_TARBALL_SHA512"
-          npm install --global ./npm-11.18.0.tgz --ignore-scripts --no-audit --no-fund
+          npm_client_dir="$RUNNER_TEMP/npm-11.18.0"
+          mkdir -p "$npm_client_dir"
+          tar -xzf npm-11.18.0.tgz -C "$npm_client_dir" --strip-components=1
+          echo "$npm_client_dir/bin" >> "$GITHUB_PATH"
+          node "$npm_client_dir/bin/npm-cli.js" --version
           rm -f npm-11.18.0.tgz
       - name: Create release app token
         id: release_app_token

--- a/scripts/check-publication-surface.mjs
+++ b/scripts/check-publication-surface.mjs
@@ -20,8 +20,8 @@ if (!releaseWorkflow.includes('id-token: write')) diagnostics.push('release work
 if (!releaseWorkflow.includes('environment: npm')) diagnostics.push('release workflow must use the npm environment')
 if (/NPM_TOKEN|NODE_AUTH_TOKEN/.test(releaseWorkflow)) diagnostics.push('release workflow must not depend on saved npm tokens')
 if (!releaseWorkflow.includes('package-manager-cache: false')) diagnostics.push('release workflow must disable package-manager caching')
-if (!/NPM_TARBALL_SHA512: [A-Za-z0-9+/]+=*/.test(releaseWorkflow) || !/npm install --global \.\/npm-11\.\d+\.\d+\.tgz/.test(releaseWorkflow)) {
-  diagnostics.push('release workflow must install npm from a SHA-512-verified tarball')
+if (!/NPM_TARBALL_SHA512: [A-Za-z0-9+/]+=*/.test(releaseWorkflow) || !/tar -xzf npm-11\.\d+\.\d+\.tgz/.test(releaseWorkflow) || !/npm_client_dir.*RUNNER_TEMP/.test(releaseWorkflow)) {
+  diagnostics.push('release workflow must extract npm from a SHA-512-verified tarball')
 }
 if (!releaseWorkflow.includes('pnpm check:release-registry')) diagnostics.push('release workflow must run the registry preflight')
 if (!releaseWorkflow.includes('recover_unpublished')) diagnostics.push('release workflow must expose explicit unpublished-version recovery')

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -30,10 +30,12 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /persist-credentials: false/)
   })
 
-  test('verifies the npm release client tarball before installing it', () => {
+  test('verifies the npm release client tarball before activating it', () => {
     assert.match(workflow, /NPM_TARBALL_URL: https:\/\/registry\.npmjs\.org\/npm\/-\/npm-11\.18\.0\.tgz/)
     assert.match(workflow, /NPM_TARBALL_SHA512: [A-Za-z0-9+/]+=*/)
     assert.match(workflow, /openssl dgst -sha512 -binary npm-11\.18\.0\.tgz/)
-    assert.match(workflow, /npm install --global \.\/npm-11\.18\.0\.tgz/)
+    assert.match(workflow, /tar -xzf npm-11\.18\.0\.tgz -C "\$npm_client_dir" --strip-components=1/)
+    assert.match(workflow, /echo "\$npm_client_dir\/bin" >> "\$GITHUB_PATH"/)
+    assert.match(workflow, /node "\$npm_client_dir\/bin\/npm-cli\.js" --version/)
   })
 })


### PR DESCRIPTION
## Summary
- extract the SHA-512-verified npm tarball into the runner temp directory
- activate its CLI through `GITHUB_PATH` without an unpinned `npm install` command
- update publication and workflow contract tests

## Validation
- `node scripts/check-publication-surface.mjs`
- `node --test scripts/release-workflow-auth.test.mjs`
- `git diff --check`