### PR TITLE
docs: make Application Patterns the canonical public name

### DIFF
--- a/apps/registry/app/docs/application-patterns-wave-06/page.tsx
+++ b/apps/registry/app/docs/application-patterns-wave-06/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function LegacyApplicationPatternsPage() {
+  redirect('/docs/application-patterns')
+}

--- a/apps/registry/content/docs/application-patterns.mdx
+++ b/apps/registry/content/docs/application-patterns.mdx
@@ -1,9 +1,9 @@
 ---
-title: Application patterns — Wave 06
-description: Twenty synthetic, evidence-first starting points for agency, clinical, privacy, content, data, infrastructure, commerce, regulated review, and security workflows.
+title: Application Patterns
+description: Evidence-first workflows for real-world applications.
 ---
 
-Wave 06 is a set of **application molds**, not a claim of customer impact or production readiness. Each entry is an existing Registry agent that you can copy, inspect, test, and adapt:
+This catalog is a set of **application molds**, not a claim of customer impact or production readiness. Each entry is an existing Registry agent that you can copy, inspect, test, and adapt:
 
 ```bash
 npx agentskit add <agent-id>
@@ -12,7 +12,7 @@ npm test -- --run registry/<agent-id>/agent.test.ts
 
 Use synthetic inputs while exploring the pattern. Inspect typed output, evidence, missing context, and review requirements. A human remains responsible for every consequential decision, external communication, policy interpretation, and production action.
 
-The [canonical guide](https://github.com/AgentsKit-io/agentskit-registry/blob/main/docs/agents/application-patterns-wave-06.md) contains the full try/inspect/contribution notes.
+The [canonical guide](https://github.com/AgentsKit-io/agentskit-registry/blob/main/docs/agents/application-patterns-wave-06.md) contains the full try/inspect/contribution notes for this edition.
 
 ## Agency, clinical, and privacy
 

--- a/apps/registry/content/docs/index.mdx
+++ b/apps/registry/content/docs/index.mdx
@@ -17,7 +17,7 @@ registry runtime and no lock-in.
 - **I want to understand Ask Registry:** see [deterministic discovery](/docs/discovery).
 - **Something failed:** use [troubleshooting](/docs/troubleshooting).
 - **I want to publish an agent:** follow [Create your own](/docs/authoring) and [Contributing](/docs/contributing).
-- **I want an application mold:** browse [Wave 06 patterns](/docs/application-patterns-wave-06) and copy the agent you want to adapt.
+- **I want an application mold:** browse [Application Patterns](/docs/application-patterns) and copy the agent you want to adapt.
 
 ## What gets installed
 

--- a/apps/registry/content/docs/meta.json
+++ b/apps/registry/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Docs",
-  "pages": ["index", "quick-start", "discovery", "using", "providers", "customizing", "validation", "troubleshooting", "authoring", "for-agents", "contributing", "application-patterns-wave-06"]
+  "pages": ["index", "quick-start", "discovery", "using", "providers", "customizing", "validation", "troubleshooting", "authoring", "for-agents", "contributing", "application-patterns"]
 }


### PR DESCRIPTION
## What changed

- Rename the public Registry page to **Application Patterns**.
- Add the stable route `/docs/application-patterns`.
- Redirect the legacy `/docs/application-patterns-wave-06` route to the stable page.
- Update the Registry docs index to use the stable public name.
- Keep the edition identifier only in the historical canonical guide and compatibility route.

## Why

“Wave 06” describes an internal batch, not a durable public product surface. Future batches should be tracked internally without leaking batch naming into public titles or URLs.

## Validation

- `pnpm --filter @agentskit/registry-app lint`
- `pnpm --filter @agentskit/registry-app build`
- Local HTTP check: stable route returns 200; legacy route returns 307 to `/docs/application-patterns`.
- Full pre-push hook: 40 quality gates, monorepo lint, and full build passed.
