### PR TITLE
fix(docs): point integration links to catalog

### DIFF
--- a/apps/docs-next/content/docs/agents/tools/index.mdx
+++ b/apps/docs-next/content/docs/agents/tools/index.mdx
@@ -31,7 +31,7 @@ Browser: `browserAgent`
 - `createMcpServer` — publish AgentsKit tools to any MCP host.
 - [Recipe: MCP bridge](/docs/reference/recipes/mcp-bridge).
 
-Use the [canonical integration catalog](https://www.agentskit.io/integrations) to browse all 50 service descriptors, or read the [integration package contract](/docs/for-agents/integrations) before implementing a connector. Dedicated service guides are linked from the catalog where available.
+Use the [canonical integration catalog](/docs/agents/tools/integrations-catalog) to browse all 50 service descriptors, or read the [integration package contract](/docs/for-agents/integrations) before implementing a connector. Dedicated service guides are linked from the catalog where available.
 
 ## Related
 

--- a/apps/docs-next/content/docs/agents/tools/integrations/index.mdx
+++ b/apps/docs-next/content/docs/agents/tools/integrations/index.mdx
@@ -5,8 +5,8 @@ description: '50-service catalog for TypeScript AI agents. Dedicated guides, pac
 
 The canonical `@agentskit/integrations` package contains **50 service descriptors**. This page covers the detailed
 guides available in the tools documentation; the [for-agents package guide](/docs/for-agents/integrations) describes
-the full descriptor registry and projection contract. The top-level [integrations hub](https://www.agentskit.io/integrations) keeps both
-surfaces discoverable without creating placeholder pages for services that do not yet have a dedicated guide.
+the full descriptor registry and projection contract. The [canonical integration catalog](/docs/agents/tools/integrations-catalog)
+keeps both surfaces discoverable without creating placeholder pages for services that do not yet have a dedicated guide.
 
 ## Categories
 


### PR DESCRIPTION
## What changed

Replace two external links to `https://www.agentskit.io/integrations` with the published internal route `/docs/agents/tools/integrations-catalog`.

## Why

The external integrations URL returns 404 and blocks the repository Lychee link check. The internal catalog is the canonical documentation surface already listed in the Tools navigation.

## Validation

- MDX lint passed for 421 files, with only existing unknown-component warnings.
- `git diff --check` passed.

## Scope

Only these two documentation files changed. No runtime, package, contract, or provider code was modified.
