### PR TITLE
fix(ci): scope models catalog token permissions

### DIFF
--- a/.github/workflows/models-dev-catalog.yml
+++ b/.github/workflows/models-dev-catalog.yml
@@ -6,13 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   freshness:
     name: Compare committed catalog with models.dev
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- set the workflow default token permissions to read-only
- grant write access only to the freshness job that opens the automated PR

This resolves the Scorecard Token-Permissions finding without changing the catalog automation behavior.

## Validation

- `git diff --check`
- job-level permissions are explicit for `contents` and `pull-requests`.