### PR TITLE
fix(release): keep npm trusted publishing OIDC-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           node-version: 22
           package-manager-cache: false
-          registry-url: https://registry.npmjs.org
       - name: Pin npm release client
         env:
           NPM_TARBALL_URL: https://registry.npmjs.org/npm/-/npm-11.18.0.tgz

--- a/scripts/release-workflow-auth.test.mjs
+++ b/scripts/release-workflow-auth.test.mjs
@@ -30,6 +30,14 @@ describe('release workflow authentication', () => {
     assert.match(workflow, /persist-credentials: false/)
   })
 
+  test('keeps npm trusted publishing free of token-auth config', () => {
+    // setup-node writes a token placeholder to .npmrc when registry-url is set.
+    // That placeholder prevents npm trusted publishing from using OIDC when no
+    // NODE_AUTH_TOKEN is configured.
+    assert.doesNotMatch(workflow, /registry-url:/)
+    assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
+  })
+
   test('verifies the npm release client tarball before activating it', () => {
     assert.match(workflow, /NPM_TARBALL_URL: https:\/\/registry\.npmjs\.org\/npm\/-\/npm-11\.18\.0\.tgz/)
     assert.match(workflow, /NPM_TARBALL_SHA512: [A-Za-z0-9+/]+=*/)


### PR DESCRIPTION
## Summary
- remove registry-url from the release workflow so npm trusted publishing can use OIDC without a token placeholder in .npmrc
- add a regression test that rejects token-auth configuration in the workflow

## Root cause
The failed release run used npm trusted publishing but actions/setup-node created a temporary .npmrc containing ${NODE_AUTH_TOKEN}. With no token configured, npm treated the publish as an invalid registry request and returned E404 for every package.

## Validation
- git diff --check
- node --test scripts/release-workflow-auth.test.mjs
- node scripts/check-publication-surface.mjs