### PR TITLE
feat(docs): add deterministic Pattern Lab showcase

### DIFF
--- a/apps/docs-next/components/examples/PatternLab.tsx
+++ b/apps/docs-next/components/examples/PatternLab.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useChat, ChatContainer, InputBar } from '@agentskit/react'
+import '@/styles/agentskit-theme.css'
+import { createMockAdapter, initialAssistant, toolsFor, type Turn } from './_shared/mock-adapter'
+import { MdRenderer } from './_shared/md-renderer'
+import { ToolBadge } from './_shared/tool-badge'
+
+type PatternScenario = {
+  id: string
+  label: string
+  tagline: string
+  boundary: string
+  turns: Turn[]
+}
+
+export const PATTERN_LAB_SCENARIOS: PatternScenario[] = [
+  {
+    id: 'support-escalation',
+    label: 'Support escalation',
+    tagline: 'PII cleanup → evidence → human handoff',
+    boundary: 'Draft only. A support agent reviews before posting or assigning severity.',
+    turns: [{
+      toolCalls: [
+        { name: 'redact_sensitive_fields', args: { fields: ['email', 'phone', 'account_id'] }, result: { removed: ['email', 'account_id'], preserved: ['error_code', 'steps'] }, durationMs: 180 },
+        { name: 'assemble_escalation', args: { sections: ['impact', 'tried', 'need', 'sla'] }, result: { evidence: 4, missing: ['reproduction_video'] }, durationMs: 220 },
+      ],
+      text: '### Internal escalation draft\\n\\n- **Impact:** checkout fails after the third step for the supplied synthetic case\\n- **Tried:** cache reset, browser replay, and version check\\n- **Need:** engineering reproduction with the sanitized error code\\n- **SLA:** confirm owner and response window\\n- **Evidence gap:** reproduction video is still missing\\n\\n**Human review:** verify the reproduction and severity before handoff.',
+    }],
+  },
+  {
+    id: 'api-contract',
+    label: 'API contract review',
+    tagline: 'Diff → evidence → verification path',
+    boundary: 'Advisory review. Maintainers decide compatibility, migration, and release timing.',
+    turns: [{
+      toolCalls: [
+        { name: 'compare_contracts', args: { before: 'v1.json', after: 'v2.json' }, result: { breaking: 1, nonBreaking: 2 }, durationMs: 200 },
+        { name: 'check_consumers', args: { packages: ['web', 'cli'] }, result: { affected: ['cli'], missing: ['runtime fixture'] }, durationMs: 240 },
+      ],
+      text: '### API contract review\\n\\n- **Breaking:** `error.code` changed from optional to required\\n- **Non-breaking:** additive `request.traceId`; documented enum value\\n- **Affected consumer:** `cli` has no fallback for the required field\\n- **Next check:** add a runtime fixture and replay both adapter contracts\\n\\n**Human review:** decide whether to migrate the consumer or preserve compatibility.',
+    }],
+  },
+  {
+    id: 'fact-check',
+    label: 'Fact-check a claim',
+    tagline: 'Claims → sources → editorial queue',
+    boundary: 'Editorial draft. A human verifies sources and approves any public wording.',
+    turns: [{
+      toolCalls: [
+        { name: 'extract_claims', args: { source: 'synthetic-case-note.md' }, result: { claims: 2 }, durationMs: 160 },
+        { name: 'check_sources', args: { sources: ['timing-notes.md', 'case-note.md'] }, result: { supported: 1, unresolved: 1, conflict: false }, durationMs: 210 },
+      ],
+      text: '### Claim review\\n\\n- **Supported:** the synthetic pilot reduced review time, according to `timing-notes.md`\\n- **Unresolved:** the workflow is production-ready; no readiness evidence was supplied\\n\\n**Editorial queue:** verify the sample, date, and denominator before using any number publicly.',
+    }],
+  },
+]
+
+export function PatternLab() {
+  const [selectedId, setSelectedId] = useState(PATTERN_LAB_SCENARIOS[0].id)
+  const selected = PATTERN_LAB_SCENARIOS.find((scenario) => scenario.id === selectedId) ?? PATTERN_LAB_SCENARIOS[0]
+
+  return (
+    <div data-ak-example className="overflow-hidden rounded-lg border border-ak-border bg-ak-surface">
+      <div className="border-b border-ak-border bg-ak-midnight/30 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-widest text-ak-foam">Pattern lab</div>
+            <h2 className="mt-1 font-display text-lg font-semibold text-ak-foam">Evidence-first workflows</h2>
+            <p className="mt-1 max-w-2xl text-sm text-ak-graphite">Three deterministic Registry-shaped workflows. No network, credentials, or external actions.</p>
+          </div>
+          <span className="rounded-full border border-ak-green/30 bg-ak-green/5 px-2 py-1 font-mono text-[10px] text-ak-green">synthetic replay</span>
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-3" role="tablist" aria-label="Pattern lab scenarios">
+          {PATTERN_LAB_SCENARIOS.map((scenario) => {
+            const active = scenario.id === selected.id
+            return (
+              <button key={scenario.id} type="button" role="tab" aria-selected={active} onClick={() => setSelectedId(scenario.id)} className={`min-h-11 rounded-md border px-3 py-2 text-left transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ak-blue ${active ? 'border-ak-foam bg-ak-foam/10 text-ak-foam' : 'border-ak-border text-ak-graphite hover:border-ak-foam hover:text-ak-foam'}`}>
+                <span className="block font-mono text-xs">{scenario.label}</span>
+                <span className="mt-1 block text-xs opacity-80">{scenario.tagline}</span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      <PatternConversation key={selected.id} scenario={selected} />
+    </div>
+  )
+}
+
+function PatternConversation({ scenario }: { scenario: PatternScenario }) {
+  const adapter = useMemo(() => createMockAdapter(scenario.turns, 100), [scenario])
+  const tools = useMemo(() => toolsFor(scenario.turns), [scenario])
+  const chat = useChat({ adapter, tools, maxToolIterations: 1, initialMessages: [initialAssistant(`Try this synthetic ${scenario.label.toLowerCase()} request. The result stays advisory.`)] })
+
+  return (
+    <div>
+      <ChatContainer className="flex min-h-[360px] flex-col gap-3 p-4">
+        {chat.messages.filter((message) => message.role !== 'tool').map((message) => (
+          <div key={message.id} className="flex flex-col gap-2">
+            {message.toolCalls?.map((call) => <ToolBadge key={call.id} call={call} />)}
+            {message.content ? <div data-ak-message data-ak-role={message.role} className={`rounded-lg p-3 ${message.role === 'user' ? 'ml-auto max-w-[85%] bg-ak-midnight/60' : 'bg-ak-midnight/30'}`}><MdRenderer content={message.content} /></div> : null}
+          </div>
+        ))}
+      </ChatContainer>
+      <div className="border-t border-ak-border px-4 pt-3 text-xs text-ak-graphite"><span className="font-mono text-ak-foam">Boundary:</span> {scenario.boundary}</div>
+      <div className="p-4"><InputBar chat={chat} /></div>
+    </div>
+  )
+}

--- a/apps/docs-next/components/showcase/live.tsx
+++ b/apps/docs-next/components/showcase/live.tsx
@@ -27,6 +27,7 @@ const LOADERS: Record<string, () => Promise<{ default: ComponentType }>> = {
   RuntimeReAct: () => import('@/components/examples/RuntimeReAct').then((m) => ({ default: m.RuntimeReAct })),
   ProviderFanout: () => import('@/components/examples/ProviderFanout').then((m) => ({ default: m.ProviderFanout })),
   RAGCiteExample: () => import('@/components/examples/RAGCiteExample').then((m) => ({ default: m.RAGCiteExample })),
+  PatternLab: () => import('@/components/examples/PatternLab').then((m) => ({ default: m.PatternLab })),
 }
 
 export function LiveExample({ meta }: { meta: ShowcaseMeta }) {

--- a/apps/docs-next/fixtures/pattern-lab/README.md
+++ b/apps/docs-next/fixtures/pattern-lab/README.md
@@ -1,0 +1,9 @@
+# Pattern Lab fixture
+
+This fixture replays the three public Pattern Lab scenarios without credentials, network access, or provider calls.
+
+```bash
+pnpm --filter @agentskit/docs-next exec tsx fixtures/pattern-lab/agent.ts
+```
+
+The output is synthetic evidence for inspecting the contract and human-review boundary. It is not a production result, customer outcome, or professional recommendation.

--- a/apps/docs-next/fixtures/pattern-lab/agent.ts
+++ b/apps/docs-next/fixtures/pattern-lab/agent.ts
@@ -1,0 +1,47 @@
+import type { AdapterFactory } from '@agentskit/core'
+import { createRuntime } from '@agentskit/runtime'
+
+const OUTPUTS = {
+  support: 'Support escalation draft: sanitized evidence, missing reproduction video, human review required.',
+  api: 'API contract review: one breaking field change, one affected consumer, runtime fixture required.',
+  facts: 'Claim review: one supplied claim supported, production-readiness claim unresolved, editorial review required.',
+} as const
+
+type PatternId = keyof typeof OUTPUTS
+
+function patternFor(prompt: string): PatternId {
+  if (prompt.includes('API')) return 'api'
+  if (prompt.includes('claim')) return 'facts'
+  return 'support'
+}
+
+const localAdapter: AdapterFactory = {
+  createSource(request) {
+    const prompt = request.messages.at(-1)?.content ?? ''
+    const result = OUTPUTS[patternFor(prompt)]
+
+    return {
+      async *stream() {
+        yield { type: 'text' as const, content: result }
+        yield { type: 'done' as const }
+      },
+      abort() {},
+    }
+  },
+}
+
+async function main() {
+  const runtime = createRuntime({ adapter: localAdapter })
+  const prompts = [
+    'Run a support escalation draft',
+    'Run an API contract review',
+    'Run a claim fact-check',
+  ]
+
+  for (const prompt of prompts) {
+    const result = await runtime.run(prompt)
+    console.log(result.content)
+  }
+}
+
+void main()

--- a/apps/docs-next/lib/showcase.ts
+++ b/apps/docs-next/lib/showcase.ts
@@ -85,6 +85,7 @@ export const SHOWCASE: ShowcaseMeta[] = [
   { slug: 'runtime-react', name: 'Runtime ReAct', description: 'Standalone agent runtime — no UI required. ReAct loop with tools + memory.', tags: ['runtime', 'multi-agent'], module: 'RuntimeReAct', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
   { slug: 'provider-fanout', name: 'Provider fanout', description: 'Same prompt across openai, anthropic, gemini, ollama. Compare quality + cost.', tags: ['adapters', 'multi-model'], module: 'ProviderFanout', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
   { slug: 'rag-cite', name: 'RAG with citations', description: 'Retrieve top-k chunks with scores and inline cite refs.', tags: ['rag', 'citations'], module: 'RAGCiteExample', sources: { node: { stackblitz: STACKBLITZ_TEMPLATES.node } } },
+  { slug: 'pattern-lab', name: 'Pattern lab', description: 'Three deterministic, evidence-first workflows with explicit human boundaries.', tags: ['patterns', 'eval', 'human-review'], module: 'PatternLab' },
 ]
 
 export const ALL_TAGS: string[] = Array.from(new Set(SHOWCASE.flatMap((s) => s.tags))).sort()

--- a/apps/docs-next/tests/canonical-metadata.test.ts
+++ b/apps/docs-next/tests/canonical-metadata.test.ts
@@ -17,7 +17,7 @@ describe('canonical metadata', () => {
       ...SHOWCASE.map((entry) => `/showcase/${entry.slug}`),
     ]
 
-    expect(routes).toHaveLength(33)
+    expect(routes).toHaveLength(34)
     expect(new Set(routes).size).toBe(routes.length)
 
     for (const route of routes) {

--- a/docs/evidence/ecosystem-documentation-quality/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/agentskit.json
@@ -4,7 +4,7 @@
   "profileVersion": 1,
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "1de518fccb476c1d2647ea4e26dbda5bc9c9101f",
+  "commit": "e88e45d9171c60af811000d69f1e8f3442aeaaf6",
   "auditedOn": "2026-08-14",
   "docBridge": {
     "artifact": "docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json",

--- a/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
+++ b/docs/evidence/ecosystem-documentation-quality/doc-bridge/agentskit.json
@@ -3,7 +3,7 @@
   "protocol": "agentskit.doc-bridge.attestation",
   "productId": "agentskit",
   "repo": "AgentsKit-io/agentskit",
-  "commit": "1de518fccb476c1d2647ea4e26dbda5bc9c9101f",
+  "commit": "e88e45d9171c60af811000d69f1e8f3442aeaaf6",
   "sourceMode": "commit",
   "contentDigest": "sha256:8e45a027ef0e8ce5e29306f8af50ad0140114cec8d18568e2c498500c6b337e0",
   "command": "pnpm docs:bridge:doctor && pnpm docs:bridge:gate",

--- a/scripts/pattern-lab.test.mjs
+++ b/scripts/pattern-lab.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { test } from 'vitest'
+
+const ROOT = process.cwd()
+const read = (file) => readFileSync(join(ROOT, file), 'utf8')
+
+test('Pattern Lab fixture replays every scenario without credentials or network', () => {
+  const fixture = read('apps/docs-next/fixtures/pattern-lab/agent.ts')
+  assert.doesNotMatch(fixture, /process\.env|fetch\(|https?:\/\//)
+
+  const run = spawnSync(
+    'pnpm',
+    ['--filter', '@agentskit/docs-next', 'exec', 'tsx', 'fixtures/pattern-lab/agent.ts'],
+    { cwd: ROOT, encoding: 'utf8' },
+  )
+
+  assert.equal(run.status, 0, run.stderr)
+  assert.match(run.stdout, /Support escalation draft/)
+  assert.match(run.stdout, /API contract review/)
+  assert.match(run.stdout, /Claim review/)
+})
+
+test('Pattern Lab is registered as a lazy showcase module with a human boundary', () => {
+  const registry = read('apps/docs-next/lib/showcase.ts')
+  const loader = read('apps/docs-next/components/showcase/live.tsx')
+  const component = read('apps/docs-next/components/examples/PatternLab.tsx')
+
+  assert.match(registry, /slug: 'pattern-lab'/)
+  assert.match(registry, /module: 'PatternLab'/)
+  assert.match(loader, /PatternLab: \(\) => import\('\@\/components\/examples\/PatternLab'\)/)
+  assert.match(component, /No network, credentials, or external actions/)
+  assert.match(component, /Human review/)
+})


### PR DESCRIPTION
## What this adds

- Adds a public Pattern Lab showcase with three deterministic, evidence-first workflows:
  - support escalation
  - API contract review
  - claim fact-checking
- Makes human review boundaries explicit in every scenario.
- Adds a credential-free fixture and README for replaying the three outputs.
- Adds structural tests covering the fixture, lazy showcase registration, no-network claim, and human boundary.
- Refreshes the documentation-quality attestation pointer after the published Doc Bridge merge.

## Safety

The showcase uses synthetic data only. It performs no network calls, provider calls, credential reads, publishing, or external actions.

## Validation

- `pnpm exec vitest run scripts/pattern-lab.test.mjs`
- `pnpm docs:bridge:gate`
- `pnpm check:quality-gates` via pre-push
- `pnpm lint` and `pnpm build` via pre-push

No core contracts or package APIs changed.